### PR TITLE
Мелкофикс сея

### DIFF
--- a/code/modules/mob/living/carbon/human/say.dm
+++ b/code/modules/mob/living/carbon/human/say.dm
@@ -43,6 +43,8 @@
 		return
 
 	var/temp = client.close_saywindow()
+	remove_typing_indicator()
+
 	if (!temp)
 		temp = winget(client, "input", "text")
 		if(findtextEx(temp, "Say ", 1, 5) && length(temp) > 4)

--- a/code/modules/mob/living/carbon/human/say.dm
+++ b/code/modules/mob/living/carbon/human/say.dm
@@ -45,8 +45,10 @@
 	var/temp = client.close_saywindow()
 	if (!temp)
 		temp = winget(client, "input", "text")
-		if(findtextEx(temp, "Say \"", 1, 6) && length(temp) > 5)
-			temp = copytext(temp, 6)
+		if(findtextEx(temp, "Say ", 1, 5) && length(temp) > 4)
+			temp = copytext(temp, 5)
+			if (text2ascii(temp, 1) == text2ascii("\""))
+				temp = copytext(temp, 2)
 			var/custom_emote_key = get_prefix_key(/decl/prefix/custom_emote)
 			if(findtext(temp, custom_emote_key, 1, 2))	//emotes
 				return

--- a/code/modules/mob/say.dm
+++ b/code/modules/mob/say.dm
@@ -6,7 +6,7 @@
 	set category = "IC"
 	return
 
-/mob/verb/say_verb(message as text)
+/mob/verb/say_verb(message as text|null)
 	set name = "Say"
 	set hidden = 1
 


### PR DESCRIPTION
Делает так, чтобы при запуске сея без аргументов (прожатие энтера в хоткейном меню или запуск Say из командной строки без доп. символов) не всплывало окно бйондовского инпута.
Попутно изменен forcesay, чтоб корректно обрабатывал вариант без кавычек( Say something вместо Say "something), который теперь возможен, и чтоб убирал индикатор набора сообщения.

- [x] Pull Request полностью завершен, мне не нужна помощь чтобы его закончить.
- [x] Я внимательно прочитал все свои изменения и багов в них не нашел.
- [x] Я запускал сервер со своими изменениями локально и все протестировал.
- [x] Я ознакомился c [Guide to Contribute](https://github.com/ChaoticOnyx/OnyxBay/blob/dev/docs/contributing.md).
