### PR TITLE
fix(antagonist preferences): double Cultist

### DIFF
--- a/code/__defines/gamemode.dm
+++ b/code/__defines/gamemode.dm
@@ -17,6 +17,9 @@
 #define BE_PLANT "BE_PLANT"
 #define BE_SYNTH "BE_SYNTH"
 #define BE_PAI   "BE_PAI"
+#define BE_BORER "BE_BORER"
+#define BE_FAMILIAR "BE_FAMILIAR"
+#define BE_SHADE "BE_SHADE"
 
 // Antagonist datum flags.
 #define ANTAG_OVERRIDE_JOB        0x1 // Assigned job is set to MODE when spawning.

--- a/code/__defines/gamemode.dm
+++ b/code/__defines/gamemode.dm
@@ -17,7 +17,6 @@
 #define BE_PLANT "BE_PLANT"
 #define BE_SYNTH "BE_SYNTH"
 #define BE_PAI   "BE_PAI"
-#define BE_BORER "BE_BORER"
 #define BE_FAMILIAR "BE_FAMILIAR"
 #define BE_SHADE "BE_SHADE"
 

--- a/code/modules/client/preference_setup/antagonism/01_candidacy.dm
+++ b/code/modules/client/preference_setup/antagonism/01_candidacy.dm
@@ -50,7 +50,10 @@
 		else
 			. += "<a href='?src=\ref[src];add_special=[antag.id]'>High</a> <span class='linkOn'>Low</span> <a href='?src=\ref[src];add_never=[antag.id]'>Never</a></br>"
 		. += "</td></tr>"
+	. += "</table><br>"
 
+	. += "<b>Offer Ghost Roles:</b><br>"
+	. += "<table>"
 	var/list/ghost_traps = get_ghost_traps()
 	for(var/ghost_trap_key in ghost_traps)
 		var/datum/ghosttrap/ghost_trap = ghost_traps[ghost_trap_key]
@@ -63,12 +66,10 @@
 			. += "<span class='danger'>\[WHITELIST\]</span><br>"
 		else if(bannedReason)
 			. += "<span class='danger'>\[BANNED\]</span><br>"
-		else if(ghost_trap.pref_check in pref.be_special_role)
-			. += "<span class='linkOn'>High</span> <a href='?src=\ref[src];del_special=[ghost_trap.pref_check]'>Low</a> <a href='?src=\ref[src];add_never=[ghost_trap.pref_check]'>Never</a></br>"
 		else if(ghost_trap.pref_check in pref.never_be_special_role)
-			. += "<a href='?src=\ref[src];add_special=[ghost_trap.pref_check]'>High</a> <a href='?src=\ref[src];del_special=[ghost_trap.pref_check]'>Low</a> <span class='linkOn'>Never</span></br>"
+			. += "<a href='?src=\ref[src];del_special=[ghost_trap.pref_check]'>Always</a> <span class='linkOn'>Never</span></br>"
 		else
-			. += "<a href='?src=\ref[src];add_special=[ghost_trap.pref_check]'>High</a> <span class='linkOn'>Low</span> <a href='?src=\ref[src];add_never=[ghost_trap.pref_check]'>Never</a></br>"
+			. += "<span class='linkOn'>Always</span> <a href='?src=\ref[src];add_never=[ghost_trap.pref_check]'>Never</a></br>"
 		. += "</td></tr>"
 	. += "</table>"
 	. = jointext(.,null)

--- a/code/modules/ghosttrap/trap.dm
+++ b/code/modules/ghosttrap/trap.dm
@@ -147,7 +147,7 @@ var/list/ghost_traps
 /datum/ghosttrap/borer
 	object = "cortical borer"
 	ban_checks = list(MODE_BORER)
-	pref_check = MODE_BORER
+	pref_check = BE_BORER
 	ghost_trap_message = "They are occupying a borer now."
 	ghost_trap_role = "Cortical Borer"
 	can_set_own_name = FALSE
@@ -203,7 +203,7 @@ datum/ghosttrap/pai/transfer_personality(mob/candidate, mob/living/silicon/robot
 ******************/
 /datum/ghosttrap/familiar
 	object = "wizard familiar"
-	pref_check = MODE_WIZARD
+	pref_check = BE_FAMILIAR
 	ghost_trap_message = "They are occupying a familiar now."
 	ghost_trap_role = "Wizard Familiar"
 	ban_checks = list(MODE_WIZARD)
@@ -214,10 +214,11 @@ datum/ghosttrap/pai/transfer_personality(mob/candidate, mob/living/silicon/robot
 /datum/ghosttrap/cult
 	object = "cultist"
 	ban_checks = list("cultist")
-	pref_check = MODE_CULTIST
+	pref_check = BE_SHADE
 	can_set_own_name = FALSE
 	ghost_trap_message = "They are occupying a cultist's body now."
 	ghost_trap_role = "Cultist"
+	list_as_special_role = FALSE
 
 /datum/ghosttrap/cult/welcome_candidate(mob/target)
 	var/obj/item/device/soulstone/S = target.loc
@@ -233,3 +234,4 @@ datum/ghosttrap/pai/transfer_personality(mob/candidate, mob/living/silicon/robot
 	object = "soul stone"
 	ghost_trap_message = "They are occupying a soul stone now."
 	ghost_trap_role = "Shade"
+	list_as_special_role = TRUE

--- a/code/modules/ghosttrap/trap.dm
+++ b/code/modules/ghosttrap/trap.dm
@@ -147,7 +147,7 @@ var/list/ghost_traps
 /datum/ghosttrap/borer
 	object = "cortical borer"
 	ban_checks = list(MODE_BORER)
-	pref_check = BE_BORER
+	pref_check = MODE_BORER
 	ghost_trap_message = "They are occupying a borer now."
 	ghost_trap_role = "Cortical Borer"
 	can_set_own_name = FALSE

--- a/code/modules/ghosttrap/trap.dm
+++ b/code/modules/ghosttrap/trap.dm
@@ -214,7 +214,7 @@ datum/ghosttrap/pai/transfer_personality(mob/candidate, mob/living/silicon/robot
 /datum/ghosttrap/cult
 	object = "cultist"
 	ban_checks = list("cultist")
-	pref_check = BE_SHADE
+	pref_check = MODE_CULTIST
 	can_set_own_name = FALSE
 	ghost_trap_message = "They are occupying a cultist's body now."
 	ghost_trap_role = "Cultist"
@@ -234,4 +234,5 @@ datum/ghosttrap/pai/transfer_personality(mob/candidate, mob/living/silicon/robot
 	object = "soul stone"
 	ghost_trap_message = "They are occupying a soul stone now."
 	ghost_trap_role = "Shade"
+	pref_check = BE_SHADE
 	list_as_special_role = TRUE


### PR DESCRIPTION
Исправил ошибку, из-за которой возможность получать оповещения о доступном вселении из призрака в культиста работала как возможность получить роль обычного культиста (и наоборот).

Более явно выделил настройки оповещений для гостов.
Убрал настройку оповещений о возможности вселения в культиста (как и раньше, их будут получать только те, кто выставил в настройках роль культиста на **Low** или **High**).
Возможность вселения в камень душ отвязана от роли культиста.
Оповещения для фамильяра отвязаны от роли визарда.

![image](https://user-images.githubusercontent.com/64479446/90948977-cb703f80-e44c-11ea-9002-12bb8c08c6bc.png)

От награды отказываюсь в пользу @MorJams (ПР #3219)

closes #2170

- [x] Pull Request полностью завершен, мне не нужна помощь чтобы его закончить.
- [x] Я внимательно прочитал все свои изменения и багов в них не нашел.
- [x] Я запускал сервер со своими изменениями локально и все протестировал.
- [x] Я ознакомился c [Guide to Contribute](https://github.com/ChaoticOnyx/OnyxBay/blob/dev/docs/contributing.md).
