### PR TITLE
fix(microbattery) organic human can't revive by using microbattery.

### DIFF
--- a/code/modules/organs/external/machine.dm
+++ b/code/modules/organs/external/machine.dm
@@ -94,9 +94,10 @@
 /obj/item/organ/internal/cell/replaced()
 	..()
 	// This is very ghetto way of rebooting an IPC. TODO better way.
-	if(owner && owner.stat == DEAD)
+	// It's time to do it. This code doesn't allow to resurrect a organic human this way.
+	if(owner && owner.stat == DEAD && BP_IS_ROBOTIC(owner.organs_by_name[parent_organ]))
 		owner.set_stat(CONSCIOUS)
-		owner.visible_message("<span class='danger'>\The [owner] twitches visibly!</span>")
+		owner.visible_message(SPAN_DANGER("\The [owner] twitches visibly!"))
 
 /obj/item/organ/internal/cell/listen()
 	if(get_charge())


### PR DESCRIPTION
Теперь синтовскую батарейку при ставке в органическое туловище ничего не делает, раньше таким образом можно было возродить человека.

Я пока не нашел иссуя, который удовлетворяет условиям найденного мною бага

<details>
<summary>Чейнджлог</summary>
🆑
bugfix: Теперь нельзя возрождать не-синтетиков с помощью установки батарейки.
/🆑
</details>

- [x] Pull Request полностью завершен, мне не нужна помощь чтобы его закончить.
- [x] Я внимательно прочитал все свои изменения и багов в них не нашел.
- [x] Я запускал сервер со своими изменениями локально и все протестировал.
- [x] Я ознакомился c [Guide to Contribute](https://github.com/ChaoticOnyx/OnyxBay/blob/dev/docs/contributing.md).
