### PR TITLE
Исправил доступ к интегральной камере.

### DIFF
--- a/code/modules/integrated_electronics/subtypes/output.dm
+++ b/code/modules/integrated_electronics/subtypes/output.dm
@@ -234,7 +234,7 @@
 /obj/item/integrated_circuit/output/video_camera/Initialize()
 	. = ..()
 	camera = new(src)
-	camera.replace_networks(list(NETWORK_THUNDER))
+	camera.replace_networks(list(NETWORK_RESEARCH))
 	on_data_written()
 
 /obj/item/integrated_circuit/output/video_camera/Destroy()


### PR DESCRIPTION
В самом описание платы написано что доступ можно получить через научную сеть.

> Takes a string as a name and a boolean to determine whether it is on, and uses  this to be a camera linked to **the research network**.

Но доступ получается в свою очередь через вкладку тандера.

Было:
![Снимок экрана (392)](https://user-images.githubusercontent.com/59255670/81983340-e6583a00-963b-11ea-8c5e-acae5808f3d5.png)

Стало:
![Снимок экрана (391)](https://user-images.githubusercontent.com/59255670/81977258-68436580-9632-11ea-847d-c9fcc30be6e4.png)

- [x] Pull Request полностью завершен, мне не нужна помощь чтобы его закончить.
- [x] Я внимательно прочитал все свои изменения и багов в них не нашел.
- [x] Я запускал сервер со своими изменениями локально и все протестировал.
- [x] Я ознакомился c [Guide to Contribute]