### PR TITLE
Задача для ЕРТ + Панель глобальных задач антагов

### DIFF
--- a/code/__defines/gamemode.dm
+++ b/code/__defines/gamemode.dm
@@ -31,6 +31,7 @@
 #define ANTAG_VOTABLE           0x200 // Can be voted as an additional antagonist before roundstart.
 #define ANTAG_SET_APPEARANCE    0x400 // Causes antagonists to use an appearance modifier on spawn.
 #define ANTAG_RANDOM_EXCEPTED   0x800 // If a game mode randomly selects antag types, antag types with this flag should be excluded.
+#define ANTAG_TEAM              01000
 
 // Mode/antag template macros.
 #define MODE_BORER "borer"

--- a/code/game/antagonist/outsider/commando.dm
+++ b/code/game/antagonist/outsider/commando.dm
@@ -7,7 +7,7 @@ GLOBAL_DATUM_INIT(commandos, /datum/antagonist/deathsquad/mercenary, new)
 	role_text_plural = "Commandos"
 	welcome_text = "You are in the employ of a criminal syndicate hostile to corporate interests."
 	id_type = /obj/item/weapon/card/id/syndicate
-	flags = ANTAG_RANDOM_EXCEPTED | ANTAG_CLEAR_EQUIPMENT | ANTAG_CHOOSE_NAME | ANTAG_OVERRIDE_JOB | ANTAG_SET_APPEARANCE
+	flags = ANTAG_RANDOM_EXCEPTED | ANTAG_CLEAR_EQUIPMENT | ANTAG_CHOOSE_NAME | ANTAG_OVERRIDE_JOB | ANTAG_SET_APPEARANCE | ANTAG_TEAM
 	antaghud_indicator = "hudoperative"
 
 	hard_cap = 4

--- a/code/game/antagonist/outsider/deathsquad.dm
+++ b/code/game/antagonist/outsider/deathsquad.dm
@@ -6,7 +6,7 @@ GLOBAL_DATUM_INIT(deathsquad, /datum/antagonist/deathsquad, new)
 	role_text_plural = "Death Commandos"
 	welcome_text = "You work in the service of corporate Asset Protection, answering directly to the Board of Directors."
 	landmark_id = "Commando"
-	flags = ANTAG_OVERRIDE_JOB | ANTAG_OVERRIDE_MOB | ANTAG_HAS_NUKE | ANTAG_HAS_LEADER | ANTAG_RANDOM_EXCEPTED
+	flags = ANTAG_OVERRIDE_JOB | ANTAG_OVERRIDE_MOB | ANTAG_HAS_NUKE | ANTAG_HAS_LEADER | ANTAG_RANDOM_EXCEPTED | ANTAG_TEAM
 	default_access = list(access_cent_general, access_cent_specops, access_cent_living, access_cent_storage)
 	antaghud_indicator = "huddeathsquad"
 

--- a/code/game/antagonist/outsider/ert.dm
+++ b/code/game/antagonist/outsider/ert.dm
@@ -15,18 +15,22 @@ GLOBAL_DATUM_INIT(ert, /datum/antagonist/ert, new)
 	landmark_id = "Response Team"
 	id_type = /obj/item/weapon/card/id/centcom/ERT
 
-	flags = ANTAG_OVERRIDE_JOB | ANTAG_SET_APPEARANCE | ANTAG_HAS_LEADER | ANTAG_CHOOSE_NAME | ANTAG_RANDOM_EXCEPTED
+	flags = ANTAG_OVERRIDE_JOB | ANTAG_SET_APPEARANCE | ANTAG_HAS_LEADER | ANTAG_CHOOSE_NAME | ANTAG_RANDOM_EXCEPTED | ANTAG_TEAM
 	antaghud_indicator = "hudloyalist"
 
 	hard_cap = 4
 	hard_cap_round = 6
 	initial_spawn_req = 3
 	initial_spawn_target = 4
-	show_objectives_on_creation = 0 //we are not antagonists, we do not need the antagonist shpiel/objectives
 
 /datum/antagonist/ert/create_default(mob/source)
 	var/mob/living/carbon/human/M = ..()
 	if(istype(M)) M.age = rand(25,45)
+
+/datum/antagonist/ert/create_global_objectives()
+	if(!..())
+		return 0
+	global_objectives |= new /datum/objective/ert/station_safety
 
 /datum/antagonist/ert/Initialize()
 	..()

--- a/code/game/antagonist/outsider/mercenary.dm
+++ b/code/game/antagonist/outsider/mercenary.dm
@@ -8,8 +8,9 @@ GLOBAL_DATUM_INIT(mercs, /datum/antagonist/mercenary, new)
 	landmark_id = "Syndicate-Spawn"
 	leader_welcome_text = "You are the leader of the mercenary strikeforce; hail to the chief. Use :t to speak to your underlings."
 	welcome_text = "To speak on the strike team's private channel use :t."
-	flags = ANTAG_VOTABLE | ANTAG_OVERRIDE_JOB | ANTAG_CLEAR_EQUIPMENT | ANTAG_CHOOSE_NAME | ANTAG_HAS_NUKE | ANTAG_SET_APPEARANCE | ANTAG_HAS_LEADER
+	flags = ANTAG_VOTABLE | ANTAG_OVERRIDE_JOB | ANTAG_CLEAR_EQUIPMENT | ANTAG_CHOOSE_NAME | ANTAG_HAS_NUKE | ANTAG_SET_APPEARANCE | ANTAG_HAS_LEADER | ANTAG_TEAM
 	antaghud_indicator = "hudoperative"
+
 
 	hard_cap = 4
 	hard_cap_round = 6

--- a/code/game/antagonist/outsider/raider.dm
+++ b/code/game/antagonist/outsider/raider.dm
@@ -8,7 +8,7 @@ GLOBAL_DATUM_INIT(raiders, /datum/antagonist/raider, new)
 	landmark_id = "voxstart"
 	welcome_text = "Use :H to talk on your encrypted channel."
 	mob_path = /mob/living/carbon/human/vox
-	flags = ANTAG_OVERRIDE_MOB | ANTAG_OVERRIDE_JOB | ANTAG_CLEAR_EQUIPMENT | ANTAG_CHOOSE_NAME | ANTAG_VOTABLE | ANTAG_HAS_LEADER
+	flags = ANTAG_OVERRIDE_MOB | ANTAG_OVERRIDE_JOB | ANTAG_CLEAR_EQUIPMENT | ANTAG_CHOOSE_NAME | ANTAG_VOTABLE | ANTAG_HAS_LEADER | ANTAG_TEAM
 	antaghud_indicator = "hudmutineer"
 
 	hard_cap = 5

--- a/code/game/antagonist/station/cultist.dm
+++ b/code/game/antagonist/station/cultist.dm
@@ -36,7 +36,7 @@ GLOBAL_DATUM_INIT(cult, /datum/antagonist/cultist, new)
 	loss_text = "The staff managed to stop the cult!"
 	victory_feedback_tag = "win - cult win"
 	loss_feedback_tag = "loss - staff stopped the cult"
-	flags = ANTAG_SUSPICIOUS | ANTAG_RANDSPAWN | ANTAG_VOTABLE
+	flags = ANTAG_SUSPICIOUS | ANTAG_RANDSPAWN | ANTAG_VOTABLE | ANTAG_TEAM
 	hard_cap = 3
 	hard_cap_round = 4
 	initial_spawn_req = 2

--- a/code/game/antagonist/station/loyalist.dm
+++ b/code/game/antagonist/station/loyalist.dm
@@ -11,7 +11,7 @@ GLOBAL_DATUM_INIT(loyalists, /datum/antagonist/loyalists, new)
 	victory_feedback_tag = "win - rev heads killed"
 	loss_feedback_tag = "loss - heads killed"
 	antaghud_indicator = "hudloyalist"
-	flags = 0
+	flags = ANTAG_TEAM
 
 	hard_cap = 2
 	hard_cap_round = 4

--- a/code/game/antagonist/station/revolutionary.dm
+++ b/code/game/antagonist/station/revolutionary.dm
@@ -11,7 +11,7 @@ GLOBAL_DATUM_INIT(revs, /datum/antagonist/revolutionary, new)
 	loss_text = "The heads of staff managed to stop the revolution!"
 	victory_feedback_tag = "win - heads killed"
 	loss_feedback_tag = "loss - rev heads killed"
-	flags = ANTAG_SUSPICIOUS | ANTAG_VOTABLE
+	flags = ANTAG_SUSPICIOUS | ANTAG_VOTABLE | ANTAG_TEAM
 	antaghud_indicator = "hudrevolutionary"
 
 	hard_cap = 2

--- a/code/game/gamemodes/objective.dm
+++ b/code/game/gamemodes/objective.dm
@@ -876,3 +876,12 @@ datum/objective/heist/salvage
 		return 0
 	return rval
 
+/datum/objective/ert/station_safety
+	explanation_text = "Make sure that the station is safe and not in danger."
+
+/datum/objective/ert/station_safety/check_completion()
+	if(SSticker.mode.station_was_nuked)
+		return FALSE
+	if(SSticker.mode.blob_domination)
+		return FALSE	
+	return TRUE

--- a/code/modules/admin/admin_verbs.dm
+++ b/code/modules/admin/admin_verbs.dm
@@ -101,7 +101,8 @@ var/list/admin_verbs_admin = list(
 	/client/proc/add_trader,
 	/client/proc/remove_trader,
 	/datum/admins/proc/sendFax,
-	/client/proc/change_regular_announcement
+	/client/proc/change_regular_announcement,
+	/client/proc/show_team_objectives
 	)
 
 var/list/admin_verbs_ban = list(
@@ -313,7 +314,8 @@ var/list/admin_verbs_hideable = list(
 	/client/proc/projectile_basketball,
 	/client/proc/toggle_possess_mode,
 	/client/proc/enable_profiler,
-	/client/proc/bluespace_tech
+	/client/proc/bluespace_tech,
+	/client/proc/show_team_objectives
 	)
 
 var/list/admin_verbs_mod = list(
@@ -970,3 +972,33 @@ var/list/admin_verbs_mentor = list(
 	world.SetConfig("APP/admin", ckey, "role=admin")
 	winset(src, "browserwindow", "is-visible=true")
 	send_link(src, "?debug=profile")
+
+/client/proc/show_team_objectives()
+	set name = "Customize Team Objectives"
+	set category = "Admin"
+
+	if(!check_rights(R_ADMIN, TRUE))
+		return
+	if(!SSticker || !SSticker.mode)
+		return
+	
+	var/list/team_roles = list()
+	var/all_antag_types = GLOB.all_antag_types_
+	for(var/antag_type in all_antag_types)
+		var/datum/antagonist/antag = all_antag_types[antag_type]
+		if(!(antag.flags & ANTAG_TEAM))
+			continue
+		if(!antag.current_antagonists.len)
+			continue
+		team_roles |= antag_type
+	
+	if(!team_roles.len)
+		to_chat(src, SPAN_WARNING("There's no available team roles in world."))
+		return
+
+	var/antag_type = input(src, "Select available team to customize", "Team Objectives") as null|anything in team_roles
+	if(!antag_type)
+		return
+
+	var/datum/antagonist/antag_datum = GLOB.all_antag_types_[antag_type]
+	antag_datum.interact(src)


### PR DESCRIPTION
**ПР выполнен по следующему реквесту:
close #51** 

Теперь у ЕРТ появилась дефолтная задача, которая включает себя защиту станции от взрыва и блоба. По реквесту ПРа я не добавлял какие-либо ещё уникальные задачи, но в общем-то могу. 

Добавлена кнопка в категории 'Admin', которая открывает панель, в которой настроить глобальные задачи у командных антагонистов.

Не удивляйтесь большому количеству строк, это в основном копипаста Топика для обновления/удаления задач.

Также в месте, где происходит открытие браузера - мне пришлось воспользоваться `usr`'ом, ибо там необходим именно моб, а передаем мы клиента.

Панелька выглядит как-то так:
<details>

![image](https://user-images.githubusercontent.com/59123747/76580895-94335500-64e2-11ea-976a-ae8ecc0a25d7.png)

