### PR TITLE
Бафф индустриального РИГа

### DIFF
--- a/code/modules/clothing/spacesuits/rig/suits/station.dm
+++ b/code/modules/clothing/spacesuits/rig/suits/station.dm
@@ -44,7 +44,7 @@
 	icon_state = "engineering_rig"
 	armor = list(melee = 75, bullet = 35, laser = 35,energy = 15, bomb = 50, bio = 100, rad = 100)
 	online_slowdown = 2
-	offline_slowdown = 6
+	offline_slowdown = 10
 	offline_vision_restriction = TINT_HEAVY
 
 	chest_type = /obj/item/clothing/suit/space/rig/industrial
@@ -52,7 +52,7 @@
 	boot_type = /obj/item/clothing/shoes/magboots/rig/industrial
 	glove_type = /obj/item/clothing/gloves/rig/industrial
 
-	allowed = list(/obj/item/device/flashlight,/obj/item/weapon/tank,/obj/item/device/suit_cooling_unit,/obj/item/stack/flag,/obj/item/weapon/storage/ore,/obj/item/device/t_scanner,/obj/item/weapon/pickaxe, /obj/item/weapon/rcd)
+	allowed = list(/obj/item/device/flashlight,/obj/item/weapon/tank,/obj/item/device/suit_cooling_unit,/obj/item/stack/flag,/obj/item/weapon/storage/ore,/obj/item/device/t_scanner,/obj/item/weapon/pickaxe, /obj/item/weapon/rcd, /obj/item/weapon/gun/energy/kinetic_accelerator, /obj/item/weapon/shovel, /obj/item/weapon/ore_radar, /obj/item/weapon/resonator)
 
 	req_access = list()
 	req_one_access = list()

--- a/code/modules/clothing/spacesuits/rig/suits/station.dm
+++ b/code/modules/clothing/spacesuits/rig/suits/station.dm
@@ -42,12 +42,10 @@
 	suit_type = "industrial hardsuit"
 	desc = "A heavy, powerful rig used by construction crews and mining corporations."
 	icon_state = "engineering_rig"
-	armor = list(melee = 60, bullet = 50, laser = 50,energy = 15, bomb = 30, bio = 100, rad = 50)
-	online_slowdown = 3
-	offline_slowdown = 10
-	vision_restriction = TINT_HEAVY
-	offline_vision_restriction = TINT_BLIND
-	emp_protection = -20
+	armor = list(melee = 75, bullet = 35, laser = 35,energy = 15, bomb = 50, bio = 100, rad = 100)
+	online_slowdown = 2
+	offline_slowdown = 6
+	offline_vision_restriction = TINT_HEAVY
 
 	chest_type = /obj/item/clothing/suit/space/rig/industrial
 	helm_type = /obj/item/clothing/head/helmet/space/rig/industrial
@@ -60,6 +58,7 @@
 	req_one_access = list()
 
 /obj/item/clothing/head/helmet/space/rig/industrial
+	brightness_on = 6
 	camera = /obj/machinery/camera/network/mining
 	species_restricted = list(SPECIES_HUMAN,SPECIES_SKRELL,SPECIES_TAJARA,SPECIES_UNATHI)
 


### PR DESCRIPTION
* Убрал ограничение зрения в активном состоянии, убрал слепоту в неактивном, теперь там обычный рестрикт, как у сварочного щитка.
* Повысил скорость на единицу. Сначала повысил на две единицы, как советовали в иссуе, но чет слишком быстро. Этот РИГ и должен быть медленным, просто не настолько ебануто медленным как сейчас. В выключенном состоянии тоже передвигаться всё так же невозможно, ибо нашлись любители.
* Повысил резист к бруту на 15 единиц, большую часть фауны можно хоть руками бить. Понизил резист к пулям и лазерам на 15 единиц, ибо не боевой РИГ. Повысил резист к взрывам, и дал полную защиту от радиации. Шахтеров частенько облучают артефакты, так что в РИГе можно будет копать без риска получить дозу. К тому же, защита от радиации на нем имеет смысл, он же для строительства в открытом космосе используется.
* Убрал какую-то странную уязвимость перед ЭМИ. Почему она была именно у этого РИГа?
* Повысил яркость встроенного фонаря. 

так ебать как там это делается, так вроде
close #1458