### PR TITLE
fix(Subspace-Analyzer)

### DIFF
--- a/code/modules/research/stock_parts.dm
+++ b/code/modules/research/stock_parts.dm
@@ -242,7 +242,7 @@
 	name = "subspace wavelength analyzer"
 	icon_state = "wavelength_analyzer"
 	desc = "A sophisticated analyzer capable of analyzing cryptic subspace wavelengths."
-	origin_tech = list(TECH_DATA = 3, TECH_MAGNETS = 4, TECH_MATERIAL = 4, TECH_BLUESPACE = 2)
+	origin_tech = list(TECH_DATA = 3, TECH_MAGNET = 4, TECH_MATERIAL = 4, TECH_BLUESPACE = 2)
 	matter = list(MATERIAL_STEEL = 30, MATERIAL_GLASS = 10)
 
 /obj/item/weapon/stock_parts/subspace/crystal


### PR DESCRIPTION
Исправил уровни исследований, получаемые при разборке подпространственного анализатора (aka subspace analyzer), на корректные.
Неисправленный вариант:
![378](https://user-images.githubusercontent.com/58848742/81985950-a8f5ab80-963f-11ea-86d9-8bf9d6f3bc0d.png)
Исправленный:
![b-g](https://user-images.githubusercontent.com/58848742/81985258-afcfee80-963e-11ea-937b-3983654b238f.PNG)

Связанных иссуев не нашёл.

- [x] Pull Request полностью завершен, мне не нужна помощь чтобы его закончить.
- [x] Я внимательно прочитал все свои изменения и багов в них не нашел.
- [x] Я запускал сервер со своими изменениями локально и все протестировал.
- [x] Я ознакомился c [Guide to Contribute](https://github.com/ChaoticOnyx/OnyxBay/blob/dev/docs/contributing.md).
