### PR TITLE
Фикс: выключенная сварка пилит решётчатый пол

### DIFF
--- a/code/game/objects/structures/lattice.dm
+++ b/code/game/objects/structures/lattice.dm
@@ -57,8 +57,9 @@
 		return
 	if(isWelder(C))
 		var/obj/item/weapon/weldingtool/WT = C
-		if(WT.remove_fuel(0, user))
-			to_chat(user, "<span class='notice'>Slicing lattice joints ...</span>")
+		if(!WT.remove_fuel(0, user))
+			return
+		to_chat(user, "<span class='notice'>Slicing lattice joints ...</span>")
 		new /obj/item/stack/rods(loc)
 		qdel(src)
 	if (istype(C, /obj/item/stack/rods))


### PR DESCRIPTION
Починил проверку на включённость и топливо сварки, из-за сломанности которой решётчатый пол можно было спилить выключенной сваркой или сваркой без топлива.

fix #2299 

- [x] Pull Request полностью завершен, мне не нужна помощь чтобы его закончить.
- [x] Я внимательно прочитал все свои изменения и багов в них не нашел.
- [x] Я запускал сервер со своими изменениями локально и все протестировал.
- [x] Я ознакомился c [Guide to Contribute](https://github.com/ChaoticOnyx/OnyxBay/blob/dev/docs/contributing.md).