### PR TITLE
Фикс кириллицы в NanoUI - теперь как родная.

### DIFF
--- a/code/game/machinery/newscaster.dm
+++ b/code/game/machinery/newscaster.dm
@@ -71,7 +71,7 @@
 	if(announcement_message)
 		newChannel.announcement = announcement_message
 	else
-		newChannel.announcement = "Breaking news from [channel_name]!"
+		newChannel.announcement = "Breaking news from [utf8_to_cp1251(channel_name)]!"
 
 	newChannel.channel_id = length(network_channels) + 1
 	network_channels += newChannel

--- a/code/modules/modular_computers/file_system/data.dm
+++ b/code/modules/modular_computers/file_system/data.dm
@@ -17,3 +17,6 @@
 
 /datum/computer_file/data/logfile
 	filetype = "LOG"
+
+/datum/computer_file/data/text
+	filetype = "TXT"

--- a/code/modules/modular_computers/file_system/programs/generic/file_browser.dm
+++ b/code/modules/modular_computers/file_system/programs/generic/file_browser.dm
@@ -31,7 +31,7 @@
 			return 1
 		var/datum/computer_file/data/F = new/datum/computer_file/data()
 		F.filename = newname
-		F.filetype = "TXT"
+		F.filetype = "DAT"
 		HDD.store_file(F)
 	if(href_list["PRG_deletefile"])
 		. = 1
@@ -92,7 +92,7 @@
 		var/oldtext = html_decode(F.stored_data)
 		oldtext = replacetext(oldtext, "\[br\]", "\n")
 
-		var/newtext = sanitize(replacetext(input(usr, "Editing file [open_file]. You may use most tags used in paper formatting:", "Text Editor", oldtext) as message|null, "\n", "\[br\]"), MAX_TEXTFILE_LENGTH)
+		var/newtext = sanitize(replacetext(input_utf8(usr, "Editing file [open_file]. You may use most tags used in paper formatting:", "Text Editor", oldtext), "\n", "\[br\]"), MAX_TEXTFILE_LENGTH)
 		if(!newtext)
 			return
 

--- a/code/modules/modular_computers/file_system/programs/generic/file_browser.dm
+++ b/code/modules/modular_computers/file_system/programs/generic/file_browser.dm
@@ -31,7 +31,6 @@
 			return 1
 		var/datum/computer_file/data/F = new/datum/computer_file/data()
 		F.filename = newname
-		F.filetype = "DAT"
 		HDD.store_file(F)
 	if(href_list["PRG_deletefile"])
 		. = 1

--- a/code/modules/modular_computers/file_system/programs/generic/ntnrc_client.dm
+++ b/code/modules/modular_computers/file_system/programs/generic/ntnrc_client.dm
@@ -31,7 +31,7 @@
 		if(!channel)
 			return 1
 		var/mob/living/user = usr
-		var/message = cp1251_to_utf8(sanitize(input(user, "Enter message or leave blank to cancel: "), 512))
+		var/message = sanitize(input(user, "Enter message or leave blank to cancel: "), 512)
 		if(!message || !channel)
 			return
 		channel.add_message(message, username)
@@ -68,7 +68,7 @@
 	if(href_list["PRG_newchannel"])
 		. = 1
 		var/mob/living/user = usr
-		var/channel_title = cp1251_to_utf8(sanitizeSafe(input(user,"Enter channel name or leave blank to cancel:"), 64))
+		var/channel_title = sanitizeSafe(input(user,"Enter channel name or leave blank to cancel:"), 64)
 		if(!channel_title)
 			return
 		var/datum/ntnet_conversation/C = new/datum/ntnet_conversation()
@@ -98,7 +98,7 @@
 	if(href_list["PRG_changename"])
 		. = 1
 		var/mob/living/user = usr
-		var/newname = cp1251_to_utf8(sanitize(input(user,"Enter new nickname or leave blank to cancel:"), 20))
+		var/newname = sanitize(input(user,"Enter new nickname or leave blank to cancel:"), 20)
 		if(!newname)
 			return 1
 		if(channel)
@@ -110,7 +110,7 @@
 		if(!channel)
 			return
 		var/mob/living/user = usr
-		var/logname = cp1251_to_utf8(input(user,"Enter desired logfile name (.log) or leave blank to cancel:"))
+		var/logname = input(user,"Enter desired logfile name (.log) or leave blank to cancel:")
 		if(!logname || !channel)
 			return 1
 		var/datum/computer_file/data/logfile = new/datum/computer_file/data/logfile()
@@ -135,7 +135,7 @@
 		if(!operator_mode || !channel)
 			return 1
 		var/mob/living/user = usr
-		var/newname = cp1251_to_utf8(sanitize(input(user, "Enter new channel name or leave blank to cancel:"), 64))
+		var/newname = sanitize(input(user, "Enter new channel name or leave blank to cancel:"), 64)
 		if(!newname || !channel)
 			return
 		channel.add_status_message("Channel renamed from [channel.title] to [newname] by operator.")

--- a/code/modules/modular_computers/file_system/programs/generic/wordprocessor.dm
+++ b/code/modules/modular_computers/file_system/programs/generic/wordprocessor.dm
@@ -109,7 +109,7 @@
 		var/newname = sanitize(input(usr, "Enter file name:", "New File") as text|null)
 		if(!newname)
 			return 1
-		var/datum/computer_file/data/F = create_file(newname)
+		var/datum/computer_file/data/F = create_file(newname, "", /datum/computer_file/data/text)
 		if(F)
 			open_file = F.filename
 			loaded_data = ""
@@ -122,7 +122,7 @@
 		var/newname = sanitize(input(usr, "Enter file name:", "Save As") as text|null)
 		if(!newname)
 			return 1
-		var/datum/computer_file/data/F = create_file(newname, loaded_data)
+		var/datum/computer_file/data/F = create_file(newname, loaded_data, /datum/computer_file/data/text)
 		if(F)
 			open_file = F.filename
 		else
@@ -179,7 +179,7 @@
 			HDD = PRG.computer.hard_drive
 			var/list/files[0]
 			for(var/datum/computer_file/F in HDD.stored_files)
-				if(F.filetype == "DAT")
+				if(F.filetype == "TXT")
 					files.Add(list(list(
 						"name" = F.filename,
 						"size" = F.size
@@ -191,7 +191,7 @@
 				data["usbconnected"] = 1
 				var/list/usbfiles[0]
 				for(var/datum/computer_file/F in RHDD.stored_files)
-					if(F.filetype == "DAT")
+					if(F.filetype == "TXT")
 						usbfiles.Add(list(list(
 							"name" = F.filename,
 							"size" = F.size,

--- a/code/modules/modular_computers/file_system/programs/generic/wordprocessor.dm
+++ b/code/modules/modular_computers/file_system/programs/generic/wordprocessor.dm
@@ -143,7 +143,7 @@
 		var/oldtext = html_decode(loaded_data)
 		oldtext = replacetext(oldtext, "\[br\]", "\n")
 
-		var/newtext = sanitize(replacetext(input(usr, "Editing file '[open_file]'. You may use most tags used in paper formatting:", "Text Editor", oldtext) as message|null, "\n", "\[br\]"), MAX_TEXTFILE_LENGTH)
+		var/newtext = sanitize(replacetext(input_utf8(usr, "Editing file '[open_file]'. You may use most tags used in paper formatting:", "Text Editor", oldtext), "\n", "\[br\]"), MAX_TEXTFILE_LENGTH)
 		if(!newtext)
 			return
 		loaded_data = newtext
@@ -179,7 +179,7 @@
 			HDD = PRG.computer.hard_drive
 			var/list/files[0]
 			for(var/datum/computer_file/F in HDD.stored_files)
-				if(F.filetype == "TXT")
+				if(F.filetype == "DAT")
 					files.Add(list(list(
 						"name" = F.filename,
 						"size" = F.size
@@ -191,7 +191,7 @@
 				data["usbconnected"] = 1
 				var/list/usbfiles[0]
 				for(var/datum/computer_file/F in RHDD.stored_files)
-					if(F.filetype == "TXT")
+					if(F.filetype == "DAT")
 						usbfiles.Add(list(list(
 							"name" = F.filename,
 							"size" = F.size,

--- a/nano/js/nano_state_manager.js
+++ b/nano/js/nano_state_manager.js
@@ -1,29 +1,29 @@
 // NanoStateManager handles data from the server and uses it to render templates
-NanoStateManager = function () 
+NanoStateManager = function ()
 {
 	// _isInitialised is set to true when all of this ui's templates have been processed/rendered
 	var _isInitialised = false;
 
 	// the data for this ui
 	var _data = null;
-	
+
 	// this is an array of callbacks which are called when new data arrives, before it is processed
 	var _beforeUpdateCallbacks = {};
 	// this is an array of callbacks which are called when new data arrives, before it is processed
-	var _afterUpdateCallbacks = {};		
-	
+	var _afterUpdateCallbacks = {};
+
 	// this is an array of state objects, these can be used to provide custom javascript logic
-	var _states = {};	
-	
+	var _states = {};
+
 	var _currentState = null;
-	
+
 	// the init function is called when the ui has loaded
 	// this function sets up the templates and base functionality
-	var init = function () 
+	var init = function ()
 	{
 		// We store initialData and templateData in the body tag, it's as good a place as any
-		_data = $('body').data('initialData');	
-		
+		_data = $('body').data('initialData');
+
 		if (_data == null || !_data.hasOwnProperty('config') || !_data.hasOwnProperty('data'))
 		{
 			alert('Error: Initial data did not load correctly.');
@@ -36,19 +36,109 @@ NanoStateManager = function ()
 		}
 
 		NanoStateManager.setCurrentState(stateKey);
-		
+
 		$(document).on('templatesLoaded', function () {
 			doUpdate(_data);
-			
+
 			_isInitialised = true;
 		});
 	};
-	
+
+	function rustoutf(str)
+	{
+		str = str.replace(/à/g, "&#x430;")
+		str = str.replace(/á/g, "&#x431;")
+		str = str.replace(/â/g, "&#x432;")
+		str = str.replace(/ã/g, "&#x433;")
+		str = str.replace(/ä/g, "&#x434;")
+		str = str.replace(/å/g, "&#x435;")
+		str = str.replace(/¸/g, "&#x451;")
+		str = str.replace(/æ/g, "&#x436;")
+		str = str.replace(/ç/g, "&#x437;")
+		str = str.replace(/è/g, "&#x438;")
+		str = str.replace(/é/g, "&#x439;")
+		str = str.replace(/ê/g, "&#x43A;")
+		str = str.replace(/ë/g, "&#x43B;")
+		str = str.replace(/ì/g, "&#x43C;")
+		str = str.replace(/í/g, "&#x43D;")
+		str = str.replace(/î/g, "&#x43E;")
+		str = str.replace(/ï/g, "&#x43F;")
+		str = str.replace(/ð/g, "&#x440;")
+		str = str.replace(/ñ/g, "&#x441;")
+		str = str.replace(/ò/g, "&#x442;")
+		str = str.replace(/ó/g, "&#x443;")
+		str = str.replace(/ô/g, "&#x444;")
+		str = str.replace(/õ/g, "&#x445;")
+		str = str.replace(/ö/g, "&#x446;")
+		str = str.replace(/÷/g, "&#x447;")
+		str = str.replace(/ø/g, "&#x448;")
+		str = str.replace(/ù/g, "&#x449;")
+		str = str.replace(/ú/g, "&#x44A;")
+		str = str.replace(/û/g, "&#x44B;")
+		str = str.replace(/ü/g, "&#x44C;")
+		str = str.replace(/ý/g, "&#x44D;")
+		str = str.replace(/þ/g, "&#x44E;")
+		str = str.replace(/&#255;/g, "&#1103;")
+		str = str.replace(/À/g, "&#x410;")
+		str = str.replace(/Á/g, "&#x411;")
+		str = str.replace(/Â/g, "&#x412;")
+		str = str.replace(/Ã/g, "&#x413;")
+		str = str.replace(/Ä/g, "&#x414;")
+		str = str.replace(/Å/g, "&#x415;")
+		str = str.replace(/¨/g, "&#x401;")
+		str = str.replace(/Æ/g, "&#x416;")
+		str = str.replace(/Ç/g, "&#x417;")
+		str = str.replace(/È/g, "&#x418;")
+		str = str.replace(/É/g, "&#x419;")
+		str = str.replace(/Ê/g, "&#x41A;")
+		str = str.replace(/Ë/g, "&#x41B;")
+		str = str.replace(/Ì/g, "&#x41C;")
+		str = str.replace(/Í/g, "&#x41D;")
+		str = str.replace(/Î/g, "&#x41E;")
+		str = str.replace(/Ï/g, "&#x41F;")
+		str = str.replace(/Ð/g, "&#x420;")
+		str = str.replace(/Ñ/g, "&#x421;")
+		str = str.replace(/Ò/g, "&#x422;")
+		str = str.replace(/Ó/g, "&#x423;")
+		str = str.replace(/Ô/g, "&#x424;")
+		str = str.replace(/Õ/g, "&#x425;")
+		str = str.replace(/Ö/g, "&#x426;")
+		str = str.replace(/×/g, "&#x427;")
+		str = str.replace(/Ø/g, "&#x428;")
+		str = str.replace(/Ù/g, "&#x429;")
+		str = str.replace(/Ú/g, "&#x42A;")
+		str = str.replace(/Û/g, "&#x42B;")
+		str = str.replace(/Ü/g, "&#x42C;")
+		str = str.replace(/Ý/g, "&#x42D;")
+		str = str.replace(/Þ/g, "&#x42E;")
+		str = str.replace(/ß/g, "&#x42F;")
+
+		return str;
+	}
+
+	function rustoutf_r(obj) {
+		if (obj !== null && typeof obj === "object") {
+			var keys = Object.keys(obj);
+
+			for (var i = 0; i < keys.length; i++) {
+				var key = keys[i];
+
+				if (typeof obj[key] === "string") {
+					obj[key] = rustoutf(obj[key]);
+				} else if (obj[key] != null && typeof obj[key] === "object") {
+					obj[key] = rustoutf_r(obj[key]);
+				}
+			}
+		}
+
+		return obj;
+	}
+
 	// Receive update data from the server
 	var receiveUpdateData = function (jsonString)
 	{
 		var updateData;
-		
+
 		//alert("recieveUpdateData called." + "<br>Type: " + typeof jsonString); //debug hook
 		try
 		{
@@ -62,7 +152,7 @@ NanoStateManager = function ()
 		}
 
 		//alert("recieveUpdateData passed trycatch block."); //debug hook
-		
+
 		if (!updateData.hasOwnProperty('data'))
 		{
 			if (_data && _data.hasOwnProperty('data'))
@@ -74,7 +164,7 @@ NanoStateManager = function ()
 				updateData['data'] = {};
 			}
 		}
-		
+
 		if (_isInitialised) // all templates have been registered, so render them
 		{
 			doUpdate(updateData);
@@ -82,7 +172,7 @@ NanoStateManager = function ()
 		else
 		{
 			_data = updateData; // all templates have not been registered. We set _data directly here which will be applied after the template is loaded with the initial data
-		}	
+		}
 	};
 
 	// This function does the update by calling the methods on the current state
@@ -100,17 +190,17 @@ NanoStateManager = function ()
             alert('data is false, return');
 			return; // A beforeUpdateCallback returned a false value, this prevents the render from occuring
 		}
-		
-		_data = data;
+
+		_data = rustoutf_r(data);
 
         _currentState.onUpdate(_data);
 
         _currentState.onAfterUpdate(_data);
 	};
-	
+
 	// Execute all callbacks in the callbacks array/object provided, updateData is passed to them for processing and potential modification
 	var executeCallbacks = function (callbacks, data)
-	{	
+	{
 		for (var key in callbacks)
 		{
 			if (callbacks.hasOwnProperty(key) && jQuery.isFunction(callbacks[key]))
@@ -118,16 +208,16 @@ NanoStateManager = function ()
                 data = callbacks[key].call(this, data);
 			}
 		}
-		
+
 		return data;
 	};
 
 	return {
-        init: function () 
+        init: function ()
 		{
             init();
         },
-		receiveUpdateData: function (jsonString) 
+		receiveUpdateData: function (jsonString)
 		{
 			receiveUpdateData(jsonString);
         },
@@ -135,7 +225,7 @@ NanoStateManager = function ()
 		{
 			_beforeUpdateCallbacks[key] = callbackFunction;
 		},
-		addBeforeUpdateCallbacks: function (callbacks) {		
+		addBeforeUpdateCallbacks: function (callbacks) {
 			for (var callbackKey in callbacks) {
 				if (!callbacks.hasOwnProperty(callbackKey))
 				{
@@ -158,7 +248,7 @@ NanoStateManager = function ()
 		{
 			_afterUpdateCallbacks[key] = callbackFunction;
 		},
-		addAfterUpdateCallbacks: function (callbacks) {		
+		addAfterUpdateCallbacks: function (callbacks) {
 			for (var callbackKey in callbacks) {
 				if (!callbacks.hasOwnProperty(callbackKey))
 				{
@@ -194,23 +284,23 @@ NanoStateManager = function ()
 		setCurrentState: function (stateKey)
 		{
 			if (typeof stateKey == 'undefined' || !stateKey) {
-				alert('ERROR: No state key was passed!');				
+				alert('ERROR: No state key was passed!');
                 return false;
             }
 			if (!_states.hasOwnProperty(stateKey))
 			{
 				alert('ERROR: Attempted to set a current state which does not exist: ' + stateKey);
 				return false;
-			}			
-			
+			}
+
 			var previousState = _currentState;
-			
+
             _currentState = _states[stateKey];
 
             if (previousState != null) {
                 previousState.onRemove(_currentState);
-            }            
-			
+            }
+
 			_currentState.onAdd(previousState);
 
             return true;
@@ -221,4 +311,3 @@ NanoStateManager = function ()
 		}
 	};
 } ();
- 


### PR DESCRIPTION
### Фичи:
- Немного улучшил этот NanoUI, теперь он все входные данные обрабатывает регулярками (быстрее на JS вроде и не сделать) и заменяет поломанную кириллицу на UTF-8.  Для этого взял функцию rustoutf из russian.dm да вставил в самое подходящее место - nano/js/nano_state_manager.js. Так что теперь кириллица работает в любом NanoUI.

- Заметил, что NanoWord сохраняет файлы с расширением DAT, но когда пытаешься их загрузить - он ищет файлы формата TXT и соответственно ничего не находит. Пытался поменять формат сохраняемых файлов на TXT - но он упорно делал их DAT, поэтому просто поменял проверяемый формат.

### Баги:
-  Я пока так и не допёр как фиксить букву "я" в функциях input, самый безболезненный способ который смог придумать - использовать input_utf8, но там буква отображается как "\Я".

![cyr](https://user-images.githubusercontent.com/55196698/64766115-2a93b780-d54e-11e9-97d4-704b67394394.jpg)