### PR TITLE
nerf(mouse): forbid them to bite organs above feet

### DIFF
--- a/code/__defines/mobs.dm
+++ b/code/__defines/mobs.dm
@@ -241,7 +241,7 @@
 #define BP_GROIN  "groin"
 #define BP_ALL_LIMBS list(BP_CHEST, BP_GROIN, BP_HEAD, BP_L_ARM, BP_R_ARM, BP_L_HAND, BP_R_HAND, BP_L_LEG, BP_R_LEG, BP_L_FOOT, BP_R_FOOT)
 #define BP_BY_DEPTH list(BP_HEAD, BP_L_HAND, BP_R_HAND, BP_L_ARM, BP_R_ARM, BP_L_FOOT, BP_R_FOOT, BP_L_LEG, BP_R_LEG, BP_GROIN, BP_CHEST)
-#define BP_BELOW_GROIN list(BP_GROIN, BP_L_FOOT, BP_R_FOOT, BP_L_LEG, BP_R_LEG)
+#define BP_FEET list(BP_L_FOOT, BP_R_FOOT)
 
 // Prosthetic helpers.
 #define BP_IS_ROBOTIC(org)  (org.status & ORGAN_ROBOTIC)

--- a/code/modules/mob/living/simple_animal/friendly/mouse.dm
+++ b/code/modules/mob/living/simple_animal/friendly/mouse.dm
@@ -122,7 +122,7 @@
 			to_chat(src, SPAN_WARNING("You can't bite while you are hiding!"))
 			return
 
-		var/available_limbs = H.lying ? BP_ALL_LIMBS : BP_BELOW_GROIN
+		var/available_limbs = H.lying ? BP_ALL_LIMBS : BP_FEET
 		var/obj/item/organ/external/limb
 		for(var/L in shuffle(available_limbs))
 			limb = H.get_organ(L)


### PR DESCRIPTION
В ходе реализации #1830 оказалось, что мыши вообще могут кусать не только стопы, но и ноги с гроином.

Это конечно смешно, но хотелось бы чтобы мыши не могли кусать людей в жестких ботинках. Да и чтобы мыши прыгали я еще ни разу не слышал.

Мыши все еще могут кусать лежащих людей куда угодно.

- [x] Pull Request полностью завершен, мне не нужна помощь чтобы его закончить.
- [x] Я внимательно прочитал все свои изменения и багов в них не нашел.
- [x] Я запускал сервер со своими изменениями локально и все протестировал.
- [x] Я ознакомился c [Guide to Contribute](https://github.com/ChaoticOnyx/OnyxBay/blob/dev/docs/contributing.md).
