### PR TITLE
tweak(chat): trivials 'n outputs

### DIFF
--- a/code/modules/client/asset_cache.dm
+++ b/code/modules/client/asset_cache.dm
@@ -236,6 +236,7 @@ You can set verify to TRUE if you want send() to sleep until the client has the 
 	)
 
 /datum/asset/group/onyxchat
+	isTrivial = FALSE
 	children = list(
 		/datum/asset/simple/jquery,
 		/datum/asset/simple/onyxchat,
@@ -249,6 +250,7 @@ You can set verify to TRUE if you want send() to sleep until the client has the 
 	)
 
 /datum/asset/simple/onyxchat
+	isTrivial = FALSE
 	verify = FALSE
 	assets = list(
 		"json2.min.js"             = 'code/modules/onyxchat/browserassets/js/json2.min.js',
@@ -259,6 +261,7 @@ You can set verify to TRUE if you want send() to sleep until the client has the 
 	)
 
 /datum/asset/simple/fontawesome
+	isTrivial = TRUE
 	verify = FALSE
 	assets = list(
 		"fa-regular-400.eot"  = 'html/font-awesome/webfonts/fa-regular-400.eot',

--- a/code/modules/client/client_procs.dm
+++ b/code/modules/client/client_procs.dm
@@ -194,7 +194,7 @@
 		src.preload_rsc = pick(config.resource_urls)
 	else src.preload_rsc = 1 // If config.resource_urls is not set, preload like normal.
 
-	to_chat(src, "<span class='warning'>If the title screen is black, resources are still downloading. Please be patient until the title screen appears.</span>")
+	DIRECT_OUTPUT(src, "<span class='warning'>If the title screen is black and chat is broken, resources are still downloading. Please be patient until the title screen appears.</span>")
 	GLOB.clients += src
 	GLOB.ckey_directory[ckey] = src
 

--- a/code/modules/onyxchat/browserOutput.dm
+++ b/code/modules/onyxchat/browserOutput.dm
@@ -199,9 +199,6 @@ GLOBAL_DATUM_INIT(iconCache, /savefile, new("tmp/iconCache.sav")) //Cache of ico
 			if (!C)
 				continue
 
-			//Send it to the old style output window.
-			C << original_message
-
 			if(!C.chatOutput || C.chatOutput.broken) // A player who hasn't updated his skin file.
 				continue
 
@@ -216,9 +213,6 @@ GLOBAL_DATUM_INIT(iconCache, /savefile, new("tmp/iconCache.sav")) //Cache of ico
 
 		if (!C)
 			return
-
-		//Send it to the old style output window.
-		C << original_message
 
 		if(!C.chatOutput || C.chatOutput.broken) // A player who hasn't updated his skin file.
 			return


### PR DESCRIPTION
эпикус сказал пора обрубать поддержку старого чата
я хз зачем но сделал пару твиков
- чат грузится первым из ассетов кроме фонтов
- страшное сообщение о загрузке ассетов запихнутов в старый чат и немного отредачено
- ту чаты больше не выводят в старый чат

(вайтспейс)

- [x] Pull Request полностью завершен, мне не нужна помощь чтобы его закончить.
- [x] Я внимательно прочитал все свои изменения и багов в них не нашел.
- [x] Я запускал сервер со своими изменениями локально и все протестировал.
- [x] Я ознакомился c [Guide to Contribute](https://github.com/ChaoticOnyx/OnyxBay/blob/dev/docs/contributing.md).
