### PR TITLE
Расчлененка для кухонного крюка

### DIFF
--- a/code/game/machinery/kitchen/gibber.dm
+++ b/code/game/machinery/kitchen/gibber.dm
@@ -222,7 +222,6 @@
 
 
 	admin_attack_log(user, occupant, "Gibbed the victim", "Was gibbed", "gibbed")
-	src.occupant.ghostize()
 
 	spawn(gib_time)
 

--- a/code/game/machinery/kitchen/gibber.dm
+++ b/code/game/machinery/kitchen/gibber.dm
@@ -184,7 +184,7 @@
 	else if(istype(src.occupant,/mob/living/carbon/human))
 		var/mob/living/carbon/human/H = occupant
 		slab_name = src.occupant.real_name
-		slab_type = H.isSynthetic() ? robotic_slab_type : H.species.meat_type
+		slab_type = H.species.meat_type
 		slab_count = 0
 		for (var/obj/item/organ/external/O in H.organs)
 			if (O.is_stump())

--- a/code/game/objects/structures/kitchen_spike.dm
+++ b/code/game/objects/structures/kitchen_spike.dm
@@ -39,9 +39,7 @@
 	. = ..()
 
 /obj/structure/kitchenspike/proc/can_spike(mob/living/victim)
-	if(!istype(victim))
-		return
-	return TRUE
+	return iscarbon(victim) || isanimal(victim)
 
 /obj/structure/kitchenspike/proc/spike(mob/user, mob/living/victim)
 	user.visible_message(SPAN_DANGER("[user] starts putting [victim] onto \the [src]..."),

--- a/code/game/objects/structures/kitchen_spike.dm
+++ b/code/game/objects/structures/kitchen_spike.dm
@@ -79,8 +79,8 @@
 	if (!buckled_mob || !buckled_mob.buckled)
 		return
 	if (unbuckling)
-		to_chat(user, SPAN_NOTICE("Someone is already trying to get [user] off \the [src], you can't help!"))
-		return
+		to_chat(user, SPAN_NOTICE("Someone is already trying to get [buckled_mob == user ? "you" : buckled_mob] off \the [src], you can't help!"))
+
 	var/mob/living/M = buckled_mob
 	if(M != user)
 		M.visible_message(\
@@ -89,7 +89,7 @@
 			SPAN("italics", "You hear a squishy wet noise.</span>"))
 		unbuckling = TRUE
 		if(!do_after(user, delay = 150, target = src))
-			if(M && M.buckled)
+			if(M && M.buckled == src)
 				M.visible_message(\
 				SPAN_WARNING("[user] fails to free [M]!"),\
 				SPAN_WARNING("[user] fails to pull you off of \the [src]."))
@@ -102,12 +102,12 @@
 		SPAN("italics", "You hear a wet squishing noise."))
 		M.adjustBruteLoss(30)
 		if(!do_after(M, delay = 600, target = src))
-			if(M && M.buckled)
+			if(M && M.buckled == src)
 				M << "<span class='warning'>You fail to free yourself!</span>"
 			return
 
 	unbuckling = FALSE
-	if(!M.buckled)
+	if(!M || M.buckled != src)
 		return
 	M.adjustBruteLoss(30)
 	src.visible_message(SPAN_DANGER("[M] falls free of \the [src]!"))
@@ -163,7 +163,6 @@
 
 		to_chat(user, SPAN_NOTICE("You've finished butchering [buckled_mob]."))
 		admin_attack_log(user, buckled_mob, "Gibbed the victim", "Was gibbed", "gibbed")
-		buckled_mob.ghostize()
 		playsound(loc, 'sound/effects/splat.ogg', 50, 1)
 		QDEL_NULL(buckled_mob)
 		return

--- a/code/game/objects/structures/kitchen_spike.dm
+++ b/code/game/objects/structures/kitchen_spike.dm
@@ -90,7 +90,7 @@
 			SPAN("italics", "You hear a squishy wet noise.</span>"))
 		unbuckling = TRUE
 		if(!do_after(user, delay = 150, target = src))
-			if(M && M.buckled == src)
+			if(M && M == buckled_mob)
 				M.visible_message(\
 				SPAN_WARNING("[user] fails to free [M]!"),\
 				SPAN_WARNING("[user] fails to pull you off of \the [src]."))
@@ -103,12 +103,12 @@
 		SPAN("italics", "You hear a wet squishing noise."))
 		M.adjustBruteLoss(30)
 		if(!do_after(M, delay = 600, target = src))
-			if(M && M.buckled == src)
+			if(M && M == buckled_mob)
 				M << "<span class='warning'>You fail to free yourself!</span>"
 			return
 
 	unbuckling = FALSE
-	if(!M || M.buckled != src)
+	if(!M || M != buckled_mob)
 		return
 	M.adjustBruteLoss(30)
 	src.visible_message(SPAN_DANGER("[M] falls free of \the [src]!"))

--- a/code/game/objects/structures/kitchen_spike.dm
+++ b/code/game/objects/structures/kitchen_spike.dm
@@ -32,7 +32,11 @@
 	if (spike(user, G.affecting))
 		qdel(G)
 	
-
+/obj/structure/kitchenspike/Destroy()
+	if (buckled_mob)
+		buckled_mob.hanging = FALSE
+		unbuckle_mob()
+	. = ..()
 
 /obj/structure/kitchenspike/proc/can_spike(mob/living/victim)
 	if(!istype(victim))

--- a/code/game/objects/structures/kitchen_spike.dm
+++ b/code/game/objects/structures/kitchen_spike.dm
@@ -80,6 +80,7 @@
 		return
 	if (unbuckling)
 		to_chat(user, SPAN_NOTICE("Someone is already trying to get [buckled_mob == user ? "you" : buckled_mob] off \the [src], you can't help!"))
+		return
 
 	var/mob/living/M = buckled_mob
 	if(M != user)

--- a/code/game/objects/structures/kitchen_spike.dm
+++ b/code/game/objects/structures/kitchen_spike.dm
@@ -168,10 +168,6 @@
 		QDEL_NULL(buckled_mob)
 		return
 
-	if (H.isSynthetic())
-		to_chat(user, SPAN_WARNING("Can't extract meat from synths!"))
-		return
-
 	var/zone = check_zone(user.zone_sel?.selecting)
 	var/obj/item/organ/external/organ = H.get_organ(zone)
 	if (BP_IS_ROBOTIC(organ))
@@ -218,7 +214,7 @@
 		user.visible_message(SPAN_WARNING("[user]'ve successfully butchered [H]'s [butchered_organ_name]!"),\
 			SPAN_NOTICE("You've successfully butchered [H]'s [butchered_organ_name]..."),\
 			SPAN("italics", "You hear a squishy wet noise.</span>"))
-		if (istype(H) && H.can_feel_pain())
+		if (H.can_feel_pain())
 			H.emote("scream")
 		H.nutrition -= slab_nutrition
 		var/obj/item/weapon/reagent_containers/food/snacks/meat/new_meat = new slab_type(get_turf(src), rand(3,8))

--- a/code/game/objects/structures/kitchen_spike.dm
+++ b/code/game/objects/structures/kitchen_spike.dm
@@ -191,8 +191,9 @@
 	for (var/obj/item/organ/external/O in H.organs)
 		if (BP_IS_ROBOTIC(O) || O.is_stump())
 			continue
-		if (istype(C))
-			meat_limbs_left += C.butchering_capacity
+		var/obj/item/organ/external/chest/OC = O
+		if (istype(OC))
+			meat_limbs_left += OC.butchering_capacity
 			continue
 		meat_limbs_left++
 	

--- a/code/game/objects/structures/kitchen_spike.dm
+++ b/code/game/objects/structures/kitchen_spike.dm
@@ -218,6 +218,8 @@
 		user.visible_message(SPAN_WARNING("[user]'ve successfully butchered [H]'s [butchered_organ_name]!"),\
 			SPAN_NOTICE("You've successfully butchered [H]'s [butchered_organ_name]..."),\
 			SPAN("italics", "You hear a squishy wet noise.</span>"))
+		if (istype(H) && H.can_feel_pain())
+			H.emote("scream")
 		H.nutrition -= slab_nutrition
 		var/obj/item/weapon/reagent_containers/food/snacks/meat/new_meat = new slab_type(get_turf(src), rand(3,8))
 		if (istype(new_meat))

--- a/code/game/objects/structures/kitchen_spike.dm
+++ b/code/game/objects/structures/kitchen_spike.dm
@@ -7,54 +7,222 @@
 	desc = "A spike for collecting meat from animals."
 	density = 1
 	anchored = 1
-	var/meat = 0
-	var/occupied
-	var/meat_type
-	var/victim_name = "corpse"
+	
+	can_buckle = 1
+	buckle_lying = 0
+	buckle_dir = SOUTH
+	var/unbuckling = FALSE
+	
 
-/obj/structure/kitchenspike/attackby(obj/item/grab/G, mob/living/carbon/human/user)
-	if(!istype(G) || !G.affecting)
-		return
-	if(occupied)
-		to_chat(user, "<span class = 'danger'>The spike already has something on it, finish collecting its meat first!</span>")
-	else
-		if(spike(G.affecting))
-			visible_message("<span class = 'danger'>[user] has forced [G.affecting] onto the spike, killing them instantly!</span>")
-			qdel(G.affecting)
-			qdel(G)
+/obj/structure/kitchenspike/attackby(obj/item/I, mob/living/carbon/human/user)
+	if (buckled_mob)
+		if (is_sharp(I))
+			slice(I, user)
 		else
-			to_chat(user, "<span class='danger'>They are too big for the spike, try something smaller!</span>")
+			to_chat(user, SPAN_DANGER("You need something sharp to do that!"))
+		return
+	var/obj/item/grab/G = I
 
-/obj/structure/kitchenspike/proc/spike(mob/living/victim)
+	if (!istype(G) || !G.affecting || !can_spike(G.affecting))
+		to_chat(user, SPAN_DANGER("You can't put that on [src]!"))
+		return
+	if (!G.force_danger())
+		to_chat(user, SPAN_DANGER("You need better grip to do it!"))
+		return
+	if (spike(user, G.affecting))
+		qdel(G)
+	
 
+
+/obj/structure/kitchenspike/proc/can_spike(mob/living/victim)
 	if(!istype(victim))
 		return
+	return TRUE
 
-	if(istype(victim, /mob/living/carbon/human))
-		var/mob/living/carbon/human/H = victim
-		if(!issmall(H))
-			return 0
-		meat_type = H.species.meat_type
-		icon_state = "spikebloody"
-	else if(istype(victim, /mob/living/carbon/alien))
-		meat_type = /obj/item/weapon/reagent_containers/food/snacks/xenomeat
-		icon_state = "spikebloodygreen"
-	else
-		return 0
-
-	victim_name = victim.name
-	occupied = 1
-	meat = 5
-	return 1
-
-/obj/structure/kitchenspike/attack_hand(mob/user as mob)
-	if(..() || !occupied)
+/obj/structure/kitchenspike/proc/spike(mob/user, mob/living/victim)
+	user.visible_message(SPAN_DANGER("[user] starts putting [victim] onto \the [src]..."),
+		SPAN("userdanger","[user] starts putting [victim] onto \the [src]..."),
+		SPAN("italics", "You hear a squishy wet noise."))
+	if(!do_mob(user, src, time = 120))
 		return
-	meat--
-	new meat_type(get_turf(src))
-	if(src.meat > 1)
-		to_chat(user, "You remove some meat from \the [victim_name].")
-	else if(src.meat == 1)
-		to_chat(user, "You remove the last piece of meat from \the [victim_name]!")
-		icon_state = "spike"
-		occupied = 0
+	if(buckled_mob)
+		return
+	if(victim.buckled)
+		return
+	playsound(src.loc, "sound/effects/splat.ogg", 50, 1)
+	victim.visible_message(SPAN_DANGER("[user] slams [victim] onto \the [src]!"),
+		SPAN("userdanger", "[user] slams [victim] onto \the [src]!"),
+		SPAN("italics", "You hear a squishy wet noise."))
+	victim.forceMove(src.loc)
+
+	var/mob/living/carbon/C = victim
+	if (istype(C) && C.can_feel_pain())
+		C.emote("scream")
+
+	var/turf/simulated/pos = get_turf(victim)
+	if(istype(victim, /mob/living/carbon/human))
+		pos.add_blood(victim)
+	else
+		pos.add_blood_floor(pos)
+	victim.adjustBruteLoss(30)
+	victim.hanging = TRUE
+	src.buckle_mob(victim)
+	return TRUE
+
+
+/obj/structure/kitchenspike/user_buckle_mob(mob/living/M, mob/living/user)
+	return FALSE
+
+/obj/structure/kitchenspike/user_unbuckle_mob(mob/living/user)
+	if (!buckled_mob || !buckled_mob.buckled)
+		return
+	if (unbuckling)
+		to_chat(user, SPAN_NOTICE("Someone is already trying to get [user] off \the [src], you can't help!"))
+		return
+	var/mob/living/M = buckled_mob
+	if(M != user)
+		M.visible_message(\
+			SPAN_WARNING("[user] tries to pull [M] free of \the [src]!"),\
+			SPAN_WARNING("[user] is trying to pull you off \the [src], opening up fresh wounds!"),\
+			SPAN("italics", "You hear a squishy wet noise.</span>"))
+		unbuckling = TRUE
+		if(!do_after(user, delay = 150, target = src))
+			if(M && M.buckled)
+				M.visible_message(\
+				SPAN_WARNING("[user] fails to free [M]!"),\
+				SPAN_WARNING("[user] fails to pull you off of \the [src]."))
+			unbuckling = FALSE
+			return
+	else
+		M.visible_message(\
+		SPAN_WARNING("[M] struggles to break free from \the [src]!"),\
+		SPAN_WARNING("You struggle to break free from \the [src], exacerbating your wounds!"),\
+		SPAN("italics", "You hear a wet squishing noise."))
+		M.adjustBruteLoss(30)
+		if(!do_after(M, delay = 600, target = src))
+			if(M && M.buckled)
+				M << "<span class='warning'>You fail to free yourself!</span>"
+			return
+
+	unbuckling = FALSE
+	if(!M.buckled)
+		return
+	M.adjustBruteLoss(30)
+	src.visible_message(SPAN_DANGER("[M] falls free of \the [src]!"))
+	M.hanging = FALSE
+	unbuckle_mob()
+	var/mob/living/carbon/C = M
+	if (istype(C) && C.can_feel_pain())
+		C.emote("scream")
+	M.AdjustWeakened(10)
+
+/obj/structure/kitchenspike/proc/slice(obj/item/I, mob/living/user)
+	if (!buckled_mob)
+		return
+
+	var/mob/living/carbon/human/H = buckled_mob
+	if (!istype(H))
+		to_chat(user, SPAN_NOTICE("You start to butcher [buckled_mob] with your [I]..."))
+		if (!do_after(user, delay = 100, target = buckled_mob))
+			return
+		var/slab_name = buckled_mob.name
+		var/slab_count = 3
+		var/slab_type = /obj/item/weapon/reagent_containers/food/snacks/meat
+		var/slab_nutrition = 20
+		if (iscarbon(buckled_mob))
+			var/mob/living/carbon/C = buckled_mob
+			slab_nutrition = C.nutrition / 15
+			if (istype(buckled_mob, /mob/living/carbon/alien))
+				slab_type = /obj/item/weapon/reagent_containers/food/snacks/xenomeat
+
+		if (istype(buckled_mob,/mob/living/simple_animal))
+			var/mob/living/simple_animal/critter = buckled_mob
+			if (critter.meat_amount)
+				slab_count = critter.meat_amount
+			if (critter.meat_type)
+				slab_type = critter.meat_type
+
+		if (issmall(buckled_mob))
+			slab_nutrition *= 0.5
+
+		slab_nutrition /= slab_count
+
+		var/reagent_transfer_amt
+		if (src.buckled_mob.reagents)
+			reagent_transfer_amt = round(buckled_mob.reagents.total_volume / slab_count, 1)
+
+		for (var/i=1 to slab_count)
+			var/obj/item/weapon/reagent_containers/food/snacks/meat/new_meat = new slab_type(src, rand(3,8))
+			if (istype(new_meat))
+				new_meat.SetName("[slab_name] [new_meat.name]")
+				new_meat.reagents.add_reagent(/datum/reagent/nutriment,slab_nutrition)
+				if (buckled_mob.reagents)
+					buckled_mob.reagents.trans_to_obj(new_meat, reagent_transfer_amt)
+
+		to_chat(user, SPAN_NOTICE("You've finished butchering [buckled_mob]."))
+		admin_attack_log(user, buckled_mob, "Gibbed the victim", "Was gibbed", "gibbed")
+		buckled_mob.ghostize()
+		playsound(loc, 'sound/effects/splat.ogg', 50, 1)
+		QDEL_NULL(buckled_mob)
+		return
+
+	if (H.isSynthetic())
+		to_chat(user, SPAN_WARNING("Can't extract meat from synths!"))
+		return
+
+	var/zone = check_zone(user.zone_sel?.selecting)
+	var/obj/item/organ/external/organ = H.get_organ(zone)
+	if (BP_IS_ROBOTIC(organ))
+		to_chat(user, SPAN_WARNING("Can't extract meat from robotic limbs!"))
+		return
+	if (!organ || organ.is_stump())
+		to_chat(user, SPAN_WARNING("Can't extract meat from there!"))
+		return
+	var/obj/item/organ/external/chest/C = organ
+	if (istype(C) && C.butchering_capacity <= 0) //workaround for chests not getting stumped/whatever
+		to_chat(user, SPAN_WARNING("Can't extract any more meat from there!"))
+		return
+
+	var/meat_limbs_left = 0
+	for (var/obj/item/organ/external/O in H.organs)
+		if (BP_IS_ROBOTIC(O) || O.is_stump())
+			continue
+		if (istype(C))
+			meat_limbs_left += C.butchering_capacity
+			continue
+		meat_limbs_left++
+	
+	var/slab_name = H.real_name
+	var/slab_type = H.species.meat_type
+	var/slab_nutrition = H.nutrition / meat_limbs_left
+	var/nutrition_transfer_mod = 0.33
+	if (issmall(H))
+		nutrition_transfer_mod *= 0.5
+	
+	var/butchered_organ_name = "[organ.name]";
+	user.visible_message(SPAN_WARNING("[user] tries to butcher [H]'s [butchered_organ_name]!"),\
+		SPAN_NOTICE("You try to butcher [H]'s [butchered_organ_name]..."),\
+		SPAN("italics", "You hear a wet squishing noise.</span>"))
+
+	if (do_after(user, delay = 20, target = H))
+		if (istype(C))
+			if (C.butchering_capacity <= 0)
+				return
+			H.apply_damage(damage = 60, damagetype = BRUTE, def_zone = zone, damage_flags = DAM_SHARP, used_weapon = I)
+			C.butchering_capacity--
+		else
+			organ.droplimb(clean = FALSE, silent = TRUE, disintegrate = DROPLIMB_BLUNT) //blunt so it gets turned into gore
+		user.visible_message(SPAN_WARNING("[user]'ve successfully butchered [H]'s [butchered_organ_name]!"),\
+			SPAN_NOTICE("You've successfully butchered [H]'s [butchered_organ_name]..."),\
+			SPAN("italics", "You hear a squishy wet noise.</span>"))
+		H.nutrition -= slab_nutrition
+		var/obj/item/weapon/reagent_containers/food/snacks/meat/new_meat = new slab_type(get_turf(src), rand(3,8))
+		if (istype(new_meat))
+			new_meat.SetName("[slab_name] [new_meat.name]")
+			new_meat.reagents.add_reagent(/datum/reagent/nutriment,slab_nutrition * nutrition_transfer_mod)
+			if (H.reagents)
+				H.reagents.trans_to_obj(new_meat, round(buckled_mob.reagents.total_volume / meat_limbs_left, 1))
+	return
+
+
+

--- a/code/modules/mob/living/carbon/human/update_icons.dm
+++ b/code/modules/mob/living/carbon/human/update_icons.dm
@@ -152,6 +152,7 @@ Please contact me on #coderbus IRC. ~Carn x
 //UPDATES OVERLAYS FROM OVERLAYS_LYING/OVERLAYS_STANDING
 /mob/living/carbon/human/update_icons()
 	lying_prev = lying	//so we don't update overlays for lying/standing unless our stance changes again
+	hanging_prev = hanging
 	update_hud()		//TODO: remove the need for this
 
 	var/list/overlays_to_apply = list()

--- a/code/modules/mob/mob.dm
+++ b/code/modules/mob/mob.dm
@@ -730,7 +730,7 @@
 	if( update_icon )	//forces a full overlay update
 		update_icon = 0
 		regenerate_icons()
-	else if( lying != lying_prev )
+	else if( lying != lying_prev || hanging != hanging_prev)
 		update_icons()
 
 	return canmove

--- a/code/modules/mob/mob_defines.dm
+++ b/code/modules/mob/mob_defines.dm
@@ -74,6 +74,8 @@
 	var/resting = 0			//Carbon
 	var/lying = 0
 	var/lying_prev = 0
+	var/hanging = FALSE
+	var/hanging_prev = FALSE
 	var/canmove = 1
 	//Allows mobs to move through dense areas without restriction. For instance, in space or out of holder objects.
 	var/incorporeal_move = 0 //0 is off, 1 is normal, 2 is for ninjas.

--- a/code/modules/modifier/helpers.dm
+++ b/code/modules/modifier/helpers.dm
@@ -25,6 +25,8 @@
 	var/matrix/M = matrix()
 	M.Scale(icon_scale)
 	M.Translate(0, 16*(icon_scale-1))
+	if (hanging)
+		M.Turn(180)
 	animate(src, transform = M, time = 10)
 
 /mob/living/carbon/human/update_transform()
@@ -40,6 +42,11 @@
 		M.Scale(icon_scale)
 		M.Translate(1,-6)
 		layer = MOB_LAYER -0.01 // Fix for a byond bug where turf entry order no longer matters
+	else if(hanging && !species.prone_icon)
+		M.Turn(180)
+		M.Scale(icon_scale)
+		M.Translate(0, -16*(icon_scale-1))
+		layer = MOB_LAYER // Fix for a byond bug where turf entry order no longer matters
 	else
 		M.Scale(icon_scale)
 		M.Translate(0, 16*(icon_scale-1))

--- a/code/modules/organs/external/_external.dm
+++ b/code/modules/organs/external/_external.dm
@@ -806,11 +806,12 @@ Note that amputating the affected organ does in fact remove the infection from t
 	if(disintegrate == DROPLIMB_EDGE && species.limbs_are_nonsolid)
 		disintegrate = DROPLIMB_BLUNT //splut
 
-	var/list/organ_msgs = get_droplimb_messages_for(disintegrate, clean)
-	if(LAZYLEN(organ_msgs) >= 3)
-		owner.visible_message("<span class='danger'>[organ_msgs[1]]</span>", \
-			"<span class='moderate'><b>[organ_msgs[2]]</b></span>", \
-			"<span class='danger'>[organ_msgs[3]]</span>")
+	if (!silent)
+		var/list/organ_msgs = get_droplimb_messages_for(disintegrate, clean)
+		if(LAZYLEN(organ_msgs) >= 3)
+			owner.visible_message("<span class='danger'>[organ_msgs[1]]</span>", \
+				"<span class='moderate'><b>[organ_msgs[2]]</b></span>", \
+				"<span class='danger'>[organ_msgs[3]]</span>")
 
 	var/mob/living/carbon/human/victim = owner //Keep a reference for post-removed().
 	var/obj/item/organ/external/parent_organ = parent

--- a/code/modules/organs/external/standard.dm
+++ b/code/modules/organs/external/standard.dm
@@ -21,7 +21,7 @@
 	artery_name = "aorta"
 	cavity_name = "thoracic"
 	limb_flags = ORGAN_FLAG_GENDERED_ICON | ORGAN_FLAG_HEALS_OVERKILL | ORGAN_FLAG_CAN_BREAK
-	var/butchering_capacity = 2
+	var/butchering_capacity = 1
 
 /obj/item/organ/external/chest/robotize()
 	if(..())

--- a/code/modules/organs/external/standard.dm
+++ b/code/modules/organs/external/standard.dm
@@ -21,6 +21,7 @@
 	artery_name = "aorta"
 	cavity_name = "thoracic"
 	limb_flags = ORGAN_FLAG_GENDERED_ICON | ORGAN_FLAG_HEALS_OVERKILL | ORGAN_FLAG_CAN_BREAK
+	var/butchering_capacity = 2
 
 /obj/item/organ/external/chest/robotize()
 	if(..())


### PR DESCRIPTION
Меняет функционал крюка, теперь на него можно вешать чуть ли не любых мобов, которых держишь вторым грабом.
Вешание и снимание моба с крюка требует некоторое время и наносит брут урон, моб может попытаться сам вырваться с крюка, на это потребуется больше времени (чем если бы его кто-то другой снимал), и в процессе нанесется дополнительный урон.
Если висящий моб не человек (и не человекоподобный), то использованием острого предмета на крюке (не на мобе) можно этого моба гибнуть подобно тому, как это делает гиббер. Если висящий моб человек (или человекоподобный) (включая мартых), то его конечности тем же образом можно рубать на мясо, но от самого тела таким образом не избавиться (хотя его тоже можно рубать на мясо).

Гриндер теперь выдает столько же мяса, сколько выдало бы нарезание на крюке (хуман без конечностей даст в гриндере меньше мяса, чем хуман с конечностями).

Вспомогательными изменениями запилены две переменные в моба, которые отвечают за висящее состояние (подобно лежачему) (тут трансформ зачем-то постоянно ресетается, поэтому просто повернуть его на 180 градусов (когда моб помещается на крюк) не канает, и нужно прокинуть в ресетающую функцию новые параметры; оно ровно для этого), одна переменная в тело (орган) (кол-во кусков мяса, которые с него вырезать можно), и починено безпалевное отделение органа (аргумент silent был, но ни на что не влиял; теперь влияет).

closes #1330

- [X] Pull Request полностью завершен, мне не нужна помощь чтобы его закончить.
- [X] Я внимательно прочитал все свои изменения и багов в них не нашел.
- [X] Я запускал сервер со своими изменениями локально и все протестировал.
- [X] Я ознакомился c [Guide to Contribute](https://github.com/ChaoticOnyx/OnyxBay/blob/dev/docs/contributing.md).
