### PR TITLE
fix(assets): stop sending assets for disconnected clients

### DIFF
--- a/code/modules/client/asset_cache.dm
+++ b/code/modules/client/asset_cache.dm
@@ -112,10 +112,12 @@ You can set verify to TRUE if you want send() to sleep until the client has the 
 //This proc will download the files without clogging up the browse() queue, used for passively sending files on connection start.
 //The proc calls procs that sleep for long times.
 /proc/getFilesSlow(client/client, list/files)
-	ASSERT(client)
 	for(var/file in files)
+		if(!client)
+			return FALSE
 		send_asset(client, file)
 		sleep(0) //queuing calls like this too quickly can cause issues in some client versions
+	return TRUE
 
 //This proc "registers" an asset, it adds it to the cache for further use, you cannot touch it from this point on or you'll fuck things up.
 //if it's an icon or something be careful, you'll have to copy it before further use.
@@ -175,7 +177,7 @@ You can set verify to TRUE if you want send() to sleep until the client has the 
 /datum/asset/proc/send_slow(client/client)
 	ASSERT(client)
 	ASSERT(istype(client))
-	getFilesSlow(client, assets)
+	return getFilesSlow(client, assets)
 
 // Check if all the assets were already sent
 /datum/asset/proc/check_sent(client/C)

--- a/code/modules/client/client_procs.dm
+++ b/code/modules/client/client_procs.dm
@@ -453,6 +453,8 @@
 		)
 
 	spawn (10) //removing this spawn causes all clients to not get verbs.
+		if(!src) // client disconnected
+			return
 		log_debug_verbose("\[ASSETS\] Start sending resources for [ckey].")
 
 		var/list/priority_assets = list()
@@ -469,7 +471,9 @@
 				priority_assets += D
 
 		for(var/datum/asset/D in (priority_assets + other_assets))
-			D.send_slow(src) //Precache the client with all other assets slowly, so as to not block other browse() calls
+			if (!D.send_slow(src)) //Precache the client with all other assets slowly, so as to not block other browse() calls
+				log_debug_verbose("\[ASSETS\] Failed to sent resources to [ckey]![src ? " Reason is client was disconnected!" : ""]")
+				return
 
 		log_debug_verbose("\[ASSETS\] Resources for [ckey] were sended!")
 


### PR DESCRIPTION
Когда клиент дисконнектится, сервер продолжает слать ему ассеты. Из-за того что клиент занулился, сервер еще и рантаймил, ругаясь на отправку ассетов в null.

Заменил пару ассертов на проверки. Теперь когда клиент дисконнектится отправка ассетов прерывается.