### PR TITLE
fix(sleeper and cryo teleport)

### DIFF
--- a/code/game/machinery/Sleeper.dm
+++ b/code/game/machinery/Sleeper.dm
@@ -369,6 +369,8 @@
 		visible_message("\The [user] starts putting [M] into \the [src].")
 
 	if(do_after(user, 20, src))
+		if(!check_compatibility(M, user))
+			return
 		if(occupant)
 			to_chat(user, "<span class='warning'>\The [src] is already occupied.</span>")
 			return

--- a/code/game/machinery/cryo.dm
+++ b/code/game/machinery/cryo.dm
@@ -199,6 +199,7 @@
 			if(M.Victim == G:affecting)
 				to_chat(usr, "[G:affecting:name] will not fit into the cryo because they have a slime latched onto their head.")
 				return
+		user.visible_message(SPAN("notice", "\The [user] begins placing \the [target] into \the [src]."), SPAN("notice", "You start placing \the [target] into \the [src]."))
 		if(!do_after(user, 30, src))
 			return
 		if(!ismob(G:affecting))

--- a/code/game/machinery/cryo.dm
+++ b/code/game/machinery/cryo.dm
@@ -199,6 +199,10 @@
 			if(M.Victim == G:affecting)
 				to_chat(usr, "[G:affecting:name] will not fit into the cryo because they have a slime latched onto their head.")
 				return
+		if(!do_after(user, 30, src))
+			return
+		if(!ismob(G:affecting))
+			return
 		var/mob/M = G:affecting
 		if(put_mob(M))
 			qdel(G)
@@ -341,17 +345,24 @@
 	update_icon()
 	return 1
 
-	//Like grab-putting, but for mouse-dropping.
-/obj/machinery/atmospherics/unary/cryo_cell/MouseDrop_T(mob/target, mob/user)
+/obj/machinery/atmospherics/unary/cryo_cell/proc/check_compatibility(mob/target, mob/user)
 	if(!CanMouseDrop(target, user))
-		return
+		return 0
 	if (!istype(target))
-		return
+		return 0
 	if (target.buckled)
 		to_chat(user, "<span class='warning'>Unbuckle the subject before attempting to move them.</span>")
+		return 0
+	return 1
+
+	//Like grab-putting, but for mouse-dropping.
+/obj/machinery/atmospherics/unary/cryo_cell/MouseDrop_T(mob/target, mob/user)
+	if(!check_compatibility(target, user))
 		return
 	user.visible_message("<span class='notice'>\The [user] begins placing \the [target] into \the [src].</span>", "<span class='notice'>You start placing \the [target] into \the [src].</span>")
 	if(!do_after(user, 30, src))
+		return
+	if(!check_compatibility(target, user))
 		return
 	put_mob(target)
 

--- a/code/game/machinery/cryo.dm
+++ b/code/game/machinery/cryo.dm
@@ -199,7 +199,7 @@
 			if(M.Victim == G:affecting)
 				to_chat(usr, "[G:affecting:name] will not fit into the cryo because they have a slime latched onto their head.")
 				return
-		user.visible_message(SPAN("notice", "\The [user] begins placing \the [G.affecting] into \the [src]."), SPAN("notice", "You start placing \the [G.affecting] into \the [src]."))
+		user.visible_message(SPAN("notice", "\The [user] begins placing \the [G:affecting] into \the [src]."), SPAN("notice", "You start placing \the [G:affecting] into \the [src]."))
 		if(!do_after(user, 30, src))
 			return
 		if(!ismob(G:affecting))

--- a/code/game/machinery/cryo.dm
+++ b/code/game/machinery/cryo.dm
@@ -199,7 +199,7 @@
 			if(M.Victim == G:affecting)
 				to_chat(usr, "[G:affecting:name] will not fit into the cryo because they have a slime latched onto their head.")
 				return
-		user.visible_message(SPAN("notice", "\The [user] begins placing \the [target] into \the [src]."), SPAN("notice", "You start placing \the [target] into \the [src]."))
+		user.visible_message(SPAN("notice", "\The [user] begins placing \the [G.affecting] into \the [src]."), SPAN("notice", "You start placing \the [G.affecting] into \the [src]."))
 		if(!do_after(user, 30, src))
 			return
 		if(!ismob(G:affecting))


### PR DESCRIPTION
Пофикшена смешнявка, когда при перетаскивании мышью игрока на слипер/крио человек мог уйти на обед, лечь на операцию, улететь на астероид, а потом форсмувнуться в машинку. Плюс, поклажа в крио человека в грабе была мгновенной, что еще круче, добавил задержку.

resolves #1639

- [x] Pull Request полностью завершен, мне не нужна помощь чтобы его закончить.
- [x] Я внимательно прочитал все свои изменения и багов в них не нашел.
- [x] Я запускал сервер со своими изменениями локально и все протестировал.
- [x] Я ознакомился c [Guide to Contribute](https://github.com/ChaoticOnyx/OnyxBay/blob/dev/docs/contributing.md).
