### PR TITLE
Фикс шкафчиков мага

### DIFF
--- a/code/controllers/subsystems/atoms.dm
+++ b/code/controllers/subsystems/atoms.dm
@@ -8,7 +8,8 @@ SUBSYSTEM_DEF(atoms)
 	init_order = SS_INIT_ATOMS
 	flags = SS_NO_FIRE
 
-	var/old_initialized
+	var/init_state = INITIALIZATION_INSSATOMS
+	var/old_init_state
 
 	var/list/late_loaders
 	var/list/created_atoms
@@ -16,15 +17,15 @@ SUBSYSTEM_DEF(atoms)
 	var/list/BadInitializeCalls = list()
 
 /datum/controller/subsystem/atoms/Initialize(timeofday)
-	initialized = INITIALIZATION_INNEW_MAPLOAD
+	init_state = INITIALIZATION_INNEW_MAPLOAD
 	InitializeAtoms()
 	return ..()
 
 /datum/controller/subsystem/atoms/proc/InitializeAtoms(list/atoms)
-	if(initialized == INITIALIZATION_INSSATOMS)
+	if(init_state == INITIALIZATION_INSSATOMS)
 		return
 
-	initialized = INITIALIZATION_INNEW_MAPLOAD
+	init_state = INITIALIZATION_INNEW_MAPLOAD
 
 	LAZYINITLIST(late_loaders)
 
@@ -50,7 +51,7 @@ SUBSYSTEM_DEF(atoms)
 	report_progress("Initialized [count] atom\s")
 	pass(count)
 
-	initialized = INITIALIZATION_INNEW_REGULAR
+	init_state = INITIALIZATION_INNEW_REGULAR
 
 	if(late_loaders.len)
 		for(var/I in late_loaders)
@@ -102,17 +103,17 @@ SUBSYSTEM_DEF(atoms)
 	..("Bad Initialize Calls:[BadInitializeCalls.len]")
 
 /datum/controller/subsystem/atoms/proc/map_loader_begin()
-	old_initialized = initialized
-	initialized = INITIALIZATION_INSSATOMS
+	old_init_state = init_state
+	init_state = INITIALIZATION_INSSATOMS
 
 /datum/controller/subsystem/atoms/proc/map_loader_stop()
-	initialized = old_initialized
+	init_state = old_init_state
 
 /datum/controller/subsystem/atoms/Recover()
-	initialized = SSatoms.initialized
-	if(initialized == INITIALIZATION_INNEW_MAPLOAD)
+	init_state = SSatoms.init_state
+	if(init_state == INITIALIZATION_INNEW_MAPLOAD)
 		InitializeAtoms()
-	old_initialized = SSatoms.old_initialized
+	old_init_state = SSatoms.old_init_state
 	BadInitializeCalls = SSatoms.BadInitializeCalls
 
 /datum/controller/subsystem/atoms/proc/InitLog()

--- a/code/game/atoms.dm
+++ b/code/game/atoms.dm
@@ -25,7 +25,7 @@
 	if(GLOB.use_preloader && (src.type == GLOB._preloader.target_path))//in case the instanciated atom is creating other atoms in New()
 		GLOB._preloader.load(src)
 
-	var/do_initialize = SSatoms.initialized
+	var/do_initialize = SSatoms.init_state
 	if(do_initialize != INITIALIZATION_INSSATOMS)
 		args[1] = do_initialize == INITIALIZATION_INNEW_MAPLOAD
 		if(SSatoms.InitAtom(src, args))

--- a/code/modules/maps/map_template.dm
+++ b/code/modules/maps/map_template.dm
@@ -36,7 +36,7 @@
 	return TRUE
 
 /datum/map_template/proc/init_atoms(var/list/atoms)
-	if (SSatoms.initialized == INITIALIZATION_INSSATOMS)
+	if (SSatoms.init_state == INITIALIZATION_INSSATOMS)
 		return // let proper initialisation handle it later
 
 	var/list/turf/turfs = list()


### PR DESCRIPTION
Фикс для #700

Судя по всему, единственное место где дверка создаётся - функция `LateInitialize()`, но её вызов никогда не происходит при создании объекта `/obj/structure/closet/wizard`. Добавил строчку при вызове `New()` и всё работает. По-хорошему, нужно перегрузить конструктор у `/obj/structure/closet` дабы он вызывался на всех шкафах, а не только на шкафах мага.