### PR TITLE
fix(cookers)

### DIFF
--- a/code/game/machinery/kitchen/cooking_machines/_cooker.dm
+++ b/code/game/machinery/kitchen/cooking_machines/_cooker.dm
@@ -107,7 +107,6 @@
 	if(istype(cooking_obj, /obj/item/weapon/holder))
 		for(var/mob/living/M in cooking_obj.contents)
 			M.death()
-			qdel(M)
 
 	// Cook the food.
 	var/cook_path
@@ -135,6 +134,9 @@
 	result.cooked |= cook_type
 
 	// Reset relevant variables.
+	if(istype(cooking_obj, /obj/item/weapon/holder))
+		for(var/mob/living/M in cooking_obj.contents)
+			qdel(M)
 	qdel(cooking_obj)
 	src.visible_message("<span class='notice'>\The [src] pings!</span>")
 	if(cooked_sound)

--- a/code/game/machinery/kitchen/cooking_machines/_cooker.dm
+++ b/code/game/machinery/kitchen/cooking_machines/_cooker.dm
@@ -134,6 +134,8 @@
 	result.cooked |= cook_type
 
 	// Reset relevant variables.
+	if(istype(cooking_obj, /obj/item/weapon/holder) && cooking_obj.contents[1])
+		qdel(cooking_obj.contents[1])
 	qdel(cooking_obj)
 	src.visible_message("<span class='notice'>\The [src] pings!</span>")
 	if(cooked_sound)
@@ -175,6 +177,8 @@
 		icon_state = off_icon
 		cooking = 0
 		return FALSE
+	else
+		return TRUE
 
 /obj/machinery/cooker/attack_hand(mob/user)
 

--- a/code/game/machinery/kitchen/cooking_machines/_cooker.dm
+++ b/code/game/machinery/kitchen/cooking_machines/_cooker.dm
@@ -107,6 +107,7 @@
 	if(istype(cooking_obj, /obj/item/weapon/holder))
 		for(var/mob/living/M in cooking_obj.contents)
 			M.death()
+			qdel(M)
 
 	// Cook the food.
 	var/cook_path
@@ -134,8 +135,6 @@
 	result.cooked |= cook_type
 
 	// Reset relevant variables.
-	if(istype(cooking_obj, /obj/item/weapon/holder) && cooking_obj.contents[1])
-		qdel(cooking_obj.contents[1])
 	qdel(cooking_obj)
 	src.visible_message("<span class='notice'>\The [src] pings!</span>")
 	if(cooked_sound)


### PR DESCRIPTION
Пофикшены кухонные приборы

Обнаружил, что вот тут https://github.com/ChaoticOnyx/OnyxBay/commit/a6eb7437e74e85076303cddec36d1b88bd2e3992#diff-cff537c745ca48ebb082adb773278ec3 была сломана функция проверки того, что в кухонной машине есть объект и что у этого объекта положение - прибор. Пофиксил. Далее нашел, что, если жарить животных, то они дюпаются, потому что при удалении объекта в печи удаляется "рука" типа /obj/item/weapon/holder, а не само животное, которое эта "рука" удерживает, поэтому проверяем и удаляем животное.

Closes #1861.

- [x] Pull Request полностью завершен, мне не нужна помощь чтобы его закончить.
- [x] Я внимательно прочитал все свои изменения и багов в них не нашел.
- [x] Я запускал сервер со своими изменениями локально и все протестировал.
- [x] Я ознакомился c [Guide to Contribute](https://github.com/ChaoticOnyx/OnyxBay/blob/dev/docs/contributing.md).
