### PR TITLE
Исправление дюпа стали.

### DIFF
--- a/code/game/objects/items/stacks/rods.dm
+++ b/code/game/objects/items/stacks/rods.dm
@@ -12,7 +12,7 @@
 	mod_weight = 0.8
 	mod_reach = 1.0
 	mod_handy = 0.8
-	matter = list(MATERIAL_STEEL = 1875)
+	matter = list(MATERIAL_STEEL = 1000)
 	max_amount = 100
 	center_of_mass = null
 	attack_verb = list("hit", "bludgeoned", "whacked")


### PR DESCRIPTION
Суть что было раньше: 
1 лист стали = 2000 ед. в автолате
1 прут = 1875 ед, в автолате
1 лист стали = 2 прутам в крафте руками
2000 != 3750
Итог дюп стали.
Мои изменения: 
matter = list(MATERIAL_STEEL = 1875) ----> matter = list(MATERIAL_STEEL = 1000)
1 лист стали= 2000
2 прута = 2000

fix #1778 