### PR TITLE
Форс icon2html в содержимом браузера

### DIFF
--- a/code/datums/browser.dm
+++ b/code/datums/browser.dm
@@ -33,11 +33,21 @@
 		return
 	add_stylesheet("common", 'html/browser/common.css') // this CSS sheet is common to all UIs
 
+/datum/browser/proc/process_icons(text)
+	//taken from to_chat(), processes all explanded \icon macros since they don't work in minibrowser (they only work in text output)
+	var/static/regex/icon_replacer = new(@/<IMG CLASS=icon SRC=(\[[^]]+])(?: ICONSTATE='([^']+)')?>/, "g")	//syntax highlighter fix -> '
+	while(icon_replacer.Find(text))
+		text =\
+			copytext(text,1,icon_replacer.index) +\
+			icon2html(locate(icon_replacer.group[1]), target = world, icon_state=icon_replacer.group[2]) +\
+			copytext(text,icon_replacer.next)
+	return text
+
 /datum/browser/proc/set_title(ntitle)
 	title = format_text(ntitle)
 
 /datum/browser/proc/add_head_content(nhead_content)
-	head_content = nhead_content
+	head_content += process_icons(nhead_content)
 
 /datum/browser/proc/set_title_buttons(ntitle_buttons)
 	title_buttons = ntitle_buttons
@@ -55,10 +65,10 @@
 	scripts[name] = file
 
 /datum/browser/proc/set_content(ncontent)
-	content = ncontent
+	content = process_icons(ncontent)
 
 /datum/browser/proc/add_content(ncontent)
-	content += ncontent
+	content += process_icons(ncontent)
 
 /datum/browser/proc/get_header()
 	var/key

--- a/code/datums/browser.dm
+++ b/code/datums/browser.dm
@@ -39,7 +39,7 @@
 	while(icon_replacer.Find(text))
 		text =\
 			copytext(text,1,icon_replacer.index) +\
-			icon2html(locate(icon_replacer.group[1]), target = world, icon_state=icon_replacer.group[2]) +\
+			icon2html(locate(icon_replacer.group[1]), target = user, icon_state=icon_replacer.group[2]) +\
 			copytext(text,icon_replacer.next)
 	return text
 


### PR DESCRIPTION
Добавляет обработку контента браузера тем самым регексом из to_chat, который меняет макрос \icon (который не работает в браузере) на картинки, генерирующиеся icon2html (который попутно отсылает нужное клиенту).

#3397 с мержем этого изменения вроде бы как не нужен, но там суть в том, что из-за того, что браузер свой на каждого клиента, этот регекс будет прогоняться по одному и тому же содержимому много раз, что не то что бы хорошо. Так что можно оба мержить (если этот вообще будет вмержен).

- [x] Pull Request полностью завершен, мне не нужна помощь чтобы его закончить.
- [x] Я внимательно прочитал все свои изменения и багов в них не нашел.
- [x] Я запускал сервер со своими изменениями локально и все протестировал.
- [x] Я ознакомился c [Guide to Contribute](https://github.com/ChaoticOnyx/OnyxBay/blob/dev/docs/contributing.md).
