### PR TITLE
T15: Blindly ported topic limiter

### DIFF
--- a/code/controllers/configuration.dm
+++ b/code/controllers/configuration.dm
@@ -105,6 +105,9 @@ var/list/gamemode_cache = list()
 	var/discordurl
 	var/githuburl
 
+	var/minutetopiclimit
+	var/secondtopiclimit
+
 	var/forbid_singulo_possession = 0
 
 	//game_options.txt configs
@@ -271,6 +274,12 @@ var/list/gamemode_cache = list()
 
 		if(type == "config")
 			switch (name)
+				if("minute_topic_limit")
+					config.minutetopiclimit = text2num(value)
+
+				if("second_topic_limit")
+					config.secondtopiclimit = text2num(value)
+
 				if ("resource_urls")
 					config.resource_urls = splittext(value, " ")
 

--- a/code/modules/client/client_defines.dm
+++ b/code/modules/client/client_defines.dm
@@ -41,6 +41,7 @@
 	var/mute_irc = 0
 	var/warned_about_multikeying = 0	// Prevents people from being spammed about multikeying every time their mob changes.
 
+	var/list/topiclimiter
 		////////////////////////////////////
 		//things that require the database//
 		////////////////////////////////////

--- a/config/example/config.txt
+++ b/config/example/config.txt
@@ -121,7 +121,7 @@ PROBABILITY conflux 2
 PROBABILITY intrigue 2
 ## Changelings & wizards
 PROBABILITY lizard 2
-	
+
 ## Changeling, malf & renegade
 PROBABILITY paranoia 2
 ## Changeling & traitor
@@ -437,3 +437,12 @@ RADIATION_MATERIAL_RESISTANCE_DIVISOR 2
 
 ## Below this point, radiation is ignored
 RADIATION_LOWER_LIMIT 0.15
+
+## TOPIC RATE LIMITING
+## This allows you to limit how many topic calls (clicking on a interface window) the client can do in any given game second and/or game minute.
+## Admins are exempt from these limits.
+## Hitting the minute limit notifies admins.
+## Set to 0 or comment out to disable.
+SECOND_TOPIC_LIMIT 10
+
+MINUTE_TOPIC_LIMIT 100


### PR DESCRIPTION
_This is blind port of topic limiter from /tg/_
It appiles to all non-admins. Rate limit is configurable, it defaults to 10 in any second and 100 in any minute.

Hitting the minute limit causes a notification to go to admins (once per minute) so that they are aware of the things going on.

The user will be notified if a topic is ignored so they know whats going on. If they trigger a notification to admins they are told about this as well.