### PR TITLE
 Прерывание речи от ударов

### DIFF
--- a/code/modules/client/client_defines.dm
+++ b/code/modules/client/client_defines.dm
@@ -61,3 +61,6 @@
 
 	//So admins know why it isn't working - Used to determine what other accounts previously logged in from this computer id
 	var/related_accounts_cid = "Requires database"
+
+	//used for initial centering of saywindow
+	var/first_say = TRUE

--- a/code/modules/mob/living/bot/secbot.dm
+++ b/code/modules/mob/living/bot/secbot.dm
@@ -404,7 +404,7 @@
 	to_chat(usr,"<span class='danger'>An arbitrary speech module is not installed in the [src]!</span>")
 
 /mob/living/bot/secbot/say_wrapper()
-	set name = "Say verb"
+	set name = "Say Verb"
 	set hidden = 1
 
 	to_chat(usr,"<span class='danger'>An arbitrary speech module is not installed in the [src]!</span>")

--- a/code/modules/mob/living/bot/secbot.dm
+++ b/code/modules/mob/living/bot/secbot.dm
@@ -404,7 +404,7 @@
 	to_chat(usr,"<span class='danger'>An arbitrary speech module is not installed in the [src]!</span>")
 
 /mob/living/bot/secbot/say_wrapper()
-	set name = ".Say"
+	set name = "Say verb"
 	set hidden = 1
 
 	to_chat(usr,"<span class='danger'>An arbitrary speech module is not installed in the [src]!</span>")

--- a/code/modules/mob/living/carbon/human/say.dm
+++ b/code/modules/mob/living/carbon/human/say.dm
@@ -45,7 +45,6 @@
 	var/temp = client.close_saywindow()
 	if (!temp)
 		temp = winget(client, "input", "text")
-		temp = trim_left(temp)
 		if(findtextEx(temp, "Say \"", 1, 6) && length(temp) > 5)
 			temp = copytext(temp, 6)
 			var/custom_emote_key = get_prefix_key(/decl/prefix/custom_emote)

--- a/code/modules/mob/living/carbon/human/say.dm
+++ b/code/modules/mob/living/carbon/human/say.dm
@@ -39,38 +39,27 @@
 
 
 /mob/living/carbon/human/proc/forcesay(list/append)
-	if(stat == CONSCIOUS)
-		if(client)
-			var/virgin = 1	//has the text been modified yet?
-			var/temp = winget(client, "input", "text")
-			if(findtextEx(temp, "Say \"", 1, 7) && length(temp) > 5)	//case sensitive means
-				var/main_key = get_prefix_key(/decl/prefix/radio_main_channel)
-				temp = replacetext(temp, main_key, "")	//general radio
+	if(stat != CONSCIOUS || !client)
+		return
 
-				var/channel_key = get_prefix_key(/decl/prefix/radio_channel_selection)
-				if(findtext(trim_left(temp), channel_key, 6, 7))	//dept radio
-					temp = copytext(trim_left(temp), 8)
-					virgin = 0
+	var/temp = client.close_saywindow()
+	if (!temp)
+		temp = winget(client, "input", "text")
+		temp = trim_left(temp)
+		if(findtextEx(temp, "Say \"", 1, 6) && length(temp) > 5)
+			temp = copytext(temp, 6)
+			var/custom_emote_key = get_prefix_key(/decl/prefix/custom_emote)
+			if(findtext(temp, custom_emote_key, 1, 2))	//emotes
+				return
+		else
+			return
+		winset(client, "input", "text=[null]")
+	temp = trim_left(temp)
 
-				if(virgin)
-					temp = copytext(trim_left(temp), 6)	//normal speech
-					virgin = 0
-
-				while(findtext(trim_left(temp), channel_key, 1, 2))	//dept radio again (necessary)
-					temp = copytext(trim_left(temp), 3)
-
-				var/custom_emote_key = get_prefix_key(/decl/prefix/custom_emote)
-				if(findtext(temp, custom_emote_key, 1, 2))	//emotes
-					return
-				temp = copytext(trim_left(temp), 1, rand(5,8))
-
-				var/trimmed = trim_left(temp)
-				if(length(trimmed))
-					if(append)
-						temp += pick(append)
-
-					say(temp)
-				winset(client, "input", "text=[null]")
+	if(length(temp))
+		if(append)
+			temp += pick(append)
+			say(temp)
 
 /mob/living/carbon/human/say_understands(mob/other,datum/language/speaking = null)
 

--- a/code/modules/mob/say.dm
+++ b/code/modules/mob/say.dm
@@ -8,10 +8,13 @@
 
 /mob/verb/say_verb(message as text)
 	set name = "Say"
-	set category = "IC"
-	if (client && usr == src)
-		client.close_saywindow()
+	set hidden = 1
+
+	ASSERT(client && usr == src)
+
+	client.close_saywindow()
 	remove_typing_indicator()
+
 	usr.say(message)
 
 /mob/verb/me_verb(message as text)

--- a/code/modules/mob/say.dm
+++ b/code/modules/mob/say.dm
@@ -9,6 +9,9 @@
 /mob/verb/say_verb(message as text)
 	set name = "Say"
 	set category = "IC"
+	if (client && usr == src)
+		client.close_saywindow()
+	remove_typing_indicator()
 	usr.say(message)
 
 /mob/verb/me_verb(message as text)

--- a/code/modules/mob/typing_indicator.dm
+++ b/code/modules/mob/typing_indicator.dm
@@ -48,7 +48,6 @@ I IS TYPIN'!'
 	QDEL_NULL(typing_indicator)
 
 
-/client/var/first_say = TRUE
 /client/proc/show_saywindow()
 	winset(src, "saywindow", "is-visible=true;focus=true")
 
@@ -80,11 +79,10 @@ I IS TYPIN'!'
 	return text
 
 /mob/verb/say_wrapper()
-	set name = ".Say"
-	set hidden = 1
+	set name = "Say verb"
+	set category = "IC"
 
-	if (!client || src != usr)
-		return
+	ASSERT(client && usr == src)
 
 	create_typing_indicator()
 	if (!client.first_say)

--- a/code/modules/mob/typing_indicator.dm
+++ b/code/modules/mob/typing_indicator.dm
@@ -79,7 +79,7 @@ I IS TYPIN'!'
 	return text
 
 /mob/verb/say_wrapper()
-	set name = "Say verb"
+	set name = "Say Verb"
 	set category = "IC"
 
 	ASSERT(client && usr == src)

--- a/code/modules/mob/typing_indicator.dm
+++ b/code/modules/mob/typing_indicator.dm
@@ -47,28 +47,50 @@ I IS TYPIN'!'
 /mob/proc/remove_typing_indicator() // A bit excessive, but goes with the creation of the indicator I suppose
 	QDEL_NULL(typing_indicator)
 
+
+/client/var/first_say = TRUE
+/client/proc/show_saywindow()
+	winset(src, "saywindow", "is-visible=true;focus=true")
+
+/client/proc/center_and_show_saywindow()
+	first_say = FALSE
+	var/our_size = winget(src, "saywindow", "outer-size")
+	var/list/our_size_split = splittext(our_size, "x")
+	var/our_size_x = text2num(our_size_split[1])
+	var/our_size_y = text2num(our_size_split[2])
+	var/main_params = winget(src, "mainwindow", "outer-size;pos;is-maximized")
+	var/list/main_params_parsed = params2list(main_params)
+	var/maximized = main_params_parsed["is-maximized"] == "true"
+	var/list/main_pos = splittext(main_params_parsed["pos"], ",")
+	var/main_pos_x = maximized ? 0 : text2num(main_pos[1])
+	var/main_pos_y = maximized ? 0 : text2num(main_pos[2])
+	var/list/main_size = splittext(main_params_parsed["outer-size"], "x")
+	var/main_size_x = text2num(main_size[1])
+	var/main_size_y = text2num(main_size[2])
+
+	var/resulting_x = main_pos_x + main_size_x / 2 - our_size_x / 2
+	var/resulting_y = main_pos_y + main_size_y / 2 - our_size_y / 2
+
+	winset(src, "saywindow", "is-visible=true;focus=true;pos=[resulting_x],[resulting_y]")
+
+/client/proc/close_saywindow()
+	var/text = winget(src, "saywindow.sayinput", "text")
+	winset(src, "saywindow", "is-visible=false;focus=false")
+	winset(src, "saywindow.sayinput", "text=\"\"")
+	return text
+
 /mob/verb/say_wrapper()
 	set name = ".Say"
 	set hidden = 1
 
+	if (!client || src != usr)
+		return
 
 	create_typing_indicator()
-	var/message = input("","say (text)") as text
-	remove_typing_indicator()
-	if(message)
-		say_verb(message)
-
-	/* Well maybe some day. Later.
-	var/dat = ""
-	dat += "<form name='Say' action='?src=\ref[src]' method='get'>"
-	dat += "<input type='hidden' name='src' value='\ref[src]'>"
-	dat += "<input type='hidden' name='choice' value='Say'>"
-	dat += "<input type='submit' value='Say'><input type='text' id='mobsay' name='mobsay' value='' style='width:350px; background-color:white;'>"
-	dat += "</form>"
-	var/datum/browser/popup = new(src, "Say", ntitle = "Say (text)", nwidth = 440, nheight = 90)
-	visible_message("<span class='danger'>[src] uses chat.</span>")
-	popup.set_content(jointext(dat,null))
-	popup.open()*/
+	if (!client.first_say)
+		client.show_saywindow()
+		return
+	client.center_and_show_saywindow()
 
 /mob/verb/me_wrapper()
 	set name = ".Me"

--- a/interface/skin.dmf
+++ b/interface/skin.dmf
@@ -127,7 +127,7 @@ macro "borghotkeymode"
 		command = ".movedown"
 	elem 
 		name = "T"
-		command = ".say"
+		command = "Say-verb"
 	elem "w_key"
 		name = "W+REP"
 		command = ".moveup"
@@ -190,7 +190,7 @@ macro "borghotkeymode"
 		command = ".screenshot"
 	elem 
 		name = "F3"
-		command = ".say"
+		command = "Say-verb"
 	elem 
 		name = "F4"
 		command = ".me"
@@ -360,7 +360,7 @@ macro "macro"
 		command = ".screenshot"
 	elem 
 		name = "F3"
-		command = ".say"
+		command = "Say-verb"
 	elem 
 		name = "F4"
 		command = ".me"
@@ -533,7 +533,7 @@ macro "hotkeymode"
 		command = ".movedown"
 	elem 
 		name = "T"
-		command = ".say"
+		command = "Say-verb"
 	elem "w_key"
 		name = "W+REP"
 		command = ".moveup"
@@ -596,7 +596,7 @@ macro "hotkeymode"
 		command = ".screenshot"
 	elem 
 		name = "F3"
-		command = ".say"
+		command = "Say-verb"
 	elem 
 		name = "F4"
 		command = ".me"
@@ -766,7 +766,7 @@ macro "borgmacro"
 		command = ".screenshot"
 	elem 
 		name = "F3"
-		command = ".say"
+		command = "Say-verb"
 	elem 
 		name = "F4"
 		command = ".me"

--- a/interface/skin.dmf
+++ b/interface/skin.dmf
@@ -1370,6 +1370,45 @@ window "infowindow"
 		command = "Changelog"
 		group = "rpanemode"
 
+window "saywindow"
+	elem "saywindow"
+		type = MAIN
+		pos = 570,452
+		size = 300x90
+		anchor1 = none
+		anchor2 = none
+		background-color = none
+		is-visible = false
+		saved-params = "size"
+		title = "say (text)"
+		statusbar = false
+		can-close = false
+		can-minimize = false
+		can-resize = false
+		outer-size = 308x117
+		inner-size = 300x90
+	elem "saybutton"
+		type = BUTTON
+		pos = 110,50
+		size = 80x25
+		anchor1 = none
+		anchor2 = none
+		background-color = none
+		border = line
+		saved-params = ""
+		text = "OK"
+		command = "say [[sayinput.text]]"
+	elem "sayinput"
+		type = INPUT
+		pos = 8,16
+		size = 280x20
+		anchor1 = none
+		anchor2 = none
+		is-default = true
+		border = sunken
+		saved-params = ""
+		command = "say"
+
 window "text_editor"
 	elem "text_editor"
 		type = MAIN

--- a/interface/skin.dmf
+++ b/interface/skin.dmf
@@ -127,7 +127,7 @@ macro "borghotkeymode"
 		command = ".movedown"
 	elem 
 		name = "T"
-		command = "Say-verb"
+		command = "Say-Verb"
 	elem "w_key"
 		name = "W+REP"
 		command = ".moveup"
@@ -190,7 +190,7 @@ macro "borghotkeymode"
 		command = ".screenshot"
 	elem 
 		name = "F3"
-		command = "Say-verb"
+		command = "Say-Verb"
 	elem 
 		name = "F4"
 		command = ".me"
@@ -360,7 +360,7 @@ macro "macro"
 		command = ".screenshot"
 	elem 
 		name = "F3"
-		command = "Say-verb"
+		command = "Say-Verb"
 	elem 
 		name = "F4"
 		command = ".me"
@@ -533,7 +533,7 @@ macro "hotkeymode"
 		command = ".movedown"
 	elem 
 		name = "T"
-		command = "Say-verb"
+		command = "Say-Verb"
 	elem "w_key"
 		name = "W+REP"
 		command = ".moveup"
@@ -596,7 +596,7 @@ macro "hotkeymode"
 		command = ".screenshot"
 	elem 
 		name = "F3"
-		command = "Say-verb"
+		command = "Say-Verb"
 	elem 
 		name = "F4"
 		command = ".me"
@@ -766,7 +766,7 @@ macro "borgmacro"
 		command = ".screenshot"
 	elem 
 		name = "F3"
-		command = "Say-verb"
+		command = "Say-Verb"
 	elem 
 		name = "F4"
 		command = ".me"


### PR DESCRIPTION
В скин добавлено окно saywindow, которое имитирует окно input, которым say_wrapper принимает ввод. say_wrapper теперь использует это окно вместо input. forcesay теперь сохраняет радио ключи и все введенное (на момент удара) сообщение (кобольд в дискорде сказал, что норм) и корректно работает с хоткейным сеем.
closes #2231

- [X] Pull Request полностью завершен, мне не нужна помощь чтобы его закончить.
- [X] Я внимательно прочитал все свои изменения и багов в них не нашел.
- [X] Я запускал сервер со своими изменениями локально и все протестировал.
- [X] Я ознакомился c [Guide to Contribute](https://github.com/ChaoticOnyx/OnyxBay/blob/dev/docs/contributing.md).
