### PR TITLE
fix(discord ooc): prevents ooc ban evasion over discord

### DIFF
--- a/code/game/world.dm
+++ b/code/game/world.dm
@@ -347,6 +347,8 @@ var/world_topic_spam_protect_time = world.timeofday
 			return
 		if(!config.vars["ooc_allowed"]&&!input["isadmin"])
 			return "globally muted"
+		if(jobban_keylist.Find("[ckey] - ooc"))
+			return "banned from ooc"
 		var/sent_message = "[create_text_tag("DISCORD OOC:")] <EM>[ckey]:</EM> <span class='message linkify'>[message]</span>"
 		for(var/client/target in GLOB.clients)
 			if(!target)


### PR DESCRIPTION
Перед отправкой сообщения в ООС через дискорд проверяем, не забанен ли, часом, у отправителя ООС.

resolve #2258 ? Не уверен, правда, что тот иссуй про баны, а не именно муты, но даже если и нет, то проблемы в этом я не вижу - за обход мута можно и бан на оос навесить.

- [x] Pull Request полностью завершен, мне не нужна помощь чтобы его закончить.
- [x] Я внимательно прочитал все свои изменения и багов в них не нашел.
- [ ] Я запускал сервер со своими изменениями локально и все протестировал.
- [x] Я ознакомился c [Guide to Contribute](https://github.com/ChaoticOnyx/OnyxBay/blob/dev/docs/contributing.md).
