### PR TITLE
fix(projectile): throw exception when projectile stuck

### DIFF
--- a/code/_helpers/logging.dm
+++ b/code/_helpers/logging.dm
@@ -2,6 +2,7 @@
 #define DIRECT_OUTPUT(A, B) A << B
 #define WRITE_FILE(file, text) DIRECT_OUTPUT(file, text)
 
+#define PRINT_ATOM(A) "[A] ([A.x], [A.y], [A.z])"
 
 // On Linux/Unix systems the line endings are LF, on windows it's CRLF, admins that don't use notepad++
 // will get logs that are one big line if the system is Linux and they are using notepad.  This solves it by adding CR to every line ending

--- a/code/modules/projectiles/projectile.dm
+++ b/code/modules/projectiles/projectile.dm
@@ -325,7 +325,8 @@
 	var/first_step = 1
 	var/i = 0
 	spawn while(src && src.loc)
-		ASSERT(++i < 512)
+		if (++i > 512)
+			throw EXCEPTION("Projectile stuck! Position: [PRINT_ATOM(current)], Target: [PRINT_ATOM(original)], Target location: [PRINT_ATOM(targloc)], Trajectory offset: ([trajectory.offset_x], [trajectory.offset_y])")
 		if(kill_count-- < 1)
 			on_impact(src.loc) //for any final impact behaviours
 			qdel(src)
@@ -462,7 +463,11 @@
 	return Process(targloc)
 
 /obj/item/projectile/test/Process(turf/targloc)
+	var/i = 0
 	while(src) //Loop on through!
+		if (++i > 512)
+			throw EXCEPTION("Projectile stuck! Position: [PRINT_ATOM(current)], Target: [PRINT_ATOM(original)], Target location: [PRINT_ATOM(targloc)], Trajectory offset: ([trajectory.offset_x], [trajectory.offset_y])")
+
 		if(result)
 			return (result - 1)
 		if((!( targloc ) || loc == targloc))


### PR DESCRIPTION
Прожектайлы имеют классное свойство зависать и вешать сервер:

```
Infinite loop suspected--switching proc to background.
If it is not an infinite loop, either do 'set background=1' or set world.loop_checks=0.
proc name: Process (/obj/item/projectile/test/Process)
source file: projectile.dm,481
usr: null
src: the projectile (/obj/item/projectile/test)
src.loc: the floor (184,118,2) (/turf/simulated/floor/tiled/white)
call stack:
the projectile (/obj/item/projectile/test): Process(the floor (184,118,2) (/turf/simulated/floor/tiled/white))
the projectile (/obj/item/projectile/test): launch(Andrzej Dresden (/mob/living/carbon/human))
check trajectory(Andrzej Dresden (/mob/living/carbon/human), the turret (/obj/machinery/porta_turret), 7, null, null)
the turret (/obj/machinery/porta_turret): assess living(Andrzej Dresden (/mob/living/carbon/human))
the turret (/obj/machinery/porta_turret): assess and assign(Andrzej Dresden (/mob/living/carbon/human), /list (/list), /list (/list))
the turret (/obj/machinery/porta_turret): Process(20)
Machines (/datum/controller/subsystem/machines): process machinery(0)
Machines (/datum/controller/subsystem/machines): fire(0)
Machines (/datum/controller/subsystem/machines): ignite(0)
Master (/datum/controller/master): RunQueue()
Master (/datum/controller/master): Loop()
Master (/datum/controller/master): StartProcessing(0)
```

Добавил на случай зависания исключения с дебажной инфой. С одной стороны они сломают зависший цикл, а с другой запишут нам дебажную инфу, чтобы понять что с этими прожектайлами происходит.

- [x] Pull Request полностью завершен, мне не нужна помощь чтобы его закончить.
- [x] Я внимательно прочитал все свои изменения и багов в них не нашел.
- [x] Я запускал сервер со своими изменениями локально и все протестировал.
- [x] Я ознакомился c [Guide to Contribute](https://github.com/ChaoticOnyx/OnyxBay/blob/dev/docs/contributing.md).
