### PR TITLE
Постоянное укатывание чата при достижении лимита сообщений едет нахуй

### DIFF
--- a/code/modules/onyxchat/browserassets/js/browserOutput.js
+++ b/code/modules/onyxchat/browserassets/js/browserOutput.js
@@ -25,7 +25,7 @@ var $messages, $subTheme, $subOptions, $subFont, $selectedSub, $contextMenu, $fi
 var opts = {
 	//General
 	'messageCount': 0, //A count...of messages...
-	'messageLimit': 2053, //A limit...for the messages...
+	'messageLimit': 5000, //A limit...for the messages...
 	'scrollSnapTolerance': 10, //If within x pixels of bottom
 	'clickTolerance': 10, //Keep focus if outside x pixels of mousedown position on mouseup
 	'imageRetryDelay': 50, //how long between attempts to reload images (in ms)
@@ -412,8 +412,8 @@ function output(message, flag) {
 
 	//Pop the top message off if history limit reached
 	if (opts.messageCount >= opts.messageLimit) {
-		$messages.children('div.entry:first-child').remove();
-		opts.messageCount--; //I guess the count should only ever equal the limit
+		$messages.children('div.entry:nth-child(-n+' + opts.messageLimit / 2 + ')').remove();
+		opts.messageCount -= opts.messageLimit / 2; //I guess the count should only ever equal the limit
 	}
 
 	// Create the element - if combining is off, we use it, and if it's on, we

--- a/code/modules/onyxchat/browserassets/js/browserOutput.js
+++ b/code/modules/onyxchat/browserassets/js/browserOutput.js
@@ -381,10 +381,10 @@ function output(message, flag) {
 
 	//Stuff we do along with appending a message
 	var atBottom = false;
+	var scrollPos = $('body,html').scrollTop();
 	if (!filteredOut) {
 		var bodyHeight = $('body').height();
 		var messagesHeight = $messages.outerHeight();
-		var scrollPos = $('body,html').scrollTop();
 
 		//Should we snap the output to the bottom?
 		if (bodyHeight + scrollPos >= messagesHeight - opts.scrollSnapTolerance) {
@@ -409,11 +409,13 @@ function output(message, flag) {
 	}
 
 	opts.messageCount++;
+	var trimmedHeight = 0;
 
 	//Pop the top message off if history limit reached
 	if (opts.messageCount >= opts.messageLimit) {
-		$messages.children('div.entry:nth-child(-n+' + opts.messageLimit / 2 + ')').remove();
-		opts.messageCount -= opts.messageLimit / 2; //I guess the count should only ever equal the limit
+		trimmedHeight = $messages.children('div.entry:first-child').outerHeight();
+		$messages.children('div.entry:first-child').remove();
+		opts.messageCount--; //I guess the count should only ever equal the limit
 	}
 
 	// Create the element - if combining is off, we use it, and if it's on, we
@@ -489,6 +491,8 @@ function output(message, flag) {
 
 	if (!filteredOut && atBottom) {
 		$('body,html').scrollTop($messages.outerHeight());
+	} else if (trimmedHeight) {
+		$('body,html').scrollTop(scrollPos - trimmedHeight);
 	}
 }
 


### PR DESCRIPTION
Количество хранящихся в чате сообщений увеличено в два с половиной раза. Теперь при достижении лимита вайпается половина истории за раз. Это позволит избежать восхитительного экспириенса, когда текст постоянно уплывал относительно окна, делая попытки его чтения или копирования отдельным, достаточно неприятным, испытанием.

- [x] Pull Request полностью завершен, мне не нужна помощь чтобы его закончить.
- [x] Я внимательно прочитал все свои изменения и багов в них не нашел.
- [x] Я запускал сервер со своими изменениями локально и все протестировал.
- [x] Я ознакомился c [Guide to Contribute](https://github.com/ChaoticOnyx/OnyxBay/blob/dev/docs/contributing.md).
