### PR TITLE
Removes excessive stun time caused by gravity and airflow, removes ineffictivity of armor

### DIFF
--- a/code/game/area/areas.dm
+++ b/code/game/area/areas.dm
@@ -284,7 +284,7 @@ var/list/mob/living/forced_ambiance_list = new
 
 		H.AdjustStunned(1)
 		H.AdjustWeakened(1)
-		to_chat(mob, "<span class='warning'>The sudden appearance of gravity makes you fall to the floor!</span>")
+		to_chat(mob, SPAN_WARNING("The sudden appearance of gravity makes you fall to the floor!"))
 
 /area/proc/prison_break()
 	var/obj/machinery/power/apc/theAPC = get_apc()

--- a/code/game/area/areas.dm
+++ b/code/game/area/areas.dm
@@ -282,13 +282,9 @@ var/list/mob/living/forced_ambiance_list = new
 		if(istype(H.shoes, /obj/item/clothing/shoes/magboots) && (H.shoes.item_flags & ITEM_FLAG_NOSLIP))
 			return
 
-		if(H.m_intent == "run")
-			H.AdjustStunned(3)
-			H.AdjustWeakened(3)
-		else
-			H.AdjustStunned(1)
-			H.AdjustWeakened(1)
-		to_chat(mob, "<span class='notice'>The sudden appearance of gravity makes you fall to the floor!</span>")
+		H.AdjustStunned(1)
+		H.AdjustWeakened(1)
+		to_chat(mob, "<span class='warning'>The sudden appearance of gravity makes you fall to the floor!</span>")
 
 /area/proc/prison_break()
 	var/obj/machinery/power/apc/theAPC = get_apc()

--- a/code/game/area/areas.dm
+++ b/code/game/area/areas.dm
@@ -35,7 +35,7 @@
 	switch(gravity_state)
 		if(AREA_GRAVITY_NEVER)
 			has_gravity = 0
-		if(AREA_GRAVITY_ALWAYS)	
+		if(AREA_GRAVITY_ALWAYS)
 			has_gravity = 1
 
 /area/proc/get_contents()
@@ -283,11 +283,11 @@ var/list/mob/living/forced_ambiance_list = new
 			return
 
 		if(H.m_intent == "run")
-			H.AdjustStunned(6)
-			H.AdjustWeakened(6)
-		else
 			H.AdjustStunned(3)
 			H.AdjustWeakened(3)
+		else
+			H.AdjustStunned(1)
+			H.AdjustWeakened(1)
 		to_chat(mob, "<span class='notice'>The sudden appearance of gravity makes you fall to the floor!</span>")
 
 /area/proc/prison_break()

--- a/code/modules/ZAS/Airflow.dm
+++ b/code/modules/ZAS/Airflow.dm
@@ -16,7 +16,7 @@ mob/proc/airflow_stun()
 		return 0
 	if(lying)
 		return 0 // Chudo-code
-	to_chat(src, "<span class='warning'>The sudden rush of air knocks you over!</span>")
+	to_chat(src, SPAN_WARNING("The sudden rush of air knocks you over!")
 	Weaken(1)
 	last_airflow_stun = world.time
 

--- a/code/modules/ZAS/Airflow.dm
+++ b/code/modules/ZAS/Airflow.dm
@@ -17,7 +17,7 @@ mob/proc/airflow_stun()
 	if(lying)
 		return 0 // Chudo-code
 	to_chat(src, SPAN_WARNING("The sudden rush of air knocks you over!"))
-	Weaken(1)
+	Weaken(rand(1,2))
 	last_airflow_stun = world.time
 
 mob/living/silicon/airflow_stun()

--- a/code/modules/ZAS/Airflow.dm
+++ b/code/modules/ZAS/Airflow.dm
@@ -16,7 +16,7 @@ mob/proc/airflow_stun()
 		return 0
 	if(lying)
 		return 0 // Chudo-code
-	to_chat(src, SPAN_WARNING("The sudden rush of air knocks you over!")
+	to_chat(src, SPAN_WARNING("The sudden rush of air knocks you over!"))
 	Weaken(1)
 	last_airflow_stun = world.time
 

--- a/code/modules/ZAS/Airflow.dm
+++ b/code/modules/ZAS/Airflow.dm
@@ -17,7 +17,7 @@ mob/proc/airflow_stun()
 	if(lying)
 		return 0 // Chudo-code
 	to_chat(src, "<span class='warning'>The sudden rush of air knocks you over!</span>")
-	Weaken(3)
+	Weaken(2)
 	last_airflow_stun = world.time
 
 mob/living/silicon/airflow_stun()

--- a/code/modules/ZAS/Airflow.dm
+++ b/code/modules/ZAS/Airflow.dm
@@ -15,7 +15,7 @@ mob/proc/airflow_stun()
 		to_chat(src, "<span class='notice'>Air suddenly rushes past you!</span>")
 		return 0
 	if(lying)
-		return 0 // Chudo-code
+		return 0
 	to_chat(src, SPAN_WARNING("The sudden rush of air knocks you over!"))
 	Weaken(rand(1,2))
 	last_airflow_stun = world.time

--- a/code/modules/ZAS/Airflow.dm
+++ b/code/modules/ZAS/Airflow.dm
@@ -14,9 +14,10 @@ mob/proc/airflow_stun()
 	if(buckled)
 		to_chat(src, "<span class='notice'>Air suddenly rushes past you!</span>")
 		return 0
-	if(!lying)
-		to_chat(src, "<span class='warning'>The sudden rush of air knocks you over!</span>")
-	Weaken(5)
+	if(lying)
+		return 0 // Chudo-code
+	to_chat(src, "<span class='warning'>The sudden rush of air knocks you over!</span>")
+	Weaken(3)
 	last_airflow_stun = world.time
 
 mob/living/silicon/airflow_stun()

--- a/code/modules/ZAS/Airflow.dm
+++ b/code/modules/ZAS/Airflow.dm
@@ -17,7 +17,7 @@ mob/proc/airflow_stun()
 	if(lying)
 		return 0 // Chudo-code
 	to_chat(src, "<span class='warning'>The sudden rush of air knocks you over!</span>")
-	Weaken(2)
+	Weaken(1)
 	last_airflow_stun = world.time
 
 mob/living/silicon/airflow_stun()

--- a/code/modules/mob/living/carbon/human/human.dm
+++ b/code/modules/mob/living/carbon/human/human.dm
@@ -921,11 +921,6 @@
 	var/obj/item/organ/internal/lungs/L = internal_organs_by_name[BP_LUNGS]
 	return L && L.is_bruised()
 
-/mob/living/carbon/human/proc/rupture_lung()
-	var/obj/item/organ/internal/lungs/L = internal_organs_by_name[BP_LUNGS]
-	if(L)
-		L.rupture()
-
 /mob/living/carbon/human/add_blood(mob/living/carbon/human/M as mob)
 	if (!..())
 		return 0

--- a/code/modules/mob/living/carbon/human/human_defense.dm
+++ b/code/modules/mob/living/carbon/human/human_defense.dm
@@ -25,7 +25,7 @@ meteor_act
 
 	var/obj/item/organ/external/organ = get_organ(def_zone)
 	var/armor = getarmor_organ(organ, P.check_armour)
-	var/penetrating_damage = ((P.damage + P.armor_penetration) * P.penetration_modifier) - armor
+	var/penetrating_damage = ((P.damage + P.armor_penetration) * P.penetration_modifier) - min(armor*1.4, 100)
 
 	//Organ damage
 	if(organ.internal_organs.len && prob(35 + max(penetrating_damage, -12.5)))

--- a/code/modules/mob/living/carbon/human/human_defense.dm
+++ b/code/modules/mob/living/carbon/human/human_defense.dm
@@ -43,7 +43,7 @@ meteor_act
 					victim.take_internal_damage(damage_amt)
 
 	//Embed or sever artery
-	if(P.can_embed() && !(species.species_flags & SPECIES_FLAG_NO_EMBED) && prob(22.5 + max(penetrating_damage, -10)) && !(prob(50) && (organ.sever_artery())))
+	if(P.can_embed() && !(species.species_flags & SPECIES_FLAG_NO_EMBED) && prob(22.5 + max(penetrating_damage, -20)) && !(prob(50) && (organ.sever_artery())))
 		var/obj/item/weapon/material/shard/shrapnel/SP = new()
 		SP.SetName((P.name != "shrapnel")? "[P.name] shrapnel" : "shrapnel")
 		SP.desc = "[SP.desc] It looks like it was fired from [P.shot_from]."

--- a/code/modules/organs/internal/lungs.dm
+++ b/code/modules/organs/internal/lungs.dm
@@ -123,8 +123,8 @@
 					if(istype(parent))
 						owner.custom_pain("You feel a stabbing pain in your [parent.name]!", 20, affecting = parent)
 		if(breath.total_moles == 0)
-		breath_fail_ratio = 1
-		handle_failed_breath()
+			breath_fail_ratio = 1
+			handle_failed_breath()
 		return 1
 
 	var/safe_pressure_min = min_breath_pressure // Minimum safe partial pressure of breathable gas in kPa

--- a/code/modules/organs/internal/lungs.dm
+++ b/code/modules/organs/internal/lungs.dm
@@ -120,10 +120,12 @@
 	if(breath_pressure < species.hazard_low_pressure || breath_pressure > species.hazard_high_pressure)
 		var/datum/gas_mixture/environment = loc.return_air_for_internal_lifeform()
 		var/env_pressure = environment.return_pressure()
-		var/lung_rupture_prob = BP_IS_ROBOTIC(src) ? prob(2.5) : prob(5) //Robotic lungs are less likely to rupture.
+		var/lung_damage_prob = BP_IS_ROBOTIC(src) ? prob(2.5) : prob(5) //Robotic lungs are less likely to rupture.
 		if(env_pressure < species.hazard_low_pressure || env_pressure > species.hazard_high_pressure)
-			if(!is_bruised() && lung_rupture_prob) //only rupture if NOT already ruptured
-				rupture()
+			if(lung_damage_prob)
+				take_internal_damage(5)
+				if(!is_bruised() && damage > min_bruised_damage) //only rupture if NOT already ruptured and lungs are damaged
+					rupture()
 	if(breath.total_moles == 0)
 		breath_fail_ratio = 1
 		handle_failed_breath()

--- a/code/modules/organs/internal/lungs.dm
+++ b/code/modules/organs/internal/lungs.dm
@@ -100,12 +100,6 @@
 
 			owner.losebreath += round(damage/2)
 
-/obj/item/organ/internal/lungs/proc/rupture()
-	var/obj/item/organ/external/parent = owner.get_organ(parent_organ)
-	if(istype(parent))
-		owner.custom_pain("You feel a stabbing pain in your [parent.name]!", 50, affecting = parent)
-	bruise()
-
 /obj/item/organ/internal/lungs/proc/handle_breath(datum/gas_mixture/breath, forced)
 	if(!owner)
 		return 1
@@ -124,9 +118,11 @@
 		if(env_pressure < species.hazard_low_pressure || env_pressure > species.hazard_high_pressure)
 			if(lung_damage_prob)
 				take_internal_damage(5)
-				if(!is_bruised() && damage > min_bruised_damage) //only rupture if NOT already ruptured and lungs are damaged
-					rupture()
-	if(breath.total_moles == 0)
+				if(is_bruised()) //only spam pain if already ruptured
+					var/obj/item/organ/external/parent = owner.get_organ(parent_organ)
+					if(istype(parent))
+						owner.custom_pain("You feel a stabbing pain in your [parent.name]!", 20, affecting = parent)
+		if(breath.total_moles == 0)
 		breath_fail_ratio = 1
 		handle_failed_breath()
 		return 1

--- a/code/modules/projectiles/projectile/bullets.dm
+++ b/code/modules/projectiles/projectile/bullets.dm
@@ -159,6 +159,7 @@
 	embed = 0
 	sharp = 0
 	armor_penetration = 2.5
+	penetration_modifier = 0.2
 
 /obj/item/projectile/bullet/pistol/rubber/c44
 	name = "rubber bullet"

--- a/code/modules/projectiles/projectile/bullets.dm
+++ b/code/modules/projectiles/projectile/bullets.dm
@@ -190,6 +190,7 @@
 	agony = 60
 	embed = 0
 	sharp = 0
+	penetration_modifier = 0.2
 
 //Should do about 80 damage at 1 tile distance (adjacent), and 50 damage at 3 tiles distance.
 //Overall less damage than slugs in exchange for more damage at very close range and more embedding


### PR DESCRIPTION
1. Уменьшено время падения от сквозняка (15 секунд -> 3 секунд). Сквозняк больше не обновляет время стана у лежачих. Бесконечный сквозняк всё ещё будет ронять кучу раз подряд, но у космонавтика будет время на включение магбутов или приседание на стул.
2. Уменьшено время падения от **внезапного** появления гравитации (18 -> 3 и 9 -> 3 секунд при беге/ходьбе соответственно). Может быть, нерфоцирк, но споткнуться и упасть дольше, чем от попадания тазера - это какое-то говно.
3. Изменена механика разрыва лёгких от слишком низкого/высокого давления. Раньше каждый вдох имел шанс (5% и 2.5% у обычных и механических) насмерть порвать лёгкие, из-за чего секундное нахождение без воздуха могло сделать фраг. Теперь - вместо этого с таким же шансом лёгкие постепенно ловят урон. Как негативный эффект - порванные лёгкие продолжат получать урон от давления и могут убиться намертво.
4. Пофиксил забытый кусок своей боёвочки и теперь броня действительно даёт хоть какую-то защиту от рвущихся артерий и застревающей шрапнели. Если в цифрах - минимальный шанс (с бронёй, превышающей урон+проникновение пули) порвать/застрять при попадании обычной пули был 7,25%. Теперь -1,25%. Например, 9мм пуля при попадании в среднюю плиту из керриера рвёт/застревает с шансом 2,5%, а пуля из матебы в неё же - 28%.
5. Значительно уменьшен шанс разрыва артерий/застревания у резиновых пулек и бинбэгов.

- [x] Pull Request полностью завершен, мне не нужна помощь чтобы его закончить.
- [x] Я внимательно прочитал все свои изменения и багов в них не нашел.
- [x] Я запускал сервер со своими изменениями локально и все протестировал.
- [x] Я ознакомился c [Guide to Contribute]
- [x] Как и обещал год назад, пытаюсь фиксить свою боёвочку.