### PR TITLE
fix_runtime(shuttle)

### DIFF
--- a/maps/exodus/exodus_shuttles.dm
+++ b/maps/exodus/exodus_shuttles.dm
@@ -88,20 +88,6 @@
 /obj/effect/shuttle_landmark/escape_pod/transit/pod5
 	number = 5
 
-//Transport shuttle
-
-/datum/shuttle/autodock/ferry/transport
-	name = "Transport"
-	warmup_time = 10
-	location = 1
-	shuttle_area = /area/shuttle/transport/centcom
-	dock_target = "centcom_transport_shuttle"
-	landmark_transition = "nav_transport_transition"
-	waypoint_offsite = "nav_transport_start"
-	waypoint_station = "nav_transport_station"
-	move_time = 30
-	defer_initialisation = TRUE // Lost shuttle, auto-initialization off
-
 /obj/effect/shuttle_landmark/transport/start
 	name = "Centcomm"
 	landmark_tag = "nav_transport_start"

--- a/maps/exodus/exodus_shuttles.dm
+++ b/maps/exodus/exodus_shuttles.dm
@@ -100,6 +100,7 @@
 	waypoint_offsite = "nav_transport_start"
 	waypoint_station = "nav_transport_station"
 	move_time = 30
+	defer_initialisation = TRUE // Lost shuttle, auto-initialization off
 
 /obj/effect/shuttle_landmark/transport/start
 	name = "Centcomm"


### PR DESCRIPTION
Отключил инициализацию на старте игры у отсутствующего шаттла. Война рантаймам! Даёшь чистые логи!

```
[11:05:41] Runtime in shuttle.dm,47: Shuttle "Transport" could not find its starting location.
  proc name: New (/datum/shuttle/New)
  src: Transport (/datum/shuttle/autodock/ferry/transport)
  call stack:
  Transport (/datum/shuttle/autodock/ferry/transport): New(null, null)
  Transport (/datum/shuttle/autodock/ferry/transport): New(null, null)
  Transport (/datum/shuttle/autodock/ferry/transport): New(null)
  Shuttle (/datum/controller/subsystem/shuttle): initialise shuttle(/datum/shuttle/autodock/ferry/... (/datum/shuttle/autodock/ferry/transport), 1)
  Shuttle (/datum/controller/subsystem/shuttle): initialize shuttles()
  Shuttle (/datum/controller/subsystem/shuttle): Initialize(291418)
  Master (/datum/controller/master): Initialize(10, 0)
```

- [x] Pull Request полностью завершен, мне не нужна помощь чтобы его закончить.
- [x] Я внимательно прочитал все свои изменения и багов в них не нашел.
- [x] Я запускал сервер со своими изменениями локально и все протестировал.
- [x] Я ознакомился c [Guide to Contribute](https://github.com/ChaoticOnyx/OnyxBay/blob/dev/docs/contributing.md).
