### PR TITLE
Skybox gc

### DIFF
--- a/code/_onclick/hud/skybox.dm
+++ b/code/_onclick/hud/skybox.dm
@@ -3,8 +3,7 @@
 	mouse_opacity = 0
 	blend_mode = BLEND_MULTIPLY
 	plane = SKYBOX_PLANE
-//	invisibility = 101
-	anchored = 1
+	anchored = TRUE
 	var/mob/owner
 	var/image/image
 	var/image/stars
@@ -15,8 +14,6 @@
 	SSskybox.skyboxes += src
 	owner = M
 	loc = null
-	SSskybox.skyboxes += src
-	//color = SSskybox.BGcolor
 	image = image('icons/turf/skybox.dmi', src, "background_[SSskybox.BGstate]")
 	overlays += image
 
@@ -40,7 +37,13 @@
 	appearance = rotation
 
 /obj/skybox/Destroy()
-	owner = null
+	overlays.Cut()
+	if(owner)
+		if(owner.skybox == src)
+			owner.skybox = null
+		owner = null
+	image = null
+	stars = null
 	SSskybox.skyboxes -= src
 	return ..()
 

--- a/code/modules/mob/living/carbon/xenobiological/items.dm
+++ b/code/modules/mob/living/carbon/xenobiological/items.dm
@@ -242,7 +242,7 @@
 	layer = RUNE_LAYER
 
 /obj/effect/golemrune/Initialize()
-	..()
+	. = ..()
 	START_PROCESSING(SSobj, src)
 
 /obj/effect/golemrune/Process()


### PR DESCRIPTION
По идее, теперь не должно сыпаться рантаймов от скайбокса. 
```dm
GC: -- [0x2007c62] | /obj/skybox was unable to be GC'd --
  proc name: crash with (/proc/crash_with)
  src: null
  call stack:
  crash with("GC: -- \[0x2007c62] | /obj/sky...")
  Garbage (/datum/controller/subsystem/garbage): HandleQueue(2)
  Garbage (/datum/controller/subsystem/garbage): fire(0)
  Garbage (/datum/controller/subsystem/garbage): ignite(0)
  Master (/datum/controller/master): RunQueue()
  Master (/datum/controller/master): Loop()
  Master (/datum/controller/master): StartProcessing(0)
```

И чуть меньше бед инит коллов 