### PR TITLE
Ребаланс фауны

### DIFF
--- a/code/modules/mob/living/simple_animal/hostile/asteroid/basilisk.dm
+++ b/code/modules/mob/living/simple_animal/hostile/asteroid/basilisk.dm
@@ -86,6 +86,7 @@
 	icon_living = "Spectator"
 	icon_aggro = "Spectator_alert"
 	icon_dead = "Spectator_dead"
+	vision_range = 5
 	speed = 4
 	maxHealth = 250
 	health = 250
@@ -94,6 +95,7 @@
 	melee_damage_lower = 20
 	melee_damage_upper = 20
 	aggro_vision_range = 9
+	idle_vision_range = 5
 	var/list/projectiletypes = list(/obj/item/projectile/temp/basilisk/spectator,
 									/obj/item/projectile/ion/small,
 									/obj/item/projectile/energy/plasmastun,

--- a/code/modules/mob/living/simple_animal/hostile/asteroid/basilisk.dm
+++ b/code/modules/mob/living/simple_animal/hostile/asteroid/basilisk.dm
@@ -18,8 +18,8 @@
 	throw_message = "does nothing against the hard shell of"
 	vision_range = 2
 	speed = 3
-	maxHealth = 100
-	health = 100
+	maxHealth = 75
+	health = 75
 	harm_intent_damage = 5
 	melee_damage_lower = 12
 	melee_damage_upper = 12
@@ -27,7 +27,7 @@
 	a_intent = "harm"
 	attack_sound = 'sound/weapons/bladeslice.ogg'
 	ranged_cooldown_cap = 4
-	aggro_vision_range = 9
+	aggro_vision_range = 7
 	idle_vision_range = 2
 
 /obj/item/projectile/temp/basilisk
@@ -36,7 +36,15 @@
 	damage_type = BURN
 	nodamage = 1
 	check_armour = "energy"
-	temperature = 50
+	temperature = 25
+	
+/obj/item/projectile/temp/basilisk/spectator
+	name = "freezing blast"
+	damage = 5
+	damage_type = BURN
+	nodamage = 0
+	check_armour = "energy"
+	temperature = 30
 
 /mob/living/simple_animal/hostile/asteroid/basilisk/GiveTarget(new_target)
 	target_mob = new_target
@@ -79,13 +87,14 @@
 	icon_aggro = "Spectator_alert"
 	icon_dead = "Spectator_dead"
 	speed = 4
-	maxHealth = 300
-	health = 300
+	maxHealth = 250
+	health = 250
 	ranged_cooldown_cap = 3
 	harm_intent_damage = 15
 	melee_damage_lower = 20
 	melee_damage_upper = 20
-	var/list/projectiletypes = list(/obj/item/projectile/temp/basilisk,
+	aggro_vision_range = 9
+	var/list/projectiletypes = list(/obj/item/projectile/temp/basilisk/spectator,
 									/obj/item/projectile/ion/small,
 									/obj/item/projectile/energy/plasmastun,
 									/obj/item/projectile/energy/declone,
@@ -93,7 +102,11 @@
 									/obj/item/projectile/energy/neurotoxin,
 									/obj/item/projectile/energy/phoron,
 									/obj/item/projectile/energy/electrode,
-									/obj/item/projectile/energy/flash)
+									/obj/item/projectile/energy/flash,
+									/obj/item/projectile/energy/flash/flare,
+									/obj/item/projectile/beam/plasmacutter,
+									/obj/item/projectile/forcebolt,
+									/obj/item/projectile/animate)
 
 /mob/living/simple_animal/hostile/asteroid/basilisk/spectator/OpenFire()
 	. = ..()

--- a/code/modules/mob/living/simple_animal/hostile/asteroid/goliath.dm
+++ b/code/modules/mob/living/simple_animal/hostile/asteroid/goliath.dm
@@ -14,10 +14,10 @@
 	move_to_delay = 40
 	ranged = 1
 	ranged_cooldown = 2 //By default, start the Goliath with his cooldown off so that people can run away quickly on first sight
-	ranged_cooldown_cap = 8
+	ranged_cooldown_cap = 14
 	friendly = "wails at"
-	vision_range = 5
-	speed = 2
+	vision_range = 4
+	speed = 3
 	maxHealth = 300
 	health = 300
 	harm_intent_damage = 0
@@ -26,7 +26,7 @@
 	attacktext = "pulverizes"
 	throw_message = "does nothing to the rocky hide of the"
 	aggro_vision_range = 9
-	idle_vision_range = 5
+	idle_vision_range = 4
 	var/pre_attack = 0
 	var/dead = FALSE
 

--- a/code/modules/mob/living/simple_animal/hostile/asteroid/sand_lurker.dm
+++ b/code/modules/mob/living/simple_animal/hostile/asteroid/sand_lurker.dm
@@ -13,7 +13,7 @@
 	move_to_delay = 20
 	friendly = "buzzes near"
 	vision_range = 2
-	aggro_vision_range = 9
+	aggro_vision_range = 6
 	idle_vision_range = 2
 	speed = 3
 	maxHealth = 50

--- a/code/modules/random_map/automata/caves.dm
+++ b/code/modules/random_map/automata/caves.dm
@@ -7,7 +7,7 @@
 	var/mineral_sparse =  /turf/simulated/mineral/random
 	var/mineral_rich = /turf/simulated/mineral/random/high_chance
 	var/list/ore_turfs = list()
-	var/max_mobs_count = 250 //maximum amount of mobs on the map. Some of the numbers lost in "frame" of the map
+	var/max_mobs_count = 200 //maximum amount of mobs on the map. Some of the numbers lost in "frame" of the map
 /datum/random_map/automata/cave_system/get_appropriate_path(var/value)
 	switch(value)
 		if(DOOR_CHAR)
@@ -113,19 +113,19 @@
 			if(MONSTER_CHAR)
 				new_path = floor_type
 				var/chance = rand(100)
-				if(chance <= 40)
+				if(chance <= 66)
 					new /mob/living/simple_animal/hostile/asteroid/sand_lurker(T)
 					count_sand_lurker++
-				else if(chance <= 70 && chance > 40)
-					new /mob/living/simple_animal/hostile/asteroid/goliath(T)
-					count_goliath++
-				else if(chance <= 85 && chance > 70)
+				else if(chance <= 82 && chance > 66)
 					new /mob/living/simple_animal/hostile/asteroid/hoverhead(T)
 					count_hoverhead++
-				else if(chance <= 95 && chance > 85)
+				else if(chance <= 90 && chance > 82)
+					new /mob/living/simple_animal/hostile/asteroid/goliath(T)
+					count_goliath++
+				else if(chance <= 98 && chance > 90)
 					new /mob/living/simple_animal/hostile/asteroid/basilisk(T)
 					count_basilisk++
-				else if (chance > 95)
+				else if (chance > 98)
 					new /mob/living/simple_animal/hostile/asteroid/basilisk/spectator(T)
 					count_basilisk_spectator++
 				mobs_count++

--- a/html/changelog.html
+++ b/html/changelog.html
@@ -29,6 +29,13 @@
 			</td>
 	</tr>
 </table>
+	
+  <h2 class="date">22 September 2018</h2>
+    <h3 class="author">Cinericius updated:</h3>
+      <ul class="changes bgimages16">
+        <li class="rscadd">Ребаланс фауны астероида. Изменены общее количество мобов, процент встречаемости разных видов и их показатели.</li>
+      </ul>
+	
   <h2 class="date">20 September 2018</h2>
     <h3 class="author">LagannPM updated:</h3>
       <ul class="changes bgimages16">

--- a/html/changelog.html
+++ b/html/changelog.html
@@ -30,12 +30,6 @@
 	</tr>
 </table>
 	
-  <h2 class="date">22 September 2018</h2>
-    <h3 class="author">Cinericius updated:</h3>
-      <ul class="changes bgimages16">
-        <li class="rscadd">Ребаланс фауны астероида. Изменены общее количество мобов, процент встречаемости разных видов и их показатели.</li>
-      </ul>
-	
   <h2 class="date">20 September 2018</h2>
     <h3 class="author">LagannPM updated:</h3>
       <ul class="changes bgimages16">


### PR DESCRIPTION
Уменьшено общее количество с 250 до 200.
Процентовка видов мобов перераспределена и теперь выглядит более разумно. Более слабых мобов стало относительно больше, а более опасных относительно меньше.
Некоторые мобы так или иначе понерфлены.
Самый опасный моб, который теперь встречается гораздо реже, стал непредсказуемее, но потерял часть здоровья.