### PR TITLE
update(loadout): add randomizer

### DIFF
--- a/code/modules/client/preference_setup/loadout/gear_tweaks.dm
+++ b/code/modules/client/preference_setup/loadout/gear_tweaks.dm
@@ -7,6 +7,9 @@
 /datum/gear_tweak/proc/get_default()
 	return
 
+/datum/gear_tweak/proc/get_random()
+	return get_default()
+
 /datum/gear_tweak/proc/tweak_gear_data(metadata, datum/gear_data)
 	return
 
@@ -32,6 +35,9 @@
 
 /datum/gear_tweak/color/get_default()
 	return valid_colors ? valid_colors[1] : COLOR_WHITE
+
+/datum/gear_tweak/color/get_random()
+	return valid_colors ? pick(valid_colors) : rgb(rand(200) + 55, rand(200) + 55, rand(200) + 55)
 
 /datum/gear_tweak/color/get_metadata(user, metadata, title = CHARACTER_PREFERENCE_INPUT_TITLE)
 	if(valid_colors)
@@ -85,6 +91,9 @@
 /datum/gear_tweak/path/get_default()
 	return valid_paths[1]
 
+/datum/gear_tweak/path/get_random()
+	return pick(valid_paths)
+
 /datum/gear_tweak/path/get_metadata(user, metadata)
 	return input(user, "Choose a type.", CHARACTER_PREFERENCE_INPUT_TITLE, metadata) as null|anything in valid_paths
 
@@ -117,6 +126,9 @@
 	. = list()
 	for(var/i = 1 to valid_contents.len)
 		. += "Random"
+
+/datum/gear_tweak/contents/get_random()
+	return "Random"
 
 /datum/gear_tweak/contents/get_metadata(user, list/metadata)
 	. = list()

--- a/code/modules/client/preference_setup/loadout/lists/earwear.dm
+++ b/code/modules/client/preference_setup/loadout/lists/earwear.dm
@@ -1,6 +1,6 @@
 // Stuff worn on the ears. Items here go in the "ears" sort_category but they must not use
 // the slot_r_ear or slot_l_ear as the slot, or else players will spawn with no headset.
-/datum/gear/ears
+/datum/gear/earmuffs
 	display_name = "earmuffs"
 	path = /obj/item/clothing/ears/earmuffs
 	sort_category = "Earwear"

--- a/code/modules/client/preference_setup/loadout/lists/xenowear.dm
+++ b/code/modules/client/preference_setup/loadout/lists/xenowear.dm
@@ -4,6 +4,7 @@
 /datum/gear/suit/unathi
 	sort_category = "Xenowear"
 	whitelisted = list(SPECIES_UNATHI)
+	path = null // Prevents display
 
 /datum/gear/suit/unathi/mantle
 	display_name = "hide mantle (Unathi)"
@@ -24,6 +25,7 @@
 /datum/gear/ears/skrell
 	sort_category = "Xenowear"
 	whitelisted = list(SPECIES_SKRELL)
+	path = null // Prevents display
 
 /datum/gear/ears/skrell/chains
 	display_name = "headtail chain selection (Skrell)"

--- a/code/modules/client/preference_setup/loadout/loadout.dm
+++ b/code/modules/client/preference_setup/loadout/loadout.dm
@@ -49,7 +49,7 @@ var/list/gear_datums = list()
 	var/current_tab = "General"
 	var/datum/gear/selected_gear
 	var/list/selected_tweaks = new
-	var/hide_unavailable_gear = 0
+	var/hide_unavailable_gear = TRUE
 	var/flag_not_enough_opyxes = FALSE
 
 /datum/category_item/player_setup_item/loadout/load_character(savefile/S)
@@ -140,7 +140,8 @@ var/list/gear_datums = list()
 	if(config.max_gear_cost < INFINITY)
 		. += "<font color = '[fcolor]'>[total_cost]/[config.max_gear_cost]</font> loadout points spent.<br>"
 	. += "<a href='?src=\ref[src];clear_loadout=1'>Clear Loadout</a><br>"
-	. += "<a href='?src=\ref[src];toggle_hiding=1'>[hide_unavailable_gear ? "Show all" : "Hide unavailable for your jobs"]</a><br>"
+	. += "<a href='?src=\ref[src];random_loadout=1'>Random Loadout</a><br>"
+	. += "<a href='?src=\ref[src];toggle_hiding=1'>[hide_unavailable_gear ? "Show unavailable for your jobs and species" : "Hide unavailable for your jobs and species"]</a><br>"
 	. += "</td>"
 
 	. += "</tr></table>"
@@ -198,12 +199,11 @@ var/list/gear_datums = list()
 	. += "<td style='white-space: nowrap; width: 40px;' class='block'>"
 	. += "<table>"
 	var/datum/loadout_category/LC = loadout_categories[current_tab]
-	var/list/jobs = new
+	var/list/selected_jobs = new
 	if(job_master)
 		for(var/job_title in (pref.job_medium|pref.job_low|pref.job_high))
-			var/datum/job/J = job_master.occupations_by_title[job_title]
-			if(J)
-				dd_insertObjectList(jobs, J)
+			if(job_master.occupations_by_title[job_title])
+				selected_jobs += job_master.occupations_by_title[job_title]
 
 	var/purchased_gears = ""
 	var/paid_gears = ""
@@ -213,6 +213,8 @@ var/list/gear_datums = list()
 		if(!(gear_name in valid_gear_choices()))
 			continue
 		var/datum/gear/G = LC.gear[gear_name]
+		if(!G.path)
+			continue
 		var/entry = ""
 		var/ticked = (G.display_name in pref.gear_list[pref.gear_slot])
 		var/display_class
@@ -233,18 +235,7 @@ var/list/gear_datums = list()
 		entry += "<td width=25%><a [display_class ? "class='[display_class]' " : ""]href='?src=\ref[src];select_gear=[html_encode(G.display_name)]'>[G.display_name]</a></td>"
 		entry += "</td></tr>"
 
-		var/allowed = TRUE
-		if(G.allowed_roles)
-			var/good_job = FALSE
-			var/bad_job = FALSE
-			for(var/datum/job/J in jobs)
-				if(J.type in G.allowed_roles)
-					good_job = TRUE
-				else
-					bad_job = TRUE
-			allowed = good_job || !bad_job
-
-		if(!hide_unavailable_gear || allowed || ticked)
+		if(!hide_unavailable_gear || gear_allowed_to_see(G, user) || ticked)
 			if(user.client.donator_info.has_item(G.type) || (G.patron_tier && user.client.donator_info.patreon_tier_available(G.patron_tier)))
 				purchased_gears += entry
 			else if(G.price || G.patron_tier)
@@ -288,19 +279,21 @@ var/list/gear_datums = list()
 
 		if(selected_gear.allowed_roles)
 			. += "<b>Has jobs restrictions!</b>"
-			if(jobs.len)
-				. += "<br>"
-				. += "<i>"
-				var/ind = 0
-				for(var/datum/job/J in jobs)
-					++ind
-					if(ind > 1)
-						. += ", "
-					if(J.type in selected_gear.allowed_roles)
-						. += "<font color='#55cc55'>[J.title]</font>"
-					else
-						. += "<font color='#cc5555'>[J.title]</font>"
-				. += "</i>"
+			. += "<br>"
+			. += "<i>"
+			var/ind = 0
+			for(var/allowed_type in selected_gear.allowed_roles)
+				if(!ispath(allowed_type, /datum/job))
+					continue
+				var/datum/job/J = job_master ? job_master.occupations_by_type[allowed_type] : new allowed_type
+				++ind
+				if(ind > 1)
+					. += ", "
+				if(selected_jobs && length(selected_jobs) && (J in selected_jobs))
+					. += "<font color='#55cc55'>[J.title]</font>"
+				else
+					. += "<font color='#808080'>[J.title]</font>"
+			. += "</i>"
 			. += "<br>"
 
 		var/desc = selected_gear.get_description(selected_tweaks)
@@ -332,19 +325,14 @@ var/list/gear_datums = list()
 			flag_not_enough_opyxes = FALSE
 			. += "<span class='notice'>You don't have enough opyxes!</span><br>"
 
-		var/is_available = TRUE
-		if(selected_gear.price && !user.client.donator_info.has_item(selected_gear.type))
-			is_available = FALSE
-		else if(selected_gear.patron_tier && !user.client.donator_info.patreon_tier_available(selected_gear.patron_tier))
-			is_available = FALSE
-
-		if(is_available)
+		if(gear_allowed_to_equip(selected_gear, user))
 			. += "<a [ticked ? "class='linkOn' " : ""]href='?src=\ref[src];toggle_gear=[html_encode(selected_gear.display_name)]'>[ticked ? "Drop" : "Take"]</a>"
 		else
 			if (selected_gear.price)
 				. += "<a class='gold' href='?src=\ref[src];buy_gear=\ref[selected_gear]'>Buy</a> "
-			var/trying_on = (pref.trying_on_gear == selected_gear.display_name)
-			. += "<a [trying_on ? "class='linkOn' " : ""]href='?src=\ref[src];try_on=1'>Try On</a>"
+			if(gear_allowed_to_see(selected_gear, user))
+				var/trying_on = (pref.trying_on_gear == selected_gear.display_name)
+				. += "<a [trying_on ? "class='linkOn' " : ""]href='?src=\ref[src];try_on=1'>Try On</a>"
 
 		. += "</td>"
 
@@ -469,6 +457,29 @@ var/list/gear_datums = list()
 		pref.trying_on_gear = null
 		pref.trying_on_tweaks.Cut()
 		return TOPIC_REFRESH_UPDATE_PREVIEW
+	if(href_list["random_loadout"])
+		var/list/gear = pref.gear_list[pref.gear_slot]
+		gear.Cut()
+		var/list/pool = new
+		if(pref.trying_on_gear)
+			pool += gear_datums[pref.trying_on_gear]
+		pref.trying_on_tweaks.Cut()
+		for(var/gear_name in gear_datums)
+			var/datum/gear/G = gear_datums[gear_name]
+			if(gear_allowed_to_equip(G, user) && G.cost <= config.max_gear_cost)
+				pool += G
+		var/points_left = config.max_gear_cost
+		while (points_left > 0 && length(pool))
+			var/datum/gear/chosen = pick(pool)
+			var/list/chosen_tweaks = new
+			for(var/datum/gear_tweak/tweak in chosen.gear_tweaks)
+				chosen_tweaks["[tweak]"] = tweak.get_random()
+			gear[chosen.display_name] = chosen_tweaks.Copy()
+			points_left -= chosen.cost
+			for(var/datum/gear/G in pool)
+				if(G.cost > points_left || (G.slot && G.slot == chosen.slot))
+					pool -= G
+		return TOPIC_REFRESH_UPDATE_PREVIEW
 	if(href_list["toggle_hiding"])
 		hide_unavailable_gear = !hide_unavailable_gear
 		return TOPIC_REFRESH
@@ -499,6 +510,40 @@ var/list/gear_datums = list()
 				var/value = pref.gear_list[key]
 				pref.gear_list[index] = value
 		return 1
+
+/datum/category_item/player_setup_item/loadout/proc/gear_allowed_to_see(datum/gear/G, mob/user)
+	if(!G || !G.path)
+		return FALSE
+	
+	if(G.allowed_roles)
+		var/list/jobs = new
+		if(job_master)
+			for(var/job_title in (pref.job_medium|pref.job_low|pref.job_high))
+				if(job_master.occupations_by_title[job_title])
+					jobs += job_master.occupations_by_title[job_title]
+		if(!jobs || !length(jobs))
+			return FALSE
+		var/job_ok = FALSE
+		for(var/datum/job/J in jobs)
+			if(J.type in G.allowed_roles)
+				job_ok = TRUE
+				break
+		if(!job_ok)
+			return FALSE
+	
+	if(G.whitelisted && !(pref.species in G.whitelisted))
+		return FALSE
+		
+	return TRUE
+
+/datum/category_item/player_setup_item/loadout/proc/gear_allowed_to_equip(datum/gear/G, mob/user)
+	if(!gear_allowed_to_see(G, user))
+		return FALSE
+	if(G.price && !user.client.donator_info.has_item(G.type))
+		return FALSE
+	if(G.patron_tier && !user.client.donator_info.patreon_tier_available(G.patron_tier))
+		return FALSE
+	return TRUE
 
 /datum/gear
 	var/display_name       //Name/index. Must be unique.


### PR DESCRIPTION
1. Добавил в лоадаут кнопку, автоматически собирающую случайную нагрузку.
![image](https://user-images.githubusercontent.com/64479446/89593900-1ab54e00-d859-11ea-82fc-c30ad64ffb6e.png)

2. Убрал возможность выбрать предмет, не подходящий к текущим настройкам профессии и расы. В том числе через кнопку 'Try On'.

3. Сделал комментарий об ограничении по профессиям более наглядным
![image](https://user-images.githubusercontent.com/64479446/89594115-ac24c000-d859-11ea-824a-7ffe09ab02e1.png)

4. Скрыл неподходящие предметы по умолчанию. Теперь список предметов в разделе "Xenowear" куда более читабельный.

5. Исправил баг, из-за которого наушники дублировались в разделе "Xenowears". Неплохо было бы ещё исправить того кодера, который решил, что вся одежда скреллов - это одежда для ушей.

- [x] Pull Request полностью завершен, мне не нужна помощь чтобы его закончить.
- [x] Я внимательно прочитал все свои изменения и багов в них не нашел.
- [x] Я запускал сервер со своими изменениями локально и все протестировал.
- [x] Я ознакомился c [Guide to Contribute](https://github.com/ChaoticOnyx/OnyxBay/blob/dev/docs/contributing.md).
