### PR TITLE
rework & fix datum/objective

### DIFF
--- a/code/game/gamemodes/objective.dm
+++ b/code/game/gamemodes/objective.dm
@@ -36,8 +36,7 @@ datum/objective
 				target = possible_target
 				break
 
-	proc/process_currently()
-		return
+	proc/update()
 
 datum/objective/assassinate
 	find_target()
@@ -114,12 +113,10 @@ datum/objective/anti_revolution/brig
 	check_completion()
 		return already_completed
 
-	process_currently()
-		if(!already_completed && target && target.current)
-			if(target.is_brigged(10 * 60))
+	update()
+		if(!already_completed && target && target.current && target.current.stat != DEAD)
+			if(target.is_brigged(10 MINUTES))
 				already_completed = 1
-				return 1
-		return 0
 
 datum/objective/anti_revolution/demote
 	find_target()
@@ -338,12 +335,10 @@ datum/objective/brig
 	check_completion()
 		return already_completed
 
-	process_currently()
-		if(!already_completed && target && target.current)
-			if(target.is_brigged(10 * 60))
+	update()
+		if(!already_completed && target && target.current && target.current.stat != DEAD)
+			if(target.is_brigged(10 MINUTES))
 				already_completed = 1
-				return 1
-		return 0
 
 // Harm a crew member, making an example of them
 datum/objective/harm

--- a/code/game/gamemodes/objective.dm
+++ b/code/game/gamemodes/objective.dm
@@ -36,7 +36,8 @@ datum/objective
 				target = possible_target
 				break
 
-
+	proc/process_currently()
+		return
 
 datum/objective/assassinate
 	find_target()
@@ -111,16 +112,13 @@ datum/objective/anti_revolution/brig
 		return target
 
 	check_completion()
-		if(already_completed)
-			return 1
+		return already_completed
 
-		if(target && target.current)
-			if(target.current.stat == DEAD)
-				return 0
-			if(target.is_brigged(10 * 60 * 10))
+	process_currently()
+		if(!already_completed && target && target.current)
+			if(target.is_brigged(10 * 60))
 				already_completed = 1
 				return 1
-			return 0
 		return 0
 
 datum/objective/anti_revolution/demote
@@ -338,17 +336,13 @@ datum/objective/brig
 		return target
 
 	check_completion()
-		if(already_completed)
-			return 1
+		return already_completed
 
-		if(target && target.current)
-			if(target.current.stat == DEAD)
-				return 0
-			// Make the actual required time a bit shorter than the official time
-			if(target.is_brigged(10 * 60 * 5))
+	process_currently()
+		if(!already_completed && target && target.current)
+			if(target.is_brigged(10 * 60))
 				already_completed = 1
 				return 1
-			return 0
 		return 0
 
 // Harm a crew member, making an example of them

--- a/code/modules/mob/living/life.dm
+++ b/code/modules/mob/living/life.dm
@@ -41,7 +41,7 @@
 
 	if(mind)
 		for(var/datum/objective/O in mind.objectives)
-			O.process_currently()
+			O.update()
 
 	return 1
 

--- a/code/modules/mob/living/life.dm
+++ b/code/modules/mob/living/life.dm
@@ -39,6 +39,10 @@
 	update_canmove()
 	handle_regular_hud_updates()
 
+	if(mind)
+		for(var/datum/objective/O in mind.objectives)
+			O.process_currently()
+
 	return 1
 
 /mob/living/proc/handle_neuromods()


### PR DESCRIPTION
Зафикшен баг, при котором не выполнялся обжектив на десятиминутный арест. Проблема заключалась в криворукости программистов, что сделали сие творение таковым, что is_brigged "запускался" и вычислялся только в конце игры. Исправлено введением нового прока для обжективов, что выполняется каждый игровой тик для каждого моба что имеет обжектив. Практически не затратно и затрагивает на данный момент только арест ревы и триторов. В идеале создает новую платформу для обжективов, что могут в потиковое вычисление.

close #3303 

✅ Pull Request полностью завершен, мне не нужна помощь чтобы его закончить.
✅ Я внимательно прочитал все свои изменения и багов в них не нашел.
~ Я запускал сервер со своими изменениями локально и все протестировал.
✅ Я ознакомился c [Guide to Contribute](https://github.com/ChaoticOnyx/OnyxBay/blob/dev/docs/contributing.md).
