### PR TITLE
Фикс рантайма у SScharacter setup

### DIFF
--- a/code/modules/client/preferences_savefile.dm
+++ b/code/modules/client/preferences_savefile.dm
@@ -25,7 +25,7 @@
 	S.cd = "/"
 
 	S["version"] << SAVEFILE_VERSION_MAX
-	SScharacter_setup.queue_preferences_save(S)
+	player_setup.save_character(S)
 	loaded_preferences = S
 	return 1
 


### PR DESCRIPTION
`Runtime in character_setup.dm, line 32: undefined proc or verb /savefile/save preferences()`