### PR TITLE
I577: Fixed toy crossbow and marshalling wand icons

### DIFF
--- a/code/game/objects/items/toys.dm
+++ b/code/game/objects/items/toys.dm
@@ -153,8 +153,8 @@
 	icon_state = "crossbow"
 	item_state = "crossbow"
 	item_icons = list(
-		icon_l_hand = 'icons/mob/onmob/items/lefthand_guns.dmi',
-		icon_r_hand = 'icons/mob/onmob/items/righthand_guns.dmi',
+		slot_l_hand_str  = 'icons/mob/onmob/items/lefthand_guns.dmi',
+		slot_r_hand_str = 'icons/mob/onmob/items/righthand_guns.dmi'
 		)
 	w_class = ITEM_SIZE_SMALL
 	attack_verb = list("attacked", "struck", "hit")
@@ -801,8 +801,8 @@
 	item_state = "marshallingwand"
 	icon = 'icons/obj/toy.dmi'
 	item_icons = list(
-		icon_l_hand = 'icons/mob/onmob/items/lefthand.dmi',
-		icon_r_hand = 'icons/mob/onmob/items/righthand.dmi',
+		slot_l_hand_str = 'icons/mob/onmob/items/lefthand.dmi',
+		slot_r_hand_str = 'icons/mob/onmob/items/righthand.dmi'
 		)
 	slot_flags = SLOT_BELT
 	w_class = ITEM_SIZE_SMALL


### PR DESCRIPTION
Исправляет #577 

Вернул игрушечному арбалету спрайт. Заодно и сигнальной палочке.

![image](https://user-images.githubusercontent.com/26259146/60025387-2fa93f00-96a2-11e9-9bff-e082bc25bb35.png)
