### PR TITLE
feat(FBP&head) FBP MMI autoeject on droplimb event

### DIFF
--- a/code/modules/organs/external/head.dm
+++ b/code/modules/organs/external/head.dm
@@ -27,6 +27,14 @@
 	var/forehead_graffiti
 	var/graffiti_style
 
+/obj/item/organ/external/head/emp_act(severity)
+	if(BP_IS_ROBOTIC(src))
+		var/obj/item/organ/internal/mmi_holder/FBP_brain = owner.internal_organs_by_name[BP_BRAIN]
+		if(istype(FBP_brain))
+			FBP_brain.stored_mmi.forceMove(get_turf(owner))
+			owner.mind.transfer_to(FBP_brain.stored_mmi.brainmob)
+			FBP_brain.stored_mmi.visible_message(SPAN_DANGER("You see a bright flash as you get catapulted out of your body. You feel disoriented, which must be normal since you're but a brain now."), SPAN_NOTICE("[owner]'s head ejects an MMI!"))
+
 /obj/item/organ/external/head/examine(mob/user)
 	. = ..()
 


### PR DESCRIPTION
Теперь синты от ММИ не умирают до конца, а из них выпадает ММИ.

~~Обнаружил~~ критический баг устранен

Возможен баг в моем английском, а так все работает.

close #3481.

- [x] Pull Request полностью завершен, мне не нужна помощь чтобы его закончить.
- [x] Я внимательно прочитал все свои изменения и багов в них не нашел.
- [x] Я запускал сервер со своими изменениями локально и все протестировал.
- [x] Я ознакомился c [Guide to Contribute](https://github.com/ChaoticOnyx/OnyxBay/blob/dev/docs/contributing.md).
