### PR TITLE
Прерывание речи от ударов 3

### DIFF
--- a/code/modules/mob/blob.dm
+++ b/code/modules/mob/blob.dm
@@ -114,8 +114,10 @@ mob/blob/DblClickOn(atom/A) //Teleport view to another blob
 	else
 		B = locate() in range("3x3", src.loc)
 
-/mob/blob/say_wrapper()
-	say(input("","say (text)"))
+/mob/blob/add_typing_indicator(is_sayinput as num|null)
+	set name = ".add_typing_indicator"
+	set hidden = 1
+	//no typing indicator for blob
 
 /mob/blob/say(message)
 	if (!message)

--- a/code/modules/mob/living/bot/secbot.dm
+++ b/code/modules/mob/living/bot/secbot.dm
@@ -403,7 +403,7 @@
 
 	to_chat(usr,"<span class='danger'>An arbitrary speech module is not installed in the [src]!</span>")
 
-/mob/living/bot/secbot/say_wrapper()
+/mob/living/bot/secbot/say_verb_fake()
 	set name = "Say Verb"
 	set hidden = 1
 

--- a/code/modules/mob/living/carbon/human/say.dm
+++ b/code/modules/mob/living/carbon/human/say.dm
@@ -43,11 +43,10 @@
 		return
 
 	var/temp = client.close_saywindow(return_content = TRUE)
-	remove_typing_indicator()
 
 	if (!temp)
 		temp = winget(client, "input", "text")
-		if(findtextEx(temp, "Say ", 1, 5) && length(temp) > 4)
+		if(length(temp) > 4 && findtextEx(temp, "Say ", 1, 5))
 			temp = copytext(temp, 5)
 			if (text2ascii(temp, 1) == text2ascii("\""))
 				temp = copytext(temp, 2)
@@ -56,7 +55,7 @@
 				return
 		else
 			return
-		winset(client, "input", "text=[null]")
+		winset(client, "input", "text=\"Say \\\"\"")
 	temp = trim_left(temp)
 
 	if(length(temp))

--- a/code/modules/mob/say.dm
+++ b/code/modules/mob/say.dm
@@ -13,9 +13,16 @@
 	ASSERT(client && usr == src)
 
 	client.close_saywindow()
-	remove_typing_indicator()
 
 	usr.say(message)
+
+/mob/verb/say_verb_fake()
+	set name = "Say Verb"
+	set category = "IC"
+
+	ASSERT(client && usr == src)
+
+	winset(usr, null, "saywindow.is-visible=true;saywindow-input.focus=true;")
 
 /mob/verb/me_verb(message as text)
 	set name = "Me"

--- a/code/modules/mob/typing_indicator.dm
+++ b/code/modules/mob/typing_indicator.dm
@@ -47,48 +47,33 @@ I IS TYPIN'!'
 /mob/proc/remove_typing_indicator() // A bit excessive, but goes with the creation of the indicator I suppose
 	QDEL_NULL(typing_indicator)
 
-
-/client/proc/show_saywindow()
-	winset(src, "saywindow", "is-visible=true;focus=true")
-
-/client/proc/center_and_show_saywindow()
-	first_say = FALSE
-	var/our_size = winget(src, "saywindow", "outer-size")
-	var/list/our_size_split = splittext(our_size, "x")
-	var/our_size_x = text2num(our_size_split[1])
-	var/our_size_y = text2num(our_size_split[2])
-	var/main_params = winget(src, "mainwindow", "outer-size;pos;is-maximized")
-	var/list/main_params_parsed = params2list(main_params)
-	var/maximized = main_params_parsed["is-maximized"] == "true"
-	var/list/main_pos = splittext(main_params_parsed["pos"], ",")
-	var/main_pos_x = maximized ? 0 : text2num(main_pos[1])
-	var/main_pos_y = maximized ? 0 : text2num(main_pos[2])
-	var/list/main_size = splittext(main_params_parsed["outer-size"], "x")
-	var/main_size_x = text2num(main_size[1])
-	var/main_size_y = text2num(main_size[2])
-
-	var/resulting_x = main_pos_x + main_size_x / 2 - our_size_x / 2
-	var/resulting_y = main_pos_y + main_size_y / 2 - our_size_y / 2
-
-	winset(src, "saywindow", "is-visible=true;focus=true;pos=[resulting_x],[resulting_y]")
-
 /client/proc/close_saywindow(return_content = FALSE)
-	winset(src, "saywindow", "is-visible=false;focus=false")
+	winset(src, null, "saywindow.is-visible=false;mapwindow.map.focus=true")
 	if (return_content)
 		. = winget(src, "saywindow.saywindow-input", "text")
 	winset(src, "saywindow.saywindow-input", "text=\"\"")
 
-/mob/verb/say_wrapper()
-	set name = "Say Verb"
-	set category = "IC"
+/mob/verb/add_typing_indicator(is_sayinput as num|null)
+	set name = ".add_typing_indicator"
+	set hidden = 1
 
-	ASSERT(client && usr == src)
+	ASSERT(client && src == usr)
 
-	create_typing_indicator()
-	if (!client.first_say)
-		client.show_saywindow()
+	if (is_sayinput)
+		create_typing_indicator()
 		return
-	client.center_and_show_saywindow()
+
+	var/text = winget(usr, "input", "text")
+	if(findtextEx(text, "Say ", 1, 5))
+		create_typing_indicator()
+
+/mob/verb/remove_typing_indicator_verb()
+	set name = ".remove_typing_indicator"
+	set hidden = 1
+
+	ASSERT(client && src == usr)
+
+	remove_typing_indicator()
 
 /mob/verb/me_wrapper()
 	set name = ".Me"

--- a/interface/skin.dmf
+++ b/interface/skin.dmf
@@ -127,7 +127,7 @@ macro "borghotkeymode"
 		command = ".movedown"
 	elem 
 		name = "T"
-		command = "Say-Verb"
+		command = ".winset \"saywindow.is-visible=true;saywindow-input.focus=true;\""
 	elem "w_key"
 		name = "W+REP"
 		command = ".moveup"
@@ -190,7 +190,7 @@ macro "borghotkeymode"
 		command = ".screenshot"
 	elem 
 		name = "F3"
-		command = "Say-Verb"
+		command = ".winset \"saywindow.is-visible=true;saywindow-input.focus=true;\""
 	elem 
 		name = "F4"
 		command = ".me"
@@ -360,7 +360,7 @@ macro "macro"
 		command = ".screenshot"
 	elem 
 		name = "F3"
-		command = "Say-Verb"
+		command = ".winset \"saywindow.is-visible=true;saywindow-input.focus=true;\""
 	elem 
 		name = "F4"
 		command = ".me"
@@ -533,7 +533,7 @@ macro "hotkeymode"
 		command = ".movedown"
 	elem 
 		name = "T"
-		command = "Say-Verb"
+		command = ".winset \"saywindow.is-visible=true;saywindow-input.focus=true;\""
 	elem "w_key"
 		name = "W+REP"
 		command = ".moveup"
@@ -596,7 +596,7 @@ macro "hotkeymode"
 		command = ".screenshot"
 	elem 
 		name = "F3"
-		command = "Say-Verb"
+		command = ".winset \"saywindow.is-visible=true;saywindow-input.focus=true;\""
 	elem 
 		name = "F4"
 		command = ".me"
@@ -766,7 +766,7 @@ macro "borgmacro"
 		command = ".screenshot"
 	elem 
 		name = "F3"
-		command = "Say-Verb"
+		command = ".winset \"saywindow.is-visible=true;saywindow-input.focus=true;\""
 	elem 
 		name = "F4"
 		command = ".me"
@@ -1138,6 +1138,8 @@ window "mainwindow"
 		is-default = true
 		border = sunken
 		saved-params = "command"
+		on-focus = ".add_typing_indicator"
+		on-blur = ".remove_typing_indicator"
 	elem "saybutton"
 		type = BUTTON
 		pos = 880,720
@@ -1146,7 +1148,7 @@ window "mainwindow"
 		anchor2 = none
 		saved-params = "is-checked"
 		text = "Chat"
-		command = ".winset \"saybutton.is-checked=true?input.command=\"!say \\\"\" macrobutton.is-checked=false:input.command=\""
+		command = ".winset \"saybutton.is-checked=true?input.command=\"!Say \\\"\" macrobutton.is-checked=false:input.command=\""
 		button-type = pushbox
 	elem "hotkey_toggle"
 		type = BUTTON
@@ -1379,20 +1381,20 @@ window "saywindow"
 		anchor2 = none
 		background-color = none
 		is-visible = false
-		saved-params = "size"
+		saved-params = "size;pos"
 		title = "say (text)"
 		statusbar = false
 		can-close = false
 		can-minimize = false
-		can-resize = false
+		can-resize = true
 		outer-size = 308x117
 		inner-size = 300x90
 	elem "saywindow-button"
 		type = BUTTON
 		pos = 110,50
 		size = 80x25
-		anchor1 = none
-		anchor2 = none
+		anchor1 = 37,56
+		anchor2 = 63,83
 		background-color = none
 		border = line
 		saved-params = ""
@@ -1402,12 +1404,14 @@ window "saywindow"
 		type = INPUT
 		pos = 8,16
 		size = 280x20
-		anchor1 = none
-		anchor2 = none
-		is-default = true
+		anchor1 = 3,18
+		anchor2 = 96,40
+		is-default = false
 		border = sunken
 		saved-params = ""
-		command = "say"
+		command = "Say "
+		on-focus = ".add_typing_indicator 1"
+		on-blur = ".remove_typing_indicator"
 
 window "text_editor"
 	elem "text_editor"


### PR DESCRIPTION
Предположительно исправляет проблемы с фокусировкой на окно хоткейного сея и обратно.
Добавляет возможность изменять размер окна хоткейного сея и выпиливает центрирование оного окна при первом вызове (теперь будет запоминать размер и расположение).
Меняет подстановку в режиме чата с say на Say (чтоб соотносилось с вербами).
Меняет работу typing indicator, теперь его наличие напрямую зависит от наличия фокуса на строке чата (будь то командная строка в режиме чата или строка в окне хоткейного сея), в частности, теперь оно работает с командной строкой в режиме чата и частично вне режима чата (если при фокусировке в строке прописан Say ", то облачко появится).
Незначительно меняет работу forcesay, теперь вместо затирания всего инпута он будет затирать только часть после Say " (чтобы можно было сразу же туда писать продолжение).

Дополнение предыдущей реализации #3149
closes #3235 

- [x] Pull Request полностью завершен, мне не нужна помощь чтобы его закончить.
- [x] Я внимательно прочитал все свои изменения и багов в них не нашел.
- [x] Я запускал сервер со своими изменениями локально и все протестировал.
- [x] Я ознакомился c [Guide to Contribute](https://github.com/ChaoticOnyx/OnyxBay/blob/dev/docs/contributing.md).
