### PR TITLE
Фикс постоянных падений от кислоты и не только.

### DIFF
--- a/code/__defines/damage_organs.dm
+++ b/code/__defines/damage_organs.dm
@@ -38,7 +38,7 @@
 #define ORGAN_MUTATED    (1<<4)  // The organ is unusable due to genetic damage.
 #define ORGAN_ARTERY_CUT (1<<6)  // The organ has had its artery cut.
 #define ORGAN_TENDON_CUT (1<<7)  // The organ has had its tendon cut.
-#define ORGAN_DISFIGURED (1<<8)  // The organ is scarred/disfigured. Alters whether or not the face can be recognised.
+#define ORGAN_DISFIGURED (1<<8)  // The organ is scarred/disfigured. Alters whether or not the face can be recognised. // I gonna eat you if you hang this flag for something that is not the face. ~TapoK
 #define ORGAN_SABOTAGED  (1<<9)  // The organ will explode if exposed to EMP, if prosthetic.
 #define ORGAN_ASSISTED   (1<<10) // The organ is partially prosthetic. No mechanical effect.
 #define ORGAN_ROBOTIC    (1<<11) // The organ is robotic. Changes numerous behaviors, search BP_IS_ROBOTIC for checks.

--- a/code/__defines/damage_organs.dm
+++ b/code/__defines/damage_organs.dm
@@ -38,7 +38,7 @@
 #define ORGAN_MUTATED    (1<<4)  // The organ is unusable due to genetic damage.
 #define ORGAN_ARTERY_CUT (1<<6)  // The organ has had its artery cut.
 #define ORGAN_TENDON_CUT (1<<7)  // The organ has had its tendon cut.
-#define ORGAN_DISFIGURED (1<<8)  // The organ is scarred/disfigured. Alters whether or not the face can be recognised. // I gonna eat you if you hang this flag for something that is not the face. ~TapoK
+#define ORGAN_DISFIGURED (1<<8)  // The organ is scarred/disfigured. Alters whether or not the face can be recognised. // I'm gonna eat you if you hang this flag for something that is not the face. ~TapoK
 #define ORGAN_SABOTAGED  (1<<9)  // The organ will explode if exposed to EMP, if prosthetic.
 #define ORGAN_ASSISTED   (1<<10) // The organ is partially prosthetic. No mechanical effect.
 #define ORGAN_ROBOTIC    (1<<11) // The organ is robotic. Changes numerous behaviors, search BP_IS_ROBOTIC for checks.

--- a/code/modules/mob/living/carbon/human/death.dm
+++ b/code/modules/mob/living/carbon/human/death.dm
@@ -92,8 +92,8 @@
 	update_hair(0)
 
 	mutations.Add(MUTATION_HUSK)
-	for(var/obj/item/organ/external/E in organs)
-		E.status |= ORGAN_DISFIGURED
+	for(var/obj/item/organ/external/head/h in organs)
+		h.status |= ORGAN_DISFIGURED
 	update_body(1)
 	return
 
@@ -112,7 +112,7 @@
 	update_hair(0)
 
 	mutations.Add(MUTATION_SKELETON)
-	for(var/obj/item/organ/external/E in organs)
-		E.status |= ORGAN_DISFIGURED
+	for(var/obj/item/organ/external/head/h in organs)
+		h.status |= ORGAN_DISFIGURED
 	update_body(1)
 	return

--- a/code/modules/organs/external/_external.dm
+++ b/code/modules/organs/external/_external.dm
@@ -1236,7 +1236,7 @@ obj/item/organ/external/proc/remove_clamps()
 	else if(is_stump())
 		qdel(src)
 
-/obj/item/organ/external/proc/disfigure(type = "brute")
+/obj/item/organ/external/head/proc/disfigure(type = "brute")
 	if(status & ORGAN_DISFIGURED)
 		return
 	if(owner)

--- a/code/modules/reagents/Chemistry-Reagents/Chemistry-Reagents-Dispenser.dm
+++ b/code/modules/reagents/Chemistry-Reagents/Chemistry-Reagents-Dispenser.dm
@@ -350,7 +350,6 @@
 				if(!screamed && affecting.can_feel_pain())
 					screamed = 1
 					H.emote("scream")
-				affecting.status |= ORGAN_DISFIGURED
 
 /datum/reagent/acid/touch_obj(obj/O)
 	if(O.unacidable)

--- a/code/modules/reagents/Chemistry-Reagents/Chemistry-Reagents-Medicine.dm
+++ b/code/modules/reagents/Chemistry-Reagents/Chemistry-Reagents-Medicine.dm
@@ -711,7 +711,7 @@
 	if(M.chem_doses[type] > 3 && ishuman(M))
 		var/mob/living/carbon/human/H = M
 		for(var/obj/item/organ/external/head/h in H.organs)
-			h.status |= ORGAN_DISFIGURED //currently only matters for the head, but might as well disfigure them all. // ONLY HEAD JESUS CHRIST ONLY HEAD, IF ITS NOT HEAD IT'S CAN'T BE HEALED AND IT WILL DESTROY handle_stance() WITH SANITY OF ALL PLAYERS WHO TOUCHED 0.00001337 UNITS OF ANY SHIT PLEASE GOD NO
+			h.status |= ORGAN_DISFIGURED //currently only matters for the head, but might as well disfigure them all. // ONLY HEAD JESUS CHRIST ONLY HEAD, IF IT'S NOT HEAD IT CAN'T BE HEALED AND IT WILL DESTROY handle_stance() WITH SANITY OF ALL PLAYERS WHO TOUCHED 0.00001337 UNITS OF ANY SHIT PLEASE GOD NO
 	if(M.chem_doses[type] > 10)
 		M.make_dizzy(5)
 		M.make_jittery(5)

--- a/code/modules/reagents/Chemistry-Reagents/Chemistry-Reagents-Medicine.dm
+++ b/code/modules/reagents/Chemistry-Reagents/Chemistry-Reagents-Medicine.dm
@@ -710,8 +710,8 @@
 	M.adjustToxLoss(-20 * removed)
 	if(M.chem_doses[type] > 3 && ishuman(M))
 		var/mob/living/carbon/human/H = M
-		for(var/obj/item/organ/external/E in H.organs)
-			E.status |= ORGAN_DISFIGURED //currently only matters for the head, but might as well disfigure them all.
+		for(var/obj/item/organ/external/head/h in H.organs)
+			h.status |= ORGAN_DISFIGURED //currently only matters for the head, but might as well disfigure them all. // ONLY HEAD JESUS CHRIST ONLY HEAD, IF ITS NOT HEAD IT'S CAN'T BE HEALED AND IT WILL DESTROY handle_stance() WITH SANITY OF ALL PLAYERS WHO TOUCHED 0.00001337 UNITS OF ANY SHIT PLEASE GOD NO
 	if(M.chem_doses[type] > 10)
 		M.make_dizzy(5)
 		M.make_jittery(5)


### PR DESCRIPTION
это история про флаг по имени ORGAN_DISFIGURED. ORGAN_DISFIGURED был обычным флагом который как обычно занимался своей жизню искривлением лица, всё было прекрасно

но однажды кто-то присвоил этот флаг всем органам, таким образом нарушив баланс сил во вселенной, ведь этот флаг можно было вылечить только для лица. такова была его задумка

затем тоби написал с его примением целую логику! и теперь, после облитого кислотой человека, тот становился инвалидом до конца своих дней, ибо вылечить у чего-то кроме головы ORGAN_DISFIGURED было невозможно

если серьёзно

- пофиксил хуйню при которой после кислоты челик вечно падал вследствие чего шок стейдж ронял сердце
- пофиксил эту хуйню у хасков(?) и скелетов. теперь если потрогать санса то после превращения вы не будете падать замертво
- кислота теперь вообще не вешает ORGAN_DISFIGURED ибо нахуй оно надо, если она на лицо упадёт то уже само искривится при получении урона другим проком
- в остальных местах флаг теперь вешается только на голову
- перевёл прок disfigure только для головы. на всякий случай

- [x] Pull Request полностью завершен, мне не нужна помощь чтобы его закончить.
- [x] Я внимательно прочитал все свои изменения и багов в них не нашел.
- [x] Я запускал сервер со своими изменениями локально и все протестировал.
- [x] Я ознакомился c [Guide to Contribute](https://github.com/ChaoticOnyx/OnyxBay/blob/dev/docs/contributing.md).
