### PR TITLE
Игроки с живым мобом могут обходить лёгкий лимит. 

### DIFF
--- a/code/controllers/configuration.dm
+++ b/code/controllers/configuration.dm
@@ -177,6 +177,7 @@ var/list/gamemode_cache = list()
 
 	var/enter_allowed = 1
 	var/player_limit = 0
+	var/hard_player_limit = 0
 
 	var/use_irc_bot = 0
 	var/irc_bot_host = ""
@@ -820,6 +821,8 @@ var/list/gamemode_cache = list()
 					radiation_lower_limit = text2num(value)
 				if("player_limit")
 					player_limit = text2num(value)
+				if("hard_player_limit")
+					hard_player_limit = text2num(value)
 
 				if("server_port")
 					server_port = text2num(value)

--- a/code/modules/client/client_procs.dm
+++ b/code/modules/client/client_procs.dm
@@ -175,18 +175,17 @@
 		qdel(src)
 		return
 
-	if(config.player_limit != 0)
-		if((GLOB.clients.len >= config.player_limit) && !(ckey in admin_datums))
-			if(config.panic_address && TopicData != "redirect")
-				alert(src,"This server is currently full and not accepting new connections. Sending you to [config.panic_server_name ? config.panic_server_name : config.panic_address].","Server Full","OK")
-				winset(src, null, "command=.options")
-				src << link("[config.panic_address]?redirect")
-			else
-				alert(src,"This server is currently full and not accepting new connections.","Server Full","OK")
+	if(config.player_limit && is_player_rejected_by_player_limit(usr, ckey))
+		if(config.panic_address && TopicData != "redirect")
+			alert(src,"This server is currently full and not accepting new connections. Sending you to [config.panic_server_name ? config.panic_server_name : config.panic_address].","Server Full","OK")
+			winset(src, null, "command=.options")
+			src << link("[config.panic_address]?redirect")
+		else
+			alert(src, "This server is currently full and not accepting new connections.","Server Full","OK")
 
-			log_admin("[ckey] tried to join but the server is full (player_limit=[config.player_limit])")
-			qdel(src)
-			return
+		log_admin("[ckey] tried to join but the server is full (player_limit=[config.player_limit])")
+		qdel(src)
+		return
 
 	// Change the way they should download resources.
 	if(config.resource_urls && config.resource_urls.len)
@@ -343,6 +342,14 @@
 	else
 		return -1
 
+/proc/is_player_rejected_by_player_limit(mob/user, ckey)
+	if(ckey in admin_datums)
+		return FALSE
+	if(GLOB.clients.len >= config.player_limit)
+		if(config.hard_player_limit && GLOB.clients.len <= config.hard_player_limit && user && (user in GLOB.living_mob_list_))
+			return FALSE
+		return TRUE
+	return FALSE
 
 /client/proc/log_client_to_db()
 


### PR DESCRIPTION
**Перед принятием ПРа необходимо выставить опцию `hard_player_limit` в конфиге на нужный.**

Позволяет игрокам с живым мобом на сервере обходить лёгкий лимит, но и если при этом при всём не заполнен тяжелый лимит.
close #1445 