### PR TITLE
Лояльные главы

### DIFF
--- a/code/__defines/mobs.dm
+++ b/code/__defines/mobs.dm
@@ -126,6 +126,7 @@
 #define COMPANY_SKEPTICAL		"Skeptical"
 #define COMPANY_OPPOSED			"Opposed"
 
+#define COMPANY_OPPOSING		list(COMPANY_SKEPTICAL,COMPANY_OPPOSED)
 #define COMPANY_ALIGNMENTS		list(COMPANY_LOYAL,COMPANY_SUPPORTATIVE,COMPANY_NEUTRAL,COMPANY_SKEPTICAL,COMPANY_OPPOSED)
 
 // Defines mob sizes, used by lockers and to determine what is considered a small sized mob, etc.

--- a/code/game/antagonist/station/changeling.dm
+++ b/code/game/antagonist/station/changeling.dm
@@ -5,8 +5,11 @@ GLOBAL_DATUM_INIT(changelings, /datum/antagonist/changeling, new)
 	role_text = "Changeling"
 	role_text_plural = "Changelings"
 	feedback_tag = "changeling_objective"
+	restricted_jobs = list(/datum/job/captain, /datum/job/hos, /datum/job/hop,
+							/datum/job/rd, /datum/job/chief_engineer, /datum/job/cmo,
+							/datum/job/merchant, /datum/job/lawyer)
+	protected_jobs = list(/datum/job/officer, /datum/job/warden, /datum/job/detective)
 	blacklisted_jobs = list(/datum/job/ai, /datum/job/cyborg)
-	protected_jobs = list(/datum/job/merchant, /datum/job/officer, /datum/job/warden, /datum/job/detective, /datum/job/captain, /datum/job/hos)
 	welcome_text = "Use say \",g message\" to communicate with your fellow changelings. Remember: you get all of their absorbed DNA if you absorb them."
 	flags = ANTAG_SUSPICIOUS | ANTAG_RANDSPAWN | ANTAG_VOTABLE
 	antaghud_indicator = "hudchangeling"

--- a/code/game/antagonist/station/cultist.dm
+++ b/code/game/antagonist/station/cultist.dm
@@ -24,7 +24,9 @@ GLOBAL_DATUM_INIT(cult, /datum/antagonist/cultist, new)
 	id = MODE_CULTIST
 	role_text = "Cultist"
 	role_text_plural = "Cultists"
-	restricted_jobs = list(/datum/job/merchant, /datum/job/lawyer, /datum/job/captain, /datum/job/hos)
+	restricted_jobs = list(/datum/job/captain, /datum/job/hos, /datum/job/hop,
+							/datum/job/rd, /datum/job/chief_engineer, /datum/job/cmo,
+							/datum/job/merchant, /datum/job/lawyer)
 	protected_jobs = list(/datum/job/officer, /datum/job/warden, /datum/job/detective)
 	blacklisted_jobs = list(/datum/job/ai, /datum/job/cyborg, /datum/job/chaplain, /datum/job/psychiatrist)
 	feedback_tag = "cult_objective"

--- a/code/game/antagonist/station/traitor.dm
+++ b/code/game/antagonist/station/traitor.dm
@@ -4,7 +4,6 @@ GLOBAL_DATUM_INIT(traitors, /datum/antagonist/traitor, new)
 /datum/antagonist/traitor
 	id = MODE_TRAITOR
 	restricted_jobs = list(/datum/job/captain, /datum/job/hos, /datum/job/hop,
-							/datum/job/rd, /datum/job/chief_engineer, /datum/job/cmo,
 							/datum/job/merchant, /datum/job/lawyer)
 	protected_jobs = list(/datum/job/officer, /datum/job/warden, /datum/job/detective)
 	flags = ANTAG_SUSPICIOUS | ANTAG_RANDSPAWN | ANTAG_VOTABLE

--- a/code/game/antagonist/station/traitor.dm
+++ b/code/game/antagonist/station/traitor.dm
@@ -3,7 +3,10 @@ GLOBAL_DATUM_INIT(traitors, /datum/antagonist/traitor, new)
 // Inherits most of its vars from the base datum.
 /datum/antagonist/traitor
 	id = MODE_TRAITOR
-	protected_jobs = list(/datum/job/merchant, /datum/job/officer, /datum/job/warden, /datum/job/detective, /datum/job/captain, /datum/job/lawyer, /datum/job/hos)
+	restricted_jobs = list(/datum/job/captain, /datum/job/hos, /datum/job/hop,
+							/datum/job/rd, /datum/job/chief_engineer, /datum/job/cmo,
+							/datum/job/merchant, /datum/job/lawyer)
+	protected_jobs = list(/datum/job/officer, /datum/job/warden, /datum/job/detective)
 	flags = ANTAG_SUSPICIOUS | ANTAG_RANDSPAWN | ANTAG_VOTABLE
 
 /datum/antagonist/traitor/get_extra_panel_options(var/datum/mind/player)

--- a/code/game/jobs/job/captain.dm
+++ b/code/game/jobs/job/captain.dm
@@ -16,6 +16,7 @@ var/datum/announcement/minor/captain_announcement = new(do_newscast = 1)
 	minimal_player_age = 14
 	minimum_character_age = 25
 	economic_modifier = 20
+	fraction_restricted = TRUE
 
 	ideal_character_age = 70 // Old geezer captains ftw
 	outfit_type = /decl/hierarchy/outfit/job/captain
@@ -39,9 +40,10 @@ var/datum/announcement/minor/captain_announcement = new(do_newscast = 1)
 	selection_color = "#2f2f7f"
 	req_admin_notify = 1
 	minimal_player_age = 14
-	minimum_character_age = 25	
+	minimum_character_age = 25
 	economic_modifier = 10
 	ideal_character_age = 50
+	fraction_restricted = TRUE
 
 	access = list(access_security, access_sec_doors, access_brig, access_forensics_lockers,
 			            access_medical, access_engine, access_change_ids, access_ai_upload, access_eva, access_heads,

--- a/code/game/jobs/job/captain.dm
+++ b/code/game/jobs/job/captain.dm
@@ -16,7 +16,7 @@ var/datum/announcement/minor/captain_announcement = new(do_newscast = 1)
 	minimal_player_age = 14
 	minimum_character_age = 25
 	economic_modifier = 20
-	fraction_restricted = TRUE
+	faction_restricted = TRUE
 
 	ideal_character_age = 70 // Old geezer captains ftw
 	outfit_type = /decl/hierarchy/outfit/job/captain
@@ -43,7 +43,7 @@ var/datum/announcement/minor/captain_announcement = new(do_newscast = 1)
 	minimum_character_age = 25
 	economic_modifier = 10
 	ideal_character_age = 50
-	fraction_restricted = TRUE
+	faction_restricted = TRUE
 
 	access = list(access_security, access_sec_doors, access_brig, access_forensics_lockers,
 			            access_medical, access_engine, access_change_ids, access_ai_upload, access_eva, access_heads,

--- a/code/game/jobs/job/civilian.dm
+++ b/code/game/jobs/job/civilian.dm
@@ -115,7 +115,7 @@
 	supervisors = "company officials and Corporate Regulations"
 	selection_color = "#515151"
 	economic_modifier = 7
-	fraction_restricted = TRUE
+	faction_restricted = TRUE
 	access = list(access_lawyer, access_sec_doors, access_maint_tunnels, access_heads)
 	minimal_access = list(access_lawyer, access_sec_doors, access_heads)
 	minimal_player_age = 10

--- a/code/game/jobs/job/civilian.dm
+++ b/code/game/jobs/job/civilian.dm
@@ -115,6 +115,7 @@
 	supervisors = "company officials and Corporate Regulations"
 	selection_color = "#515151"
 	economic_modifier = 7
+	fraction_restricted = TRUE
 	access = list(access_lawyer, access_sec_doors, access_maint_tunnels, access_heads)
 	minimal_access = list(access_lawyer, access_sec_doors, access_heads)
 	minimal_player_age = 10

--- a/code/game/jobs/job/engineering.dm
+++ b/code/game/jobs/job/engineering.dm
@@ -10,10 +10,8 @@
 	selection_color = "#7f6e2c"
 	req_admin_notify = 1
 	economic_modifier = 10
-
+	fraction_restricted = TRUE
 	ideal_character_age = 50
-
-
 	access = list(access_engine, access_engine_equip, access_tech_storage, access_maint_tunnels,
 			            access_teleporter, access_external_airlocks, access_atmospherics, access_emergency_storage, access_eva,
 			            access_heads, access_construction, access_sec_doors,
@@ -23,7 +21,7 @@
 			            access_heads, access_construction, access_sec_doors,
 			            access_ce, access_RC_announce, access_keycard_auth, access_tcomsat, access_ai_upload)
 	minimal_player_age = 14
-	minimum_character_age = 25	
+	minimum_character_age = 25
 	outfit_type = /decl/hierarchy/outfit/job/engineering/chief_engineer
 
 /datum/job/engineer

--- a/code/game/jobs/job/engineering.dm
+++ b/code/game/jobs/job/engineering.dm
@@ -10,7 +10,7 @@
 	selection_color = "#7f6e2c"
 	req_admin_notify = 1
 	economic_modifier = 10
-	fraction_restricted = TRUE
+	faction_restricted = TRUE
 	ideal_character_age = 50
 	access = list(access_engine, access_engine_equip, access_tech_storage, access_maint_tunnels,
 			            access_teleporter, access_external_airlocks, access_atmospherics, access_emergency_storage, access_eva,

--- a/code/game/jobs/job/job.dm
+++ b/code/game/jobs/job/job.dm
@@ -21,6 +21,7 @@
 	var/head_position = 0                 // Is this position Command?
 	var/minimum_character_age = 0
 	var/ideal_character_age = 30
+	var/fraction_restricted = FALSE
 	var/create_record = 1                 // Do we announce/make records for people who spawn on this job?
 
 	var/account_allowed = 1               // Does this job type come with a station account?

--- a/code/game/jobs/job/job.dm
+++ b/code/game/jobs/job/job.dm
@@ -21,7 +21,7 @@
 	var/head_position = 0                 // Is this position Command?
 	var/minimum_character_age = 0
 	var/ideal_character_age = 30
-	var/fraction_restricted = FALSE
+	var/faction_restricted = FALSE
 	var/create_record = 1                 // Do we announce/make records for people who spawn on this job?
 
 	var/account_allowed = 1               // Does this job type come with a station account?

--- a/code/game/jobs/job/medical.dm
+++ b/code/game/jobs/job/medical.dm
@@ -10,6 +10,7 @@
 	selection_color = "#026865"
 	req_admin_notify = 1
 	economic_modifier = 10
+	fraction_restricted = TRUE
 	access = list(access_medical, access_medical_equip, access_morgue, access_genetics, access_heads,
 			access_chemistry, access_virology, access_cmo, access_surgery, access_RC_announce,
 			access_keycard_auth, access_sec_doors, access_psychiatrist, access_eva, access_maint_tunnels, access_external_airlocks)
@@ -18,7 +19,7 @@
 			access_keycard_auth, access_sec_doors, access_psychiatrist, access_eva, access_maint_tunnels, access_external_airlocks)
 
 	minimal_player_age = 14
-	minimum_character_age = 25	
+	minimum_character_age = 25
 	ideal_character_age = 50
 	outfit_type = /decl/hierarchy/outfit/job/medical/cmo
 

--- a/code/game/jobs/job/medical.dm
+++ b/code/game/jobs/job/medical.dm
@@ -10,7 +10,7 @@
 	selection_color = "#026865"
 	req_admin_notify = 1
 	economic_modifier = 10
-	fraction_restricted = TRUE
+	faction_restricted = TRUE
 	access = list(access_medical, access_medical_equip, access_morgue, access_genetics, access_heads,
 			access_chemistry, access_virology, access_cmo, access_surgery, access_RC_announce,
 			access_keycard_auth, access_sec_doors, access_psychiatrist, access_eva, access_maint_tunnels, access_external_airlocks)

--- a/code/game/jobs/job/science.dm
+++ b/code/game/jobs/job/science.dm
@@ -10,6 +10,7 @@
 	selection_color = "#ad6bad"
 	req_admin_notify = 1
 	economic_modifier = 15
+	fraction_restricted = TRUE
 	access = list(access_rd, access_heads, access_tox, access_genetics, access_morgue,
 			            access_tox_storage, access_teleporter, access_sec_doors,
 			            access_research, access_robotics, access_xenobiology, access_ai_upload, access_tech_storage,
@@ -19,7 +20,7 @@
 			            access_research, access_robotics, access_xenobiology, access_ai_upload, access_tech_storage,
 			            access_RC_announce, access_keycard_auth, access_tcomsat, access_gateway, access_xenoarch, access_network)
 	minimal_player_age = 14
-	minimum_character_age = 25	
+	minimum_character_age = 25
 	ideal_character_age = 50
 	outfit_type = /decl/hierarchy/outfit/job/science/rd
 

--- a/code/game/jobs/job/science.dm
+++ b/code/game/jobs/job/science.dm
@@ -10,7 +10,7 @@
 	selection_color = "#ad6bad"
 	req_admin_notify = 1
 	economic_modifier = 15
-	fraction_restricted = TRUE
+	faction_restricted = TRUE
 	access = list(access_rd, access_heads, access_tox, access_genetics, access_morgue,
 			            access_tox_storage, access_teleporter, access_sec_doors,
 			            access_research, access_robotics, access_xenobiology, access_ai_upload, access_tech_storage,

--- a/code/game/jobs/job/security.dm
+++ b/code/game/jobs/job/security.dm
@@ -10,6 +10,7 @@
 	selection_color = "#8e2929"
 	req_admin_notify = 1
 	economic_modifier = 10
+	fraction_restricted = TRUE
 	access = list(access_security, access_eva, access_sec_doors, access_brig, access_armory,
 			            access_forensics_lockers, access_morgue, access_maint_tunnels, access_all_personal_lockers,
 			            access_research, access_engine, access_mining, access_medical, access_construction, access_mailsorting,
@@ -19,7 +20,7 @@
 			            access_research, access_engine, access_mining, access_medical, access_construction, access_mailsorting,
 			            access_heads, access_hos, access_RC_announce, access_keycard_auth, access_gateway, access_external_airlocks)
 	minimal_player_age = 14
-	minimum_character_age = 25	
+	minimum_character_age = 25
 	outfit_type = /decl/hierarchy/outfit/job/security/hos
 
 /datum/job/hos/equip(var/mob/living/carbon/human/H)

--- a/code/game/jobs/job/security.dm
+++ b/code/game/jobs/job/security.dm
@@ -10,7 +10,7 @@
 	selection_color = "#8e2929"
 	req_admin_notify = 1
 	economic_modifier = 10
-	fraction_restricted = TRUE
+	faction_restricted = TRUE
 	access = list(access_security, access_eva, access_sec_doors, access_brig, access_armory,
 			            access_forensics_lockers, access_morgue, access_maint_tunnels, access_all_personal_lockers,
 			            access_research, access_engine, access_mining, access_medical, access_construction, access_mailsorting,

--- a/code/modules/client/preference_setup/occupation/occupation.dm
+++ b/code/modules/client/preference_setup/occupation/occupation.dm
@@ -114,12 +114,12 @@
 			. += "<del>[rank]</del></td><td><b> \[BANNED]</b></td></tr>"
 			continue
 
-		if(job.fraction_restricted)
+		if(job.faction_restricted)
 			if(user.client?.prefs.faction != GLOB.using_map.company_name)
 				. += "<del>[rank]</del></td><td><b> \[FOR [uppertext(GLOB.using_map.company_name)] EMPLOYESS ONLY]</b></td></tr>"
 				continue
-			if(user.client?.prefs.nanotrasen_relation != COMPANY_LOYAL)
-				. += "<del>[rank]</del></td><td><b> \[HIGH LOYALTY REQUIRED]</b></td></tr>"
+			if(user.client?.prefs.nanotrasen_relation in COMPANY_OPPOSING)
+				. += "<del>[rank]</del></td><td><b> \[LOW LOYALTY IS FORBIDDEN]</b></td></tr>"
 				continue
 
 		if(!job.player_old_enough(user.client))

--- a/code/modules/client/preference_setup/occupation/occupation.dm
+++ b/code/modules/client/preference_setup/occupation/occupation.dm
@@ -113,6 +113,15 @@
 		else if(bannedReason)
 			. += "<del>[rank]</del></td><td><b> \[BANNED]</b></td></tr>"
 			continue
+
+		if(job.fraction_restricted)
+			if(user.client?.prefs.faction != GLOB.using_map.company_name)
+				. += "<del>[rank]</del></td><td><b> \[FOR [uppertext(GLOB.using_map.company_name)] EMPLOYESS ONLY]</b></td></tr>"
+				continue
+			if(user.client?.prefs.nanotrasen_relation != COMPANY_LOYAL)
+				. += "<del>[rank]</del></td><td><b> \[HIGH LOYALTY REQUIRED]</b></td></tr>"
+				continue
+
 		if(!job.player_old_enough(user.client))
 			var/available_in_days = job.available_in_days(user.client)
 			. += "<del>[rank]</del></td><td> \[IN [(available_in_days)] DAYS]</td></tr>"

--- a/code/modules/mob/new_player/new_player.dm
+++ b/code/modules/mob/new_player/new_player.dm
@@ -442,6 +442,8 @@
 		if(job && IsJobAvailable(job))
 			if(job.minimum_character_age && (client.prefs.age < job.minimum_character_age))
 				continue
+			if(job.fraction_restricted && client.prefs.faction != GLOB.using_map.company_name && client.prefs.nanotrasen_relation != COMPANY_LOYAL)
+				continue
 
 			var/active = 0
 			// Only players with the job assigned and AFK for less than 10 minutes count as active

--- a/code/modules/mob/new_player/new_player.dm
+++ b/code/modules/mob/new_player/new_player.dm
@@ -442,7 +442,7 @@
 		if(job && IsJobAvailable(job))
 			if(job.minimum_character_age && (client.prefs.age < job.minimum_character_age))
 				continue
-			if(job.fraction_restricted && client.prefs.faction != GLOB.using_map.company_name && client.prefs.nanotrasen_relation != COMPANY_LOYAL)
+			if(job.faction_restricted && client.prefs.faction != GLOB.using_map.company_name && client.prefs.nanotrasen_relation in COMPANY_OPPOSING)
 				continue
 
 			var/active = 0


### PR DESCRIPTION
**ПР выполнен по согласованному реквесту:
close #199** 

Коротко: 

- Глав могут брать только те персонажи, у которых выставлена фракция НТ.
- Главы требуют теперь как минимум нейтральную лояльность к НТ.
- Главы больше не становятся антагонистами на станции раунд-стартом. Исключение: РД, СМО и СЕ могут быть предателями.

**Я не веду обсуждения в этом ПР'е. 
На дальнейшие изменения в этом ПР'е влияет только тот человек, что согласовал его.**