### PR TITLE
drag n drop feature for recharge station and AI death notification for borgs

### DIFF
--- a/code/game/machinery/rechargestation.dm
+++ b/code/game/machinery/rechargestation.dm
@@ -268,3 +268,13 @@
 	set src in oview(1)
 
 	go_in(usr)
+
+/obj/machinery/recharge_station/MouseDrop_T(var/mob/target, var/mob/user)
+	if(!CanMouseDrop(target, user))
+		return
+	if(!istype(target,/mob/living/silicon))
+		return
+	if(target.buckled)
+		to_chat(user, "<span class='warning'>Unbuckle the subject before attempting to move them.</span>")
+		return
+	go_in(target, user)

--- a/code/modules/mob/living/silicon/ai/death.dm
+++ b/code/modules/mob/living/silicon/ai/death.dm
@@ -17,5 +17,7 @@
 		var/obj/item/weapon/aicard/card = loc
 		card.update_icon()
 
+	for (var/mob/living/silicon/robot/R in connected_robots)
+		to_chat(R, "<span class='notice'>You lost signal from your master [src.name].</span>")
 	. = ..(gibbed,"gives one shrill beep before falling lifeless.", "You have suffered a critical system failure, and are dead.")
 	set_density(1)


### PR DESCRIPTION
Можно запихивать синтов и и боргов в станции зарядки перетаскиванием
При смерти ИИ привязаным боргам приходит сообщение о потери сигнала с ИИ (в чейнджлоге ошибка, там идет оповещение ИИ о смерти борга а не наоборот)