### PR TITLE
Забираем удаленное взаимодействие с канистрами у ИИшника.

### DIFF
--- a/code/game/machinery/atmoalter/canister.dm
+++ b/code/game/machinery/atmoalter/canister.dm
@@ -277,7 +277,7 @@ update_flag
 	GLOB.nanomanager.update_uis(src) // Update all NanoUIs attached to src
 
 /obj/machinery/portable_atmospherics/canister/attack_ai(var/mob/user as mob)
-	ui_interact(user)
+	return
 
 /obj/machinery/portable_atmospherics/canister/attack_hand(var/mob/user as mob)
 	ui_interact(user)

--- a/code/modules/mob/living/silicon/robot/drone/drone_items.dm
+++ b/code/modules/mob/living/silicon/robot/drone/drone_items.dm
@@ -375,6 +375,11 @@
 				A.cell = null
 
 				user.visible_message("<span class='danger'>[user] removes the power cell from [A]!</span>", "You remove the power cell.")
+	
+	else if(istype(target,/obj/machinery/portable_atmospherics/canister))
+		var/obj/machinery/portable_atmospherics/canister/A = target
+		A.ui_interact(user)
+	
 	else
 		to_chat(user, "<span class='notice'>[src] can't interact with \the [target].</span>")
 


### PR DESCRIPTION
По реквесту Легата и многочисленным просьбам игроков, забрал у ИИшника возможность взаимодействия с газовыми канистрами на станции. Борги и дроны могут подключиться к интерфейсу канистры с помощью встроенного манипулятора.