### PR TITLE
Убрал возможность заходить за того же персонажа в одном раунде

### DIFF
--- a/code/modules/mob/new_player/new_player.dm
+++ b/code/modules/mob/new_player/new_player.dm
@@ -196,6 +196,13 @@
 		if (!client.EAMS_CheckForAccess())
 			return
 
+		//Prevents people rejoining as same character.
+		for (var/mob/living/carbon/human/C in SSmobs.mob_list)
+			var/char_name = client.prefs.real_name
+			if(char_name == C.real_name)
+				to_chat (usr, "<span class='danger'>There is a character that already exists with the same name: <b>[C.real_name]</b>, please join with a different one.</span>")
+				return
+			
 		if(!config.enter_allowed)
 			to_chat(usr, "<span class='notice'>There is an administrative lock on entering the game!</span>")
 			return


### PR DESCRIPTION
Портировал с поляриса и немного подправил. Запрещает заходить за персонажа с таким же именем. Удобно.

- [x] Pull Request полностью завершен, мне не нужна помощь чтобы его закончить.
- [x] Я внимательно прочитал все свои изменения и багов в них не нашел.
- [x] Я запускал сервер со своими изменениями локально и все протестировал.
- [x] Я ознакомился c [Guide to Contribute](https://github.com/ChaoticOnyx/OnyxBay/blob/dev/docs/contributing.md).
