### PR TITLE
Исправление водорода

### DIFF
--- a/code/modules/materials/materials.dm
+++ b/code/modules/materials/materials.dm
@@ -649,7 +649,7 @@ var/list/name_to_material
 	is_fusion_fuel = 1
 
 /material/mhydrogen
-	name = "mhydrogen"
+	name = MATERIAL_HYDROGEN
 	stack_type = /obj/item/stack/material/mhydrogen
 	icon_colour = "#e6c5de"
 	stack_origin_tech = list(TECH_MATERIAL = 6, TECH_POWER = 6, TECH_MAGNET = 5)

--- a/code/modules/mining/ore_datum.dm
+++ b/code/modules/mining/ore_datum.dm
@@ -165,7 +165,7 @@ var/global/list/ores_by_type = list()
 	worth = 8
 
 /ore/hydrogen
-	name = "mhydrogen"
+	name = MATERIAL_HYDROGEN
 	display_name = "metallic hydrogen"
 	smelts_to = MATERIAL_TRITIUM
 	compresses_to = MATERIAL_HYDROGEN


### PR DESCRIPTION
Исправляет ошибку, связанную с неправильным названием материала и руды:
`[02:50:28][ERROR] Unable to acquire material by name 'hydrogen'`