### PR TITLE
fix(preferences): runtime in 05_settings.dm,54: Cannot read null.client

### DIFF
--- a/code/modules/client/preference_setup/global/05_settings.dm
+++ b/code/modules/client/preference_setup/global/05_settings.dm
@@ -51,7 +51,7 @@
 		// if the preference has never been set, or if the player is no longer allowed to set the it, set it to default
 		preference_mob() // we don't care about the mob it returns, but it finds the correct client.
 		if(!client_pref.may_set(pref.client) || !(client_pref.key in pref.preference_values))
-			pref.preference_values[client_pref.key] = client_pref.get_default_value(preference_mob().client)
+			pref.preference_values[client_pref.key] = client_pref.get_default_value(pref.client)
 
 
 	// Clean out preferences that no longer exist.


### PR DESCRIPTION
Фиксим пачку рантаймов:

```
[17:50:37] Runtime in 05_settings.dm,54: Cannot read null.client<br />
  proc name: sanitize preferences (/datum/category_item/player_setup_item/player_global/settings/sanitize_preferences)<br />
  src: Settings (/datum/category_item/player_setup_item/player_global/settings)<br />
  call stack:<br />
  Settings (/datum/category_item/player_setup_item/player_global/settings): sanitize preferences()<br />
  Global (/datum/category_group/player_setup_category/global_preferences): sanitize setup()<br />
  /datum/category_collection/pla... (/datum/category_collection/player_setup_collection): sanitize setup()<br />
  /datum/preferences (/datum/preferences): sanitize preferences()<br />
  /datum/preferences (/datum/preferences): New(Florrie (/client))<br />
  Florrie (/client): New(null)<br />
  Florrie (/client): New()<br />
```