### PR TITLE
tweak(ladder): В третьем грабе можно таскать людей по лестницам

### DIFF
--- a/code/modules/mob/grab/normal/norm_neck.dm
+++ b/code/modules/mob/grab/normal/norm_neck.dm
@@ -18,6 +18,7 @@
 	can_throw = 1
 	force_danger = 1
 	restrains = 1
+	ladder_carry = 1
 
 	icon_state = "kill"
 

--- a/code/modules/multiz/structures.dm
+++ b/code/modules/multiz/structures.dm
@@ -16,6 +16,7 @@
 	var/obj/structure/ladder/target_down
 
 	var/const/climb_time = 2 SECONDS
+	var/const/drag_time = 15 SECONDS
 	var/static/list/climbsounds = list('sound/effects/ladder.ogg','sound/effects/ladder2.ogg','sound/effects/ladder3.ogg','sound/effects/ladder4.ogg')
 
 /obj/structure/ladder/Initialize()
@@ -71,7 +72,10 @@
 		to_chat(M, "<span class='notice'>You fail to reach \the [src].</span>")
 		return
 
+	var/dragging = FALSE
+
 	for (var/obj/item/grab/G in M)
+		dragging = TRUE
 		G.adjust_position()
 
 	var/direction = target_ladder == target_up ? "up" : "down"
@@ -82,7 +86,9 @@
 
 	target_ladder.audible_message("<span class='notice'>You hear something coming [direction] \the [src]</span>")
 
-	if(do_after(M, climb_time, src))
+	var/time = dragging ? drag_time : climb_time
+
+	if(do_after(M, time, src))
 		climbLadder(M, target_ladder)
 		for (var/obj/item/grab/G in M)
 			G.adjust_position(force = 1)


### PR DESCRIPTION
В красном грабе теперь можно таскать людей по вертикальным лестницам. Такой перенос длится 15 секунд вместо двух.
close #1027

- [x] Pull Request полностью завершен, мне не нужна помощь чтобы его закончить.
- [x] Я внимательно прочитал все свои изменения и багов в них не нашел.
- [x] Я запускал сервер со своими изменениями локально и все протестировал.
- [x] Я ознакомился c [Guide to Contribute](https://github.com/ChaoticOnyx/OnyxBay/blob/dev/docs/contributing.md).
