### PR TITLE
Фикс диспенсеров у киборгов

### DIFF
--- a/code/modules/mob/living/silicon/robot/robot_items.dm
+++ b/code/modules/mob/living/silicon/robot/robot_items.dm
@@ -737,6 +737,9 @@
 				user.visible_message("<span class='notice'>\The [user] starts recycling [A]...</span>")
 				if(do_after(user,recycling_time,src))
 					to_chat(user, "<span class='notice'>\The [src] consumes [A] and you get some energy back.</span>")
+					if(istype(A, /obj/structure/closet))
+						var/obj/structure/closet/C = A
+						C.dump_contents()
 					qdel(A)
 					if(istype(user,/mob/living/silicon/robot))
 						var/mob/living/silicon/robot/R = user


### PR DESCRIPTION
Нек-ые из них пожирают ящики, да вот только ящики они эти не опустошают, из-за чего всё содержимое попадало в нулспейс. В том числе и игроки.