### PR TITLE
fix(cell_charger): fix cell dubling on insert

### DIFF
--- a/code/game/machinery/cell_charger.dm
+++ b/code/game/machinery/cell_charger.dm
@@ -47,7 +47,7 @@
 			if(a.power_equip == 0) // There's no APC in this area, don't try to cheat power!
 				to_chat(user, "<span class='warning'>The [name] blinks red as you try to insert the cell!</span>")
 				return
-			if(!user.unEquip(W, src))
+			if(!user.unEquip(W, FALSE, src))
 				return
 			charging = W
 			set_power()


### PR DESCRIPTION
Починил дюп батарейки зарядником.

На самом деле дюп не настоящий, а тупо одна батарейка была сразу в двух местах. Ничего особенного.

Сделал forceMove, как делается в аналогичных местах.

close #986