### PR TITLE
Мелкофиксы бумаги

### DIFF
--- a/code/game/gamemodes/cult/runes.dm
+++ b/code/game/gamemodes/cult/runes.dm
@@ -926,7 +926,7 @@
 	var/obj/item/weapon/paper/target
 	var/tainted = 0
 	for(var/obj/item/weapon/paper/P in get_turf(src))
-		if(!P.info)
+		if(P.is_clean())
 			target = P
 			break
 		else

--- a/code/game/machinery/nuclear_bomb.dm
+++ b/code/game/machinery/nuclear_bomb.dm
@@ -422,26 +422,26 @@ var/bomb_set
 /obj/item/weapon/folder/envelope/nuke_instructions/Initialize()
 	. = ..()
 	var/obj/item/weapon/paper/R = new(src)
-	R.set_content("<center><img src=sollogo.png><br><br>\
-	<b>Warning: Classified<br>[GLOB.using_map.station_name] Self-Destruct System - Instructions</b></center><br><br>\
+	R.set_content("\[center\]\[br\]\[br\]\
+	\[b\]Warning: Classified\[br\][GLOB.using_map.station_name] Self-Destruct System - Instructions\[/b\]\[/center\]\[br\]\[br\]\
 	In the event of a Delta-level emergency, this document will guide you through the activation of the vessel's \
-	on-board nuclear self-destruct system. Please read carefully.<br><br>\
-	1) (Optional) Announce the imminent activation to any surviving crew members, and begin evacuation procedures.<br>\
-	2) Notify two heads of staff, both with ID cards with access to the ship's Keycard Authentication Devices.<br>\
-	3) Proceed to the self-destruct chamber, located on Deck One by the stairwell.<br>\
-	4) Unbolt the door and enter the chamber.<br>\
+	on-board nuclear self-destruct system. Please read carefully.\[br\]\[br\]\
+	1) (Optional) Announce the imminent activation to any surviving crew members, and begin evacuation procedures.\[br\]\
+	2) Notify two heads of staff, both with ID cards with access to the ship's Keycard Authentication Devices.\[br\]\
+	3) Proceed to the self-destruct chamber, located on Deck One by the stairwell.\[br\]\
+	4) Unbolt the door and enter the chamber.\[br\]\
 	5) Both heads of staff should stand in front of their own Keycard Authentication Devices. On the KAD interface, select \
-	Grant Nuclear Authentication Code. Both heads of staff should then swipe their ID cards simultaneously.<br>\
-	6) The KAD will now display the Authentication Code. Memorize this code.<br>\
-	7) Insert the nuclear authentication disk into the self-destruct terminal.<br>\
-	8) Enter the code into the self-destruct terminal.<br>\
+	Grant Nuclear Authentication Code. Both heads of staff should then swipe their ID cards simultaneously.\[br\]\
+	6) The KAD will now display the Authentication Code. Memorize this code.\[br\]\
+	7) Insert the nuclear authentication disk into the self-destruct terminal.\[br\]\
+	8) Enter the code into the self-destruct terminal.\[br\]\
 	9) Authentication procedures are now complete. Open the two cabinets containing the nuclear cylinders. They are \
-	located on the back wall of the chamber.<br>\
-	10) Place the cylinders upon the six nuclear cylinder inserters.<br>\
-	11) Activate the inserters. The cylinders will be pulled down into the self-destruct system.<br>\
-	12) Return to the terminal. Enter the desired countdown time.<br>\
-	13) When ready, disable the safety switch.<br>\
-	14) Start the countdown.<br><br>\
+	located on the back wall of the chamber.\[br\]\
+	10) Place the cylinders upon the six nuclear cylinder inserters.\[br\]\
+	11) Activate the inserters. The cylinders will be pulled down into the self-destruct system.\[br\]\
+	12) Return to the terminal. Enter the desired countdown time.\[br\]\
+	13) When ready, disable the safety switch.\[br\]\
+	14) Start the countdown.\[br\]\[br\]\
 	This concludes the instructions.", "vessel self-destruct instructions")
 
 	//stamp the paper

--- a/code/modules/paperwork/paper.dm
+++ b/code/modules/paperwork/paper.dm
@@ -19,9 +19,9 @@
 	body_parts_covered = HEAD
 	attack_verb = list("bapped")
 
-	var/info		//What's actually written on the paper.
-	var/info_links	//A different version of the paper which includes html links at fields and EOF
-	var/stamps		//The (text for the) stamps on the paper.
+	var/info = ""   //What's actually written on the paper.
+	var/info_links  //A different version of the paper which includes html links at fields and EOF
+	var/stamps      //The (text for the) stamps on the paper.
 	var/free_space = MAX_PAPER_MESSAGE_LEN
 	var/stamps_generated = TRUE
 	var/list/stamped
@@ -118,9 +118,9 @@
 	if(title)
 		SetName(title)
 	info = html_encode(text)
-	info = parsepencode(text, is_init = TRUE)
+	info = parsepencode(info, is_init = TRUE)
 	update_icon()
-	update_space(info)
+	update_space()
 	generateinfolinks()
 
 /obj/item/weapon/paper/update_icon()
@@ -134,6 +134,9 @@
 /obj/item/weapon/paper/proc/update_space()
 	free_space = initial(free_space)
 	free_space -= length(strip_html_properly(info_links)) //using info_links to also count field prompts
+
+/obj/item/weapon/paper/proc/is_clean()
+	return free_space == initial(free_space)
 
 /obj/item/weapon/paper/examine(mob/user)
 	. = ..()
@@ -309,7 +312,7 @@
 
 	return t
 
-/obj/item/weapon/paper/verb/parse_named_fields()
+/obj/item/weapon/paper/proc/parse_named_fields()
 	var/list/matches = list()
 	named_field_extraction_regex.next = 1
 	while (named_field_extraction_regex.Find(info))


### PR DESCRIPTION
Фиксит руну культа, которая привязывается к бумаге. Конкретно исправляет механизм проверки "чистоты" бумаги.
Делает parse_named_fields проком (как-то оно стало вербом, и этого никто не заметил).
Исправляет html_encode в set_contents бумаги (оно там было и предполагалось, что оно применяется к входу, но там был беекод и оно не применялось, и чет я проглядел, когда ранее копался в этом). Попутно правит формат инструкции к нюке (который бумаге кормит хтмл теги, хотя не должен).
Мелочи: меняет табы на пробелы в выравнивании комментов, добавляет дефолтное значение содержимому бумаги, убирает лишний аргумент из update_space.

closes #3410

- [x] Pull Request полностью завершен, мне не нужна помощь чтобы его закончить.
- [x] Я внимательно прочитал все свои изменения и багов в них не нашел.
- [x] Я запускал сервер со своими изменениями локально и все протестировал.
- [x] Я ознакомился c [Guide to Contribute](https://github.com/ChaoticOnyx/OnyxBay/blob/dev/docs/contributing.md).
