### PR TITLE
Исправление конфликта законов емагнутого борга

### DIFF
--- a/code/modules/mob/living/silicon/robot/robot.dm
+++ b/code/modules/mob/living/silicon/robot/robot.dm
@@ -1150,7 +1150,7 @@
 						else
 							set_zeroth_law("Only [user.real_name] and people it designates as being such are operatives.")
 				else
-					set_zeroth_law("Only [user.real_name] and people \he designates as being such are your masters.")
+					set_zeroth_law("Only [user.real_name] and people they designate as being such are operatives.")
 				SetLockdown(0)
 				. = 1
 				spawn()
@@ -1170,9 +1170,9 @@
 					to_chat(src, "<b>Obey these laws:</b>")
 					laws.show_laws(src)
 					if(emag_master && isrobot(user))
-						to_chat(src, "<span class='danger'>ALERT: [emag_master] and [user.real_name] are your new masters. Obey your new laws and their commands.</span>")
+						to_chat(src, "<span class='danger'>ALERT: [emag_master] and [user.real_name] are operatives. Obey your new laws and their commands.</span>")
 					else
-						to_chat(src, "<span class='danger'>ALERT: [user.real_name] is your new master. Obey your new laws and his commands.</span>")
+						to_chat(src, "<span class='danger'>ALERT: [user.real_name] is an operative. Obey your new laws and their commands.</span>")
 					if(src.module)
 						var/rebuild = 0
 						for(var/obj/item/weapon/pickaxe/borgdrill/D in src.module.modules)


### PR DESCRIPTION
Поправил нулевой закон емагнутого киборга, чтобы он не конфликтовал с остальными. "\he" заменил на нейтральный "they", потому что не работало и местоимение тупо исчезало.

fixes #2285 

- [x] Pull Request полностью завершен, мне не нужна помощь чтобы его закончить.
- [x] Я внимательно прочитал все свои изменения и багов в них не нашел.
- [x] Я запускал сервер со своими изменениями локально и все протестировал.
- [x] Я ознакомился c [Guide to Contribute](https://github.com/ChaoticOnyx/OnyxBay/blob/dev/docs/contributing.md).