### PR TITLE
Баллы карго за талеры.

### DIFF
--- a/code/game/supplyshuttle.dm
+++ b/code/game/supplyshuttle.dm
@@ -116,6 +116,7 @@ var/list/point_source_descriptions = list(
 	"crate" = "From exported crates",
 	"phoron" = "From exported phoron",
 	"platinum" = "From exported platinum",
+	"thaler" = "From exported money",
 	"virology" = "From uploaded antibody data",
 	"total" = "Total" // If you're adding additional point sources, add it here in a new line. Don't forget to put a comma after the old last line.
 	)
@@ -133,6 +134,7 @@ var/list/point_source_descriptions = list(
 	var/points_per_slip = 2
 	var/points_per_platinum = 5 // 5 points per sheet
 	var/points_per_phoron = 5
+	var/points_per_thaler = 0.5
 	var/point_sources = list()
 	var/pointstotalsum = 0
 	var/pointstotal = 0
@@ -209,7 +211,13 @@ var/list/point_source_descriptions = list(
 							switch(P.get_material_name())
 								if("phoron") phoron_count += P.get_amount()
 								if("platinum") plat_count += P.get_amount()
+						if(istype(A, /obj/item/weapon/spacecash))
+							thal_count += P.get_amount()
 				qdel(MA)
+
+		if(thal_count)
+			var/temp = thal_count * points_per_thaler
+			add_points_from_source(temp, "thaler")
 
 		if(phoron_count)
 			var/temp = phoron_count * points_per_phoron

--- a/code/game/supplyshuttle.dm
+++ b/code/game/supplyshuttle.dm
@@ -183,6 +183,7 @@ var/list/point_source_descriptions = list(
 	proc/sell()
 		var/phoron_count = 0
 		var/plat_count = 0
+		var/thal_count = 0
 		for(var/area/subarea in shuttle.shuttle_area)
 			for(var/atom/movable/MA in subarea)
 				if(MA.anchored)	continue

--- a/code/game/supplyshuttle.dm
+++ b/code/game/supplyshuttle.dm
@@ -212,7 +212,8 @@ var/list/point_source_descriptions = list(
 								if("phoron") phoron_count += P.get_amount()
 								if("platinum") plat_count += P.get_amount()
 						if(istype(A, /obj/item/weapon/spacecash))
-							thal_count += P.get_amount()
+							var/obj/item/weapon/spacecash/PCash = A
+							thal_count += PCash.get_amount()
 				qdel(MA)
 
 		if(thal_count)

--- a/code/game/supplyshuttle.dm
+++ b/code/game/supplyshuttle.dm
@@ -214,7 +214,7 @@ var/list/point_source_descriptions = list(
 								if("platinum") plat_count += P.get_amount()
 						if(istype(A, /obj/item/weapon/spacecash))
 							var/obj/item/weapon/spacecash/PCash = A
-							thal_count += PCash.get_amount()
+							thal_count += PCash.worth
 				qdel(MA)
 
 		if(thal_count)


### PR DESCRIPTION
1. Добавлена возможность отправлять в карго-шаттле деньги на ЦК, и получать за них баллы, с коэффициентом 0.5. То есть за 1 таллер - 0.5 балла.

Обоснование:
Поломанные зоны на астероиде не дают добывать достаточно ресурсов для РнД (то есть автоматические буровые установки невозможно использовать - в земле нет ресурсов).
Баллы карго копятся очень, ОЧЕНЬ медленно.
Можно отправлять некоторые ресурсы на ЦК конечно, но только вот это просто смешно:
points_per_phoron = 5
Т.е. с полного стака форона ты получаешь 250 баллов карго.
В итоге мы имеем очень слабо юзабельный отдел.
Это может помочь несколько реанимировать финансовую систему добавлением еще одного пути сбыта денег.