### PR TITLE
Proximity System

### DIFF
--- a/baystation12.dme
+++ b/baystation12.dme
@@ -739,6 +739,7 @@
 #include "code\game\objects\effects\misc.dm"
 #include "code\game\objects\effects\overlays.dm"
 #include "code\game\objects\effects\portals.dm"
+#include "code\game\objects\effects\proximity.dm"
 #include "code\game\objects\effects\spiders.dm"
 #include "code\game\objects\effects\step_triggers.dm"
 #include "code\game\objects\effects\temporary_effect.dm"

--- a/code/__defines/flags.dm
+++ b/code/__defines/flags.dm
@@ -18,8 +18,6 @@ GLOBAL_LIST_INIT(bitflags, list(1, 2, 4, 8, 16, 32, 64, 128, 256, 512, 1024, 204
 #define ATOM_FLAG_OPEN_CONTAINER         0x0010 // Is an open container for chemistry purposes.
 #define ATOM_FLAG_INITIALIZED            0x0020 // Has this atom been initialized
 
-#define MOVABLE_FLAG_PROXMOVE            0x0001 // Does this object require proximity checking in Enter()?
-
 #define OBJ_FLAG_ANCHORABLE              0x0001 // This object can be stuck in place with a tool
 #define OBJ_FLAG_CONDUCTIBLE             0x0002 // Conducts electricity. (metal etc.)
 

--- a/code/_helpers/game.dm
+++ b/code/_helpers/game.dm
@@ -1,5 +1,11 @@
 //This file was auto-corrected by findeclaration.exe on 25.5.2012 20:42:31
 
+#define RANGE_TURFS(RADIUS, CENTER) \
+  block( \
+    locate(max(CENTER.x-(RADIUS),1),          max(CENTER.y-(RADIUS),1),          CENTER.z), \
+    locate(min(CENTER.x+(RADIUS),world.maxx), min(CENTER.y+(RADIUS),world.maxy), CENTER.z) \
+  )
+
 /proc/dopage(src,target)
 	var/href_list
 	var/href

--- a/code/game/atoms.dm
+++ b/code/game/atoms.dm
@@ -11,6 +11,9 @@
 	var/simulated = 1 //filter for actions - used by lighting overlays
 	var/fluorescent // Shows up under a UV light.
 
+	///Proximity monitor associated with this atom
+	var/datum/proximity_monitor/proximity_monitor
+
 	///Chemistry.
 	var/datum/reagents/reagents = null
 
@@ -65,6 +68,7 @@
 
 /atom/Destroy()
 	QDEL_NULL(reagents)
+	QDEL_NULL(proximity_monitor)
 	. = ..()
 
 /atom/proc/reveal_blood()

--- a/code/game/atoms_movable.dm
+++ b/code/game/atoms_movable.dm
@@ -2,8 +2,6 @@
 	appearance_flags = TILE_BOUND
 	glide_size = 8
 
-	var/movable_flags
-
 	var/last_move = null
 	var/anchored = 0
 	// var/elevation = 2    - not used anywhere

--- a/code/game/machinery/camera/motion.dm
+++ b/code/game/machinery/camera/motion.dm
@@ -2,7 +2,10 @@
 	var/list/motionTargets = list()
 	var/detectTime = 0
 	var/alarm_delay = 100 // Don't forget, there's another 10 seconds in queueAlarm()
-	movable_flags = MOVABLE_FLAG_PROXMOVE
+
+/obj/machinery/camera/Initialize()
+	. = ..()
+	proximity_monitor = new(src, 2)
 
 /obj/machinery/camera/internal_process()
 	..()

--- a/code/game/machinery/flasher.dm
+++ b/code/game/machinery/flasher.dm
@@ -13,7 +13,6 @@
 	var/base_state = "mflash"
 	anchored = 1
 	idle_power_usage = 2
-	movable_flags = MOVABLE_FLAG_PROXMOVE
 	var/_wifi_id
 	var/datum/wifi/receiver/button/flasher/wifi_receiver
 
@@ -30,6 +29,7 @@
 	. = ..()
 	if(_wifi_id)
 		wifi_receiver = new(_wifi_id, src)
+	proximity_monitor = new(src, 0)
 
 /obj/machinery/flasher/Destroy()
 	qdel(wifi_receiver)
@@ -112,27 +112,29 @@
 		flash()
 	..(severity)
 
-/obj/machinery/flasher/portable/HasProximity(atom/movable/AM as mob|obj)
-	if ((src.disable) || (src.last_flash && world.time < src.last_flash + 150))
+/obj/machinery/flasher/portable/HasProximity(atom/movable/AM)
+	if (disable || (last_flash && world.time < last_flash + 150))
 		return
 
-	if(istype(AM, /mob/living/carbon))
+	if(iscarbon(AM))
 		var/mob/living/carbon/M = AM
-		if ((M.m_intent != "walk") && (src.anchored))
-			src.flash()
+		if ((M.m_intent != "walk") && (anchored))
+			flash()
 
-/obj/machinery/flasher/portable/attackby(obj/item/weapon/W as obj, mob/user as mob)
+/obj/machinery/flasher/portable/attackby(obj/item/weapon/W, mob/user)
 	if(isWrench(W))
 		add_fingerprint(user)
-		src.anchored = !src.anchored
+		anchored = !anchored
 
-		if (!src.anchored)
+		if (!anchored)
 			user.show_message(text("<span class='warning'>[src] can now be moved.</span>"))
-			src.overlays.Cut()
+			overlays.Cut()
+			proximity_monitor.SetRange(0)
 
 		else if (src.anchored)
 			user.show_message(text("<span class='warning'>[src] is now secured.</span>"))
-			src.overlays += "[base_state]-s"
+			overlays += "[base_state]-s"
+			proximity_monitor.SetRange(range)
 
 /obj/machinery/button/flasher
 	name = "flasher button"

--- a/code/game/objects/effects/proximity.dm
+++ b/code/game/objects/effects/proximity.dm
@@ -1,0 +1,123 @@
+/datum/proximity_monitor
+	var/atom/host	//the atom we are tracking
+	var/atom/hasprox_receiver //the atom that will receive HasProximity calls.
+	var/atom/last_host_loc
+	var/list/checkers //list of /obj/effect/abstract/proximity_checkers
+	var/current_range
+	var/ignore_if_not_on_turf	//don't check turfs in range if the host's loc isn't a turf
+	var/wire = FALSE
+
+/datum/proximity_monitor/New(atom/_host, range, _ignore_if_not_on_turf = TRUE)
+	checkers = list()
+	last_host_loc = _host.loc
+	ignore_if_not_on_turf = _ignore_if_not_on_turf
+	current_range = range
+	SetHost(_host)
+
+/datum/proximity_monitor/proc/SetHost(atom/H, atom/R)
+	if(H == host)
+		return
+	if(host)
+		GLOB.moved_event.unregister(host, src, .proc/HandleMove)
+	if(R)
+		hasprox_receiver = R
+	else if(hasprox_receiver == host) //Default case
+		hasprox_receiver = H
+	host = H
+	GLOB.moved_event.register(host, src, .proc/HandleMove)
+	last_host_loc = host.loc
+	SetRange(current_range,TRUE)
+
+/datum/proximity_monitor/Destroy()
+	host = null
+	last_host_loc = null
+	hasprox_receiver = null
+	QDEL_NULL_LIST(checkers)
+	return ..()
+
+/datum/proximity_monitor/proc/HandleMove()
+	var/atom/_host = host
+	var/atom/new_host_loc = ignore_if_not_on_turf ? _host.loc : get_turf(_host)
+	if(last_host_loc != new_host_loc)
+		last_host_loc = new_host_loc	//hopefully this won't cause GC issues with containers
+		var/curr_range = current_range
+		SetRange(curr_range, TRUE)
+		if(curr_range)
+			hasprox_receiver.HasProximity(host)	//if we are processing, we're guaranteed to be a movable
+
+/datum/proximity_monitor/proc/SetRange(range, force_rebuild = FALSE)
+	if(!force_rebuild && range == current_range)
+		return FALSE
+	. = TRUE
+
+	current_range = range
+
+	var/list/checkers_local = checkers
+	var/old_checkers_len = checkers_local.len
+
+	var/atom/_host = host
+
+	var/atom/loc_to_use = ignore_if_not_on_turf ? _host.loc : get_turf(_host)
+	if(wire && !isturf(loc_to_use)) //it makes assemblies attached on wires work
+		loc_to_use = get_turf(loc_to_use)
+	if(!isturf(loc_to_use))	//only check the host's loc
+		if(range)
+			var/obj/effect/abstract/proximity_checker/pc
+			if(old_checkers_len)
+				pc = checkers_local[old_checkers_len]
+				--checkers_local.len
+				QDEL_NULL_LIST(checkers_local)
+			else
+				pc = new(loc_to_use, src)
+
+			checkers_local += pc	//only check the host's loc
+		return
+
+	var/list/turfs = RANGE_TURFS(range, loc_to_use)
+	var/turfs_len = turfs.len
+	var/old_checkers_used = min(turfs_len, old_checkers_len)
+
+	//reuse what we can
+	for(var/I in 1 to old_checkers_len)
+		if(I <= old_checkers_used)
+			var/obj/effect/abstract/proximity_checker/pc = checkers_local[I]
+			if(pc)
+				pc.loc = turfs[I]
+			else
+				checkers += new /obj/effect/abstract/proximity_checker(turfs[I], src)
+		else
+			qdel(checkers_local[I])	//delete the leftovers
+
+	if(old_checkers_len < turfs_len)
+		//create what we lack
+		for(var/I in (old_checkers_used + 1) to turfs_len)
+			checkers_local += new /obj/effect/abstract/proximity_checker(turfs[I], src)
+	else
+		checkers_local.Cut(old_checkers_used + 1, old_checkers_len)
+
+	// for some reasons proximity_monitor removes himself from GLOB.moved_event.event_sources
+	// so we want to re-check
+	if(!(host in GLOB.moved_event.event_sources))	
+		GLOB.moved_event.register(host, src, .proc/HandleMove)
+
+/obj/effect/abstract/proximity_checker
+	invisibility = INVISIBILITY_SYSTEM
+	anchored = TRUE
+	var/datum/proximity_monitor/monitor
+
+/obj/effect/abstract/proximity_checker/Initialize(mapload, datum/proximity_monitor/_monitor)
+	. = ..()
+	if(_monitor)
+		monitor = _monitor
+	else
+		crash_with("proximity_checker created without host")
+		return INITIALIZE_HINT_QDEL
+
+/obj/effect/abstract/proximity_checker/Destroy()
+	monitor = null
+	return ..()
+
+/obj/effect/abstract/proximity_checker/Crossed(atom/movable/AM)
+	set waitfor = FALSE
+	if(monitor)
+		monitor.hasprox_receiver.HasProximity(AM)

--- a/code/game/objects/items/devices/transfer_valve.dm
+++ b/code/game/objects/items/devices/transfer_valve.dm
@@ -11,7 +11,6 @@
 	var/mob/attacher = null
 	var/valve_open = 0
 	var/toggle = 1
-	movable_flags = MOVABLE_FLAG_PROXMOVE
 
 /obj/item/device/transfer_valve/proc/process_activation(obj/item/device/D)
 
@@ -61,6 +60,8 @@
 		if(attached_device)
 			to_chat(user, "<span class='warning'>There is already an device attached to the valve, remove it first.</span>")
 			return
+		if(A.proximity_monitor)
+			A.proximity_monitor.SetHost(src, A)
 		user.remove_from_mob(item)
 		attached_device = A
 		A.forceMove(src)
@@ -74,13 +75,6 @@
 		attacher = user
 		SSnano.update_uis(src) // update all UIs attached to src
 	return
-
-
-/obj/item/device/transfer_valve/HasProximity(atom/movable/AM as mob|obj)
-	if(!attached_device)	return
-	attached_device.HasProximity(AM)
-	return
-
 
 /obj/item/device/transfer_valve/attack_self(mob/user as mob)
 	ui_interact(user)
@@ -121,8 +115,12 @@
 		toggle_valve()
 	else if(attached_device)
 		if(href_list["rem_device"])
+			if(attached_device.proximity_monitor)
+				attached_device.proximity_monitor.SetHost(attached_device, attached_device)
+			if(istype(attached_device, /obj/item/device/assembly))
+				var/obj/item/device/assembly/A = attached_device
+				A.holder = null
 			attached_device.loc = get_turf(src)
-			attached_device:holder = null
 			attached_device = null
 			update_icon()
 		if(href_list["device"])

--- a/code/game/turfs/turf.dm
+++ b/code/game/turfs/turf.dm
@@ -156,18 +156,6 @@ var/const/enterloopsanity = 100
 			M.inertia_dir = 0
 			M.make_floating(0) //we know we're not on solid ground so skip the checks to save a bit of processing
 
-	var/objects = 0
-	if(A && (A.movable_flags & MOVABLE_FLAG_PROXMOVE))
-		for(var/atom/movable/thing in range(1))
-			if(objects > enterloopsanity) break
-			objects++
-			spawn(0)
-				if(A)
-					A.HasProximity(thing, 1)
-					if ((thing && A) && (thing.movable_flags & MOVABLE_FLAG_PROXMOVE))
-						thing.HasProximity(A, 1)
-	return
-
 /turf/proc/adjacent_fire_act(turf/simulated/floor/source, temperature, volume)
 	return
 

--- a/code/modules/assembly/holder.dm
+++ b/code/modules/assembly/holder.dm
@@ -3,7 +3,6 @@
 	icon = 'icons/obj/assemblies/new_assemblies.dmi'
 	icon_state = "holder"
 	item_state = "assembly"
-	movable_flags = MOVABLE_FLAG_PROXMOVE
 	obj_flags = OBJ_FLAG_CONDUCTIBLE
 	throwforce = 5
 	w_class = ITEM_SIZE_SMALL
@@ -15,201 +14,186 @@
 	var/obj/item/device/assembly/a_right = null
 	var/obj/special_assembly = null
 
-	proc/attach(var/obj/item/device/D, var/obj/item/device/D2, var/mob/user)
-		return
+/obj/item/device/assembly_holder/proc/attach(obj/item/device/D, obj/item/device/D2, mob/user)
+	return
 
-	proc/attach_special(var/obj/O, var/mob/user)
-		return
+/obj/item/device/assembly_holder/proc/attach_special(obj/O, var/mob/user)
+	return
 
-	proc/process_activation(var/obj/item/device/D)
-		return
+/obj/item/device/assembly_holder/proc/process_activation(obj/item/device/D)
+	return
 
-	proc/detached()
-		return
-
-
-	IsAssemblyHolder()
-		return 1
+/obj/item/device/assembly_holder/proc/detached()
+	return
 
 
-	attach(var/obj/item/device/D, var/obj/item/device/D2, var/mob/user)
-		if((!D)||(!D2))	return 0
-		if((!isassembly(D))||(!isassembly(D2)))	return 0
-		if((D:secured)||(D2:secured))	return 0
-		if(user)
-			user.remove_from_mob(D)
-			user.remove_from_mob(D2)
-		D:holder = src
-		D2:holder = src
-		D.loc = src
-		D2.loc = src
-		a_left = D
-		a_right = D2
-		SetName("[D.name]-[D2.name] assembly")
-		update_icon()
-		usr.put_in_hands(src)
+/obj/item/device/assembly_holder/IsAssemblyHolder()
+	return 1
 
-		return 1
-
-
-	attach_special(var/obj/O, var/mob/user)
-		if(!O)	return
-		if(!O.IsSpecialAssembly())	return 0
-
-/*		if(O:Attach_Holder())
-			special_assembly = O
-			update_icon()
-			src.SetName("[a_left.name] [a_right.name] [special_assembly.name] assembly")
-*/
-		return
-
-
+/obj/item/device/assembly_holder/attach(obj/item/device/assembly/D, obj/item/device/assembly/D2, mob/user)
+	if(!istype(D) || !istype(D2))
+		return FALSE
+	if(D.secured || D2.secured)
+		return FALSE
+	if(user)
+		user.remove_from_mob(D)
+		user.remove_from_mob(D2)
+	D.holder = src
+	D2.holder = src
+	D.loc = src
+	D2.loc = src
+	if(D.proximity_monitor)
+		D.proximity_monitor.SetHost(src, D)
+	if(D2.proximity_monitor)
+		D2.proximity_monitor.SetHost(src, D2)
+	a_left = D
+	a_right = D2
+	SetName("[D.name]-[D2.name] assembly")
 	update_icon()
-		overlays.Cut()
-		if(a_left)
-			overlays += "[a_left.icon_state]_left"
-			for(var/O in a_left.attached_overlays)
-				overlays += "[O]_l"
-		if(a_right)
-			src.overlays += "[a_right.icon_state]_right"
-			for(var/O in a_right.attached_overlays)
-				overlays += "[O]_r"
-		if(master)
-			master.update_icon()
+	user.put_in_hands(src)
+	return 1
 
-/*		if(special_assembly)
-			special_assembly.update_icon()
-			if(special_assembly:small_icon_state)
-				src.overlays += special_assembly:small_icon_state
-				for(var/O in special_assembly:small_icon_state_overlays)
-					src.overlays += O
-*/
-
-	examine(mob/user)
-		. = ..(user)
-		if ((in_range(src, user) || src.loc == user))
-			if (src.secured)
-				to_chat(user, "\The [src] is ready!")
-			else
-				to_chat(user, "\The [src] can be attached!")
-		return
+/obj/item/device/assembly_holder/attach_special(obj/O, mob/user)
+	if(!O)	return
+	if(!O.IsSpecialAssembly())	return 0
+	return
 
 
-	HasProximity(atom/movable/AM as mob|obj)
-		if(a_left)
-			a_left.HasProximity(AM)
-		if(a_right)
-			a_right.HasProximity(AM)
-		if(special_assembly)
-			special_assembly.HasProximity(AM)
+/obj/item/device/assembly_holder/update_icon()
+	overlays.Cut()
+	if(a_left)
+		overlays += "[a_left.icon_state]_left"
+		for(var/O in a_left.attached_overlays)
+			overlays += "[O]_l"
+	if(a_right)
+		src.overlays += "[a_right.icon_state]_right"
+		for(var/O in a_right.attached_overlays)
+			overlays += "[O]_r"
+	if(master)
+		master.update_icon()
+
+/obj/item/device/assembly_holder/examine(mob/user)
+	. = ..(user)
+	if ((in_range(src, user) || src.loc == user))
+		if (src.secured)
+			to_chat(user, "\The [src] is ready!")
+		else
+			to_chat(user, "\The [src] can be attached!")
+	return
 
 
-	Crossed(atom/movable/AM as mob|obj)
-		if(a_left)
-			a_left.Crossed(AM)
-		if(a_right)
-			a_right.Crossed(AM)
-		if(special_assembly)
-			special_assembly.Crossed(AM)
+/obj/item/device/assembly_holder/HasProximity(atom/movable/AM)
+	if(a_left)
+		a_left.HasProximity(AM)
+	if(a_right)
+		a_right.HasProximity(AM)
+	if(special_assembly)
+		special_assembly.HasProximity(AM)
 
 
-	on_found(mob/finder as mob)
-		if(a_left)
-			a_left.on_found(finder)
-		if(a_right)
-			a_right.on_found(finder)
-		if(special_assembly)
-			if(istype(special_assembly, /obj/item))
-				var/obj/item/S = special_assembly
-				S.on_found(finder)
+/obj/item/device/assembly_holder/Crossed(atom/movable/AM as mob|obj)
+	if(a_left)
+		a_left.Crossed(AM)
+	if(a_right)
+		a_right.Crossed(AM)
+	if(special_assembly)
+		special_assembly.Crossed(AM)
 
 
-	Move()
-		..()
-		if(a_left && a_right)
-			a_left.holder_movement()
-			a_right.holder_movement()
-//		if(special_assembly)
-//			special_assembly:holder_movement()
-		return
+/obj/item/device/assembly_holder/on_found(mob/finder as mob)
+	if(a_left)
+		a_left.on_found(finder)
+	if(a_right)
+		a_right.on_found(finder)
+	if(special_assembly)
+		if(istype(special_assembly, /obj/item))
+			var/obj/item/S = special_assembly
+			S.on_found(finder)
 
 
-	attack_hand()//Perhapse this should be a holder_pickup proc instead, can add if needbe I guess
-		if(a_left && a_right)
-			a_left.holder_movement()
-			a_right.holder_movement()
-//		if(special_assembly)
-//			special_assembly:Holder_Movement()
-		..()
-		return
+/obj/item/device/assembly_holder/Move()
+	..()
+	if(a_left && a_right)
+		a_left.holder_movement()
+		a_right.holder_movement()
+	return
 
 
-	attackby(obj/item/weapon/W as obj, mob/user as mob)
-		if(isScrewdriver(W))
-			if(!a_left || !a_right)
-				to_chat(user, "<span class='warning'>BUG:Assembly part missing, please report this!</span>")
-				return
-			a_left.toggle_secure()
-			a_right.toggle_secure()
-			secured = !secured
-			if(secured)
-				to_chat(user, "<span class='notice'>\The [src] is ready!</span>")
-			else
-				to_chat(user, "<span class='notice'>\The [src] can now be taken apart!</span>")
-			update_icon()
+/obj/item/device/assembly_holder/attack_hand()//Perhapse this should be a holder_pickup proc instead, can add if needbe I guess
+	if(a_left && a_right)
+		a_left.holder_movement()
+		a_right.holder_movement()
+	..()
+	return
+
+
+/obj/item/device/assembly_holder/attackby(obj/item/weapon/W, mob/user)
+	if(isScrewdriver(W))
+		if(!a_left || !a_right)
+			to_chat(user, "<span class='warning'>BUG:Assembly part missing, please report this!</span>")
 			return
-		else if(W.IsSpecialAssembly())
-			attach_special(W, user)
+		a_left.toggle_secure()
+		a_right.toggle_secure()
+		secured = !secured
+		if(secured)
+			to_chat(user, "<span class='notice'>\The [src] is ready!</span>")
 		else
-			..()
+			to_chat(user, "<span class='notice'>\The [src] can now be taken apart!</span>")
+		update_icon()
 		return
+	else if(W.IsSpecialAssembly())
+		attach_special(W, user)
+	else
+		..()
+	return
 
 
-	attack_self(mob/user as mob)
-		src.add_fingerprint(user)
-		if(src.secured)
-			if(!a_left || !a_right)
-				to_chat(user, "<span class='warning'>Assembly part missing!</span>")
-				return
-			if(istype(a_left,a_right.type))//If they are the same type it causes issues due to window code
-				switch(alert("Which side would you like to use?",,"Left","Right"))
-					if("Left")	a_left.attack_self(user)
-					if("Right")	a_right.attack_self(user)
-				return
-			else
-				if(!istype(a_left,/obj/item/device/assembly/igniter))
-					a_left.attack_self(user)
-				if(!istype(a_right,/obj/item/device/assembly/igniter))
-					a_right.attack_self(user)
+/obj/item/device/assembly_holder/attack_self(mob/user as mob)
+	src.add_fingerprint(user)
+	if(src.secured)
+		if(!a_left || !a_right)
+			to_chat(user, "<span class='warning'>Assembly part missing!</span>")
+			return
+		if(istype(a_left,a_right.type))//If they are the same type it causes issues due to window code
+			switch(alert("Which side would you like to use?",,"Left","Right"))
+				if("Left")	a_left.attack_self(user)
+				if("Right")	a_right.attack_self(user)
+			return
 		else
-			var/turf/T = get_turf(src)
-			if(!T)	return 0
-			if(a_left)
-				a_left:holder = null
-				a_left.loc = T
-			if(a_right)
-				a_right:holder = null
-				a_right.loc = T
-			spawn(0)
-				qdel(src)
-		return
+			if(!istype(a_left,/obj/item/device/assembly/igniter))
+				a_left.attack_self(user)
+			if(!istype(a_right,/obj/item/device/assembly/igniter))
+				a_right.attack_self(user)
+	else
+		var/turf/T = get_turf(src)
+		if(!T)	return 0
+		if(a_left)
+			a_left.holder = null
+			a_left.loc = T
+			if(a_left.proximity_monitor)
+				a_left.proximity_monitor.SetHost(a_left, a_left)
+		if(a_right)
+			a_right.holder = null
+			a_right.loc = T
+			if(a_right.proximity_monitor)
+				a_right.proximity_monitor.SetHost(a_right, a_right)
+		spawn(0)
+			qdel(src)
+	return
 
 
-	process_activation(var/obj/D, var/normal = 1, var/special = 1)
-		if(!D)	return 0
-		if(!secured)
-			visible_message("\icon[src] *beep* *beep*", "*beep* *beep*")
-		if((normal) && (a_right) && (a_left))
-			if(a_right != D)
-				a_right.pulsed(0)
-			if(a_left != D)
-				a_left.pulsed(0)
-		if(master)
-			master.receive_signal()
-//		if(special && special_assembly)
-//			if(!special_assembly == D)
-//				special_assembly.dothings()
-		return 1
+/obj/item/device/assembly_holder/process_activation(var/obj/D, var/normal = 1, var/special = 1)
+	if(!D)	return 0
+	if(!secured)
+		visible_message("\icon[src] *beep* *beep*", "*beep* *beep*")
+	if((normal) && (a_right) && (a_left))
+		if(a_right != D)
+			a_right.pulsed(0)
+		if(a_left != D)
+			a_left.pulsed(0)
+	if(master)
+		master.receive_signal()
+	return 1
 
 
 /obj/item/device/assembly_holder/New()
@@ -220,14 +204,11 @@
 	GLOB.listening_objects -= src
 	return ..()
 
-
 /obj/item/device/assembly_holder/hear_talk(mob/living/M as mob, msg, verb, datum/language/speaking)
 	if(a_right)
 		a_right.hear_talk(M,msg,verb,speaking)
 	if(a_left)
 		a_left.hear_talk(M,msg,verb,speaking)
-
-
 
 
 /obj/item/device/assembly_holder/timer_igniter

--- a/code/modules/hydroponics/spreading/spreading.dm
+++ b/code/modules/hydroponics/spreading/spreading.dm
@@ -110,6 +110,7 @@
 	spread_chance = seed.get_trait(TRAIT_POTENCY)
 	spread_distance = (growth_type ? round(spread_chance * 0.6) : round(spread_chance * 0.3))
 	possible_children = seed.get_trait(TRAIT_POTENCY)
+	proximity_monitor = new(src, 1)
 	update_icon()
 	addtimer(CALLBACK(src, .proc/post_initialize), 1)
 

--- a/code/modules/mob/mob_defines.dm
+++ b/code/modules/mob/mob_defines.dm
@@ -3,7 +3,6 @@
 
 	appearance_flags = PIXEL_SCALE
 	animate_movement = 2
-	movable_flags = MOVABLE_FLAG_PROXMOVE
 
 	virtual_mob = /mob/observer/virtual/mob
 

--- a/code/modules/power/singularity/containment_field.dm
+++ b/code/modules/power/singularity/containment_field.dm
@@ -10,10 +10,13 @@
 	unacidable = 1
 	use_power = POWER_USE_OFF
 	light_range = 4
-	movable_flags = MOVABLE_FLAG_PROXMOVE
 	var/obj/machinery/field_generator/FG1 = null
 	var/obj/machinery/field_generator/FG2 = null
 	var/hasShocked = 0 //Used to add a delay between shocks. In some cases this used to crash servers by spawning hundreds of sparks every second.
+
+/obj/machinery/containment_field/Initialize()
+	. = ..()
+	proximity_monitor = new(src, 1)
 
 /obj/machinery/containment_field/Destroy()
 	if(FG1 && !FG1.clean_up)
@@ -22,27 +25,24 @@
 		FG2.cleanup()
 	. = ..()
 
-/obj/machinery/containment_field/attack_hand(mob/user as mob)
+/obj/machinery/containment_field/attack_hand(mob/user)
 	if(get_dist(src, user) > 1)
 		return 0
 	else
 		shock(user)
 		return 1
 
-
 /obj/machinery/containment_field/ex_act(severity)
 	return 0
 
-/obj/machinery/containment_field/HasProximity(atom/movable/AM as mob|obj)
-	if(istype(AM,/mob/living/silicon) && prob(40))
+/obj/machinery/containment_field/HasProximity(atom/movable/AM)
+	if(issilicon(AM) && prob(40))
 		shock(AM)
-		return 1
-	if(istype(AM,/mob/living/carbon) && prob(50))
+		return TRUE
+	if(iscarbon(AM) && prob(50))
 		shock(AM)
-		return 1
-	return 0
-
-
+		return TRUE
+	return FALSE
 
 /obj/machinery/containment_field/shock(mob/living/user as mob)
 	if(hasShocked)

--- a/code/modules/projectiles/guns/launcher/slugsling.dm
+++ b/code/modules/projectiles/guns/launcher/slugsling.dm
@@ -7,11 +7,13 @@
 	var/break_on_impact = 1 //There are two modes to the eggs.
 							//One breaks the egg on hit,
 
+/obj/item/weapon/slugegg/Initialize()
+	. = ..()
+	proximity_monitor = new(src, 0)
+
 /obj/item/weapon/slugegg/throw_impact(atom/hit_atom, speed)
 	if(break_on_impact)
 		squish()
-	else
-		movable_flags |= MOVABLE_FLAG_PROXMOVE //Dont want it active during the throw... loooots of unneeded checking.
 	return ..()
 
 /obj/item/weapon/slugegg/attack_self(mob/living/user)
@@ -20,7 +22,7 @@
 
 /obj/item/weapon/slugegg/HasProximity(atom/movable/AM)
 	if(isliving(AM))
-		if(istype(AM,/mob/living/carbon/human))
+		if(ishuman(AM))
 			var/mob/living/carbon/human/H = AM
 			if(H.species && H.species.name == SPECIES_VOX)
 				return


### PR DESCRIPTION
Вместо того, чтобы проверять каждый атом на HasProximity вокруг другого атома при заходе на турф - мы создаём поле из слушателей, которые при триггере (Crossed) передают сигнал владельцу.

Должно снизить лаги, поскольку конкретно сейчас у нас вызывается куча пустых проверок, которые ничего не делают.
```
Proc			Self CPU Time 	Total CPU Time	Real Time 	Overtime	Calls	
/atom/proc/HasProximity	8,125		15,974		24,069		0,595		2882942	
```

Одолжено с ТГ.