### PR TITLE
Фикс сервисного борга, добавлены стопки, кружки и стаканы для виски

### DIFF
--- a/code/game/objects/items/weapons/RSF.dm
+++ b/code/game/objects/items/weapons/RSF.dm
@@ -54,6 +54,18 @@ RSF
 		to_chat(user, "Changed dispensing mode to 'Dice Pack'")
 		return
 	if (mode == 5)
+		mode = 6
+		to_chat(user, "Changed dispensing mode to 'Shot glass'")
+		return
+	if (mode == 6)
+		mode = 7
+		to_chat(user, "Changed dispensing mode to 'Rocks glass'")
+		return
+	if (mode == 7)
+		mode = 8
+		to_chat(user, "Changed dispensing mode to 'Beer Mug'")
+		return
+	if (mode == 8)
 		mode = 1
 		to_chat(user, "Changed dispensing mode to 'Cigarette'")
 		return
@@ -93,6 +105,15 @@ RSF
 		if(5)
 			product = new /obj/item/weapon/storage/pill_bottle/dice()
 			used_energy = 200
+		if(6)
+			product = new /obj/item/weapon/reagent_containers/food/drinks/glass2/shot()
+			used_energy = 20
+		if(7)
+			product = new /obj/item/weapon/reagent_containers/food/drinks/glass2/rocks()
+			used_energy = 50
+		if(8)
+			product = new /obj/item/weapon/reagent_containers/food/drinks/glass2/mug()
+			used_energy = 50
 
 	to_chat(user, "Dispensing [product ? product : "product"]...")
 	product.loc = get_turf(A)


### PR DESCRIPTION
Добавил в код пару строчек, теперь сервисный борг кроме полупинтовиков может синтезировать стопки, стаканы для виски и кружки для пива. Затронут только один файл, пропихните, как только сервак упадет.