### PR TITLE
Нерфаем мышей после обновы

### DIFF
--- a/code/modules/mob/living/living_powers.dm
+++ b/code/modules/mob/living/living_powers.dm
@@ -9,6 +9,11 @@
 	if(incapacitated())
 		return
 
+	if(world.time < last_special + 5 SECONDS)
+		to_chat(src, SPAN_WARNING("You need to wait a bit!"))
+		return
+	last_special = world.time
+
 	hiding = !hiding
 	if(hiding)
 		to_chat(src, "<span class='notice'>You are now hiding.</span>")

--- a/code/modules/mob/living/simple_animal/friendly/mouse.dm
+++ b/code/modules/mob/living/simple_animal/friendly/mouse.dm
@@ -16,8 +16,8 @@
 	speak_chance = 1
 	turns_per_move = 5
 	see_in_dark = 6
-	maxHealth = 5
-	health = 5
+	maxHealth = 1
+	health = 1
 	meat_type = /obj/item/weapon/reagent_containers/food/snacks/meat
 	response_help  = "pets"
 	response_disarm = "gently pushes aside"
@@ -118,6 +118,10 @@
 	if(ishuman(A))
 		var/mob/living/carbon/human/H = A
 
+		if(hiding)
+			to_chat(src, SPAN_WARNING("You can't bite while you are hiding!"))
+			return
+
 		var/available_limbs = H.lying ? BP_ALL_LIMBS : BP_BELOW_GROIN
 		var/obj/item/organ/external/limb
 		for(var/L in shuffle(available_limbs))
@@ -126,13 +130,14 @@
 				break
 
 		var/blocked = H.run_armor_check(limb.organ_tag, "melee")
-		if(H.apply_damage(rand(2, 5), BRUTE, limb.organ_tag, blocked) && prob(70 - blocked))
+		if(H.apply_damage(rand(1, 2), BRUTE, limb.organ_tag, blocked) && prob(70 - blocked))
 			limb.germ_level += rand(75, 150)
 			if(virus)
 				infect_virus2(H, virus)
 		visible_message(SPAN_DANGER("[src] bites [H]'s [organ_name_by_zone(H, limb.organ_tag)]!"),
 						SPAN_WARNING("You bite [H]'s [organ_name_by_zone(H, limb.organ_tag)]!"))
 		admin_attack_log(src, H, "Bit the victim", "Was bitten", "bite")
+		setClickCooldown(DEFAULT_ATTACK_COOLDOWN)
 		do_attack_animation(H)
 		playsound(loc, attack_sound, 25, 1, 1)
 		return

--- a/code/modules/mob/observer/ghost/ghost.dm
+++ b/code/modules/mob/observer/ghost/ghost.dm
@@ -383,45 +383,6 @@ This is the proc mobs get to turn into a ghost. Forked from ghostize due to comp
 		var/rads = SSradiation.get_rads_at_turf(t)
 		to_chat(src, "<span class='notice'>Radiation level: [rads ? rads : "0"] Bq.</span>")
 
-/mob/observer/ghost/verb/become_mouse()
-	set name = "Become mouse"
-	set category = "Ghost"
-
-	if(config.disable_player_mice)
-		to_chat(src, "<span class='warning'>Spawning as a mouse is currently disabled.</span>")
-		return
-
-	if(!MayRespawn(1, ANIMAL_SPAWN_DELAY))
-		return
-
-	var/turf/T = get_turf(src)
-	if(!T || (T.z in GLOB.using_map.admin_levels))
-		to_chat(src, "<span class='warning'>You may not spawn as a mouse on this Z-level.</span>")
-		return
-
-	var/response = alert(src, "Are you -sure- you want to become a mouse?","Are you sure you want to squeek?","Squeek!","Nope!")
-	if(response != "Squeek!") return  //Hit the wrong key...again.
-
-
-	//find a viable mouse candidate
-	var/mob/living/simple_animal/mouse/host
-	var/obj/machinery/atmospherics/unary/vent_pump/vent_found
-	var/list/found_vents = list()
-	for(var/obj/machinery/atmospherics/unary/vent_pump/v in SSmachines.machinery)
-		if(!v.welded && v.z == T.z)
-			found_vents.Add(v)
-	if(found_vents.len)
-		vent_found = pick(found_vents)
-		host = new /mob/living/simple_animal/mouse(vent_found.loc)
-	else
-		to_chat(src, "<span class='warning'>Unable to find any unwelded vents to spawn mice at.</span>")
-	if(host)
-		if(config.uneducated_mice)
-			host.universal_understand = 0
-		announce_ghost_joinleave(src, 0, "They are now a mouse.")
-		host.ckey = src.ckey
-		host.status_flags |= NO_ANTAG
-		to_chat(host, "<span class='info'>You are now a mouse. Try to avoid interaction with players, and do not give hints away that you are more than a simple rodent.</span>")
 /mob/observer/ghost/verb/view_manfiest()
 	set name = "Show Crew Manifest"
 	set category = "Ghost"


### PR DESCRIPTION
- Запрещаем атаковать в то время, когда они прячутся.
- Добавляем дополнительный кулдаун после атаки.
- Добавляем кулдаун после использования кнопки `hide`.
- Уменьшаем здоровье до одной единички.
- Уменьшаем урон до 1 - 2.
- Убираем кнопку `Become Mouse`.
