### PR TITLE
Исправление работы термостата в настенном AirAlarm

### DIFF
--- a/code/game/machinery/alarm.dm
+++ b/code/game/machinery/alarm.dm
@@ -294,9 +294,9 @@
 	return 0
 
 /obj/machinery/alarm/proc/get_danger_level(current_value, list/danger_levels)
-	if((current_value >= danger_levels[4] && danger_levels[4] > 0) || current_value <= danger_levels[1])
+	if((current_value > danger_levels[4] && danger_levels[4] > 0) || current_value < danger_levels[1])
 		return 2
-	if((current_value >= danger_levels[3] && danger_levels[3] > 0) || current_value <= danger_levels[2])
+	if((current_value > danger_levels[3] && danger_levels[3] > 0) || current_value < danger_levels[2])
 		return 1
 	return 0
 


### PR DESCRIPTION
Суть проблемы:
При выставлении на термостате крайних температур 0С и 40С, тот никак на это не реагировал.
Крайние температуры считались недопустимыми из за проверки >= и <=.
Решение: Замена проверок на > и < соответственно.
fix #1780
P.S Решение разжевано и положено в рот автору by TermService