### PR TITLE
Починил дупликацию текста админ факса

### DIFF
--- a/code/modules/admin/admin.dm
+++ b/code/modules/admin/admin.dm
@@ -1487,7 +1487,7 @@ var/global/floorIsLava = 0
 			P.admindatum = src
 			P.origin = replyorigin
 			P.destination = sendto
-
+			P.appendable = FALSE//I don't know why, but otherwise it duplicates message with it's "write"
 			P.adminbrowse()
 
 /client/proc/check_fax_history()

--- a/code/modules/admin/admin.dm
+++ b/code/modules/admin/admin.dm
@@ -1487,7 +1487,7 @@ var/global/floorIsLava = 0
 			P.admindatum = src
 			P.origin = replyorigin
 			P.destination = sendto
-			P.appendable = FALSE//I don't know why, but otherwise it duplicates message with it's "write"
+
 			P.adminbrowse()
 
 /client/proc/check_fax_history()

--- a/code/modules/paperwork/adminpaper.dm
+++ b/code/modules/paperwork/adminpaper.dm
@@ -65,7 +65,6 @@
 
 
 /obj/item/weapon/paper/admin/proc/adminbrowse()
-	generateinfolinks()
 	generateHeader()
 	generateFooter()
 	updateDisplay()


### PR DESCRIPTION
Я пытался разобраться с тем, почему админ факс дублирует вводимый текст, ответом оказалось то, что он каким-то образом вызывает generateinfolinks таким видом, что текст и endtag прилетает два раза. Вот быстрофикс

fix #3583


- [* ] Pull Request полностью завершен, мне не нужна помощь чтобы его закончить.
- [ *] Я внимательно прочитал все свои изменения и багов в них не нашел.
- [ *] Я запускал сервер со своими изменениями локально и все протестировал.
- [*] Я ознакомился c [Guide to Contribute](https://github.com/ChaoticOnyx/OnyxBay/blob/dev/docs/contributing.md).
