### PR TITLE
feat(donator): decorate ckey in ooc with patreon tier color

### DIFF
--- a/code/__defines/client.dm
+++ b/code/__defines/client.dm
@@ -1,2 +1,17 @@
 #define CLIENT_MIN_FPS 0
 #define CLIENT_MAX_FPS 1000
+
+#define PATREON_NONE      "none"
+#define PATREON_CARGO     "cargo"
+#define PATREON_ENGINEER  "engineer"
+#define PATREON_SCIENTIST "scientist"
+#define PATREON_HOS       "hos"
+#define PATREON_CAPTAIN   "captain"
+#define PATREON_WIZARD    "wizard"
+#define PATREON_CULTIST   "cultist"
+#define PATREON_ASSISTANT "assistant"
+
+#define PATREON_ALL_TIERS list(\
+	PATREON_NONE, PATREON_CARGO, PATREON_ENGINEER, \
+	PATREON_SCIENTIST, PATREON_HOS, PATREON_CAPTAIN, \
+	PATREON_WIZARD, PATREON_CULTIST, PATREON_ASSISTANT)

--- a/code/datums/communication/ooc.dm
+++ b/code/datums/communication/ooc.dm
@@ -37,12 +37,13 @@
 
 	var/can_badmin = !is_stealthed && can_select_ooc_color(C) && (C.prefs.ooccolor != initial(C.prefs.ooccolor))
 	var/ooc_color = C.prefs.ooccolor
+	var/decorated_ckey = C.donator_info.get_decorated_ooc_name(C)
 
 	webhook_send_ooc(C.key, message)
 	for(var/client/target in GLOB.clients)
 		if(target.is_key_ignored(C.key)) // If we're ignored by this person, then do nothing.
 			continue
-		var/sent_message = "[create_text_tag("ooc", "OOC:", target)] <EM>[C.key]:</EM> <span class='message linkify'>[message]</span>"
+		var/sent_message = "[create_text_tag("ooc", "OOC:", target)] <EM>[decorated_ckey]:</EM> <span class='message linkify'>[message]</span>"
 		if(can_badmin)
 			receive_communication(C, target, "<span class='ooc'><font color='[ooc_color]'>[sent_message]</font></span>")
 		else

--- a/code/modules/client/preference_setup/global/05_settings.dm
+++ b/code/modules/client/preference_setup/global/05_settings.dm
@@ -30,11 +30,11 @@
 		pref.preference_values = list()
 		for(var/datum/client_preference/cp in get_client_preferences())
 			if(cp.key in preferences_enabled)
-				pref.preference_values[cp.key] = cp.options[1] // for the converted preferences, the truthy value is going to be the first one...
+				pref.preference_values[cp.key] = cp.get_options(preference_mob().client)[1] // for the converted preferences, the truthy value is going to be the first one...
 			else if(cp.key in preferences_disabled)
-				pref.preference_values[cp.key] = cp.options[2] // ...and the falsy value the second
+				pref.preference_values[cp.key] = cp.get_options(preference_mob().client)[2] // ...and the falsy value the second
 			else
-				pref.preference_values[cp.key] = cp.default_value
+				pref.preference_values[cp.key] = cp.get_default_value(preference_mob().client)
 		return 1
 
 /datum/category_item/player_setup_item/player_global/settings/sanitize_preferences()
@@ -51,7 +51,7 @@
 		// if the preference has never been set, or if the player is no longer allowed to set the it, set it to default
 		preference_mob() // we don't care about the mob it returns, but it finds the correct client.
 		if(!client_pref.may_set(pref.client) || !(client_pref.key in pref.preference_values))
-			pref.preference_values[client_pref.key] = client_pref.default_value
+			pref.preference_values[client_pref.key] = client_pref.get_default_value(preference_mob().client)
 
 
 	// Clean out preferences that no longer exist.
@@ -77,7 +77,7 @@
 		. += "<tr><td>[client_pref.description]: </td>"
 
 		var/selected_option = pref_mob.get_preference_value(client_pref.key)
-		for(var/option in client_pref.options)
+		for(var/option in client_pref.get_options(pref_mob.client))
 			var/is_selected = selected_option == option
 			. += "<td><a class='[is_selected ? "linkOn" : ""]' href='?src=\ref[src];pref=[client_pref.key];value=[option]'><b>[option]</b></a>"
 
@@ -114,7 +114,7 @@
 	if(!cp)
 		return FALSE
 
-	if((prefs.preference_values[cp.key] != set_preference) && (set_preference in cp.options))
+	if((prefs.preference_values[cp.key] != set_preference) && (set_preference in cp.get_options(src)))
 		prefs.preference_values[cp.key] = set_preference
 		cp.changed(mob, set_preference)
 		return TRUE
@@ -127,14 +127,14 @@
 	if(!cp)
 		return FALSE
 
-	var/next_option = next_in_list(prefs.preference_values[cp.key], cp.options)
+	var/next_option = next_in_list(prefs.preference_values[cp.key], cp.get_options(src))
 	return set_preference(preference, next_option)
 
 /mob/proc/get_preference_value(preference)
 	if(!client)
 		var/datum/client_preference/cp = get_client_preference(preference)
 		if(cp)
-			return cp.default_value
+			return cp.get_default_value(client)
 		else
 			return null
 

--- a/code/modules/client/preference_setup/global/preferences.dm
+++ b/code/modules/client/preference_setup/global/preferences.dm
@@ -77,6 +77,12 @@ var/list/_client_preferences_by_type
 /datum/client_preference/proc/changed(mob/preference_mob, new_value)
 	return
 
+/datum/client_preference/proc/get_options(client/given_client)
+	return options
+
+/datum/client_preference/proc/get_default_value(client/given_client)
+	return default_value
+
 /*********************
 * Player Preferences *
 *********************/
@@ -245,6 +251,22 @@ var/list/_client_preferences_by_type
 	key = "SHOW_CREDITS"
 	options = list(GLOB.PREF_NO, GLOB.PREF_YES)
 	default_value = GLOB.PREF_NO
+
+/datum/client_preference/ooc_name_color
+	description = "OOC Name Color"
+	key = "OOC_NAME_COLOR"
+
+/datum/client_preference/staff/may_set(client/given_client)
+	ASSERT(given_client)
+	return given_client.donator_info && given_client.donator_info.patron_type != PATREON_NONE
+
+/datum/client_preference/ooc_name_color/get_options(client/given_client)
+	ASSERT(given_client)
+	return given_client.donator_info.get_available_ooc_patreon_tiers()
+
+/datum/client_preference/ooc_name_color/get_default_value(client/given_client)
+	ASSERT(given_client)
+	return given_client.donator_info.patron_type
 
 /********************
 * General Staff Preferences *

--- a/code/modules/donations/new/donations.dm
+++ b/code/modules/donations/new/donations.dm
@@ -106,6 +106,8 @@ SUBSYSTEM_DEF(donations)
 		player.donator_info.donator = TRUE
 		player.donator_info.points = query.item[1]
 		player.donator_info.patron_type = query.item[2]
+
+	player.donator_info.on_loaded(player)
 	
 	return TRUE
 

--- a/code/modules/donations/new/donator.dm
+++ b/code/modules/donations/new/donator.dm
@@ -1,5 +1,28 @@
-
 /datum/donator_info
 	var/donator = FALSE
-	var/patron_type
+	var/patron_type = PATREON_NONE
 	var/points
+
+/datum/donator_info/proc/on_loaded(client/C)
+	if(patron_type != PATREON_NONE)
+		C.set_preference(/datum/client_preference/ooc_name_color, patron_type)
+
+/datum/donator_info/proc/get_decorated_ooc_name(client/C)
+	var/choosen_ooc_patreon_tier = C.get_preference_value(/datum/client_preference/ooc_name_color)
+	switch(choosen_ooc_patreon_tier)
+		if(PATREON_CARGO)     return "<span class=\"pt_cargo\">[C.key]</span>"
+		if(PATREON_ENGINEER)  return "<span class=\"pt_engineer\">[C.key]</span>"
+		if(PATREON_SCIENTIST) return "<span class=\"pt_scientist\">[C.key]</span>"
+		if(PATREON_HOS)       return "<span class=\"pt_hos\">[C.key]</span>"
+		if(PATREON_CAPTAIN)   return "<span class=\"pt_captain\">[C.key]</span>"
+		if(PATREON_WIZARD)    return "<span class=\"pt_wizard\">[C.key]</span>"
+		if(PATREON_CULTIST)   return "<span class=\"pt_cultist\">[C.key]</span>"
+		if(PATREON_ASSISTANT) return "<span class=\"pt_assistant\">[C.key]</span>"
+	return C.key
+
+/datum/donator_info/proc/get_available_ooc_patreon_tiers()
+    . = list()
+    for(var/type in PATREON_ALL_TIERS)
+        . += type
+        if(type == patron_type)
+            break

--- a/code/modules/onyxchat/browserassets/css/browserOutput.css
+++ b/code/modules/onyxchat/browserassets/css/browserOutput.css
@@ -262,6 +262,16 @@ em						{font-style: normal;	font-weight: bold;}
 .ooc .admin				{color: #b82e00;}
 .ooc .aooc				{color: #960018;}
 
+/* OOC Patreon Tiers */
+.ooc .pt_cargo			{color: #5c72bc;}
+.ooc .pt_engineer		{color: #009cb7;}
+.ooc .pt_scientist		{color: #b54a9d;}
+.ooc .pt_hos			{color: #e51919;}
+.ooc .pt_captain		{color: #e5b232;}
+.ooc .pt_wizard			{color: #ed0776;}
+.ooc .pt_cultist		{color: #ea4f07;}
+.ooc .pt_assistant		{color: #74767a;}
+
 /* Admin: Private Messages */
 .pm  .howto				{color: #ff0000;	font-weight: bold;		font-size: 200%;}
 .pm  .in				{color: #ff0000;}

--- a/code/modules/onyxchat/browserassets/css/browserOutput_marines.css
+++ b/code/modules/onyxchat/browserassets/css/browserOutput_marines.css
@@ -236,6 +236,16 @@ em						{font-style: normal;	font-weight: bold;}
 .ooc .admin				{color: #b82e00;}
 .ooc .aooc				{color: #960018;}
 
+/* OOC Patreon Tiers */
+.ooc .pt_cargo			{color: #5c72bc;}
+.ooc .pt_engineer		{color: #009cb7;}
+.ooc .pt_scientist		{color: #b54a9d;}
+.ooc .pt_hos			{color: #e51919;}
+.ooc .pt_captain		{color: #e5b232;}
+.ooc .pt_wizard			{color: #ed0776;}
+.ooc .pt_cultist		{color: #ea4f07;}
+.ooc .pt_assistant		{color: #74767a;}
+
 /* Admin: Private Messages */
 .pm  .howto				{color: #ff0000;	font-weight: bold;		font-size: 200%;}
 .pm  .in				{color: #ff0000;}

--- a/code/modules/onyxchat/browserassets/css/browserOutput_white.css
+++ b/code/modules/onyxchat/browserassets/css/browserOutput_white.css
@@ -258,6 +258,16 @@ em						{font-style: normal;font-weight: bold;}
 .ooc .admin				{color: #b82e00;}
 .ooc .aooc				{color: #960018;}
 
+/* OOC Patreon Tiers */
+.ooc .pt_cargo			{color: #5c72bc;}
+.ooc .pt_engineer		{color: #009cb7;}
+.ooc .pt_scientist		{color: #b54a9d;}
+.ooc .pt_hos			{color: #e51919;}
+.ooc .pt_captain		{color: #e5b232;}
+.ooc .pt_wizard			{color: #ed0776;}
+.ooc .pt_cultist		{color: #ea4f07;}
+.ooc .pt_assistant		{color: #74767a;}
+
 /* Admin: Private Messages */
 .pm  .howto				{color: #ff0000;font-weight: bold;font-size: 200%;}
 .pm  .in				{color: #ff0000;}

--- a/code/modules/onyxchat/browserassets/css/styles_template.css
+++ b/code/modules/onyxchat/browserassets/css/styles_template.css
@@ -261,6 +261,16 @@ em						{font-style: normal;	font-weight: bold;}
 .ooc .admin				{color: #b82e00;}
 .ooc .aooc				{color: #960018;}
 
+/* OOC Patreon Tiers */
+.ooc .pt_cargo			{color: #5c72bc;}
+.ooc .pt_engineer		{color: #009cb7;}
+.ooc .pt_scientist		{color: #b54a9d;}
+.ooc .pt_hos			{color: #e51919;}
+.ooc .pt_captain		{color: #e5b232;}
+.ooc .pt_wizard			{color: #ed0776;}
+.ooc .pt_cultist		{color: #ea4f07;}
+.ooc .pt_assistant		{color: #74767a;}
+
 /* Admin: Private Messages */
 .pm  .howto				{color: #ff0000;	font-weight: bold;		font-size: 200%;}
 .pm  .in				{color: #ff0000;}

--- a/code/stylesheet.dm
+++ b/code/stylesheet.dm
@@ -27,6 +27,16 @@ em						{font-style: normal;font-weight: bold;}
 .ooc .admin				{color: #b82e00;}
 .ooc .aooc				{color: #960018;}
 
+/* OOC Patreon Tiers */
+.ooc .pt_cargo			{color: #5c72bc;}
+.ooc .pt_engineer		{color: #009cb7;}
+.ooc .pt_scientist		{color: #b54a9d;}
+.ooc .pt_hos			{color: #e51919;}
+.ooc .pt_captain		{color: #e5b232;}
+.ooc .pt_wizard			{color: #ed0776;}
+.ooc .pt_cultist		{color: #ea4f07;}
+.ooc .pt_assistant		{color: #74767a;}
+
 /* Admin: Private Messages */
 .pm  .howto				{color: #ff0000;	font-weight: bold;		font-size: 200%;}
 .pm  .in				{color: #ff0000;}


### PR DESCRIPTION
Добавил патронам уникальные цвета для никнейма в OOC. Выглядит это так:

![image](https://user-images.githubusercontent.com/5204667/75224115-f0933680-57b8-11ea-919b-10d5b1ec2e5d.png)

Патроны могут выбрать цвет любого тира более низкого уровня или вовсе отключить эту фичу в префенсах.

На сервере пока не заработает с реальными патронами, потому что бот не заполняет эту инфу в базе. Но это я тоже скоро сделаю.

close #1007