### PR TITLE
Починка пожирания

### DIFF
--- a/code/game/objects/items/crayons.dm
+++ b/code/game/objects/items/crayons.dm
@@ -167,6 +167,10 @@
 
 /obj/item/weapon/pen/crayon/attack(mob/living/carbon/M as mob, mob/user as mob)
 	if(istype(M) && M == user)
+		var/obj/item/blocked = M.check_mouth_coverage()
+		if(blocked)
+			to_chat(user, SPAN_WARNING("\The [blocked] is in the way!"))
+			return 1
 		to_chat(M, "You take a bite of the [src.name] and swallow it.")
 		M.nutrition += 1
 		M.reagents.add_reagent(/datum/reagent/crayon_dust,min(5,uses)/3)

--- a/code/modules/mob/holder.dm
+++ b/code/modules/mob/holder.dm
@@ -81,7 +81,10 @@ var/list/holder_mob_icon_cache = list()
 	// Devour on click on self with holder
 	if(target == user && istype(user,/mob/living/carbon))
 		var/mob/living/carbon/M = user
-
+		var/obj/item/blocked = M.check_mouth_coverage()
+		if(blocked)
+			to_chat(user, SPAN_WARNING("\The [blocked] is in the way!"))
+			return 1
 		for(var/mob/victim in src.contents)
 			M.devour(victim)
 

--- a/code/modules/mob/living/carbon/carbon.dm
+++ b/code/modules/mob/living/carbon/carbon.dm
@@ -47,24 +47,23 @@
 			user.last_special = world.time + 50
 			src.visible_message("<span class='danger'>You hear something rumbling inside [src]'s stomach...</span>")
 			var/obj/item/I = user.get_active_hand()
-			if(I && I.force)
-				var/d = rand(round(I.force / 4), I.force)
-				if(istype(src, /mob/living/carbon/human))
-					var/mob/living/carbon/human/H = src
-					var/obj/item/organ/external/organ = H.get_organ(BP_CHEST)
-					if (istype(organ))
-						organ.take_external_damage(d, 0)
-					H.updatehealth()
-				else
-					src.take_organ_damage(d)
-				user.visible_message("<span class='danger'>[user] attacks [src]'s stomach wall with the [I.name]!</span>")
-				playsound(user.loc, 'sound/effects/attackblob.ogg', 50, 1)
+			var/d = (I && I.force) ? rand(round(I.force / 4), I.force) : rand(1, 6) //give a chance to creatures without hands
+			if(istype(src, /mob/living/carbon/human))
+				var/mob/living/carbon/human/H = src
+				var/obj/item/organ/external/organ = H.get_organ(BP_GROIN)
+				if (istype(organ))
+					organ.take_external_damage(d, 0)
+				H.updatehealth()
+			else
+				src.take_organ_damage(d)
+			user.visible_message("<span class='danger'>[user] attacks [src]'s stomach wall!</span>")
+			playsound(user.loc, 'sound/effects/attackblob.ogg', 50, 1)
 
-				if(prob(src.getBruteLoss() - 50))
-					for(var/atom/movable/A in stomach_contents)
-						A.loc = loc
-						stomach_contents.Remove(A)
-					src.gib()
+			if(prob(src.getBruteLoss() - 50))
+				for(var/atom/movable/A in stomach_contents)
+					A.loc = loc
+					stomach_contents.Remove(A)
+				src.gib()
 
 /mob/living/carbon/gib()
 	for(var/mob/M in src)

--- a/code/modules/mob/living/carbon/carbon.dm
+++ b/code/modules/mob/living/carbon/carbon.dm
@@ -47,23 +47,23 @@
 			user.last_special = world.time + 50
 			src.visible_message("<span class='danger'>You hear something rumbling inside [src]'s stomach...</span>")
 			var/obj/item/I = user.get_active_hand()
-			var/d = (I && I.force) ? rand(round(I.force / 4), I.force) : rand(1, 6) //give a chance to creatures without hands
+			var/dmg = (I && I.force) ? rand(round(I.force / 4), I.force) : rand(1, 6) //give a chance to creatures without hands
 			if(istype(src, /mob/living/carbon/human))
 				var/mob/living/carbon/human/H = src
 				var/obj/item/organ/external/organ = H.get_organ(BP_GROIN)
 				if (istype(organ))
-					organ.take_external_damage(d, 0)
+					organ.take_external_damage(dmg, 0)
 				H.updatehealth()
 			else
-				src.take_organ_damage(d)
+				take_organ_damage(dmg)
 			user.visible_message("<span class='danger'>[user] attacks [src]'s stomach wall!</span>")
 			playsound(user.loc, 'sound/effects/attackblob.ogg', 50, 1)
 
-			if(prob(src.getBruteLoss() - 50))
+			if(prob(getBruteLoss() - 50))
 				for(var/atom/movable/A in stomach_contents)
 					A.loc = loc
 					stomach_contents.Remove(A)
-				src.gib()
+				gib()
 
 /mob/living/carbon/gib()
 	for(var/mob/M in src)

--- a/code/modules/mob/living/simple_animal/simple_animal.dm
+++ b/code/modules/mob/living/simple_animal/simple_animal.dm
@@ -45,8 +45,8 @@
 	var/cold_damage_per_tick = 2	//same as heat_damage_per_tick, only if the bodytemperature it's lower than minbodytemp
 	var/fire_alert = 0
 	var/oxygen_alert = 0
-	var/toxins_alert = 0	
-	
+	var/toxins_alert = 0
+
 	//Atmos effect - Yes, you can make creatures that require phoron or co2 to survive. N2O is a trace gas and handled separately, hence why it isn't here. It'd be hard to add it. Hard and me don't mix (Yes, yes make all the dick jokes you want with that.) - Errorage
 	var/min_gas = list("oxygen" = 5)
 	var/max_gas = list("phoron" = 1, "carbon_dioxide" = 5)
@@ -74,7 +74,7 @@
 
 /mob/living/simple_animal/Life()
 	..()
-	if(!living_observers_present(GetConnectedZlevels(z)))
+	if(!living_observers_present(GetConnectedZlevels(z)) && !(z == 0))
 		return
 	//Health
 	if(stat == DEAD)
@@ -162,7 +162,7 @@
 					atmos_suitable = 0
 					toxins_alert = 1
 				else
-					toxins_alert = 0					
+					toxins_alert = 0
 
 	//Atmos effect
 	if(bodytemperature < minbodytemp)


### PR DESCRIPTION
Оказалось, что содержимое желудков космонавтов находится на нулевом Z-уровне, а симплмобы не умирают и вообще не обрабатываются, пока на их Z-уровне нет игрока, оттого и вечное существование без переваривания. Кроме того, пробить желудок изнутри можно было только с предметом в руках. Это починено.
Мобов через маску кушать теперь нельзя, мелки тоже. Вилку я съесть не смог.

В процессе тестирования обнаружилось, что съедение не мешает мышам кусать обжору за ноги, но я без понятия, как это фиксить. Впрочем, мыши-ИИ не кусаются, а игрок успеет немногое до переваривания, так что, думаю, не страшно.

close #2176

- [x] Pull Request полностью завершен, мне не нужна помощь чтобы его закончить.
- [ ] Я внимательно прочитал все свои изменения и багов в них не нашел.
- [x] Я запускал сервер со своими изменениями локально и все протестировал.
- [x] Я ознакомился c [Guide to Contribute](https://github.com/ChaoticOnyx/OnyxBay/blob/dev/docs/contributing.md).
