### PR TITLE
More server-friendly vortex behavior.

### DIFF
--- a/code/game/objects/items/weapons/teleportation.dm
+++ b/code/game/objects/items/weapons/teleportation.dm
@@ -341,7 +341,7 @@ Frequency:
 			to_chat(user, SPAN_WARNING("You fail to activate your Vortex Manipulator - local space-time can't hold any more active VMs."))
 			return
 		active = 1
-		unique_id = rand(0000, 9999)
+		unique_id = random_id(/obj/item/weapon/vortex_manipulator, 1111, 9999)
 		log_and_message_admins("has activated Vortex Manipulator [unique_id]!")
 		to_chat(user, SPAN_NOTICE("You successfully activate Vortex Manipulator. Its unique identifier is now: [unique_id]"))
 		return

--- a/code/game/objects/items/weapons/teleportation.dm
+++ b/code/game/objects/items/weapons/teleportation.dm
@@ -276,7 +276,7 @@ Frequency:
 	var/mob/living/carbon/human/H = vm_owner
 	if(!vcell || !cover_open)
 		return
-	if(world.time > emp_prevent_until)
+	if(world.time < emp_prevent_until)
 		return
 	emp_prevent_until = world.time + 13 SECONDS
 	if(timelord_mode || (severity == 2))

--- a/code/game/objects/items/weapons/teleportation.dm
+++ b/code/game/objects/items/weapons/teleportation.dm
@@ -336,8 +336,11 @@ Frequency:
 		to_chat(user, SPAN_NOTICE("You attempt to activate Vortex Manipulator"))
 		var/counter = 0
 		for(var/obj/item/weapon/vortex_manipulator/VM in GLOB.vortex_manipulators)
-			counter = counter + !(VM.timelord_mode)
-		if (!timelord_mode && (counter > 3))
+			if(!VM.timelord_mode)
+				counter++
+				if(timelord_mode || counter > 3)
+					break
+		if (counter > 3)
 			to_chat(user, SPAN_WARNING("You fail to activate your Vortex Manipulator - local space-time can't hold any more active VMs."))
 			return
 		active = 1

--- a/code/game/objects/items/weapons/teleportation.dm
+++ b/code/game/objects/items/weapons/teleportation.dm
@@ -337,7 +337,7 @@ Frequency:
 		counter = 0
 		for(var/obj/item/weapon/vortex_manipulator/VM in GLOB.vortex_manipulators)
 			counter = counter + !(VM.timelord_mode)
-		if counter > 3 && !timelord_mode:
+		if (counter > 3 && !timelord_mode)
 			to_chat(user, SPAN_WARNING("You fail to activate your Vortex Manipulator - local space-time can't hold any more active VMs."))
 			return
 		active = 1

--- a/code/game/objects/items/weapons/teleportation.dm
+++ b/code/game/objects/items/weapons/teleportation.dm
@@ -334,15 +334,14 @@ Frequency:
 /obj/item/weapon/vortex_manipulator/proc/self_activate(mob/living/carbon/human/user)
 	if(!active)
 		to_chat(user, SPAN_NOTICE("You attempt to activate Vortex Manipulator"))
-		var/counter = 0
-		for(var/obj/item/weapon/vortex_manipulator/VM in GLOB.vortex_manipulators)
-			if(!VM.timelord_mode)
-				counter++
-				if(timelord_mode || counter > 3)
-					break
-		if (counter > 3)
-			to_chat(user, SPAN_WARNING("You fail to activate your Vortex Manipulator - local space-time can't hold any more active VMs."))
-			return
+		if(!timelord_mode)
+			var/counter = 0
+			for(var/obj/item/weapon/vortex_manipulator/VM in GLOB.vortex_manipulators)
+				if(VM.active && !VM.timelord_mode)
+					counter++
+			if (counter > 3)
+				to_chat(user, SPAN_WARNING("You fail to activate your Vortex Manipulator - local space-time can't hold any more active VMs."))
+				return
 		active = 1
 		unique_id = random_id(/obj/item/weapon/vortex_manipulator, 1111, 9999)
 		log_and_message_admins("has activated Vortex Manipulator [unique_id]!")

--- a/code/game/objects/items/weapons/teleportation.dm
+++ b/code/game/objects/items/weapons/teleportation.dm
@@ -334,7 +334,7 @@ Frequency:
 /obj/item/weapon/vortex_manipulator/proc/self_activate(mob/living/carbon/human/user)
 	if(!active)
 		to_chat(user, SPAN_NOTICE("You attempt to activate Vortex Manipulator"))
-		counter = 0
+		var/counter = 0
 		for(var/obj/item/weapon/vortex_manipulator/VM in GLOB.vortex_manipulators)
 			counter = counter + !(VM.timelord_mode)
 		if (!timelord_mode && (counter > 3))

--- a/code/game/objects/items/weapons/teleportation.dm
+++ b/code/game/objects/items/weapons/teleportation.dm
@@ -144,7 +144,7 @@ Frequency:
 	var/list/possible_ids = list(1, 2, 3)
 	var/list/beacon_locations = list()
 	var/obj/item/weapon/cell/vcell
-	var/last_emp_timestamp = 0
+	var/emp_prevent_until = 0
 	throwforce = 5
 	w_class = ITEM_SIZE_SMALL
 	throw_speed = 3
@@ -276,9 +276,9 @@ Frequency:
 	var/mob/living/carbon/human/H = vm_owner
 	if(!vcell || !cover_open)
 		return
-	if(last_emp_timestamp + 13 SECONDS > world.time)
+	if(world.time > emp_prevent_until)
 		return
-	last_emp_timestamp = world.time
+	emp_prevent_until = world.time + 13 SECONDS
 	if(timelord_mode || (severity == 2))
 		if(prob(25))
 			if(prob(50))

--- a/code/game/objects/items/weapons/teleportation.dm
+++ b/code/game/objects/items/weapons/teleportation.dm
@@ -337,7 +337,7 @@ Frequency:
 		counter = 0
 		for(var/obj/item/weapon/vortex_manipulator/VM in GLOB.vortex_manipulators)
 			counter = counter + !(VM.timelord_mode)
-		if (counter > 3 && !timelord_mode)
+		if (!timelord_mode && (counter > 3))
 			to_chat(user, SPAN_WARNING("You fail to activate your Vortex Manipulator - local space-time can't hold any more active VMs."))
 			return
 		active = 1


### PR DESCRIPTION
Rebalance.
Also fixes issue with O(N) intended malfunctions for 'battle function' becoming O(N^unknown) due to malfunction calling itself on each iteration.
Therefore, chance for each type of malfunction was raised a bit.
Charge costs multiplied, as there was no 'bluespace cell' with 10k total capacity when previous values were implemented.
Reworked 'vortex cap' for non-timelord VMs.
Plus, EMP now won't strike single vortex manipulator multiple times in small time intervals.