### PR TITLE
feat(donations): add boombox and custom tape to loadout for patrons

### DIFF
--- a/code/modules/admin/topic.dm
+++ b/code/modules/admin/topic.dm
@@ -2015,6 +2015,27 @@
 		S.channel = 703
 		sound_to(usr, S)
 
+	else if(href_list["wipe_tape_data"])
+		var/obj/item/music_tape/tape = locate(href_list["wipe_tape_data"])
+		if(!tape.track)
+			to_chat(usr, "This [tape] have no data or already is wiped. Report it to developers.")
+			return
+
+		if(alert("Wipe data written by [(tape.uploader_ckey) ? tape.uploader_ckey : "UNKNOWN PLAYER"]?",,"Yes", "No") == "Yes")
+			if(istype(tape.loc, /obj/machinery/media/jukebox))
+				var/obj/machinery/media/jukebox/J = tape.loc
+				if(J.current_track == tape.track)
+					J.StopPlaying()
+					J.current_track = null
+
+			if(istype(tape.loc, /obj/item/music_player))
+				var/obj/item/music_player/mp = tape.loc
+				if(mp.mode)
+					mp.StopPlaying()
+
+			tape.ruin()
+			tape.SetName("burned [initial(tape.name)]")
+
 	// player info stuff
 
 	if(href_list["add_player_info"])

--- a/code/modules/client/preference_setup/loadout/lists/utility.dm
+++ b/code/modules/client/preference_setup/loadout/lists/utility.dm
@@ -56,6 +56,28 @@
 	path = /obj/item/clothing/mask/gas/clear
 	price = 15
 
+/datum/gear/utility/music_tape_custom
+	display_name = "music tape (custom)"
+	description = {"
+		A dusty tape, which can hold anything. Only what you need is blow the dust away and you will be able to play it again.
+		<br><br>
+		<b>Be careful!</b> Don't use it to play music/sounds which can be annoying for other players. Admins can erase your music if they consider it unacceptable or even ban you for abusing it.
+	"}
+	path = /obj/item/music_tape/custom
+	patron_tier = PATREON_HOS
+
+/datum/gear/utility/boombox
+	display_name = "boombox"
+	description = {"
+		A musical audio player station, also known as boombox or ghettobox. Very robust.
+		<br><br>
+		<b>Be careful!</b> Don't use it to play music/sounds which can be annoying for other players. Admins can delete your boombox if they consider your music unacceptable or even ban you for abusing it.
+	"}
+	path = /obj/item/music_player/boombox
+	flags = GEAR_HAS_COLOR_SELECTION
+	patron_tier = PATREON_ASSISTANT
+	cost = 4
+
 /****************
 modular computers
 ****************/

--- a/code/modules/client/preference_setup/loadout/loadout.dm
+++ b/code/modules/client/preference_setup/loadout/loadout.dm
@@ -219,10 +219,11 @@ var/list/gear_datums = list()
 		if(G != selected_gear)
 			if(ticked)
 				display_class = "white"
+			else if(G.patron_tier)
+				if(!user.client.donator_info.patreon_tier_available(G.patron_tier))
+					display_class = "gold"
 			else if(G.price)
-				if(user.client.donator_info.has_item(G.type))
-					display_class = null
-				else
+				if(!user.client.donator_info.has_item(G.type))
 					display_class = "gold"
 			else
 				display_class = "gray"
@@ -244,9 +245,9 @@ var/list/gear_datums = list()
 			allowed = good_job || !bad_job
 
 		if(!hide_unavailable_gear || allowed || ticked)
-			if(user.client.donator_info.has_item(G.type))
+			if(user.client.donator_info.has_item(G.type) || (G.patron_tier && user.client.donator_info.patreon_tier_available(G.patron_tier)))
 				purchased_gears += entry
-			else if(G.price)
+			else if(G.price || G.patron_tier)
 				paid_gears += entry
 			else
 				not_paid_gears += entry
@@ -308,6 +309,11 @@ var/list/gear_datums = list()
 			. += desc
 			. += "<br>"
 
+		if(selected_gear.patron_tier)
+			. += "<br>"
+			. += "<b>Patreon tier: [patron_tier_decorated(selected_gear.patron_tier)]</b>"
+			. += "<br>"
+
 		if(selected_gear.price)
 			. += "<br>"
 			. += "<b>Price: [selected_gear.price] opyx[selected_gear.price != 1 ? "es" : ""]</b>"
@@ -326,11 +332,20 @@ var/list/gear_datums = list()
 			flag_not_enough_opyxes = FALSE
 			. += "<span class='notice'>You don't have enough opyxes!</span><br>"
 
-		if(!selected_gear.price || user.client.donator_info.has_item(selected_gear.type))
+		var/is_available = TRUE
+		if(selected_gear.price && !user.client.donator_info.has_item(selected_gear.type))
+			is_available = FALSE
+		else if(selected_gear.patron_tier && !user.client.donator_info.patreon_tier_available(selected_gear.patron_tier))
+			is_available = FALSE
+
+		if(is_available)
 			. += "<a [ticked ? "class='linkOn' " : ""]href='?src=\ref[src];toggle_gear=[html_encode(selected_gear.display_name)]'>[ticked ? "Drop" : "Take"]</a>"
 		else
+			if (selected_gear.price)
+				. += "<a class='gold' href='?src=\ref[src];buy_gear=\ref[selected_gear]'>Buy</a> "
 			var/trying_on = (pref.trying_on_gear == selected_gear.display_name)
-			. += "<a class='gold' href='?src=\ref[src];buy_gear=\ref[selected_gear]'>Buy</a> <a [trying_on ? "class='linkOn' " : ""]href='?src=\ref[src];try_on=1'>Try On</a>"
+			. += "<a [trying_on ? "class='linkOn' " : ""]href='?src=\ref[src];try_on=1'>Try On</a>"
+
 		. += "</td>"
 
 	. += "</tr></table>"
@@ -367,7 +382,11 @@ var/list/gear_datums = list()
 		return TOPIC_REFRESH_UPDATE_PREVIEW
 	if(href_list["toggle_gear"])
 		var/datum/gear/TG = gear_datums[href_list["toggle_gear"]]
-		ASSERT(!TG.price || user.client.donator_info.has_item(TG.type)) // someone trying to tricking us? However, it's may be just a bug
+
+		// check if someone trying to tricking us. However, it's may be just a bug
+		ASSERT(!TG.price || user.client.donator_info.has_item(TG.type))
+		ASSERT(!TG.patron_tier || user.client.donator_info.patreon_tier_available(TG.patron_tier))
+
 		if(TG.display_name in pref.gear_list[pref.gear_slot])
 			pref.gear_list[pref.gear_slot] -= TG.display_name
 		else
@@ -487,6 +506,7 @@ var/list/gear_datums = list()
 	var/path               //Path to item.
 	var/cost = 1           //Number of points used. Items in general cost 1 point, storage/armor/gloves/special use costs 2 points.
 	var/price              //Price of item, opyxes
+	var/patron_tier        //Patron tier restriction
 	var/slot               //Slot to equip to.
 	var/list/allowed_roles //Roles that can spawn with this item.
 	var/whitelisted        //Term to check the whitelist for..

--- a/code/modules/donations/new/donator.dm
+++ b/code/modules/donations/new/donator.dm
@@ -10,6 +10,18 @@
 		if(PATREON_CULTIST)   return "pt_cultist"
 		if(PATREON_ASSISTANT) return "pt_assistant"
 
+/proc/patron_tier_decorated(tier)
+	if(tier == PATREON_NONE)
+		return null
+
+	switch(tier)
+		if(PATREON_CARGO) . = "Cargo Technician"
+		if(PATREON_HOS) . = "Head of Security"
+		else
+			. = capitalize(tier)
+
+	return "<span class='[patron_tier_to_css_class(tier)]'>[.]</span>"
+
 /datum/donator_info
 	var/donator = FALSE
 	var/patron_type = PATREON_NONE
@@ -27,16 +39,7 @@
 	return "<span class='[patron_tier_to_css_class(choosen_ooc_patreon_tier)]'>[C.key]</span>"
 
 /datum/donator_info/proc/get_full_patron_tier()
-	if(patron_type == PATREON_NONE)
-		return null
-
-	switch(patron_type)
-		if(PATREON_CARGO) . = "Cargo Technician"
-		if(PATREON_HOS) . = "Head of Security"
-		else
-			. = capitalize(patron_type)
-
-	return "<span class='[patron_tier_to_css_class(patron_type)]'>[.]</span>"
+	return patron_tier_decorated(patron_type)
 
 /datum/donator_info/proc/get_available_ooc_patreon_tiers()
 	. = list()

--- a/code/modules/music_player/_music_player.dm
+++ b/code/modules/music_player/_music_player.dm
@@ -46,9 +46,6 @@ GLOBAL_LIST_EMPTY(music_players)
 	var/power_usage = 250
 	var/obj/item/music_tape/tape = null
 
-	// Used for identification
-	var/serial_number
-
 /obj/item/music_player/Initialize()
 	. = ..()
 	if(type == /obj/item/music_player)
@@ -65,16 +62,13 @@ GLOBAL_LIST_EMPTY(music_players)
 			tape = new tape(src)
 
 		sound_id = "[/obj/item/music_player]_[sequential_id(/obj/item/music_player)]"
-		serial_number = "[random_id(/obj/item/music_player, 100, 999)]"
 		GLOB.music_players += src
-		log_and_message_admins("MUSIC PLAYER: <a href='?_src_=holder;adminplayerobservefollow=\ref[src]'>#[serial_number]</a> has been created.")
 		update_icon()
 
 /obj/item/music_player/Destroy()
 	set_mode(PLAYER_STATE_OFF)
 	QDEL_NULL(cell)
 	QDEL_NULL(tape)
-	log_and_message_admins("MUSIC PLAYER: #[serial_number] is deleted.")
 	GLOB.music_players -= src
 	. = ..()
 
@@ -421,7 +415,7 @@ GLOBAL_LIST_EMPTY(music_players)
 
 	mode = PLAYER_STATE_PLAY
 	START_PROCESSING(SSobj, src)
-	log_and_message_admins("launched [src] <a href='?_src_=holder;adminplayerobservefollow=\ref[src]'>#[serial_number]</a> with the song \"[tape.track.title]\".")
+	log_and_message_admins("launched <a href='?_src_=holder;adminplayerobservefollow=\ref[src]'>[src]</a> with the song \"[tape.track.title]\".")
 
 	if(prob(break_chance))
 		break_act()

--- a/code/modules/music_player/subtypes_player.dm
+++ b/code/modules/music_player/subtypes_player.dm
@@ -1,6 +1,6 @@
 // Boombox
 /obj/item/music_player/boombox
-	name = "black boombox"
+	name = "boombox"
 	desc = "A musical audio player station, also known as boombox or ghettobox. Very robust."
 	icon = 'sprites/object.dmi'
 	icon_state = "boombox"

--- a/code/modules/music_player/subtypes_tape.dm
+++ b/code/modules/music_player/subtypes_tape.dm
@@ -33,5 +33,10 @@
 
 	if(new_sound && new_name && !track)
 		track = new /datum/track(new_name, new_sound)
+		uploader_ckey = user.ckey
 		return TRUE
 	return FALSE
+
+/obj/item/music_tape/custom/ruin()
+	QDEL_NULL(track)
+	..()


### PR DESCRIPTION
* Добавил бумбокс и пустую кассету (на которую можно записать свою музыку) в лоадаут для патронов. Бумбокс требует ранга патрона Ассистент, а кассета - ХоСа.
* Убрал ID у бумбокса, т.к. он неоч полезный и спамит педалей когда бумбокс тыкают в лоадауте.
* Починил педальный вайп музыки с кастомной кассеты.

ПР согласован с сенатом

- [x] Pull Request полностью завершен, мне не нужна помощь чтобы его закончить.
- [x] Я внимательно прочитал все свои изменения и багов в них не нашел.
- [x] Я запускал сервер со своими изменениями локально и все протестировал.
- [x] Я ознакомился c [Guide to Contribute](https://github.com/ChaoticOnyx/OnyxBay/blob/dev/docs/contributing.md).
