### PR TITLE
Возможный фикс генерации руды на астероиде.

### DIFF
--- a/maps/exodus/exodus_define.dm
+++ b/maps/exodus/exodus_define.dm
@@ -36,5 +36,5 @@
 
 /datum/map/exodus/perform_map_generation()
 	new /datum/random_map/automata/cave_system(null, 1, 1, 6, 255, 255) // Create the mining Z-level.
-	new /datum/random_map/noise/ore(null, 1, 1, 6, 64, 64)         // Create the mining ore distribution map.
+	new /datum/random_map/noise/ore(null, 1, 1, 6, 255, 255)         // Create the mining ore distribution map.
 	return 1


### PR DESCRIPTION
Скорее всего из-за того, что был выставлен плохой maxx и maxy - необходимое число руды не генерировалось даже после нескольких попыток, что послужило отсутствием руды в песке на астероиде.

Фикс не проверялся.