### PR TITLE
cyborg can process surgery without clothes penalty

### DIFF
--- a/code/modules/surgery/surgery.dm
+++ b/code/modules/surgery/surgery.dm
@@ -85,9 +85,7 @@
 		if(H.eye_blind)
 			. -= 60
 
-	if(clothes_penalty)
-		if (issilicon(user))
-			return
+	if(clothes_penalty && !issilicon(user))
 		var/clothes = get_target_clothes(target, target_zone)
 		for(var/obj/item/I in clothes)
 			if(I.item_flags & (ITEM_FLAG_THICKMATERIAL|ITEM_FLAG_STOPPRESSUREDAMAGE))

--- a/code/modules/surgery/surgery.dm
+++ b/code/modules/surgery/surgery.dm
@@ -86,6 +86,8 @@
 			. -= 60
 
 	if(clothes_penalty)
+		if (issilicon(user))
+			return
 		var/clothes = get_target_clothes(target, target_zone)
 		for(var/obj/item/I in clothes)
 			if(I.item_flags & (ITEM_FLAG_THICKMATERIAL|ITEM_FLAG_STOPPRESSUREDAMAGE))


### PR DESCRIPTION
Балансим обновы.
(не влияет на скафандры и прочее толстое дерьмо)
close #1446 

почему баг:
у боргов нет синего граба -> борги не могут быстро снимать одежду с пациентов -> пациенты умирают потому что их хрен прооперируют борги -> борги сломаны и за них теперь хрен прооперируешь -> если что-то сломано это баг