### PR TITLE
fix(blob.update_hud): RUNTIME: Cannot read null.blob_powerbar

### DIFF
--- a/code/modules/mob/blob.dm
+++ b/code/modules/mob/blob.dm
@@ -152,10 +152,10 @@ mob/blob/DblClickOn(atom/A) //Teleport view to another blob
 	if (is_dead())
 		return
 
-	var/datum/hud/blob/H = hud_used
-
-	if (!H)
+	if (!hud_used)
 		InitializeHud()
+
+	var/datum/hud/blob/H = hud_used
 
 	var/number_of_cores = blob_cores.len
 	var/matrix/M = matrix()


### PR DESCRIPTION
close #3186 фикс рантайма суть которого, что про инициализации худа оно не присваивалось худу из рантайма.

✅ Pull Request полностью завершен, мне не нужна помощь чтобы его закончить.
✅ Я внимательно прочитал все свои изменения и багов в них не нашел.
✅ Я запускал сервер со своими изменениями локально и все протестировал.
✅ Я ознакомился c [Guide to Contribute](https://github.com/ChaoticOnyx/OnyxBay/blob/dev/docs/contributing.md).