### PR TITLE
Revert "Алмазный бур для Рипли стал хуже обычного, а обычный стал хуйней"

### DIFF
--- a/code/game/mecha/equipment/tools/tools.dm
+++ b/code/game/mecha/equipment/tools/tools.dm
@@ -79,50 +79,50 @@
 	force = 15
 	required_type = list(/obj/mecha/working/ripley, /obj/mecha/combat)
 
-	action(atom/target)
-		if(!action_checks(target)) return
-		if(isobj(target))
-			var/obj/target_obj = target
-			if(!target_obj.vars.Find("unacidable") || target_obj.unacidable)	return
-		set_ready_state(0)
-		chassis.use_power(energy_drain)
-		chassis.visible_message("<span class='danger'>\The [chassis] starts to drill \the [target]</span>", "<span class='warning'>You hear a large drill.</span>")
-		occupant_message("<span class='danger'>You start to drill \the [target]</span>")
-		var/T = chassis.loc
-		var/C = target.loc	//why are these backwards? we may never know -Pete
-		if(do_after_cooldown(target))
-			if(T == chassis.loc && src == chassis.selected)
-				if(istype(target, /turf/simulated/wall))
-					var/turf/simulated/wall/W = target
-					if(W.reinf_material)
-						occupant_message("<span class='warning'>\The [target] is too durable to drill through.</span>")
-					else
-						log_message("Drilled through \the [target]")
-						target.ex_act(2)
-				else if(istype(target, /turf/simulated/mineral) || istype(target, /turf/simulated/floor/asteroid) || istype(target, /obj/structure/rock))
-					if (istype(target, /turf/simulated/mineral))
-						for(var/turf/simulated/mineral/M in range(chassis,1))
-							if(get_dir(chassis,M)&chassis.dir)
-								M.GetDrilled()
-					else if (istype(target, /turf/simulated/floor/asteroid))
-						for(var/turf/simulated/floor/asteroid/M in range(chassis,1))
-							if(get_dir(chassis,M)&chassis.dir)
-								M.gets_dug()
-					else if(istype(target, /obj/structure/rock))
-						for(var/obj/structure/rock/R in range(chassis,1))
-							if(get_dir(chassis,R)&chassis.dir)
-								qdel(R)
-					log_message("Drilled through \the [target]")
-					if(locate(/obj/item/mecha_parts/mecha_equipment/tool/hydraulic_clamp) in chassis.equipment)
-						var/obj/structure/ore_box/ore_box = locate(/obj/structure/ore_box) in chassis:cargo
-						if(ore_box)
-							for(var/obj/item/weapon/ore/ore in range(chassis,1))
-								if(get_dir(chassis,ore)&chassis.dir)
-									ore.Move(ore_box)
-				else if(target.loc == C)
+/obj/item/mecha_parts/mecha_equipment/tool/drill/action(atom/target)
+	if(!action_checks(target)) return
+	if(isobj(target))
+		var/obj/target_obj = target
+		if(!target_obj.vars.Find("unacidable") || target_obj.unacidable)	return
+	set_ready_state(0)
+	chassis.use_power(energy_drain)
+	chassis.visible_message("<span class='danger'>\The [chassis] starts to drill \the [target]</span>", "<span class='warning'>You hear a large drill.</span>")
+	occupant_message("<span class='danger'>You start to drill \the [target]</span>")
+	var/T = chassis.loc
+	var/C = target.loc	//why are these backwards? we may never know -Pete
+	if(do_after_cooldown(target))
+		if(T == chassis.loc && src == chassis.selected)
+			if(istype(target, /turf/simulated/wall))
+				var/turf/simulated/wall/W = target
+				if(W.reinf_material)
+					occupant_message("<span class='warning'>\The [target] is too durable to drill through.</span>")
+				else
 					log_message("Drilled through \the [target]")
 					target.ex_act(2)
-		return 1
+			else if(istype(target, /turf/simulated/mineral) || istype(target, /turf/simulated/floor/asteroid) || istype(target, /obj/structure/rock))
+				if (istype(target, /turf/simulated/mineral))
+					for(var/turf/simulated/mineral/M in range(chassis,1))
+						if(get_dir(chassis,M)&chassis.dir)
+							M.GetDrilled()
+				else if (istype(target, /turf/simulated/floor/asteroid))
+					for(var/turf/simulated/floor/asteroid/M in range(chassis,1))
+						if(get_dir(chassis,M)&chassis.dir)
+							M.gets_dug()
+				else if(istype(target, /obj/structure/rock))
+					for(var/obj/structure/rock/R in range(chassis,1))
+						if(get_dir(chassis,R)&chassis.dir)
+							qdel(R)
+				log_message("Drilled through \the [target]")
+				if(locate(/obj/item/mecha_parts/mecha_equipment/tool/hydraulic_clamp) in chassis.equipment)
+					var/obj/structure/ore_box/ore_box = locate(/obj/structure/ore_box) in chassis:cargo
+					if(ore_box)
+						for(var/obj/item/weapon/ore/ore in range(chassis,1))
+							if(get_dir(chassis,ore)&chassis.dir)
+								ore.Move(ore_box)
+			else if(target.loc == C)
+				log_message("Drilled through \the [target]")
+				target.ex_act(2)
+	return 1
 
 /obj/item/mecha_parts/mecha_equipment/tool/drill/diamonddrill
 	name = "diamond drill"
@@ -132,48 +132,48 @@
 	equip_cooldown = 20
 	force = 15
 
-	action(atom/target)
-		if(!action_checks(target)) return
-		if(isobj(target))
-			var/obj/target_obj = target
-			if(target_obj.unacidable)	return
-		set_ready_state(0)
-		chassis.use_power(energy_drain)
-		chassis.visible_message("<span class='danger'>\The [chassis] starts to drill \the [target]</span>", "<span class='warning'>You hear a large drill.</span>")
-		occupant_message("<span class='danger'>You start to drill \the [target]</span>")
-		var/T = chassis.loc
-		var/C = target.loc	//why are these backwards? we may never know -Pete
-		if(do_after_cooldown(target))
-			if(T == chassis.loc && src == chassis.selected)
-				if(istype(target, /turf/simulated/wall))
-					var/turf/simulated/wall/W = target
-					if(!W.reinf_material || do_after_cooldown(target))//To slow down how fast mechs can drill through the station
-						log_message("Drilled through \the [target]")
-						target.ex_act(3)
-					else if(istype(target, /turf/simulated/mineral) || istype(target, /turf/simulated/floor/asteroid) || istype(target, /obj/structure/rock))
-						if (istype(target, /turf/simulated/mineral))
-							for(var/turf/simulated/mineral/M in range(chassis,1))
-								if(get_dir(chassis,M)&chassis.dir)
-									M.GetDrilled()
-						else if (istype(target, /turf/simulated/floor/asteroid))
-							for(var/turf/simulated/floor/asteroid/M in range(chassis,1))
-								if(get_dir(chassis,M)&chassis.dir)
-									M.gets_dug()
-						else if(istype(target, /obj/structure/rock))
-							for(var/obj/structure/rock/R in range(chassis,1))
-								if(get_dir(chassis,R)&chassis.dir)
-									qdel(R)
-						log_message("Drilled through \the [target]")
-						if(locate(/obj/item/mecha_parts/mecha_equipment/tool/hydraulic_clamp) in chassis.equipment)
-							var/obj/structure/ore_box/ore_box = locate(/obj/structure/ore_box) in chassis:cargo
-							if(ore_box)
-								for(var/obj/item/weapon/ore/ore in range(chassis,1))
-									if(get_dir(chassis,ore)&chassis.dir)
-										ore.Move(ore_box)
-				else if(target.loc == C)
+/obj/item/mecha_parts/mecha_equipment/tool/drill/diamonddrill/action(atom/target)
+	if(!action_checks(target)) return
+	if(isobj(target))
+		var/obj/target_obj = target
+		if(!target_obj.vars.Find("unacidable") || target_obj.unacidable)	return
+	set_ready_state(0)
+	chassis.use_power(energy_drain)
+	chassis.visible_message("<span class='danger'>\The [chassis] starts to drill \the [target]</span>", "<span class='warning'>You hear a large drill.</span>")
+	occupant_message("<span class='danger'>You start to drill \the [target]</span>")
+	var/T = chassis.loc
+	var/C = target.loc	//why are these backwards? we may never know -Pete
+	if(do_after_cooldown(target))
+		if(T == chassis.loc && src == chassis.selected)
+			if(istype(target, /turf/simulated/wall))
+				var/turf/simulated/wall/W = target
+				if(!W.reinf_material || do_after_cooldown(target))//To slow down how fast mechs can drill through the station
 					log_message("Drilled through \the [target]")
-					target.ex_act(2)
-		return 1
+					target.ex_act(3)
+			else if(istype(target, /turf/simulated/mineral) || istype(target, /turf/simulated/floor/asteroid) || istype(target, /obj/structure/rock))
+				if (istype(target, /turf/simulated/mineral))
+					for(var/turf/simulated/mineral/M in range(chassis,1))
+						if(get_dir(chassis,M)&chassis.dir)
+							M.GetDrilled()
+				else if (istype(target, /turf/simulated/floor/asteroid))
+					for(var/turf/simulated/floor/asteroid/M in range(chassis,1))
+						if(get_dir(chassis,M)&chassis.dir)
+							M.gets_dug()
+				else if(istype(target, /obj/structure/rock))
+					for(var/obj/structure/rock/R in range(chassis,1))
+						if(get_dir(chassis,R)&chassis.dir)
+							qdel(R)
+				log_message("Drilled through \the [target]")
+				if(locate(/obj/item/mecha_parts/mecha_equipment/tool/hydraulic_clamp) in chassis.equipment)
+					var/obj/structure/ore_box/ore_box = locate(/obj/structure/ore_box) in chassis:cargo
+					if(ore_box)
+						for(var/obj/item/weapon/ore/ore in range(chassis,1))
+							if(get_dir(chassis,ore)&chassis.dir)
+								ore.Move(ore_box)
+			else if(target.loc == C)
+				log_message("Drilled through \the [target]")
+				target.ex_act(2)
+	return 1
 
 /obj/item/mecha_parts/mecha_equipment/tool/extinguisher
 	name = "extinguisher"

--- a/code/game/mecha/equipment/tools/tools.dm
+++ b/code/game/mecha/equipment/tools/tools.dm
@@ -79,25 +79,26 @@
 	force = 15
 	required_type = list(/obj/mecha/working/ripley, /obj/mecha/combat)
 
-/obj/item/mecha_parts/mecha_equipment/tool/drill/action(atom/target)
-	if(!action_checks(target)) return
-	if(isobj(target))
-		var/obj/target_obj = target
-		if(target_obj.unacidable)	return
-		
-	set_ready_state(0)
-	chassis.use_power(energy_drain)
-	chassis.visible_message("<span class='danger'>\The [chassis] starts to drill \the [target]</span>", "<span class='warning'>You hear a large drill.</span>")
-	occupant_message("<span class='danger'>You start to drill \the [target]</span>")
-	var/T = chassis.loc
-	var/C = target.loc	//why are these backwards? we may never know -Pete
-	if(do_after_cooldown(target))
-		if(T == chassis.loc && src == chassis.selected)
-			if(istype(target, /turf/simulated/wall))
-				var/turf/simulated/wall/W = target
-				if(!W.reinf_material || do_after_cooldown(target))//To slow down how fast mechs can drill through the station
-					log_message("Drilled through \the [target]")
-					target.ex_act(3)
+	action(atom/target)
+		if(!action_checks(target)) return
+		if(isobj(target))
+			var/obj/target_obj = target
+			if(!target_obj.vars.Find("unacidable") || target_obj.unacidable)	return
+		set_ready_state(0)
+		chassis.use_power(energy_drain)
+		chassis.visible_message("<span class='danger'>\The [chassis] starts to drill \the [target]</span>", "<span class='warning'>You hear a large drill.</span>")
+		occupant_message("<span class='danger'>You start to drill \the [target]</span>")
+		var/T = chassis.loc
+		var/C = target.loc	//why are these backwards? we may never know -Pete
+		if(do_after_cooldown(target))
+			if(T == chassis.loc && src == chassis.selected)
+				if(istype(target, /turf/simulated/wall))
+					var/turf/simulated/wall/W = target
+					if(W.reinf_material)
+						occupant_message("<span class='warning'>\The [target] is too durable to drill through.</span>")
+					else
+						log_message("Drilled through \the [target]")
+						target.ex_act(2)
 				else if(istype(target, /turf/simulated/mineral) || istype(target, /turf/simulated/floor/asteroid) || istype(target, /obj/structure/rock))
 					if (istype(target, /turf/simulated/mineral))
 						for(var/turf/simulated/mineral/M in range(chassis,1))
@@ -118,11 +119,10 @@
 							for(var/obj/item/weapon/ore/ore in range(chassis,1))
 								if(get_dir(chassis,ore)&chassis.dir)
 									ore.Move(ore_box)
-			else if(target.loc == C)
-				log_message("Drilled through \the [target]")
-				target.ex_act(2)
-	return 1
-	
+				else if(target.loc == C)
+					log_message("Drilled through \the [target]")
+					target.ex_act(2)
+		return 1
 
 /obj/item/mecha_parts/mecha_equipment/tool/drill/diamonddrill
 	name = "diamond drill"
@@ -132,50 +132,48 @@
 	equip_cooldown = 20
 	force = 15
 
-/obj/item/mecha_parts/mecha_equipment/tool/drill/diamonddrill/action(atom/target)
-	if(!action_checks(target)) return
-	if(isobj(target))
-		var/obj/target_obj = target
-		if(!target_obj.vars.Find("unacidable") || target_obj.unacidable)	return
-	set_ready_state(0)
-	chassis.use_power(energy_drain)
-	chassis.visible_message("<span class='danger'>\The [chassis] starts to drill \the [target]</span>", "<span class='warning'>You hear a large drill.</span>")
-	occupant_message("<span class='danger'>You start to drill \the [target]</span>")
-	var/T = chassis.loc
-	var/C = target.loc	//why are these backwards? we may never know -Pete
-	if(do_after_cooldown(target))
-		if(T == chassis.loc && src == chassis.selected)
-			if(istype(target, /turf/simulated/wall))
-				var/turf/simulated/wall/W = target
-				if(W.reinf_material)
-					occupant_message("<span class='warning'>\The [target] is too durable to drill through.</span>")
-				else
+	action(atom/target)
+		if(!action_checks(target)) return
+		if(isobj(target))
+			var/obj/target_obj = target
+			if(target_obj.unacidable)	return
+		set_ready_state(0)
+		chassis.use_power(energy_drain)
+		chassis.visible_message("<span class='danger'>\The [chassis] starts to drill \the [target]</span>", "<span class='warning'>You hear a large drill.</span>")
+		occupant_message("<span class='danger'>You start to drill \the [target]</span>")
+		var/T = chassis.loc
+		var/C = target.loc	//why are these backwards? we may never know -Pete
+		if(do_after_cooldown(target))
+			if(T == chassis.loc && src == chassis.selected)
+				if(istype(target, /turf/simulated/wall))
+					var/turf/simulated/wall/W = target
+					if(!W.reinf_material || do_after_cooldown(target))//To slow down how fast mechs can drill through the station
+						log_message("Drilled through \the [target]")
+						target.ex_act(3)
+					else if(istype(target, /turf/simulated/mineral) || istype(target, /turf/simulated/floor/asteroid) || istype(target, /obj/structure/rock))
+						if (istype(target, /turf/simulated/mineral))
+							for(var/turf/simulated/mineral/M in range(chassis,1))
+								if(get_dir(chassis,M)&chassis.dir)
+									M.GetDrilled()
+						else if (istype(target, /turf/simulated/floor/asteroid))
+							for(var/turf/simulated/floor/asteroid/M in range(chassis,1))
+								if(get_dir(chassis,M)&chassis.dir)
+									M.gets_dug()
+						else if(istype(target, /obj/structure/rock))
+							for(var/obj/structure/rock/R in range(chassis,1))
+								if(get_dir(chassis,R)&chassis.dir)
+									qdel(R)
+						log_message("Drilled through \the [target]")
+						if(locate(/obj/item/mecha_parts/mecha_equipment/tool/hydraulic_clamp) in chassis.equipment)
+							var/obj/structure/ore_box/ore_box = locate(/obj/structure/ore_box) in chassis:cargo
+							if(ore_box)
+								for(var/obj/item/weapon/ore/ore in range(chassis,1))
+									if(get_dir(chassis,ore)&chassis.dir)
+										ore.Move(ore_box)
+				else if(target.loc == C)
 					log_message("Drilled through \the [target]")
 					target.ex_act(2)
-			else if(istype(target, /turf/simulated/mineral) || istype(target, /turf/simulated/floor/asteroid) || istype(target, /obj/structure/rock))
-				if (istype(target, /turf/simulated/mineral))
-					for(var/turf/simulated/mineral/M in range(chassis,1))
-						if(get_dir(chassis,M)&chassis.dir)
-							M.GetDrilled()
-				else if (istype(target, /turf/simulated/floor/asteroid))
-					for(var/turf/simulated/floor/asteroid/M in range(chassis,1))
-						if(get_dir(chassis,M)&chassis.dir)
-							M.gets_dug()
-				else if(istype(target, /obj/structure/rock))
-					for(var/obj/structure/rock/R in range(chassis,1))
-						if(get_dir(chassis,R)&chassis.dir)
-							qdel(R)
-				log_message("Drilled through \the [target]")
-				if(locate(/obj/item/mecha_parts/mecha_equipment/tool/hydraulic_clamp) in chassis.equipment)
-					var/obj/structure/ore_box/ore_box = locate(/obj/structure/ore_box) in chassis:cargo
-					if(ore_box)
-						for(var/obj/item/weapon/ore/ore in range(chassis,1))
-							if(get_dir(chassis,ore)&chassis.dir)
-								ore.Move(ore_box)
-			else if(target.loc == C)
-				log_message("Drilled through \the [target]")
-				target.ex_act(2)
-	return 1
+		return 1
 
 /obj/item/mecha_parts/mecha_equipment/tool/extinguisher
 	name = "extinguisher"


### PR DESCRIPTION
Reverts ChaoticOnyx/OnyxBay#2033
Из-за этого ПРа Рипли стал неиграбельным мехом вместо просто плохого меха. Из-за желания автора пофиксить отступ проверка кода стала очень сложной и были внесены изменения, не описанные в ПР(например, то, что обычная дрель теперь может ломать укрепленные стены). Из-за проебанного отступа логика была похерена, и блок кода `101-120` с рудами попал в логическую зону стены, из-за чего становится недоступным вовсе, то есть руда не копается как руда и не помещается в сумку.
Откатите это и напишите нормально вместе с нормальным ребалансом Рипли.
P.S. И отступы фиксить нужно в отдельном коммите, а не все в один.