### PR TITLE
Removes 2 borgs limit in favor of the Great 3 Borgs Limit

### DIFF
--- a/code/game/jobs/job/silicon.dm
+++ b/code/game/jobs/job/silicon.dm
@@ -25,7 +25,7 @@
 	title = "Cyborg"
 	department_flag = MSC
 
-	total_positions = 2
+	total_positions = 3
 	spawn_positions = 2
 	supervisors = "your laws and the AI"	//Nodrak
 	selection_color = "#254c25"


### PR DESCRIPTION
Добавил третий слот для боргов. При этом раундстартом может быть только двое, но третий может зайти позже. Модули в любом случае занимаются, так что в стандартном раунде будет один щитсекборг и двое других. Два борга на 60 игроков - такое.

- [x] Pull Request полностью завершен, мне не нужна помощь чтобы его закончить.
- [x] Я внимательно прочитал все свои изменения и багов в них не нашел.
- [x] Я запускал сервер со своими изменениями локально и все протестировал.
- [x] Я ознакомился c [Guide to Contribute](https://github.com/ChaoticOnyx/OnyxBay/blob/dev/docs/contributing.md).
