### PR TITLE
Менее занятые автолаты

### DIFF
--- a/code/game/machinery/autolathe.dm
+++ b/code/game/machinery/autolathe.dm
@@ -245,6 +245,8 @@
 		for(var/material in making.resources)
 			if(!isnull(stored_material[material]))
 				if(stored_material[material] < round(making.resources[material] * mat_efficiency) * multiplier)
+					busy = FALSE
+					update_use_power(POWER_USE_IDLE)
 					return TOPIC_REFRESH
 
 		//Consume materials.

--- a/code/game/machinery/autolathe.dm
+++ b/code/game/machinery/autolathe.dm
@@ -222,6 +222,7 @@
 			return TOPIC_HANDLED
 		show_category = choice
 		. = TOPIC_REFRESH
+		updateUsrDialog()
 
 	else if(href_list["make"] && machine_recipes)
 		. = TOPIC_REFRESH
@@ -237,7 +238,7 @@
 			log_and_message_admins("tried to exploit an autolathe to duplicate an item!", user)
 			return TOPIC_HANDLED
 
-		busy = 1
+		busy = TRUE
 		update_use_power(POWER_USE_ACTIVE)
 
 		//Check if we still have the materials.
@@ -251,12 +252,13 @@
 			if(!isnull(stored_material[material]))
 				stored_material[material] = max(0, stored_material[material] - round(making.resources[material] * mat_efficiency) * multiplier)
 
+		updateUsrDialog()
 		//Fancy autolathe animation.
 		flick("autolathe_n", src)
 
 		sleep(build_time)
 
-		busy = 0
+		busy = FALSE
 		update_use_power(POWER_USE_IDLE)
 
 		//Sanity check.
@@ -269,7 +271,6 @@
 			S.amount = multiplier
 			S.update_icon()
 
-	updateUsrDialog()
 
 /obj/machinery/autolathe/update_icon()
 	icon_state = (panel_open ? "autolathe_t" : "autolathe")


### PR DESCRIPTION
Интерфейс автолата обновлялся слишком медленно, из-за чего имелась возможность при быстром закликивании после распечатывания предмета и до обновления окна отправить в печать то, на что не хватает ресурсов, что приводило к вечному зависанию машины и невозможности дальнейшей с ней работы до вмешательства педальными кнопками. Теперь окно обновляется без задержки, что исправит проблему.

fix #3000 fix #1893

- [x] Pull Request полностью завершен, мне не нужна помощь чтобы его закончить.
- [x] Я внимательно прочитал все свои изменения и багов в них не нашел.
- [x] Я запускал сервер со своими изменениями локально и все протестировал.
- [x] Я ознакомился c [Guide to Contribute](https://github.com/ChaoticOnyx/OnyxBay/blob/dev/docs/contributing.md).
