### PR TITLE
tweak(rdconsole.protolathe)

### DIFF
--- a/code/modules/research/rdconsole.dm
+++ b/code/modules/research/rdconsole.dm
@@ -730,9 +730,9 @@ won't update every console in existence) but it's more of a hassle to do. Also, 
 						continue
 					var/temp_dat
 					for(var/M in D.materials)
-						temp_dat += ", [D.materials[M]*linked_imprinter.mat_efficiency] [CallMaterialName(M)]"
+						temp_dat += ", [D.materials[M]*linked_lathe.mat_efficiency] [CallMaterialName(M)]"
 					for(var/T in D.chemicals)
-						temp_dat += ", [D.chemicals[T]*linked_imprinter.mat_efficiency] [CallReagentName(T)]"
+						temp_dat += ", [D.chemicals[T]*linked_lathe.mat_efficiency] [CallReagentName(T)]"
 					if(temp_dat)
 						temp_dat = " \[[copytext(temp_dat, 3)]\]"
 					if(linked_lathe.canBuild(D, 1))


### PR DESCRIPTION
Удалена необходимость иметь подключенный **Circuit Imprinter**, чтобы выдать список крафта протолата. Также заменен _mat_efficiency_ для крафта протолата, ибо печатный станок тут никаким боком не вписывается.

✅ Pull Request полностью завершен, мне не нужна помощь чтобы его закончить.
✅ Я внимательно прочитал все свои изменения и багов в них не нашел.
✅ Я запускал сервер со своими изменениями локально и все протестировал.
✅ Я ознакомился c [Guide to Contribute](https://github.com/ChaoticOnyx/OnyxBay/blob/dev/docs/contributing.md).