### PR TITLE
refact(pain): update pain on Process

### DIFF
--- a/code/modules/mob/living/carbon/human/human.dm
+++ b/code/modules/mob/living/carbon/human/human.dm
@@ -1551,7 +1551,7 @@
 		for(var/obj/item/organ/external/org in organs)
 			var/list/status = list()
 
-			var/feels = 1 + round(org.pain/100, 0.1)
+			var/feels = 1 + round(org.get_pain()/100, 0.1)
 			var/brutedamage = org.brute_dam * feels
 			var/burndamage = org.burn_dam * feels
 

--- a/code/modules/mob/living/carbon/human/human_organs.dm
+++ b/code/modules/mob/living/carbon/human/human_organs.dm
@@ -149,7 +149,7 @@
 				spawn(10)
 					qdel(spark_system)
 
-		else if(E.is_broken() || (E.pain >= E.pain_disability_threshold))
+		else if(E.is_broken() || (E.get_pain() >= E.pain_disability_threshold))
 			stance_d_l += 2
 
 		else if(E.is_dislocated())
@@ -177,7 +177,7 @@
 				spawn(10)
 					qdel(spark_system)
 
-		else if(E.is_broken() || (E.pain >= E.pain_disability_threshold))
+		else if(E.is_broken() || (E.get_pain() >= E.pain_disability_threshold))
 			stance_d_r += 2
 
 		else if(E.is_dislocated())

--- a/code/modules/organs/external/_external.dm
+++ b/code/modules/organs/external/_external.dm
@@ -24,6 +24,7 @@
 	var/burn_ratio = 0                 // Ratio of current burn damage to max damage.
 	var/last_dam = -1                  // used in healing/processing calculations.
 	var/pain = 0                       // How much the limb hurts.
+	var/full_pain = 0                  // Overall pain including damages.
 	var/pain_disability_threshold      // Point at which a limb becomes unusable due to pain.
 
 	// A bitfield for a collection of limb behavior flags.
@@ -411,7 +412,7 @@ This function completely restores a damaged organ to perfect condition.
 	brute_dam = 0
 	burn_dam = 0
 	germ_level = 0
-	pain = 0
+	remove_all_pain()
 	genetic_degradation = 0
 	for(var/datum/wound/wound in wounds)
 		wound.embedded_objects.Cut()
@@ -532,7 +533,7 @@ This function completely restores a damaged organ to perfect condition.
 
 //Determines if we even need to process this organ.
 /obj/item/organ/external/proc/need_process()
-	if(get_pain())
+	if(get_full_pain())
 		return 1
 	if(status & (ORGAN_CUT_AWAY|ORGAN_BLEEDING|ORGAN_BROKEN|ORGAN_DEAD|ORGAN_MUTATED))
 		return 1
@@ -549,11 +550,7 @@ This function completely restores a damaged organ to perfect condition.
 
 /obj/item/organ/external/Process()
 	if(owner)
-
-		if(pain)
-			pain -= owner.lying ? 3 : 1
-			if(pain<0)
-				pain = 0
+		update_pain()
 
 		// Process wounds, doing healing etc. Only do this every few ticks to save processing power
 		if(owner.life_tick % wound_update_accuracy == 0)
@@ -562,7 +559,7 @@ This function completely restores a damaged organ to perfect condition.
 		//Infections
 		update_germs()
 	else
-		pain = 0
+		remove_all_pain()
 		..()
 
 //Updating germ levels. Handles organ germ levels and necrosis.
@@ -822,7 +819,7 @@ Note that amputating the affected organ does in fact remove the infection from t
 	var/use_blood_colour = species.get_blood_colour(owner)
 
 	removed(null, ignore_children)
-	add_pain(60)
+	adjust_pain(60)
 	if(!clean)
 		victim.shock_stage += min_broken_damage
 
@@ -837,7 +834,7 @@ Note that amputating the affected organ does in fact remove the infection from t
 			stump.SetName("stump of \a [name]")
 			stump.artery_name = "mangled [artery_name]"
 			stump.arterial_bleed_severity = arterial_bleed_severity
-			stump.add_pain(max_damage)
+			stump.adjust_pain(max_damage)
 			if(BP_IS_ROBOTIC(src))
 				stump.robotize()
 			stump.wounds |= W
@@ -1480,7 +1477,7 @@ obj/item/organ/external/proc/remove_clamps()
 		to_chat(owner, "<span class='danger'>You feel extreme pain!</span>")
 
 		var/max_halloss = round(owner.species.total_health * 0.8 * ((100 - armor) / 100)) //up to 80% of passing out, further reduced by armour
-		add_pain(Clamp(0, max_halloss - owner.getHalLoss(), 30))
+		adjust_pain(Clamp(0, max_halloss - owner.getHalLoss(), 30))
 
 //Adds autopsy data for used_weapon.
 /obj/item/organ/external/proc/add_autopsy_data(used_weapon, damage)

--- a/code/modules/organs/external/_external_icons.dm
+++ b/code/modules/organs/external/_external_icons.dm
@@ -173,7 +173,7 @@ var/list/robot_hud_colours = list("#ffffff","#cccccc","#aaaaaa","#888888","#6666
 
 	// Calculate the required color index.
 	var/dam_state = min(1,((brute_dam+burn_dam)/max(1,max_damage)))
-	var/min_dam_state = min(1,(get_pain()/max(1,max_damage)))
+	var/min_dam_state = min(1,(get_full_pain()/max(1,max_damage)))
 	if(min_dam_state && dam_state < min_dam_state)
 		dam_state = min_dam_state
 	// Apply colour and return product.

--- a/code/modules/organs/pain.dm
+++ b/code/modules/organs/pain.dm
@@ -18,7 +18,7 @@ mob/living/carbon/proc/custom_pain(message, power, force, obj/item/organ/externa
 	// Excessive halloss is horrible, just give them enough to make it visible.
 	if(!nohalloss && power)
 		if(affecting)
-			affecting.add_pain(ceil(power/2))
+			affecting.adjust_pain(ceil(power/2))
 		else
 			adjustHalLoss(ceil(power/2))
 


### PR DESCRIPTION
Немного переписал логику боли так, чтобы она меньше грузила сервер. Теперь боль считается один раз за тик в Process. Метод get_pain() возвращает посчитанное ранее значение.

Также явно разделил методы get_pain и get_full_pain. Первый метод - только накопившаяся боль из разных источников, а второй добавляет также боль от урона и увечий.

Методы add_pain и remove_pain схлопнулись в adjust_pain.

fix #1951 

- [x] Pull Request полностью завершен, мне не нужна помощь чтобы его закончить.
- [x] Я внимательно прочитал все свои изменения и багов в них не нашел.
- [ ] Я запускал сервер со своими изменениями локально и все протестировал.
Не запускал, т.к. локально хрен протестишь боль. По коду все нормально, вроде, но на крайняк ничего кроме боли сломаться не должно. Если сломается боль - узнаем по репортам, больше не вижу вариантов.
- [x] Я ознакомился c [Guide to Contribute](https://github.com/ChaoticOnyx/OnyxBay/blob/dev/docs/contributing.md).
