### PR TITLE
Improper nuclear disk behavior

### DIFF
--- a/code/game/machinery/nuclear_bomb.dm
+++ b/code/game/machinery/nuclear_bomb.dm
@@ -377,9 +377,6 @@ var/bomb_set
 	GLOB.moved_event.register(src, src, /obj/item/weapon/disk/nuclear/proc/check_z_level)
 
 /obj/item/weapon/disk/nuclear/proc/check_z_level()
-	if(!(istype(SSticker.mode, /datum/game_mode/nuclear)))
-		GLOB.moved_event.unregister(src, src, /obj/item/weapon/disk/nuclear/proc/check_z_level) // However, when we are certain unregister if necessary
-		return
 	var/turf/T = get_turf(src)
 	if(!T || isNotStationLevel(T.z))
 		qdel(src)


### PR DESCRIPTION
Fixes:
1) Nuclear disk could've been transported from station in mixed gamemodes (e.g. siege, crossfire); obviously this resulted in nuclear operatives being unable to blow nuclear bomb, as disk cannot be tracked properly outside of the station.
2) For gamemodes without mercenaries, it was still a big problem that nuclear disk could be thrown into space. As is is unique, there were no in-game ways of returning it back from various space z-levels (first - you can't track it, second - you can't transport it with handtele or teleporter hub).
Related issues:
fix #1933, fix #1932 