### PR TITLE
Fixed bad initialization calls

### DIFF
--- a/code/game/objects/items/paintkit.dm
+++ b/code/game/objects/items/paintkit.dm
@@ -145,7 +145,12 @@
 	var/list/ripleys = typesof(/obj/item/device/kit/paint/ripley)
 	var/build_path = pick(ripleys)
 	new build_path(src.loc)
-	qdel(src)
+
+// Make InitAtom QDEL our creation kit as we already have ripley by now
+// TODO [V] Refactor this random ripley generator using factory
+/obj/item/device/kit/paint/ripley/random/Initialize()
+	. = ..()
+	return INITIALIZE_HINT_QDEL
 
 // Durand kits.
 /obj/item/device/kit/paint/durand

--- a/code/modules/mining/mine_turfs.dm
+++ b/code/modules/mining/mine_turfs.dm
@@ -38,6 +38,7 @@ var/list/mining_floors = list()
 	has_resources = 1
 
 /turf/simulated/mineral/Initialize()
+	. = ..()
 	if (!mining_walls["[src.z]"])
 		mining_walls["[src.z]"] = list()
 	mining_walls["[src.z]"] += src
@@ -415,6 +416,7 @@ var/list/mining_floors = list()
 	var/mineralChance = 100 //10 //means 10% chance of this plot changing to a mineral deposit
 
 /turf/simulated/mineral/random/Initialize()
+	. = ..()
 	if (prob(mineralChance) && !mineral)
 		var/mineral_name = pickweight(mineralSpawnChanceList) //temp mineral name
 		mineral_name = lowertext(mineral_name)
@@ -422,7 +424,6 @@ var/list/mining_floors = list()
 			mineral = ore_data[mineral_name]
 			UpdateMineral()
 	MineralSpread()
-	. = ..()
 
 /turf/simulated/mineral/random/high_chance
 	mineralChance = 100 //25
@@ -450,6 +451,7 @@ var/list/mining_floors = list()
 	has_resources = 1
 
 /turf/simulated/floor/asteroid/Initialize()
+	. = ..()
 	if (!mining_floors["[src.z]"])
 		mining_floors["[src.z]"] = list()
 	mining_floors["[src.z]"] += src

--- a/code/modules/power/smes_construction.dm
+++ b/code/modules/power/smes_construction.dm
@@ -42,14 +42,14 @@
 // These are used on individual outposts as backup should power line be cut, or engineering outpost lost power.
 // 1M Charge, 150K I/O
 /obj/machinery/power/smes/buildable/outpost_substation/Initialize()
-	..()
+	. = ..()
 	component_parts += new /obj/item/weapon/smes_coil/weak(src)
 	recalc_coils()
 
 // This one is pre-installed on engineering shuttle. Allows rapid charging/discharging for easier transport of power to outpost
 // 11M Charge, 2.5M I/O
 /obj/machinery/power/smes/buildable/power_shuttle/Initialize()
-	..()
+	. = ..()
 	component_parts += new /obj/item/weapon/smes_coil/super_io(src)
 	component_parts += new /obj/item/weapon/smes_coil/super_io(src)
 	component_parts += new /obj/item/weapon/smes_coil(src)


### PR DESCRIPTION
Профайлер говорит, что есть BadInitializeCalls в количестве 7 штук. Поправил инициализацию везде, кроме первого пункта.
1. /mob/new_player
2. /obj/item/device/kit/paint/ripley/random
3. /obj/machinery/power/smes/buildable/outpost_substation
4. /turf/simulated/mineral
5. /turf/simulated/floor/asteroid
6. /turf/simulated/mineral/random/high_chance
7. /turf/simulated/mineral/random