### PR TITLE
Тени с ТГ

### DIFF
--- a/code/__defines/_planes+layers.dm
+++ b/code/__defines/_planes+layers.dm
@@ -75,118 +75,107 @@ What is the naming convention for planes or layers?
 #define OPENSPACE_PLANE -463
 #define OVER_OPENSPACE_PLANE -22
 
+#define FLOOR_PLANE						-2
+#define DEFAULT_PLANE                   -1
+#define BLACKNESS_PLANE 0
 
-#define BELOW_TURF_PLANE             -22 // objects that are below turfs. Useful for asteroid smoothing or other such magic.
-	// TURF_LAYER 2
+	#define PLATING_LAYER               1
+	//ABOVE PLATING
+	#define HOLOMAP_LAYER               1.01
+	#define DECAL_PLATING_LAYER         1.02
+	#define DISPOSALS_PIPE_LAYER        1.03
+	#define LATTICE_LAYER               1.04
+	#define PIPE_LAYER                  1.05
+	#define WIRE_LAYER                  1.06
+	#define WIRE_TERMINAL_LAYER         1.07
+	#define ABOVE_WIRE_LAYER            1.08
+	//TURF PLANE
+	#define TURF_LAYER					2
+	#define TURF_DETAIL_LAYER           2.01
+	#define TURF_SHADOW_LAYER           2.02
+	//ABOVE TURF
+	#define DECAL_LAYER                 2.03
+	#define RUNE_LAYER                  2.04
+	#define ABOVE_TILE_LAYER            2.05
+	#define EXPOSED_PIPE_LAYER          2.06
+	#define EXPOSED_WIRE_LAYER          2.07
+	#define EXPOSED_WIRE_TERMINAL_LAYER 2.08
+	#define CATWALK_LAYER               2.09
+	#define BLOOD_LAYER                 2.10
+	#define MOUSETRAP_LAYER             2.11
+	#define PLANT_LAYER                 2.12
+	//HIDING MOB
+	#define HIDING_MOB_LAYER            2.13
+	#define SHALLOW_FLUID_LAYER         2.14
+	#define MOB_SHADOW_LAYER            2.15
+	//OBJ
+	#define BELOW_DOOR_LAYER            2.16
+	#define OPEN_DOOR_LAYER             2.17
+	#define BELOW_TABLE_LAYER           2.18
+	#define TABLE_LAYER                 2.19
+	#define BELOW_OBJ_LAYER             2.20
+	#define STRUCTURE_LAYER             2.21
+	// OBJ_LAYER                        3
+	#define ABOVE_OBJ_LAYER             3.01
+	#define CLOSED_DOOR_LAYER           3.02
+	#define ABOVE_DOOR_LAYER            3.03
+	#define SIDE_WINDOW_LAYER           3.04
+	#define FULL_WINDOW_LAYER           3.05
+	#define ABOVE_WINDOW_LAYER          3.06
+	//LYING MOB AND HUMAN
+	#define LYING_MOB_LAYER             3.07
+	#define LYING_HUMAN_LAYER           3.08
+	#define BASE_ABOVE_OBJ_LAYER        3.09
+	//HUMAN
+	#define BASE_HUMAN_LAYER            3.10
+	//MOB
+	#define MECH_UNDER_LAYER            3.11
+	// MOB_LAYER                        4
+	#define MECH_BASE_LAYER             4.01
+	#define MECH_INTERMEDIATE_LAYER     4.02
+	#define MECH_PILOT_LAYER            4.03
+	#define MECH_LEG_LAYER              4.04
+	#define MECH_COCKPIT_LAYER          4.05
+	#define MECH_ARM_LAYER              4.06
+	#define MECH_GEAR_LAYER             4.07
+	//ABOVE HUMAN
+	#define ABOVE_HUMAN_LAYER           4.08
+	#define VEHICLE_LOAD_LAYER          4.09
+	#define CAMERA_LAYER                4.10
+	//BLOB
+	#define BLOB_SHIELD_LAYER           4.11
+	#define BLOB_NODE_LAYER             4.12
+	#define BLOB_CORE_LAYER	            4.13
+	//EFFECTS BELOW LIGHTING
+	#define BELOW_PROJECTILE_LAYER      4.14
+	#define DEEP_FLUID_LAYER            4.15
+	#define FIRE_LAYER                  4.16
+	#define PROJECTILE_LAYER            4.17
+	#define ABOVE_PROJECTILE_LAYER      4.18
+	#define SINGULARITY_LAYER           4.19
+	#define POINTER_LAYER               4.20
 
-#define PLATING_PLANE                -21
+	//OBSERVER
+	#define OBSERVER_LAYER              5.1
+	#define OBFUSCATION_LAYER           5.2
 
-#define ABOVE_PLATING_PLANE          -20
+	#define BASE_AREA_LAYER             999
 
-	#define HOLOMAP_LAYER        1 // NOTE: ENSURE this is equal to the one at ABOVE_TURF_PLANE!
-	#define DECAL_PLATING_LAYER  2
-	#define DISPOSALS_PIPE_LAYER 3
-	#define LATTICE_LAYER        4
-	#define PIPE_LAYER           5
-	#define WIRE_LAYER           6
-	#define WIRE_TERMINAL_LAYER  7
-	#define ABOVE_WIRE_LAYER     8
+#define OBSERVER_PLANE             1
 
-#define TURF_PLANE				-19
-
-	#define BASE_TURF_LAYER -999
-	#define TURF_DETAIL_LAYER 1
-
-#define ABOVE_TURF_PLANE              -18 // For items which should appear above turfs but below other objects and hiding mobs, eg: wires & pipes
-
-	// #define HOLOMAP_LAYER               1 // NOTE: ENSURE this is equal to the one at ABOVE_PLATING_PLANE!
-	#define DECAL_LAYER                 2
-	#define RUNE_LAYER                  3
-	#define ABOVE_TILE_LAYER            4
-	#define EXPOSED_PIPE_LAYER          5
-	#define EXPOSED_WIRE_LAYER          6
-	#define EXPOSED_WIRE_TERMINAL_LAYER 7
-	#define CATWALK_LAYER               8
-	#define BLOOD_LAYER                 9
-	#define MOUSETRAP_LAYER             10
-	#define PLANT_LAYER                 11
-
-#define HIDING_MOB_PLANE              -16 // for hiding mobs like MoMMIs or spiders or whatever, under most objects but over pipes & such.
-
-	#define HIDING_MOB_LAYER 0
-
-#define OBJ_PLANE                     -15 // For objects which appear below humans.
-	#define BELOW_DOOR_LAYER        0.25
-	#define OPEN_DOOR_LAYER         0.5
-	#define BELOW_TABLE_LAYER       0.75
-	#define TABLE_LAYER             1
-	#define BELOW_OBJ_LAYER         2
-	// OBJ_LAYER                    3
-	#define ABOVE_OBJ_LAYER         4
-	#define CLOSED_DOOR_LAYER       5
-	#define ABOVE_DOOR_LAYER        6
-	#define SIDE_WINDOW_LAYER       7
-	#define FULL_WINDOW_LAYER       8
-	#define ABOVE_WINDOW_LAYER      9
-
-#define LYING_MOB_PLANE               -14 // other mobs that are lying down.
-
-	#define LYING_MOB_LAYER 0
-
-#define LYING_HUMAN_PLANE             -13 // humans that are lying down
-
-	#define LYING_HUMAN_LAYER 0
-
-#define ABOVE_OBJ_PLANE               -12 // for objects that are below humans when they are standing but above them when they are not. - eg, blankets.
-
-	#define BASE_ABOVE_OBJ_LAYER 0
-
-#define HUMAN_PLANE                   -11 // For Humans that are standing up.
-	// MOB_LAYER 4
-
-#define MOB_PLANE                      -7 // For Mobs.
-	// MOB_LAYER 4
-
-#define ABOVE_HUMAN_PLANE              -6 // For things that should appear above humans.
-
-	#define ABOVE_HUMAN_LAYER  0
-	#define VEHICLE_LOAD_LAYER 1
-	#define CAMERA_LAYER       2
-
-#define BLOB_PLANE                     -5 // For Blobs, which are above humans.
-
-	#define BLOB_SHIELD_LAYER		1
-	#define BLOB_NODE_LAYER			2
-	#define BLOB_CORE_LAYER			3
-
-#define EFFECTS_BELOW_LIGHTING_PLANE   -4 // For special effects.
-
-	#define BELOW_PROJECTILE_LAYER  2
-	#define FIRE_LAYER              3
-	#define PROJECTILE_LAYER        4
-	#define ABOVE_PROJECTILE_LAYER  5
-	#define SINGULARITY_LAYER       6
-	#define POINTER_LAYER           7
-
-#define OBSERVER_PLANE                 -3 // For observers and ghosts
-
-#define LIGHTING_PLANE 			       -2 // For Lighting. - The highest plane (ignoring all other even higher planes)
-
+#define LIGHTING_PLANE             2 // For Lighting. - The highest plane (ignoring all other even higher planes)
 	#define LIGHTBULB_LAYER        0
 	#define LIGHTING_LAYER         1
 	#define ABOVE_LIGHTING_LAYER   2
 
-#define EFFECTS_ABOVE_LIGHTING_PLANE   -1 // For glowy eyes, laser beams, etc. that shouldn't be affected by darkness
+#define EFFECTS_ABOVE_LIGHTING_PLANE   3 // For glowy eyes, laser beams, etc. that shouldn't be affected by darkness
 	#define EYE_GLOW_LAYER         1
 	#define BEAM_PROJECTILE_LAYER  2
 	#define SUPERMATTER_WALL_LAYER 3
 
-#define BASE_PLANE 				        0 // Not for anything, but this is the default.
-	#define BASE_AREA_LAYER 999
+#define OBFUSCATION_PLANE				4 // AI
 
-#define OBSCURITY_PLANE 		        2 // For visualnets, such as the AI's static.
-
-#define FULLSCREEN_PLANE                3 // for fullscreen overlays that do not cover the hud.
+#define FULLSCREEN_PLANE                5 // for fullscreen overlays that do not cover the hud.
 
 	#define FULLSCREEN_LAYER    0
 	#define DAMAGE_LAYER        1
@@ -194,25 +183,25 @@ What is the naming convention for planes or layers?
 	#define BLIND_LAYER         3
 	#define CRIT_LAYER          4
 
-#define HUD_PLANE                       4 // For the Head-Up Display
+#define HUD_PLANE                    6
+	#define UNDER_HUD_LAYER              0
+	#define HUD_BASE_LAYER               2
+	#define HUD_ITEM_LAYER               3
+	#define HUD_ABOVE_ITEM_LAYER         4
 
-	#define UNDER_HUD_LAYER      0
-	#define HUD_BASE_LAYER       1
-	#define HUD_ITEM_LAYER       2
-	#define HUD_ABOVE_ITEM_LAYER 3
 
+//This is difference between planes used for atoms and effects
+#define PLANE_DIFFERENCE              3
 
-//This is difference between highest and lowest visible
-#define PLANE_DIFFERENCE              22
-/image
-	plane = FLOAT_PLANE			// this is defunct, lummox fixed this on recent compilers, but it will bug out if I remove it for coders not on the most recent compile.
+/atom
+	plane = DEFAULT_PLANE
 
 /image/proc/plating_decal_layerise()
-	plane = ABOVE_PLATING_PLANE
+	plane = DEFAULT_PLANE
 	layer = DECAL_PLATING_LAYER
 
 /image/proc/turf_decal_layerise()
-	plane = ABOVE_TURF_PLANE
+	plane = DEFAULT_PLANE
 	layer = DECAL_LAYER
 
 /atom/proc/hud_layerise()
@@ -231,6 +220,20 @@ What is the naming convention for planes or layers?
 	appearance_flags = PLANE_MASTER
 	screen_loc = "CENTER,CENTER"
 	globalscreen = 1
+
+	proc
+		backdrop(mob/mymob)
+
+/obj/screen/plane_master/ambient_occlusion
+	appearance_flags = KEEP_TOGETHER | PLANE_MASTER
+	blend_mode = BLEND_OVERLAY
+	plane = DEFAULT_PLANE
+
+	backdrop(mob/mymob)
+		filters = list()
+
+		if (istype(mymob) && mymob.client && mymob.get_preference_value("AMBIENT_OCCLUSION") == GLOB.PREF_YES)
+			filters += filter(type="drop_shadow", x=0, y=-2, size=4, border=4, color="#04080FAA")
 
 /obj/screen/plane_master/ghost_master
 	plane = OBSERVER_PLANE

--- a/code/_onclick/hud/hud.dm
+++ b/code/_onclick/hud/hud.dm
@@ -16,6 +16,14 @@
 	else
 		hud_used = new /datum/hud
 
+	var/obj/screen/plane_master/ambient_occlusion/ao = (locate(/obj/screen/plane_master/ambient_occlusion) in client.screen)
+
+	if (!ao)
+		ao = new()
+		client.screen += ao
+
+	ao.backdrop(src)
+
 /datum/hud
 	var/mob/mymob
 
@@ -100,7 +108,6 @@
 						if(H.wear_suit) H.wear_suit.screen_loc = null
 					if(slot_wear_mask)
 						if(H.wear_mask) H.wear_mask.screen_loc = null
-
 
 /datum/hud/proc/persistant_inventory_update()
 	if(!mymob)

--- a/code/game/area/Space Station 13 areas.dm
+++ b/code/game/area/Space Station 13 areas.dm
@@ -24,7 +24,6 @@ NOTE: there are two lists of areas in the end of this file: centcom and station 
 	name = "Unknown"
 	icon = 'icons/turf/areas.dmi'
 	icon_state = "unknown"
-	plane = BASE_PLANE
 	layer = BASE_AREA_LAYER
 	luminosity = 0
 	mouse_opacity = 0

--- a/code/game/atoms_movable.dm
+++ b/code/game/atoms_movable.dm
@@ -1,6 +1,4 @@
 /atom/movable
-	plane = OBJ_PLANE
-
 	appearance_flags = TILE_BOUND
 	glide_size = 8
 

--- a/code/game/gamemodes/cult/runes.dm
+++ b/code/game/gamemodes/cult/runes.dm
@@ -5,7 +5,6 @@
 	icon = 'icons/effects/uristrunes.dmi'
 	icon_state = "blank"
 	unacidable = 1
-	plane = ABOVE_TURF_PLANE
 	layer = RUNE_LAYER
 
 	var/blood

--- a/code/game/machinery/camera/camera.dm
+++ b/code/game/machinery/camera/camera.dm
@@ -6,7 +6,7 @@
 	use_power = POWER_USE_ACTIVE
 	idle_power_usage = 5
 	active_power_usage = 10
-	plane = ABOVE_HUMAN_PLANE
+
 	layer = CAMERA_LAYER
 
 	var/list/network = list(NETWORK_EXODUS)

--- a/code/game/machinery/cryo.dm
+++ b/code/game/machinery/cryo.dm
@@ -6,9 +6,8 @@
 	icon_state = "pod_preview"
 	density = 1
 	anchored = 1.0
-	plane = ABOVE_HUMAN_PLANE // this needs to be fairly high so it displays over most things, but it needs to be under lighting
 	interact_offline = 1
-	layer = ABOVE_HUMAN_LAYER
+	layer = ABOVE_HUMAN_LAYER // this needs to be fairly high so it displays over most things, but it needs to be under lighting
 
 	var/on = 0
 	idle_power_usage = 20

--- a/code/game/machinery/floor_light.dm
+++ b/code/game/machinery/floor_light.dm
@@ -5,7 +5,6 @@ var/list/floor_light_cache = list()
 	icon = 'icons/obj/machines/floor_light.dmi'
 	icon_state = "base"
 	desc = "A backlit floor panel."
-	plane = ABOVE_TURF_PLANE
 	layer = ABOVE_TILE_LAYER
 	anchored = 0
 	use_power = POWER_USE_ACTIVE

--- a/code/game/machinery/hologram.dm
+++ b/code/game/machinery/hologram.dm
@@ -36,7 +36,7 @@ var/const/HOLOPAD_MODE = RANGE_BASED
 	desc = "It's a floor-mounted device for projecting holographic images."
 	icon_state = "holopad-B0"
 
-	plane = ABOVE_TURF_PLANE
+	plane = FLOOR_PLANE
 	layer = ABOVE_TILE_LAYER
 
 	var/power_per_hologram = 500 //per usage per hologram
@@ -251,7 +251,6 @@ For the other part of the code, check silicon say.dm. Particularly robot talk.*/
 		if(A.holo_icon_malf == TRUE)
 			hologram.overlays += icon("icons/effects/effects.dmi", "malf-scanline")
 	hologram.mouse_opacity = 0//So you can't click on it.
-	hologram.plane = ABOVE_HUMAN_PLANE
 	hologram.layer = ABOVE_HUMAN_LAYER //Above all the other objects/mobs. Or the vast majority of them.
 	hologram.anchored = 1//So space wind cannot drag it.
 	if(caller_id)

--- a/code/game/machinery/magnet.dm
+++ b/code/game/machinery/magnet.dm
@@ -11,7 +11,6 @@
 	name = "Electromagnetic Generator"
 	desc = "A device that uses powernet to create points of magnetic energy."
 	level = 1		// underfloor
-	plane = ABOVE_PLATING_PLANE
 	layer = ABOVE_WIRE_LAYER
 	anchored = 1
 	idle_power_usage = 50

--- a/code/game/machinery/navbeacon.dm
+++ b/code/game/machinery/navbeacon.dm
@@ -6,7 +6,6 @@ var/global/list/navbeacons = list()
 	name = "navigation beacon"
 	desc = "A radio beacon used for bot navigation."
 	level = 1
-	plane = ABOVE_PLATING_PLANE
 	layer = ABOVE_WIRE_LAYER
 	anchored = 1
 

--- a/code/game/machinery/syndicatebeacon.dm
+++ b/code/game/machinery/syndicatebeacon.dm
@@ -84,7 +84,6 @@
 
 	anchored = 0
 	density = 1
-	plane = ABOVE_OBJ_PLANE
 	layer = BASE_ABOVE_OBJ_LAYER //so people can't hide it and it's REALLY OBVIOUS
 	stat = 0
 

--- a/code/game/mecha/mech_bay.dm
+++ b/code/game/mecha/mech_bay.dm
@@ -4,7 +4,6 @@
 	icon = 'icons/mecha/mech_bay.dmi'
 	icon_state = "recharge_floor"
 	density = 0
-	plane = ABOVE_TURF_PLANE
 	layer = ABOVE_TILE_LAYER
 	anchored = 1
 	idle_power_usage = 200	// Some electronics, passive drain.

--- a/code/game/mecha/mecha.dm
+++ b/code/game/mecha/mecha.dm
@@ -16,7 +16,6 @@
 	opacity = 1 ///opaque. Menacing.
 	anchored = 1 //no pulling around.
 	unacidable = 1 //and no deleting hoomans inside
-	plane = OBJ_PLANE
 	layer = ABOVE_WINDOW_LAYER //icon draw layer
 	infra_luminosity = 15 //byond implementation is bugged.
 	anchor_fall = TRUE

--- a/code/game/mecha/mecha_wreckage.dm
+++ b/code/game/mecha/mecha_wreckage.dm
@@ -11,7 +11,6 @@
 	anchored = 0
 	opacity = 0
 
-	plane = OBJ_PLANE
 	layer = BELOW_OBJ_LAYER
 
 	var/list/welder_salvage = list(/obj/item/stack/material/plasteel,/obj/item/stack/material/steel,/obj/item/stack/rods)

--- a/code/game/objects/auras/radiant_aura.dm
+++ b/code/game/objects/auras/radiant_aura.dm
@@ -2,7 +2,6 @@
 	name = "radiant aura"
 	icon = 'icons/effects/effects.dmi'
 	icon_state = "fire_goon"
-	plane = OBJ_PLANE
 	layer = ABOVE_WINDOW_LAYER
 
 /obj/aura/radiant_aura/New()

--- a/code/game/objects/effects/chem/chemsmoke.dm
+++ b/code/game/objects/effects/chem/chemsmoke.dm
@@ -4,7 +4,6 @@
 /obj/effect/effect/smoke/chem
 	icon = 'icons/effects/chemsmoke.dmi'
 	opacity = 0
-	plane = EFFECTS_BELOW_LIGHTING_PLANE
 	layer = ABOVE_PROJECTILE_LAYER
 	time_to_live = 300
 	pass_flags = PASS_FLAG_TABLE | PASS_FLAG_GRILLE | PASS_FLAG_GLASS //PASS_FLAG_GLASS is fine here, it's just so the visual effect can "flow" around glass

--- a/code/game/objects/effects/decals/Cleanable/fuel.dm
+++ b/code/game/objects/effects/decals/Cleanable/fuel.dm
@@ -2,7 +2,6 @@
 	//Liquid fuel is used for things that used to rely on volatile fuels or phoron being contained to a couple tiles.
 	icon = 'icons/effects/effects.dmi'
 	icon_state = "fuel"
-	plane = ABOVE_TURF_PLANE
 	layer = BLOOD_LAYER
 	anchored = 1
 	var/amount = 1

--- a/code/game/objects/effects/decals/Cleanable/misc.dm
+++ b/code/game/objects/effects/decals/Cleanable/misc.dm
@@ -63,7 +63,7 @@
 	desc = "Somebody should remove that."
 	density = 0
 	anchored = 1
-	plane = ABOVE_HUMAN_PLANE
+
 	layer = ABOVE_HUMAN_LAYER
 	icon = 'icons/effects/effects.dmi'
 	icon_state = "cobweb1"
@@ -81,7 +81,7 @@
 	desc = "Somebody should remove that."
 	density = 0
 	anchored = 1
-	plane = ABOVE_HUMAN_PLANE
+
 	layer = ABOVE_HUMAN_LAYER
 	icon = 'icons/effects/effects.dmi'
 	icon_state = "cobweb2"

--- a/code/game/objects/effects/decals/decal.dm
+++ b/code/game/objects/effects/decals/decal.dm
@@ -1,5 +1,4 @@
 /obj/effect/decal
-	plane = ABOVE_TURF_PLANE
 	layer = DECAL_LAYER
 
 /obj/effect/decal/fall_damage()

--- a/code/game/objects/effects/decals/misc.dm
+++ b/code/game/objects/effects/decals/misc.dm
@@ -3,7 +3,6 @@
 	desc = "It's an arrow hanging in mid-air. There may be a wizard about."
 	icon = 'icons/mob/screen1.dmi'
 	icon_state = "arrow"
-	plane = EFFECTS_BELOW_LIGHTING_PLANE
 	layer = POINTER_LAYER
 	anchored = 1
 	mouse_opacity = 0
@@ -12,5 +11,4 @@
 /obj/effect/decal/spraystill
 	density = 0
 	anchored = 1
-	plane = EFFECTS_BELOW_LIGHTING_PLANE
 	layer = PROJECTILE_LAYER

--- a/code/game/objects/effects/decals/warning_stripes.dm
+++ b/code/game/objects/effects/decals/warning_stripes.dm
@@ -6,7 +6,6 @@
 	var/turf/T=get_turf(src)
 	var/image/I=image(icon, icon_state = icon_state, dir = dir)
 	I.color=color
-	I.plane = ABOVE_TURF_PLANE
 	I.layer = DECAL_LAYER
 	T.overlays += I
 	qdel(src)

--- a/code/game/objects/effects/effect_system.dm
+++ b/code/game/objects/effects/effect_system.dm
@@ -490,7 +490,7 @@ steam.start() -- spawns the effect
 	icon_state = "hitmarker"
 	density = 0
 	anchored = 1
-	plane = ABOVE_HUMAN_PLANE
+
 	layer = ABOVE_HUMAN_LAYER
 
 /obj/effect/effect/hitmarker/Initialize()

--- a/code/game/objects/effects/mines.dm
+++ b/code/game/objects/effects/mines.dm
@@ -3,7 +3,6 @@
 	desc = "I Better stay away from that thing."
 	density = 1
 	anchored = 1
-	plane = OBJ_PLANE
 	layer = OBJ_LAYER
 	icon = 'icons/obj/weapons.dmi'
 	icon_state = "uglymine"

--- a/code/game/objects/effects/overlays.dm
+++ b/code/game/objects/effects/overlays.dm
@@ -17,7 +17,7 @@
 	icon = 'icons/misc/beach2.dmi'
 	icon_state = "palm1"
 	density = 1
-	plane = ABOVE_HUMAN_PLANE
+
 	layer = ABOVE_HUMAN_LAYER
 	anchored = 1
 
@@ -26,7 +26,7 @@
 	icon = 'icons/misc/beach2.dmi'
 	icon_state = "palm2"
 	density = 1
-	plane = ABOVE_HUMAN_PLANE
+
 	layer = ABOVE_HUMAN_LAYER
 	anchored = 1
 
@@ -48,7 +48,6 @@
 	icon = 'icons/effects/wallrot.dmi'
 	anchored = 1
 	density = 1
-	plane = ABOVE_TURF_PLANE
 	layer = ABOVE_TILE_LAYER
 	mouse_opacity = 0
 

--- a/code/game/objects/effects/spiders.dm
+++ b/code/game/objects/effects/spiders.dm
@@ -114,7 +114,6 @@
 	desc = "It never stays still for long."
 	icon_state = "guard"
 	anchored = 0
-	plane = OBJ_PLANE
 	layer = BELOW_OBJ_LAYER
 	health = 3
 	var/mob/living/simple_animal/hostile/giant_spider/greater_form
@@ -289,7 +288,6 @@
 	icon = 'icons/effects/effects.dmi'
 	icon_state = "greenshatter"
 	anchored = 1
-	plane = ABOVE_TURF_PLANE
 	layer = BLOOD_LAYER
 
 /obj/effect/spider/cocoon

--- a/code/game/objects/effects/temporary_effect.dm
+++ b/code/game/objects/effects/temporary_effect.dm
@@ -4,7 +4,7 @@
 	unacidable = 1
 	mouse_opacity = 0
 	density = 0
-	plane = ABOVE_HUMAN_PLANE
+
 	layer = ABOVE_HUMAN_LAYER
 
 /obj/effect/temporary/Initialize(var/mapload, var/duration = 30, var/_icon = 'icons/effects/effects.dmi', var/_state)

--- a/code/game/objects/explosion_recursive.dm
+++ b/code/game/objects/explosion_recursive.dm
@@ -118,4 +118,5 @@ proc/explosion_rec(turf/epicenter, power, shaped)
 	explosion_resistance = 10
 
 /turf/simulated/wall
+	plane = DEFAULT_PLANE
 	explosion_resistance = 10

--- a/code/game/objects/items/devices/spy_bug.dm
+++ b/code/game/objects/items/devices/spy_bug.dm
@@ -4,7 +4,6 @@
 	icon = 'icons/obj/weapons.dmi'
 	icon_state = "eshield0"
 	item_state = "nothing"
-	plane = OBJ_PLANE
 	layer = BELOW_TABLE_LAYER
 
 	obj_flags = OBJ_FLAG_CONDUCTIBLE

--- a/code/game/objects/items/shooting_range.dm
+++ b/code/game/objects/items/shooting_range.dm
@@ -104,7 +104,6 @@
 		bmark.pixel_x = p_x
 		bmark.pixel_y = p_y
 		bmark.icon = 'icons/effects/effects.dmi'
-		bmark.plane = OBJ_PLANE
 		bmark.layer = ABOVE_OBJ_LAYER
 		bmark.icon_state = "scorch"
 

--- a/code/game/objects/items/weapons/policetape.dm
+++ b/code/game/objects/items/weapons/policetape.dm
@@ -316,7 +316,7 @@ var/list/tape_roll_applications = list()
 
 /obj/item/tape/proc/lift(time)
 	lifted = 1
-	plane = ABOVE_HUMAN_PLANE
+
 	layer = ABOVE_HUMAN_LAYER
 	spawn(time)
 		lifted = 0

--- a/code/game/objects/items/weapons/weaponry.dm
+++ b/code/game/objects/items/weapons/weaponry.dm
@@ -173,7 +173,7 @@
 
 /obj/effect/energy_net/post_buckle_mob(mob/living/M)
 	if(buckled_mob)
-		plane = ABOVE_HUMAN_PLANE
+
 		layer = ABOVE_HUMAN_LAYER
 		visible_message("\The [M] was caught in [src]!")
 	else

--- a/code/game/objects/structures/bedsheet_bin.dm
+++ b/code/game/objects/structures/bedsheet_bin.dm
@@ -12,7 +12,6 @@ LINEN BINS
 	item_state = "bedsheet"
 	randpixel = 0
 	slot_flags = SLOT_BACK
-	plane = ABOVE_OBJ_PLANE
 	layer = BASE_ABOVE_OBJ_LAYER
 	throwforce = 1
 	throw_speed = 1
@@ -39,7 +38,7 @@ LINEN BINS
 	else
 		folded = 0
 		icon_state = initial(icon_state)
-		
+
 /obj/item/weapon/bedsheet/blue
 	icon_state = "sheetblue"
 	item_state = "sheetblue"

--- a/code/game/objects/structures/catwalk.dm
+++ b/code/game/objects/structures/catwalk.dm
@@ -5,7 +5,6 @@
 	icon_state = "catwalk"
 	density = 0
 	anchored = 1.0
-	plane = ABOVE_TURF_PLANE
 	layer = CATWALK_LAYER
 
 /obj/structure/catwalk/Initialize()

--- a/code/game/objects/structures/curtains.dm
+++ b/code/game/objects/structures/curtains.dm
@@ -2,14 +2,13 @@
 	name = "curtain"
 	icon = 'icons/obj/curtain.dmi'
 	icon_state = "closed"
-	plane = ABOVE_OBJ_PLANE
 	layer = BASE_ABOVE_OBJ_LAYER
 	opacity = 1
 	density = 0
 
 /obj/structure/curtain/open
 	icon_state = "open"
-	plane = ABOVE_HUMAN_PLANE
+
 	layer = ABOVE_HUMAN_LAYER
 	opacity = 0
 
@@ -29,10 +28,10 @@
 	set_opacity(!opacity)
 	if(opacity)
 		icon_state = "closed"
-		plane = ABOVE_HUMAN_PLANE
+
 	else
 		icon_state = "open"
-		plane = ABOVE_OBJ_PLANE
+		layer = ABOVE_OBJ_LAYER
 
 /obj/structure/curtain/black
 	name = "black curtain"

--- a/code/game/objects/structures/flora.dm
+++ b/code/game/objects/structures/flora.dm
@@ -4,7 +4,7 @@
 	anchored = 1
 	density = 1
 	pixel_x = -16
-	plane = ABOVE_HUMAN_PLANE
+
 	layer = ABOVE_HUMAN_LAYER
 
 /obj/structure/flora/tree/pine
@@ -88,7 +88,7 @@
 	name = "potted plant"
 	icon = 'icons/obj/plants.dmi'
 	icon_state = "plant-26"
-	plane = ABOVE_HUMAN_PLANE
+
 	layer = ABOVE_HUMAN_LAYER
 	var/dead = FALSE
 
@@ -245,7 +245,7 @@
 	desc = "Really brings the room together."
 	icon = 'icons/obj/plants.dmi'
 	icon_state = "plant-01"
-	plane = ABOVE_HUMAN_PLANE
+
 	layer = ABOVE_HUMAN_LAYER
 
 /obj/structure/flora/pottedplant/large

--- a/code/game/objects/structures/girders.dm
+++ b/code/game/objects/structures/girders.dm
@@ -2,7 +2,6 @@
 	icon_state = "girder"
 	anchored = 1
 	density = 1
-	plane = OBJ_PLANE
 	layer = BELOW_OBJ_LAYER
 	w_class = ITEM_SIZE_NO_CONTAINER
 	var/state = 0

--- a/code/game/objects/structures/lattice.dm
+++ b/code/game/objects/structures/lattice.dm
@@ -6,7 +6,6 @@
 	density = 0
 	anchored = 1.0
 	w_class = ITEM_SIZE_NORMAL
-	plane = ABOVE_PLATING_PLANE
 	layer = LATTICE_LAYER
 	//	obj_flags = OBJ_FLAG_CONDUCTIBLE
 

--- a/code/game/objects/structures/pit.dm
+++ b/code/game/objects/structures/pit.dm
@@ -118,7 +118,6 @@
 /obj/structure/pit/closed/grave/Initialize()
 	var/obj/structure/closet/coffin/C = new(src.loc)
 	var/obj/item/remains/human/bones = new(C)
-	bones.plane = LYING_MOB_PLANE
 	bones.layer = LYING_MOB_LAYER
 	var/obj/structure/gravemarker/random/R = new(src.loc)
 	R.generate()

--- a/code/game/objects/structures/plasticflaps.dm
+++ b/code/game/objects/structures/plasticflaps.dm
@@ -5,7 +5,7 @@
 	icon_state = "plasticflaps"
 	density = 0
 	anchored = 1
-	plane = ABOVE_HUMAN_PLANE
+
 	layer = ABOVE_HUMAN_LAYER
 	explosion_resistance = 5
 	var/list/mobs_can_pass = list(

--- a/code/game/objects/structures/stool_bed_chair_nest/chairs.dm
+++ b/code/game/objects/structures/stool_bed_chair_nest/chairs.dm
@@ -45,7 +45,6 @@
 		var/image/I = image('icons/obj/furniture.dmi', "[base_icon]_over")
 		if(material_alteration & MATERIAL_ALTERATION_COLOR)
 			I.color = material.icon_colour
-		I.plane = ABOVE_HUMAN_PLANE
 		I.layer = ABOVE_HUMAN_LAYER
 		stool_cache[cache_key] = I
 	overlays |= stool_cache[cache_key]
@@ -56,7 +55,6 @@
 			var/image/I =  image(icon, "[base_icon]_padding_over")
 			if(material_alteration & MATERIAL_ALTERATION_COLOR)
 				I.color = padding_material.icon_colour
-			I.plane = ABOVE_HUMAN_PLANE
 			I.layer = ABOVE_HUMAN_LAYER
 			stool_cache[padding_cache_key] = I
 		overlays |= stool_cache[padding_cache_key]
@@ -65,7 +63,6 @@
 		cache_key = "[base_icon]-armrest-[padding_material.name]"
 		if(isnull(stool_cache[cache_key]))
 			var/image/I = image(icon, "[base_icon]_armrest")
-			I.plane = ABOVE_HUMAN_PLANE
 			I.layer = ABOVE_HUMAN_LAYER
 			if(material_alteration & MATERIAL_ALTERATION_COLOR)
 				I.color = padding_material.icon_colour

--- a/code/game/objects/structures/stool_bed_chair_nest/wheelchair.dm
+++ b/code/game/objects/structures/stool_bed_chair_nest/wheelchair.dm
@@ -17,7 +17,6 @@
 	..()
 	overlays = null
 	var/image/O = image(icon = 'icons/obj/furniture.dmi', icon_state = "w_overlay", dir = src.dir)
-	O.plane = ABOVE_HUMAN_PLANE
 	O.layer = ABOVE_HUMAN_LAYER
 	overlays += O
 	if(buckled_mob)

--- a/code/game/objects/structures/transit_tubes.dm
+++ b/code/game/objects/structures/transit_tubes.dm
@@ -7,7 +7,7 @@
 	icon = 'icons/obj/pipes/transit_tube.dmi'
 	icon_state = "E-W"
 	density = 1
-	plane = ABOVE_HUMAN_PLANE
+
 	layer = ABOVE_HUMAN_LAYER
 	anchored = 1.0
 	var/list/tube_dirs = null

--- a/code/game/objects/structures/watercloset.dm
+++ b/code/game/objects/structures/watercloset.dm
@@ -100,7 +100,7 @@
 	name = "mist"
 	icon = 'icons/obj/watercloset.dmi'
 	icon_state = "mist"
-	plane = ABOVE_HUMAN_PLANE
+
 	layer = ABOVE_HUMAN_LAYER
 	anchored = 1
 	mouse_opacity = 0

--- a/code/game/turfs/flooring/flooring_decals.dm
+++ b/code/game/turfs/flooring/flooring_decals.dm
@@ -6,7 +6,7 @@ var/list/floor_decals = list()
 /obj/effect/floor_decal
 	name = "floor decal"
 	icon = 'icons/turf/flooring/decals.dmi'
-	plane = ABOVE_TURF_PLANE
+	plane = FLOOR_PLANE
 	layer = DECAL_LAYER
 	appearance_flags = RESET_COLOR
 	var/supplied_dir
@@ -20,7 +20,7 @@ var/list/floor_decals = list()
 	if(supplied_dir) set_dir(supplied_dir)
 	var/turf/T = get_turf(src)
 	if(istype(T, /turf/simulated/floor) || istype(T, /turf/unsimulated/floor))
-		plane = T.is_plating() ? ABOVE_PLATING_PLANE : ABOVE_TURF_PLANE
+		layer = T.is_plating() ? DECAL_PLATING_LAYER : DECAL_LAYER
 		var/cache_key = "[alpha]-[color]-[dir]-[icon_state]-[plane]-[layer]"
 		if(!floor_decals[cache_key])
 			var/image/I = image(icon = src.icon, icon_state = src.icon_state, dir = src.dir)
@@ -550,7 +550,6 @@ var/list/floor_decals = list()
 	icon_state = "snowfloor"
 
 /obj/effect/floor_decal/floordetail
-	plane = TURF_PLANE
 	layer = TURF_DETAIL_LAYER
 	color = COLOR_GUNMETAL
 	icon_state = "manydot"

--- a/code/game/turfs/flooring/flooring_premade.dm
+++ b/code/game/turfs/flooring/flooring_premade.dm
@@ -3,7 +3,7 @@
 	name = "plating"
 	icon = 'icons/turf/flooring/plating.dmi'
 	icon_state = "plating"
-	plane = PLATING_PLANE
+
 
 
 //GRID FLOORING
@@ -168,6 +168,7 @@
 	icon = 'icons/turf/flooring/linoleum.dmi'
 	icon_state = "lino"
 	initial_flooring = null
+	plane = DEFAULT_PLANE
 
 /turf/simulated/floor/trim/lino
 	name = "lino"

--- a/code/game/turfs/simulated/floor.dm
+++ b/code/game/turfs/simulated/floor.dm
@@ -53,7 +53,7 @@
 	desc = base_desc
 	icon = base_icon
 	icon_state = base_icon_state
-	plane = PLATING_PLANE
+
 
 	if(flooring)
 		flooring.on_remove()
@@ -61,7 +61,7 @@
 			var/obj/F =  new flooring.build_type(src)
 			if (color)
 				F.color = color
-			var/obj/item/stack/tile/T = null	
+			var/obj/item/stack/tile/T = null
 			if (istype(F,/obj/item/stack/tile))	//checking if stack is a tile cause only tiles can store decals
 				T = F
 				T.stored_decals = src.decals
@@ -72,7 +72,7 @@
 
 	if (base_color)
 		color = base_color
-	
+
 	set_light(0)
 	broken = null
 	burnt = null
@@ -87,6 +87,6 @@
 		O.hide(O.hides_under_flooring() && src.flooring)
 
 	if(flooring)
-		plane = TURF_PLANE
+		layer = TURF_LAYER
 	else
-		plane = PLATING_PLANE
+		layer = PLATING_LAYER

--- a/code/game/turfs/simulated/floor_icon.dm
+++ b/code/game/turfs/simulated/floor_icon.dm
@@ -44,7 +44,7 @@ var/list/flooring_cache = list()
 
 	else if(decals && decals.len)
 		for(var/image/I in decals)
-			if(I.plane != ABOVE_PLATING_PLANE)
+			if(I.layer != DECAL_PLATING_LAYER)
 				continue
 			overlays |= I
 

--- a/code/game/turfs/turf.dm
+++ b/code/game/turfs/turf.dm
@@ -2,8 +2,8 @@
 	icon = 'icons/turf/floors.dmi'
 	level = 1
 
-	plane = TURF_PLANE
-	layer = BASE_TURF_LAYER
+	layer = TURF_LAYER
+	plane = FLOOR_PLANE
 
 	var/turf_flags
 

--- a/code/game/turfs/unsimulated/walls.dm
+++ b/code/game/turfs/unsimulated/walls.dm
@@ -4,6 +4,7 @@
 	icon_state = "riveted"
 	opacity = 1
 	density = 1
+	plane = DEFAULT_PLANE
 
 /turf/unsimulated/wall/fakeglass
 	name = "window"

--- a/code/modules/ZAS/Fire.dm
+++ b/code/modules/ZAS/Fire.dm
@@ -116,7 +116,6 @@ turf/proc/hotspot_expose(exposed_temperature, exposed_volume, soh = 0)
 	icon = 'icons/effects/fire.dmi'
 	icon_state = "1"
 	light_color = "#ed9200"
-	plane = EFFECTS_BELOW_LIGHTING_PLANE
 	layer = FIRE_LAYER
 
 	var/firelevel = 1 //Calculated by gas_mixture.calculate_firelevel()

--- a/code/modules/admin/verbs/debug.dm
+++ b/code/modules/admin/verbs/debug.dm
@@ -454,7 +454,6 @@
 /obj/effect/debugmarker
 	icon = 'icons/effects/lighting_overlay.dmi'
 	icon_state = "transparent"
-	plane = ABOVE_TURF_PLANE
 	layer = HOLOMAP_LAYER
 	alpha = 127
 
@@ -471,7 +470,7 @@
 		var/netcolor = rgb(rand(100,255),rand(100,255),rand(100,255))
 		for(var/obj/structure/cable/C in PN.cables)
 			var/image/I = image('icons/effects/lighting_overlay.dmi', get_turf(C), "transparent")
-			I.plane = ABOVE_TURF_PLANE
+			I.layer = DECAL_LAYER
 			I.alpha = 127
 			I.color = netcolor
 			I.maptext = "\ref[PN]"

--- a/code/modules/admin/verbs/mapping.dm
+++ b/code/modules/admin/verbs/mapping.dm
@@ -328,4 +328,4 @@ var/list/debug_verbs = list (
 	feedback_add_details("admin_verb","mOBJ") //If you are copy-pasting this, ensure the 2nd parameter is unique to the new proc!
 
 /proc/get_zas_image(var/turf/T, var/icon_state)
-	return image_repository.atom_image(T, 'icons/misc/debug_group.dmi', icon_state, plane = ABOVE_TURF_PLANE, layer = ABOVE_TILE_LAYER)
+	return image_repository.atom_image(T, 'icons/misc/debug_group.dmi', icon_state, plane = DEFAULT_PLANE, layer = ABOVE_TILE_LAYER)

--- a/code/modules/assembly/mousetrap.dm
+++ b/code/modules/assembly/mousetrap.dm
@@ -122,6 +122,5 @@
 	if(usr.incapacitated())
 		return
 
-	plane = ABOVE_TURF_PLANE
 	layer = MOUSETRAP_LAYER
 	to_chat(usr, "<span class='notice'>You hide [src].</span>")

--- a/code/modules/atmospherics/atmospherics.dm
+++ b/code/modules/atmospherics/atmospherics.dm
@@ -17,7 +17,7 @@ Pipelines + Other Objects -> Pipe network
 	var/nodealert = 0
 	var/power_rating //the maximum amount of power the machine can use to do work, affects how powerful the machine is, in Watts
 
-	plane = ABOVE_TURF_PLANE
+	plane = FLOOR_PLANE
 	layer = EXPOSED_PIPE_LAYER
 
 	var/connect_types = CONNECT_TYPE_REGULAR
@@ -49,7 +49,6 @@ Pipelines + Other Objects -> Pipe network
 
 /obj/machinery/atmospherics/hide(var/do_hide)
 	if(do_hide && level == 1)
-		plane = ABOVE_PLATING_PLANE
 		layer = PIPE_LAYER
 	else
 		reset_plane_and_layer()

--- a/code/modules/atmospherics/components/shutoff.dm
+++ b/code/modules/atmospherics/components/shutoff.dm
@@ -31,7 +31,6 @@
 /obj/machinery/atmospherics/valve/shutoff/hide(var/do_hide)
 	if(do_hide)
 		if(level == 1)
-			plane = ABOVE_PLATING_PLANE
 			layer = PIPE_LAYER
 		else if(level == 2)
 			..()

--- a/code/modules/atmospherics/components/unary/unary_base.dm
+++ b/code/modules/atmospherics/components/unary/unary_base.dm
@@ -9,6 +9,7 @@
 	var/obj/machinery/atmospherics/node
 
 	var/datum/pipe_network/network
+	plane = DEFAULT_PLANE
 
 	New()
 		..()

--- a/code/modules/atmospherics/components/unary/vent_pump.dm
+++ b/code/modules/atmospherics/components/unary/vent_pump.dm
@@ -10,6 +10,7 @@
 /obj/machinery/atmospherics/unary/vent_pump
 	icon = 'icons/atmos/vent_pump.dmi'
 	icon_state = "map_vent"
+	plane = FLOOR_PLANE
 
 	name = "Air Vent"
 	desc = "Has a valve and pump attached to it."

--- a/code/modules/atmospherics/components/unary/vent_scrubber.dm
+++ b/code/modules/atmospherics/components/unary/vent_scrubber.dm
@@ -1,6 +1,7 @@
 /obj/machinery/atmospherics/unary/vent_scrubber
 	icon = 'icons/atmos/vent_scrubber.dmi'
 	icon_state = "map_scrubber_off"
+	plane = FLOOR_PLANE
 
 	name = "Air Scrubber"
 	desc = "Has a valve and pump attached to it."

--- a/code/modules/blob/blob.dm
+++ b/code/modules/blob/blob.dm
@@ -11,7 +11,6 @@
 	anchored = 1
 	mouse_opacity = 2
 
-	plane = BLOB_PLANE
 	layer = BLOB_SHIELD_LAYER
 
 	var/maxHealth = 30

--- a/code/modules/client/preference_setup/global/preferences.dm
+++ b/code/modules/client/preference_setup/global/preferences.dm
@@ -201,6 +201,21 @@ var/list/_client_preferences_by_type
 	key = "HARDSUIT_ACTIVATION"
 	options = list(GLOB.PREF_MIDDLE_CLICK, GLOB.PREF_CTRL_CLICK, GLOB.PREF_ALT_CLICK, GLOB.PREF_CTRL_SHIFT_CLICK)
 
+/datum/client_preference/ambient_occlusion
+	description = "Toggle Ambient Occlusion"
+	key = "AMBIENT_OCCLUSION"
+	options = list(GLOB.PREF_YES, GLOB.PREF_NO)
+
+/datum/client_preference/ambient_occlusion/changed(mob/preference_mob, new_value)
+	if (preference_mob.client)
+		var/obj/screen/plane_master/ambient_occlusion/ao = (locate(/obj/screen/plane_master/ambient_occlusion) in preference_mob.client.screen)
+
+		if (!ao)
+			ao = new()
+			preference_mob.client.screen += ao
+
+		ao.backdrop(preference_mob)
+
 /********************
 * General Staff Preferences *
 ********************/

--- a/code/modules/hydroponics/spreading/spreading.dm
+++ b/code/modules/hydroponics/spreading/spreading.dm
@@ -45,7 +45,6 @@
 	density = 0
 	icon = 'icons/obj/hydroponics_growing.dmi'
 	icon_state = ""
-	plane = OBJ_PLANE
 	layer = OBJ_LAYER
 	pass_flags = PASS_FLAG_TABLE
 	mouse_opacity = 1

--- a/code/modules/mining/drilling/drill.dm
+++ b/code/modules/mining/drilling/drill.dm
@@ -3,7 +3,7 @@
 	anchored = 0
 	use_power = POWER_USE_OFF //The drill takes power directly from a cell.
 	density = 1
-	plane = ABOVE_HUMAN_PLANE
+
 	layer = ABOVE_HUMAN_LAYER //So it draws over mobs in the tile north of it.
 
 /obj/machinery/mining/drill

--- a/code/modules/mob/living/carbon/human/human_defines.dm
+++ b/code/modules/mob/living/carbon/human/human_defines.dm
@@ -1,5 +1,5 @@
 /mob/living/carbon/human
-	plane = HUMAN_PLANE
+	layer = BASE_HUMAN_LAYER
 
 	//Hair colour and style
 	var/r_hair = 0

--- a/code/modules/mob/living/carbon/human/human_helpers.dm
+++ b/code/modules/mob/living/carbon/human/human_helpers.dm
@@ -208,10 +208,8 @@
 
 /mob/living/carbon/human/reset_layer()
 	if(hiding)
-		plane = HIDING_MOB_PLANE
 		layer = HIDING_MOB_LAYER
 	else if(lying)
-		plane = LYING_HUMAN_PLANE
 		layer = LYING_HUMAN_LAYER
 	else
 		..()

--- a/code/modules/mob/living/carbon/xenobiological/items.dm
+++ b/code/modules/mob/living/carbon/xenobiological/items.dm
@@ -238,7 +238,6 @@
 	icon = 'icons/obj/rune.dmi'
 	icon_state = "golem"
 	unacidable = 1
-	plane = ABOVE_TURF_PLANE
 	layer = RUNE_LAYER
 
 /obj/effect/golemrune/Initialize()

--- a/code/modules/mob/living/living.dm
+++ b/code/modules/mob/living/living.dm
@@ -759,7 +759,6 @@ default behaviour is:
 
 /mob/living/reset_layer()
 	if(hiding)
-		plane = HIDING_MOB_PLANE
 		layer = HIDING_MOB_LAYER
 	else
 		..()

--- a/code/modules/mob/mob.dm
+++ b/code/modules/mob/mob.dm
@@ -732,7 +732,6 @@
 
 /mob/proc/reset_layer()
 	if(lying)
-		plane = LYING_MOB_PLANE
 		layer = LYING_MOB_LAYER
 	else
 		reset_plane_and_layer()

--- a/code/modules/mob/mob_defines.dm
+++ b/code/modules/mob/mob_defines.dm
@@ -1,6 +1,5 @@
 /mob
 	density = 1
-	plane = MOB_PLANE
 
 	appearance_flags = PIXEL_SCALE
 	animate_movement = 2

--- a/code/modules/mob/observer/freelook/chunk.dm
+++ b/code/modules/mob/observer/freelook/chunk.dm
@@ -23,7 +23,7 @@
 	var/image/obfuscation = obfuscation_images[T]
 	if(!obfuscation)
 		obfuscation = image(icon, T, icon_state)
-		obfuscation.plane = OBSCURITY_PLANE
+		obfuscation.plane = OBFUSCATION_PLANE
 		if(!obfuscation_underlay)
 			// Creating a new icon of a fairly common icon state, adding some random color to prevent address searching, and hoping being static kills memory locality
 			var/turf/floor = /turf/simulated/floor/tiled

--- a/code/modules/multiz/structures.dm
+++ b/code/modules/multiz/structures.dm
@@ -166,7 +166,6 @@
 	density = 0
 	opacity = 0
 	anchored = 1
-	plane = ABOVE_TURF_PLANE
 	layer = RUNE_LAYER
 
 /obj/structure/stairs/Initialize()

--- a/code/modules/overmap/exoplanets/desert.dm
+++ b/code/modules/overmap/exoplanets/desert.dm
@@ -130,7 +130,6 @@
 	if(buckled_mob)
 		overlays += buckled_mob
 		var/image/I = image(icon,icon_state="overlay")
-		I.plane = ABOVE_HUMAN_PLANE
 		I.layer = ABOVE_HUMAN_LAYER
 		overlays += I
 

--- a/code/modules/power/cable.dm
+++ b/code/modules/power/cable.dm
@@ -35,7 +35,6 @@ var/list/possible_cable_coil_colours
 	var/d1 = 0
 	var/d2 = 1
 
-	plane = ABOVE_TURF_PLANE
 	layer = EXPOSED_WIRE_LAYER
 
 	color = COLOR_RED

--- a/code/modules/power/fusion/core/_core.dm
+++ b/code/modules/power/fusion/core/_core.dm
@@ -12,7 +12,7 @@ var/list/fusion_cores = list()
 	desc = "An enormous solenoid for generating extremely high power electromagnetic fields. It includes a kinetic energy harvester."
 	icon = 'icons/obj/machines/power/fusion_core.dmi'
 	icon_state = "core0"
-	plane = ABOVE_HUMAN_PLANE
+
 	layer = ABOVE_HUMAN_LAYER
 	density = 1
 	use_power = POWER_USE_IDLE

--- a/code/modules/power/lighting.dm
+++ b/code/modules/power/lighting.dm
@@ -22,7 +22,7 @@
 	icon = 'icons/obj/lighting.dmi'
 	icon_state = "tube-construct-stage1"
 	anchored = 1
-	plane = ABOVE_HUMAN_PLANE
+
 	layer = ABOVE_HUMAN_LAYER
 
 	var/stage = 1
@@ -119,7 +119,7 @@
 	icon = 'icons/obj/lighting.dmi'
 	icon_state = "bulb-construct-stage1"
 	anchored = 1
-	plane = ABOVE_HUMAN_PLANE
+
 	layer = ABOVE_HUMAN_LAYER
 	stage = 1
 	fixture_type = /obj/machinery/light/small
@@ -139,7 +139,7 @@
 	icon_state = "tube1"
 	desc = "A lighting fixture."
 	anchored = 1
-	plane = ABOVE_HUMAN_PLANE
+
 	layer = ABOVE_HUMAN_LAYER  					// They were appearing under mobs which is a little weird - Ostaf
 	use_power = POWER_USE_ACTIVE
 	idle_power_usage = 2

--- a/code/modules/power/singularity/singularity.dm
+++ b/code/modules/power/singularity/singularity.dm
@@ -7,7 +7,6 @@
 	icon_state = "singularity_s1"
 	anchored = 1
 	density = 1
-	plane = EFFECTS_BELOW_LIGHTING_PLANE
 	layer = SINGULARITY_LAYER
 	light_range = 6
 	unacidable = 1 //Don't comment this out.

--- a/code/modules/power/terminal.dm
+++ b/code/modules/power/terminal.dm
@@ -8,7 +8,6 @@
 	icon_state = "term"
 	desc = "It's an underfloor wiring terminal for power equipment."
 	level = 1
-	plane = ABOVE_TURF_PLANE
 	layer = EXPOSED_WIRE_TERMINAL_LAYER
 	var/obj/machinery/power/master = null
 	anchored = 1
@@ -28,8 +27,8 @@
 
 /obj/machinery/power/terminal/hide(var/do_hide)
 	if(do_hide && level == 1)
-		plane = ABOVE_PLATING_PLANE
 		layer = WIRE_TERMINAL_LAYER
+		plane = FLOOR_PLANE
 	else
 		reset_plane_and_layer()
 

--- a/code/modules/projectiles/targeting/targeting_overlay.dm
+++ b/code/modules/projectiles/targeting/targeting_overlay.dm
@@ -6,7 +6,7 @@
 	anchored = 1
 	density = 0
 	opacity = 0
-	plane = ABOVE_HUMAN_PLANE
+
 	layer = ABOVE_HUMAN_LAYER
 	simulated = 0
 	mouse_opacity = 0
@@ -165,7 +165,7 @@ obj/aiming_overlay/proc/update_aiming_deferred()
 	update_icon()
 	forceMove(get_turf(target))
 	START_PROCESSING(SSobj, src)
-	
+
 	if(do_after(owner,12,target,progress = 0))
 		to_chat(target, "<span class='danger'>You now have a gun pointed at you. No sudden moves!</span>")
 		aiming_with = thing
@@ -186,7 +186,7 @@ obj/aiming_overlay/proc/update_aiming_deferred()
 		return
 
 
-	
+
 
 /obj/aiming_overlay/update_icon()
 	if(locked)

--- a/code/modules/random_map/drop/droppod_doors.dm
+++ b/code/modules/random_map/drop/droppod_doors.dm
@@ -6,7 +6,6 @@
 	anchored = 1
 	density = 1
 	opacity = 1
-	plane = OBJ_PLANE
 	layer = ABOVE_DOOR_LAYER
 	var/deploying
 	var/deployed

--- a/code/modules/recycling/disposal.dm
+++ b/code/modules/recycling/disposal.dm
@@ -659,7 +659,6 @@
 	dir = 0				// dir will contain dominant direction for junction pipes
 	var/health = 10 	// health points 0-10
 	alpha = 192 // Plane and alpha modified for mapping, reset to normal on spawn.
-	plane = ABOVE_TURF_PLANE
 	layer = DISPOSALS_PIPE_LAYER
 	var/base_icon_state	// initial icon state on map
 	var/sortType = ""
@@ -668,7 +667,6 @@
 	New()
 		..()
 		alpha = 255
-		plane = ABOVE_PLATING_PLANE
 		base_icon_state = icon_state
 		return
 

--- a/code/modules/shield_generators/shield.dm
+++ b/code/modules/shield_generators/shield.dm
@@ -3,7 +3,7 @@
 	icon = 'icons/obj/machines/shielding.dmi'
 	icon_state = "shield_impact"
 	anchored = 1
-	plane = ABOVE_HUMAN_PLANE
+
 	layer = ABOVE_HUMAN_LAYER
 	density = 0
 
@@ -19,7 +19,7 @@
 	icon = 'icons/obj/machines/shielding.dmi'
 	icon_state = "shield_normal"
 	anchored = 1
-	plane = ABOVE_HUMAN_PLANE
+
 	layer = ABOVE_HUMAN_LAYER
 	density = 1
 	invisibility = 0

--- a/code/modules/shieldgen/energy_field.dm
+++ b/code/modules/shieldgen/energy_field.dm
@@ -7,7 +7,6 @@
 	icon = 'icons/obj/machines/shielding.dmi'
 	icon_state = "shield_normal"
 	anchored = 1
-	plane = EFFECTS_BELOW_LIGHTING_PLANE
 	layer = PROJECTILE_LAYER
 	density = 0
 	invisibility = 101

--- a/code/modules/spells/aoe_turf/conjure/conjure.dm
+++ b/code/modules/spells/aoe_turf/conjure/conjure.dm
@@ -55,7 +55,6 @@ How they spawn stuff is decided by behaviour vars, which are explained below
 		animation.set_density(0)
 		animation.anchored = 1
 		animation.icon = 'icons/effects/effects.dmi'
-		animation.plane = HUMAN_PLANE
 		animation.layer = MOB_LAYER
 		animation.master = summoned_object
 		if(istype(summoned_object,/mob)) //we want them to NOT attack us.

--- a/code/modules/tables/flipping.dm
+++ b/code/modules/tables/flipping.dm
@@ -86,7 +86,7 @@
 
 	set_dir(direction)
 	if(dir != NORTH)
-		plane = ABOVE_HUMAN_PLANE
+
 		layer = ABOVE_HUMAN_LAYER
 	atom_flags &= ~ATOM_FLAG_CLIMBABLE //flipping tables allows them to be used as makeshift barriers
 	flipped = 1

--- a/code/modules/turbolift/turbolift_console.dm
+++ b/code/modules/turbolift/turbolift_console.dm
@@ -4,7 +4,6 @@
 	icon = 'icons/obj/turbolift.dmi'
 	anchored = 1
 	density = 0
-	plane = OBJ_PLANE
 	layer = ABOVE_OBJ_LAYER
 
 	var/datum/turbolift/lift

--- a/code/modules/vehicles/vehicle.dm
+++ b/code/modules/vehicles/vehicle.dm
@@ -7,7 +7,7 @@
 /obj/vehicle
 	name = "vehicle"
 	icon = 'icons/obj/vehicles.dmi'
-	plane = ABOVE_HUMAN_PLANE
+
 	layer = ABOVE_HUMAN_LAYER
 	density = 1
 	anchored = 1

--- a/maps/away/errant_pisces/errant_pisces.dm
+++ b/maps/away/errant_pisces/errant_pisces.dm
@@ -143,7 +143,7 @@ obj/structure/net/Initialize(var/mapload)
 /obj/structure/net/net_wall
 	icon_state = "net_w"
 	density = 1
-	plane = ABOVE_HUMAN_PLANE
+
 	layer = ABOVE_HUMAN_LAYER
 
 /obj/structure/net/net_wall/Initialize(var/mapload)

--- a/maps/random_ruins/exoplanet_ruins/monoliths/monoliths.dm
+++ b/maps/random_ruins/exoplanet_ruins/monoliths/monoliths.dm
@@ -11,7 +11,7 @@
 	desc = "An obviously artifical structure of unknown origin. The symbols '<font face='Shage'>DWNbTX</font>' are engraved on the base."
 	icon = 'icons/obj/monolith.dmi'
 	icon_state = "jaggy1"
-	plane = ABOVE_HUMAN_PLANE
+
 	layer = ABOVE_HUMAN_LAYER
 	density = 1
 	anchored = 1


### PR DESCRIPTION
Можно считтать закрытием #745. Портировал вот **[это](https://github.com/Baystation12/Baystation12/commit/264bf4594a06f45b7668d7291e46ebf0b22c80a0)** с бэя и добавил тени как на ТГ.

99% изменений - убрал назначения объектам плейнов. Где нашёл траблы с отображением - пофиксил и назначил нужный плэйн.

При создании худа добавляется мастер плэйн `/obj/screen/master_plane/ambient_occlusion` на плэйн DEFAULT_PLANE, который и выполняет работу с фильтрами.

Включается/отключается в преференсах.

~~RTX~~ Тени Off:
![rtx_off](https://user-images.githubusercontent.com/55196698/65378942-e1b7cd80-dcc8-11e9-8c01-e6c230fd0d3d.png)
Тени On:
![rtx_on](https://user-images.githubusercontent.com/55196698/65378943-e3819100-dcc8-11e9-886d-4b7a46664de7.png)