### PR TITLE
fix(storyteller): fix balancing and spawn_antagonist trigger

### DIFF
--- a/code/modules/storyteller/characters/support.dm
+++ b/code/modules/storyteller/characters/support.dm
@@ -50,13 +50,17 @@
 			triggers.Remove(choosen_trigger)
 		while (!result && triggers.len)
 
-		if(!result) // no one of our triggers works, we can't do anything with balance :(
+		if(!result)
+			_log_debug("Triggers don't work! We can't fix the balance :(")
 			break
 
 		if (choosen_trigger == /storyteller_trigger/spawn_antagonist/traitor)
 			security_advantage -= 4
 		else
 			security_advantage -= 8
+
+		if (security_advantage <= 5)
+			balancing_is_needed = FALSE
 
 	if (balancing_is_needed)
 		_log_debug("Security Advantage after balancing: [security_advantage]")

--- a/code/modules/storyteller/triggers/spawn_antagonists_triggers.dm
+++ b/code/modules/storyteller/triggers/spawn_antagonists_triggers.dm
@@ -7,7 +7,7 @@
 	var/datum/antagonist/antag = GLOB.all_antag_types_[antagonist_id]
 	var/result = antag.attempt_auto_spawn(called_by_storyteller=TRUE)
 	_log_debug("[capitalize(antagonist_id)] was tried to be spawned. Success: [result]")
-	return
+	return result
 
 /storyteller_trigger/spawn_antagonist/traitor/New()
 	name = "Spawn Traitor"


### PR DESCRIPTION
Пофиксил спавн антагонистов сторителлером.

Из-за двух багов он спавнил только одного трейтора и одного чейнжа, не пересчитывая баланс. Сейчас поправил, теперь он будет спавнить чейнжей и трейторов до тех пор пока баланс не исправится.

Локально не тестировал, ибо сложно и неудобно. На сервере посмотрим, если тут будут баги опять - ничего плохого не случится.

- [x] Pull Request полностью завершен, мне не нужна помощь чтобы его закончить.
- [x] Я внимательно прочитал все свои изменения и багов в них не нашел.
- [ ] Я запускал сервер со своими изменениями локально и все протестировал.
- [x] Я ознакомился c [Guide to Contribute](https://github.com/ChaoticOnyx/OnyxBay/blob/dev/docs/contributing.md).
