### PR TITLE
Всплывающие окна не перехватывают фокус

### DIFF
--- a/code/datums/browser.dm
+++ b/code/datums/browser.dm
@@ -109,6 +109,8 @@
 	if (width && height)
 		window_size = "size=[width]x[height];"
 	user << browse(get_content(), "window=[window_id];[window_size][window_options]")
+	spawn()
+		winset(user, "mapwindow.map", "focus=true")
 	if (use_onclose)
 		onclose(user, window_id, ref)
 
@@ -120,6 +122,8 @@
 
 /datum/browser/proc/close()
 	user << browse(null, "window=[window_id]")
+	spawn()
+		winset(user, "mapwindow.map", "focus=true")
 
 // This will allow you to show an icon in the browse window
 // This is added to mob so that it can be used without a reference to the browser object


### PR DESCRIPTION
Теперь главное окно игры остаётся активным после открытия/закрытия всплывающего интерфейса. Другими словами, игрок теперь не теряет возможность ходить с помощью стрелочек клавиатуры после щелчка по АТМ или открытия панели бота.
Подобное поведение уже было у консолей (можно было открыть интерфейс консоли и отойти), я скопипастил его на другие случаи. 

- [x] Pull Request полностью завершен, мне не нужна помощь чтобы его закончить.
- [x] Я внимательно прочитал все свои изменения и багов в них не нашел.
- [x] Я запускал сервер со своими изменениями локально и все протестировал.
- [x] Я ознакомился c [Guide to Contribute](https://github.com/ChaoticOnyx/OnyxBay/blob/dev/docs/contributing.md).