### PR TITLE
Фиксы вампиров, измененный текст сообщений.

### DIFF
--- a/code/game/gamemodes/vampire/vampire_powers.dm
+++ b/code/game/gamemodes/vampire/vampire_powers.dm
@@ -62,6 +62,7 @@
 	var/blood = 0
 	var/blood_total = 0
 	var/blood_usable = 0
+	var/blood_drained = 0
 
 	vampire.status |= VAMP_DRAINING
 
@@ -73,12 +74,8 @@
 		remembrance = "remembered"
 	admin_attack_log(src, T, "drained blood from [key_name(T)], who [remembrance] the encounter.", "had their blood drained by [key_name(src)] and [remembrance] the encounter.", "is draining blood from")
 
-	if(vampire.stealth)
-		to_chat(T, SPAN_WARNING("You are unable to resist or even move. Your mind blanks as you're being fed upon."))
-		T.paralysis = 3400
-	else
-		to_chat(T, SPAN_WARNING("You are unable to resist or even move. Your mind is acutely aware of what's occuring."))
-		T.paralysis = 3400
+	to_chat(T, SPAN_WARNING("You feel yourself falling into a pleasant dream, from which even a smile appeared on your face."))
+	T.paralysis = 3400
 
 	playsound(src.loc, 'sound/effects/drain_blood.ogg', 50, 1)
 
@@ -87,7 +84,9 @@
 		if (!mind.vampire)
 			to_chat(src, SPAN_DANGER("Your fangs have disappeared!"))
 			return
-
+		if (blood_drained >= 115)
+			to_chat(src, SPAN_DANGER("You can't drink even more blood!"))
+			break
 		blood_total = vampire.blood_total
 		blood_usable = vampire.blood_usable
 
@@ -105,6 +104,7 @@
 			blood = min(15, T.vessel.get_reagent_amount(/datum/reagent/blood))
 			vampire.blood_total += blood
 			vampire.blood_usable += blood
+			blood_drained += blood
 
 			frenzy_lower_chance = 40
 
@@ -122,6 +122,7 @@
 		else
 			blood = min(5, T.vessel.get_reagent_amount(/datum/reagent/blood))
 			vampire.blood_usable += blood
+			blood_drained += blood
 
 			frenzy_lower_chance = 40
 
@@ -134,10 +135,14 @@
 				update_msg += SPAN_NOTICE(" and have [vampire.blood_usable] left to use.")
 			else
 				update_msg += SPAN_NOTICE(".")
-
 			to_chat(src, update_msg)
+
+		if (blood_drained >= 70 && blood_drained < 85)
+			to_chat(src, SPAN_WARNING("You have enough amount of drained blood."))
+
+
 		check_vampire_upgrade()
-		T.vessel.remove_reagent(/datum/reagent/blood, 5)
+		T.vessel.remove_reagent(/datum/reagent/blood, 15)
 
 	vampire.status &= ~VAMP_DRAINING
 
@@ -148,9 +153,15 @@
 	if(target_aware)
 		T.paralysis = 0
 		if(T.stat != DEAD && vampire.stealth)
-			to_chat(T, SPAN_WARNING("You remember nothing about being fed upon. Instead, you simply remember having a pleasant encounter with [src.name]."))
+			to_chat(T, SPAN_WARNING("You remember nothing about the cause of blacked out. Instead, you simply remember having a pleasant encounter with [src.name]"))
 		else if(T.stat != DEAD)
-			to_chat(T, SPAN_WARNING("You remember everything about being fed upon. How you react to [src.name]'s actions is up to you."))
+			to_chat(T, SPAN_WARNING("You remember everything that happened. Remember how blood was sucked from your neck. It gave you pleasure, like a pleasant dream. You feel great. How you react to [src.name]'s actions is up to you."))
+	verbs -= /mob/living/carbon/human/proc/vampire_drain_blood
+	if(blood_drained <= 85)
+
+		ADD_VERB_IN_IF(src, 1800, /mob/living/carbon/human/proc/vampire_drain_blood, CALLBACK(src, .proc/finish_vamp_timeout))
+	else
+		ADD_VERB_IN_IF(src, 2400, /mob/living/carbon/human/proc/vampire_drain_blood, CALLBACK(src, .proc/finish_vamp_timeout))
 
 // Check that our target is alive, logged in, and any other special cases
 /mob/living/carbon/human/proc/check_drain_target_state(mob/living/carbon/human/T)
@@ -931,7 +942,7 @@
 	to_chat(src, SPAN_WARNING("You have corrupted another mortal with the taint of the Veil. Beware: they will awaken hungry and maddened; not bound to any master."))
 
 	T.mind.vampire.blood_usable = 0
-	T.mind.vampire.frenzy = 250
+	T.mind.vampire.frenzy = 50
 	T.vampire_check_frenzy()
 
 	vampire.status &= ~VAMP_DRAINING

--- a/code/modules/reagents/reagent_containers/blood_pack.dm
+++ b/code/modules/reagents/reagent_containers/blood_pack.dm
@@ -41,7 +41,7 @@
 			user.visible_message(SPAN_WARNING("[user] raises \the [src] up to their mouth and bites into it."), SPAN_NOTICE("You raise \the [src] up to your mouth and bite into it, starting to drain its contents.<br>You need to stand still."))
 			being_feed = TRUE
 			vampire_marks = TRUE
-			while (do_after(user, 25, 5, 1))
+			while (do_after(user, 30, src))
 				if(!user)
 					return
 				var/blood_taken = 0


### PR DESCRIPTION
Перезарядка абилки сосания крови. Лимит в 115 крови с процесса выкачки, а также момент в 85, после которого время перезарядки вырастает вдвое, поэтому появляется еще выбор пососать меньше для более быстрой перезарядки, а не сосать до упора. В итоге имеем такой расклад: лимит в 115 единиц крови, 3 минуты стандартной перезарядки, 6 увеличенной в случае пресыщения, момент начала пресыщения в 85 единиц крови. Можно сосать кровь из пакетов, измененный текст сообщений, а также уменьшенный уровень "безумия" у новообращенных.

close #3490
close #3489

- [x] Pull Request полностью завершен, мне не нужна помощь чтобы его закончить.
- [x] Я внимательно прочитал все свои изменения и багов в них не нашел.
- [x] Я запускал сервер со своими изменениями локально и все протестировал.
- [x] Я ознакомился c [Guide to Contribute](https://github.com/ChaoticOnyx/OnyxBay/blob/dev/docs/contributing.md).
