### PR TITLE
fix(Integrated lighting)

### DIFF
--- a/code/modules/integrated_electronics/core/assemblies.dm
+++ b/code/modules/integrated_electronics/core/assemblies.dm
@@ -396,8 +396,6 @@
 
 // Actually removes the component, doesn't perform any checks.
 /obj/item/device/electronic_assembly/proc/remove_component(obj/item/integrated_circuit/component)
-	if(istype(component, /obj/item/integrated_circuit/output/light))
-		src.set_light(0)
 	component.disconnect_all()
 	component.dropInto(loc)
 	component.assembly = null

--- a/code/modules/integrated_electronics/core/assemblies.dm
+++ b/code/modules/integrated_electronics/core/assemblies.dm
@@ -396,6 +396,8 @@
 
 // Actually removes the component, doesn't perform any checks.
 /obj/item/device/electronic_assembly/proc/remove_component(obj/item/integrated_circuit/component)
+	if(istype(component, /obj/item/integrated_circuit/output/light))
+		src.set_light(0)
 	component.disconnect_all()
 	component.dropInto(loc)
 	component.assembly = null

--- a/code/modules/integrated_electronics/subtypes/output.dm
+++ b/code/modules/integrated_electronics/subtypes/output.dm
@@ -71,8 +71,8 @@
 	outputs = list()
 	activators = list("toggle light" = IC_PINTYPE_PULSE_IN)
 	spawn_flags = IC_SPAWN_DEFAULT|IC_SPAWN_RESEARCH
-	var/light_toggled = 0
-	var/light_brightness = 1
+	var/light_toggled = FALSE
+	var/light_brightness = 4
 	var/light_rgb = "#ffffff"
 	power_draw_idle = 0 // Adjusted based on brightness.
 
@@ -83,7 +83,7 @@
 /obj/item/integrated_circuit/output/light/proc/update_lighting()
 	if(light_toggled)
 		if(assembly)
-			assembly.set_light(light_brightness, 1, 4, 2, light_rgb)
+			assembly.set_light(light_brightness, 4, light_rgb)
 	else
 		if(assembly)
 			assembly.set_light(0)
@@ -113,7 +113,7 @@
 	var/brightness = get_pin_data(IC_INPUT, 2)
 
 	if(new_color && isnum(brightness))
-		brightness = Clamp(brightness, 0, 1)
+		brightness = Clamp(brightness, 0, 7)
 		light_rgb = new_color
 		light_brightness = brightness
 

--- a/code/modules/integrated_electronics/subtypes/output.dm
+++ b/code/modules/integrated_electronics/subtypes/output.dm
@@ -93,6 +93,12 @@
 	light_toggled = FALSE
 	update_lighting()
 
+/obj/item/integrated_circuit/output/light/disconnect_all()
+	if(light_toggled)
+		light_toggled = FALSE
+		update_lighting()
+	..()
+
 /obj/item/integrated_circuit/output/light/advanced
 	name = "advanced light"
 	desc = "A light that takes a hexadecimal color value and a brightness value, and can be toggled on/off by pulsing it."


### PR DESCRIPTION
Починил работу интегральных лампочек в следующих аспектах:
-Лампочки теперь в принципе могут светить.
-При вытаскивании платы лампочки из ассембли, собственно ассембли не продолжает светиться без лампочки.
Новые значения дальности света взял из фонарика (или лампы накаливания) для обычной лампы, а для улучшенной - люминисцентной лампы.
Мощность (сила, яркость) света в соответствии с фонариком/лампой накаливания у всех интегральных ламп.

close #1037

- [x] Pull Request полностью завершен, мне не нужна помощь чтобы его закончить.
- [x] Я внимательно прочитал все свои изменения и багов в них не нашел.
- [x] Я запускал сервер со своими изменениями локально и все протестировал.
- [x] Я ознакомился c [Guide to Contribute](https://github.com/ChaoticOnyx/OnyxBay/blob/dev/docs/contributing.md).
