### PR TITLE
Фикс предметов, "зависающих" на экране при удалении из рюкзака.

### DIFF
--- a/code/game/objects/items.dm
+++ b/code/game/objects/items.dm
@@ -97,6 +97,16 @@
 		m.update_inv_r_hand()
 		m.update_inv_l_hand()
 		src.loc = null
+	if(maptext)
+		maptext = ""
+	if(istype(src.loc, /obj/item/weapon/storage))
+		var/obj/item/weapon/storage/storage = src.loc
+		storage.prepare_ui()
+		var/datum/storage_ui/s_ui = storage.storage_ui
+		if(s_ui)
+			s_ui.on_pre_remove(usr, src)
+		storage.contents -= src
+		storage.update_ui_after_item_removal()
 	return ..()
 
 /obj/item/device


### PR DESCRIPTION
Исправил ситуацию при удалении предмета, лежащего в рюкзаке (ящике/другом хранилище), когда иконка этого предмета навсегда прилипала к экрану.

close #2193 

- [x] Pull Request полностью завершен, мне не нужна помощь чтобы его закончить.
- [x] Я внимательно прочитал все свои изменения и багов в них не нашел.
- [x] Я запускал сервер со своими изменениями локально и все протестировал.
- [x] Я ознакомился c [Guide to Contribute](https://github.com/ChaoticOnyx/OnyxBay/blob/dev/docs/contributing.md).
