### PR TITLE
fix_runtime(archeology)

### DIFF
--- a/code/modules/xenoarcheaology/finds/find_spawning.dm
+++ b/code/modules/xenoarcheaology/finds/find_spawning.dm
@@ -91,13 +91,13 @@
 
 	I.origin_tech = list()
 	if(prob(50))
-		I.origin_tech.Add(TECH_MATERIAL = pick(1, 2, 3, 4, 5, 6))
+		I.origin_tech[TECH_MATERIAL] = pick(1, 2, 3, 4, 5, 6)
 	if(prob(25))
-		I.origin_tech.Add(TECH_ENGINEERING = pick(1, 2, 3, 4, 5, 6))
+		I.origin_tech[TECH_ENGINEERING] = pick(1, 2, 3, 4, 5, 6)
 	if(prob(10))
-		I.origin_tech.Add(TECH_MAGNET = pick(1, 2, 3, 4, 5, 6))
+		I.origin_tech[TECH_MAGNET] = pick(1, 2, 3, 4, 5, 6)
 	if(prob(5))
-		I.origin_tech.Add(TECH_PHORON = pick(1, 2, 3, 4, 5, 6))
+		I.origin_tech[TECH_PHORON] = pick(1, 2, 3, 4, 5, 6)
 
 	return INITIALIZE_HINT_QDEL
 


### PR DESCRIPTION
Устранил рантайм из-за ошибки в синтаксисе.

Если кому интересно, Dream Maker распознавал такую строчку не как list association, а как named argument: `I.origin_tech.Add(TECH_MATERIAL = pick(1, 2, 3, 4, 5, 6))`.

close #2503 

- [x] Pull Request полностью завершен, мне не нужна помощь чтобы его закончить.
- [x] Я внимательно прочитал все свои изменения и багов в них не нашел.
- [x] Я запускал сервер со своими изменениями локально и все протестировал.
- [x] Я ознакомился c [Guide to Contribute](https://github.com/ChaoticOnyx/OnyxBay/blob/dev/docs/contributing.md).
