### PR TITLE
Связанные люди не могут складывать стулья

### DIFF
--- a/code/game/objects/structures/stool_bed_chair_nest/chairs.dm
+++ b/code/game/objects/structures/stool_bed_chair_nest/chairs.dm
@@ -145,7 +145,11 @@
 /obj/structure/bed/chair/MouseDrop(over_object, src_location, over_location)
 	..()
 	if(foldable && (over_object == usr && (in_range(src, usr) || usr.contents.Find(src))))
-		if(!ishuman(usr))	return
+		if(!ishuman(usr))
+			return
+		var/mob/living/carbon/human/H = usr
+		if(H.handcuffed)
+			return
 		if(buckled_mob)
 			visible_message(SPAN_WARN("[buckled_mob] falls down as [usr] collapses \the [src.name]!"))
 			var/mob/living/occupant = unbuckle_mob()

--- a/code/game/objects/structures/stool_bed_chair_nest/chairs.dm
+++ b/code/game/objects/structures/stool_bed_chair_nest/chairs.dm
@@ -148,7 +148,7 @@
 		if(!ishuman(usr))
 			return
 		var/mob/living/carbon/human/H = usr
-		if(H.handcuffed)
+		if(H.restrained())
 			return
 		if(buckled_mob)
 			visible_message(SPAN_WARN("[buckled_mob] falls down as [usr] collapses \the [src.name]!"))


### PR DESCRIPTION
Двери открывать не могут, а стулья складывают. Даже тот стул, к которому привязаны. Что позволяет заменить двухминутное сидение в резисте не слишком ужасным уроном по гроину и относительно коротким станом, а к тому же уронить зазевавшегося рядом сидящего швардена или офицерика. Или вообще кого угодно.
В общем, поправил, добавил проверку на наручники - теперь если человек связан, то ничего не сложит.