### PR TITLE
fix(taperecorder.hear_talk): record real speak sign, when activate …

### DIFF
--- a/code/game/objects/items/devices/taperecorder.dm
+++ b/code/game/objects/items/devices/taperecorder.dm
@@ -94,9 +94,9 @@
 		if(speaking)
 			if(!speaking.machine_understands)
 				msg = speaking.scramble(msg)
-			mytape.record_speech("[M.name] [speaking.format_message_plain(msg, verb)]")
+			mytape.record_speech("[M.GetVoice()] [speaking.format_message_plain(msg, verb)]")
 		else
-			mytape.record_speech("[M.name] [verb], \"[msg]\"")
+			mytape.record_speech("[M.GetVoice()] [verb], \"[msg]\"")
 
 
 /obj/item/device/taperecorder/see_emote(mob/M as mob, text, emote_type)


### PR DESCRIPTION
Исправлен баг, при котором в диктофон записывалась реальная Sign(-а) голоса, вместо мимика/войс ченджера.

resolve #2677

:white_check_mark:  Pull Request полностью завершен, мне не нужна помощь чтобы его закончить.
:white_check_mark:  Я внимательно прочитал все свои изменения и багов в них не нашел.
:white_check_mark:  Я запускал сервер со своими изменениями локально и все протестировал.
:white_check_mark:  Я ознакомился c [Guide to Contribute](https://github.com/ChaoticOnyx/OnyxBay/blob/dev/docs/contributing.md).
