### PR TITLE
Починка infest'а у хедкраба

### DIFF
--- a/code/game/gamemodes/changeling/changeling_powers.dm
+++ b/code/game/gamemodes/changeling/changeling_powers.dm
@@ -1756,7 +1756,7 @@ var/list/datum/absorbed_dna/hivemind_bank = list()
 		BIO = locate() in src.contents
 
 	if(!BIO)
-		return
+		BIO = new(src)
 	var/mob/M = A
 
 	BIO.change_host(A)


### PR DESCRIPTION
Иногда, в редких случаях, у хедкраба пропадала его биоструктура, из-за чего при Infest'e игрок не мог перенестись в новое тело. Почему пропадает биоструктура - вопрос на который трудно ответить, ибо это ДедФилькин код.

fix #2163 

- [x] Pull Request полностью завершен, мне не нужна помощь чтобы его закончить.
- [x] Я внимательно прочитал все свои изменения и багов в них не нашел.
- [x] Я запускал сервер со своими изменениями локально и все протестировал.
- [x] Я ознакомился c [Guide to Contribute](https://github.com/ChaoticOnyx/OnyxBay/blob/dev/docs/contributing.md).
