### PR TITLE
Fix(new_player.dm) ЖИЗНЬ ДАЛЬТОНИКАМ

### DIFF
--- a/code/modules/mob/login.dm
+++ b/code/modules/mob/login.dm
@@ -74,6 +74,8 @@
 	reload_fullscreen() // Reload any fullscreen overlays this mob has.
 	add_click_catcher()
 
+	client.mob.update_client_color();
+
 	//set macro to normal incase it was overriden (like cyborg currently does)
 	var/hotkey_mode = client.get_preference_value("DEFAULT_HOTKEY_MODE")
 	if (hotkey_mode == GLOB.PREF_NO)

--- a/code/modules/mob/new_player/new_player.dm
+++ b/code/modules/mob/new_player/new_player.dm
@@ -340,7 +340,6 @@
 		return client.prefs.char_rank
 
 /mob/new_player/proc/AttemptLateSpawn(datum/job/job, spawning_at)
-	animate(client, color = null, time = 10) // delete all old special color shaders
 	if(src != usr)
 		return 0
 	if(GAME_STATE != RUNLEVEL_GAME)
@@ -386,6 +385,7 @@
 
 	character = job_master.EquipRank(character, job.title, 1)					//equips the human
 	equip_custom_items(character)
+	character.apply_traits()
 	// AIs don't need a spawnpoint, they must spawn at an empty core
 	if(character.mind.assigned_role == "AI")
 
@@ -420,8 +420,6 @@
 			M.playsound_local(M.loc, 'sound/signals/arrival1.ogg', 75)
 
 		matchmaker.do_matchmaking()
-	if (character.mind.assigned_role != "AI" && character.mind.assigned_role != "Cyborg")
-		character.apply_traits() // Preventing traits from being applied to silicons
 	log_and_message_admins("has joined the round as [character.mind.assigned_role].", character)
 	qdel(src)
 
@@ -474,7 +472,6 @@
 	src << browse(jointext(dat, null), "window=latechoices;size=450x640;can_close=1")
 
 /mob/new_player/proc/create_character(turf/spawn_turf)
-	animate(client, color = null, time = 10) // delete all old special color shaders
 	spawning = 1
 	close_spawn_windows()
 
@@ -539,6 +536,7 @@
 		mind.traits = client.prefs.traits.Copy()
 		mind.transfer_to(new_character)					//won't transfer key since the mind is not active
 
+	new_character.apply_traits()
 	new_character.SetName(real_name)
 	new_character.dna.ready_dna(new_character)
 	new_character.dna.b_type = client.prefs.b_type
@@ -560,9 +558,6 @@
 	// Give them their cortical stack if we're using them.
 	if(config && config.use_cortical_stacks && new_character.client && new_character.client.prefs.has_cortical_stack /*&& new_character.should_have_organ(BP_BRAIN)*/)
 		new_character.create_stack()
-
-	if (new_character.mind.assigned_role != "AI" && new_character.mind.assigned_role != "Cyborg")
-		new_character.apply_traits()
 
 	return new_character
 

--- a/code/modules/mob/new_player/new_player.dm
+++ b/code/modules/mob/new_player/new_player.dm
@@ -202,7 +202,7 @@
 			if(char_name == C.real_name)
 				to_chat (usr, "<span class='danger'>There is a character that already exists with the same name: <b>[C.real_name]</b>, please join with a different one.</span>")
 				return
-			
+
 		if(!config.enter_allowed)
 			to_chat(usr, "<span class='notice'>There is an administrative lock on entering the game!</span>")
 			return
@@ -340,6 +340,7 @@
 		return client.prefs.char_rank
 
 /mob/new_player/proc/AttemptLateSpawn(datum/job/job, spawning_at)
+	animate(client, color = null, time = 10) // delete all old special color shaders
 	if(src != usr)
 		return 0
 	if(GAME_STATE != RUNLEVEL_GAME)
@@ -385,7 +386,6 @@
 
 	character = job_master.EquipRank(character, job.title, 1)					//equips the human
 	equip_custom_items(character)
-	character.apply_traits()
 	// AIs don't need a spawnpoint, they must spawn at an empty core
 	if(character.mind.assigned_role == "AI")
 
@@ -420,6 +420,8 @@
 			M.playsound_local(M.loc, 'sound/signals/arrival1.ogg', 75)
 
 		matchmaker.do_matchmaking()
+	if (character.mind.assigned_role != "AI" && character.mind.assigned_role != "Cyborg")
+		character.apply_traits() // Preventing traits from being applied to silicons
 	log_and_message_admins("has joined the round as [character.mind.assigned_role].", character)
 	qdel(src)
 
@@ -472,6 +474,7 @@
 	src << browse(jointext(dat, null), "window=latechoices;size=450x640;can_close=1")
 
 /mob/new_player/proc/create_character(turf/spawn_turf)
+	animate(client, color = null, time = 10) // delete all old special color shaders
 	spawning = 1
 	close_spawn_windows()
 
@@ -536,7 +539,6 @@
 		mind.traits = client.prefs.traits.Copy()
 		mind.transfer_to(new_character)					//won't transfer key since the mind is not active
 
-	new_character.apply_traits()
 	new_character.SetName(real_name)
 	new_character.dna.ready_dna(new_character)
 	new_character.dna.b_type = client.prefs.b_type
@@ -558,6 +560,9 @@
 	// Give them their cortical stack if we're using them.
 	if(config && config.use_cortical_stacks && new_character.client && new_character.client.prefs.has_cortical_stack /*&& new_character.should_have_organ(BP_BRAIN)*/)
 		new_character.create_stack()
+
+	if (new_character.mind.assigned_role != "AI" && new_character.mind.assigned_role != "Cyborg")
+		new_character.apply_traits()
 
 	return new_character
 


### PR DESCRIPTION
Добавление трейтов выносим в самый конец создания персонажа, т.к, когда трейт на дальтонизм тригерит update_client_color(), у хуманов доходит до 109 строки (helpers.dm) и какого-то хуя if(!client) возвращает true и в итоге не происходит обновления цветов, а у железяк наоборот, if(!client) возвращает false и цвета обновляются.
Также добавил в начало создания персонажа animate(client, color = null, time = 10), чтобы при перерождении не накладывались старые цвета.

Fix #593 

- [x] Pull Request полностью завершен, мне не нужна помощь чтобы его закончить.
- [ ] Я внимательно прочитал все свои изменения и багов в них не нашел. 
P.S Вроде все работает нормально, но это не точно.
- [x] Я запускал сервер со своими изменениями локально и все протестировал.
- [x] Я ознакомился c [Guide to Contribute](https://github.com/ChaoticOnyx/OnyxBay/blob/dev/docs/contributing.md).
