### PR TITLE
Фикс выноса вещей с голодека

### DIFF
--- a/code/game/objects/objs.dm
+++ b/code/game/objects/objs.dm
@@ -17,6 +17,11 @@
 	var/anchor_fall = FALSE
 
 /obj/Destroy()
+	var/obj/item/smallDelivery/delivery = loc
+
+	if (istype(delivery))
+		delivery.wrapped = null
+
 	STOP_PROCESSING(SSobj, src)
 	return ..()
 

--- a/code/modules/recycling/sortingmachinery.dm
+++ b/code/modules/recycling/sortingmachinery.dm
@@ -133,7 +133,10 @@
 	var/tag_x
 
 /obj/item/smallDelivery/proc/unwrap(var/mob/user)
-	if (!wrapped || !Adjacent(user))
+	if (!wrapped)
+		qdel(src)
+
+	if (!Adjacent(user))
 		return
 	wrapped.forceMove(user.loc)
 	user.drop_item()


### PR DESCRIPTION
#742. qdel на предмете который мы выносим не работал, видимо, из-за ссылки на этот самый объект в обёрточной бумаге, из-за чего предмет с голодека не удалялся. Также, изменил проверку при открытии обёрточной бумаги - она теперь удаляется если пустая.

Ещё почему-то когда выходил с голодека - я буквально вошёл в бесконечный цикл, но это уже другая история.