### PR TITLE
Фикс id растений/Фикс флора диска

### DIFF
--- a/code/modules/hydroponics/seed.dm
+++ b/code/modules/hydroponics/seed.dm
@@ -696,7 +696,7 @@
 		if(istype(user)) to_chat(user, "You [harvest_sample ? "take a sample" : "harvest"] from the [display_name].")
 		//This may be a new line. Update the global if it is.
 		if(name == "new line" || !(name in SSplants.seeds))
-			uid = SSplants.seeds.len + 1
+			uid = sequential_id(/datum/seed/)
 			name = "[uid]"
 			SSplants.seeds[name] = src
 

--- a/code/modules/hydroponics/seed_machines.dm
+++ b/code/modules/hydroponics/seed_machines.dm
@@ -175,7 +175,7 @@
 		seed.loc = get_turf(src)
 
 		if(seed.seed.name == "new line" || isnull(SSplants.seeds[seed.seed.name]))
-			seed.seed.uid = SSplants.seeds.len + 1
+			seed.seed.uid = sequential_id(/datum/seed/)
 			seed.seed.name = "[seed.seed.uid]"
 			SSplants.seeds[seed.seed.name] = seed.seed
 

--- a/code/modules/hydroponics/seed_machines.dm
+++ b/code/modules/hydroponics/seed_machines.dm
@@ -101,12 +101,8 @@
 		else
 			var/obj/item/weapon/disk/botany/B = W
 
-			if(B.genes && B.genes.len)
-				if(!disk_needs_genes)
-					to_chat(user, "That disk already has gene data loaded.")
-					return
-			else
-				if(disk_needs_genes)
+			if(disk_needs_genes)
+				if(!B.genes || !B.genes.len)
 					to_chat(user, "That disk does not have any gene data loaded.")
 					return
 


### PR DESCRIPTION
### **Фикс id растений:**
Проблема связана со стартовыми 10 ксенорастениями в автомате ксенофлоры. Им присваиваются uid #186-196. После мутаций или изменений в ксено, uid новых растений начинается с #86 и увеличивается на 1 за каждое из этих действий. В итоге когда uid пересекаются с растениями из автомата, случаются чудеса, описанные в иссуе. 
Теперь uid новых растений будет генерироваться через sequential_id.

fix #2755 

### **Фикс диска:**
Довольно полезная фича не работала из-за одного условия. 
Теперь диск с генами можно вставлять в экстрактор, что позволяет записывать несколько генов и прививать их семенам одновременно.


- [x] Pull Request полностью завершен, мне не нужна помощь чтобы его закончить.
- [x] Я внимательно прочитал все свои изменения и багов в них не нашел.
- [x] Я запускал сервер со своими изменениями локально и все протестировал.
- [x] Я ознакомился c [Guide to Contribute](https://github.com/ChaoticOnyx/OnyxBay/blob/dev/docs/contributing.md).
