### PR TITLE
Усиливаем последствия от взрыва суперматерии.

### DIFF
--- a/code/game/objects/structures/crates_lockers/closets.dm
+++ b/code/game/objects/structures/crates_lockers/closets.dm
@@ -263,6 +263,8 @@
 	for(var/obj/machinery/M in loc)
 		if(M.anchored)
 			continue
+		if(istype(M, /obj/machinery/power/supermatter))
+			continue
 		var/structure_size = content_size(M)
 		if(CLOSET_CHECK_TOO_BIG(structure_size))
 			break

--- a/code/modules/modular_computers/computers/modular_computer/damage.dm
+++ b/code/modules/modular_computers/computers/modular_computer/damage.dm
@@ -36,7 +36,13 @@
 // Stronger explosions cause serious damage to internal components
 // Minor explosions are mostly mitigitated by casing.
 /obj/item/modular_computer/ex_act(severity)
-	take_damage(rand(100,200) / severity, 30 / severity)
+	switch(severity)
+		if(1)
+			break_apart()
+		if(2)
+			take_damage(rand(100,200), 30)
+		if(3)
+			take_damage(rand(50, 100), 15)
 
 // EMPs are similar to explosions, but don't cause physical damage to the casing. Instead they screw up the components
 /obj/item/modular_computer/emp_act(severity)

--- a/code/modules/power/smes.dm
+++ b/code/modules/power/smes.dm
@@ -477,9 +477,13 @@
 		take_damage(Proj.damage)
 
 /obj/machinery/power/smes/ex_act(severity)
-	// Two strong explosions will destroy a SMES.
-	// Given the SMES creates another explosion on it's destruction it sounds fairly reasonable.
-	take_damage(250 / severity)
+	switch(severity)
+		if(1)
+			qdel(src)
+		if(2)
+			take_damage(rand(100, 250))
+		if(3)
+			take_damage(rand(50, 100))
 
 /obj/machinery/power/smes/examine(mob/user)
 	. = ..()

--- a/code/modules/supermatter/supermatter.dm
+++ b/code/modules/supermatter/supermatter.dm
@@ -71,7 +71,7 @@
 	var/grav_pulling = 0
 	// Time in ticks between delamination ('exploding') and exploding (as in the actual boom)
 	var/pull_time = 300
-	var/explosion_power = 9
+	var/explosion_power = 27
 
 	var/emergency_issued = 0
 
@@ -104,8 +104,8 @@
 	var/aw_delam = FALSE
 	var/aw_EPR = FALSE
 
-/obj/machinery/power/supermatter/New()
-	..()
+/obj/machinery/power/supermatter/Initialize()
+	. = ..()
 	uid = gl_uid++
 
 /obj/machinery/power/supermatter/proc/handle_admin_warnings()
@@ -207,6 +207,14 @@
 
 		mob.Weaken(DETONATION_MOB_CONCUSSION)
 		to_chat(mob, "<span class='danger'>An invisible force slams you against the ground!</span>")
+		
+		if(iscarbon(mob))
+			var/mob/living/carbon/C = mob
+			var/area/A = get_area(TM)
+			if(A && !(A.area_flags & AREA_FLAG_RAD_SHIELDED))
+				var/dist = 200 - get_dist(src, C)
+				if(dist >= 1)
+					C.hallucination(round(dist * 1.5), dist)
 
 	// Effect 2: Z-level wide electrical pulse
 	for(var/obj/machinery/power/apc/A in SSmachines.machinery)
@@ -229,7 +237,8 @@
 		// Causes SMESes to shut down for a bit
 		var/random_change = rand(100 - DETONATION_SHUTDOWN_RNG_FACTOR, 100 + DETONATION_SHUTDOWN_RNG_FACTOR) / 100
 		S.energy_fail(round(DETONATION_SHUTDOWN_SMES * random_change))
-
+		if(prob(100 - get_dist(src, S) * 0.5))
+			S.grounding = 0
 	// Effect 3: Break solar arrays
 
 	for(var/obj/machinery/power/solar/S in SSmachines.machinery)
@@ -238,12 +247,9 @@
 		if(prob(DETONATION_SOLAR_BREAK_CHANCE))
 			S.set_broken(TRUE)
 
-
-
 	// Effect 4: Medium scale explosion
-	spawn(0)
-		explosion(TS, explosion_power/2, explosion_power, explosion_power * 2, explosion_power * 4, 1)
-		qdel(src)
+	explosion(TS, explosion_power/2, explosion_power, explosion_power * 2, explosion_power * 4, 1)
+	qdel(src)
 
 //Changes color and luminosity of the light to these values if they were not already set
 /obj/machinery/power/supermatter/proc/shift_light(lum, clr)
@@ -402,17 +408,17 @@
 		damage += proj_damage * config_bullet_energy
 	return 0
 
-/obj/machinery/power/supermatter/attack_robot(mob/user as mob)
+/obj/machinery/power/supermatter/attack_robot(mob/user)
 	if(Adjacent(user))
 		return attack_hand(user)
 	else
 		ui_interact(user)
 	return
 
-/obj/machinery/power/supermatter/attack_ai(mob/user as mob)
+/obj/machinery/power/supermatter/attack_ai(mob/user)
 	ui_interact(user)
 
-/obj/machinery/power/supermatter/attack_hand(mob/user as mob)
+/obj/machinery/power/supermatter/attack_hand(mob/user)
 	user.visible_message("<span class=\"warning\">\The [user] reaches out and touches \the [src], inducing a resonance... \his body starts to glow and bursts into flames before flashing into ash.</span>",\
 		"<span class=\"danger\">You reach out and touch \the [src]. Everything starts burning and all you can hear is ringing. Your last thought is \"That was not a wise decision.\"</span>",\
 		"<span class=\"warning\">You hear an uneartly ringing, then what sounds like a shrilling kettle as you are washed with a wave of heat.</span>")
@@ -447,7 +453,7 @@
 		ui.set_auto_update(1)
 
 
-/obj/machinery/power/supermatter/attackby(obj/item/weapon/W as obj, mob/living/user as mob)
+/obj/machinery/power/supermatter/attackby(obj/item/weapon/W, mob/living/user)
 	if(istype(W, /obj/item/weapon/tape_roll))
 		to_chat(user, "You repair some of the damage to \the [src] with \the [W].")
 		damage = max(damage -10, 0)
@@ -461,11 +467,10 @@
 
 	user.apply_effect(150, IRRADIATE, blocked = user.getarmor(null, "rad"))
 
-
-/obj/machinery/power/supermatter/Bumped(atom/AM as mob|obj)
+/obj/machinery/power/supermatter/Bumped(atom/AM)
 	if(istype(AM, /obj/effect))
 		return
-	if(istype(AM, /mob/living))
+	if(isliving(AM))
 		AM.visible_message("<span class=\"warning\">\The [AM] slams into \the [src] inducing a resonance... \his body starts to glow and catch flame before flashing into ash.</span>",\
 		"<span class=\"danger\">You slam into \the [src] as your ears are filled with unearthly ringing. Your last thought is \"Oh, fuck.\"</span>",\
 		"<span class=\"warning\">You hear an uneartly ringing, then what sounds like a shrilling kettle as you are washed with a wave of heat.</span>")
@@ -474,7 +479,6 @@
 		"<span class=\"warning\">You hear a loud crack as you are washed with a wave of heat.</span>")
 
 	Consume(AM)
-
 
 /obj/machinery/power/supermatter/proc/Consume(mob/living/user)
 	if(istype(user))
@@ -497,8 +501,22 @@
 
 
 /proc/supermatter_pull(atom/target, pull_range = 255, pull_power = STAGE_FIVE)
-	for(var/atom/A in range(pull_range, target))
-		A.singularity_pull(target, pull_power)
+	var/list/movable_atoms = list()
+	for(var/atom/movable/AM in range(pull_range, target))
+		movable_atoms += AM
+
+	var/turf/below = GetBelow(target)
+	if(below)
+		for(var/atom/movable/AM in range(round(pull_range * 0.75), below))
+			movable_atoms += AM
+
+	var/turf/above = GetAbove(target)
+	if(above)
+		for(var/atom/movable/AM in range(round(pull_range * 0.75), above))
+			movable_atoms += AM
+
+	for(var/atom/movable/AM in movable_atoms)
+		AM.singularity_pull(target, pull_power)
 
 /obj/machinery/power/supermatter/GotoAirflowDest(n) //Supermatter not pushed around by airflow
 	return


### PR DESCRIPTION
СМ является важным объектом на Исходе, её проёб должен караться намного сильнее, чем сейчас.

- СМ теперь притягивает объекты с нижних/верхних уровней.
- Взрыв от СМ теперь полностью зависит от значения EER. Чем он больше - тем сильнее взрыв. При экстремально мощном заряде выдается дополнительное сообщение по общей частоте, с предупреждением о том, что ожидается очень мощный взрыв.
- Взрыв от СМ может вызвать замыкание у СМЕСов неподалеку.
- Взрыв от СМ может вызвать галлюцинации у людей, находящиеся в зоне без радиационной защиты. Чем ближе к эпицентру - тем сильнее галлюцинации.
- СМ больше нельзя спрятать в шкафчике.

Также поправил реагирование некоторых объектов на взрывы, чтобы после него не было такого, что ты приходишь к месту происшествия, а там космос и... невредимая модульная консоль. Хотя это всё ещё неидеально, и нужно много чего трогать, что лично мне пока что лень.

Скриншот от последствий усиленного взрыва СМ:
<details>

![image](https://user-images.githubusercontent.com/59123747/75235004-a9af3c00-57cc-11ea-9f17-1c7e55b02f88.png)

</details>

Если будут неплохие идеи как дополнить этот ПР - пишите. 