### PR TITLE
Фикс экономики карго

### DIFF
--- a/code/datums/supplypacks/hydroponics.dm
+++ b/code/datums/supplypacks/hydroponics.dm
@@ -175,7 +175,7 @@
 					/obj/structure/flora/pottedplant/tropical,
 					/obj/structure/flora/pottedplant/dead,
 					/obj/structure/flora/pottedplant/decorative)
-	cost = 3
+	cost = 6
 	containertype = /obj/structure/closet/crate/large/hydroponics
 	containername = "\improper Potted plant crate"
 	supply_method = /decl/supply_method/randomized

--- a/code/datums/supplypacks/hydroponics.dm
+++ b/code/datums/supplypacks/hydroponics.dm
@@ -147,7 +147,7 @@
 
 /decl/hierarchy/supply_pack/hydroponics/pottedplant
 	name = "Potted plant crate"
-	num_contained = 1
+	num_contained = 2
 	contains = list(/obj/structure/flora/pottedplant,
 					/obj/structure/flora/pottedplant/large,
 					/obj/structure/flora/pottedplant/fern,


### PR DESCRIPTION
#334 
Стоимость горшков с цветами поднята до 6, чтобы убрать дюп. Даже если проставлять печать, выходит возврат в 6 очков и итоговая прибыль 0.