### PR TITLE
Пища для гурманов

### DIFF
--- a/code/datums/recipe.dm
+++ b/code/datums/recipe.dm
@@ -77,6 +77,10 @@
 		for(var/obj/O in container.InsertedContents())
 			if(istype(O,/obj/item/weapon/reagent_containers/food/snacks/grown))
 				continue // Fruit is handled in check_fruit().
+			if(istype(O, /obj/item/organ))
+				var/obj/item/organ/org = O
+				if(!org.disable_food_organ)
+					O = org.food_organ
 			var/found = 0
 			for(var/i = 1; i < checklist.len+1; i++)
 				var/item_type = checklist[i]

--- a/code/game/machinery/kitchen/cooking_machines/cereal.dm
+++ b/code/game/machinery/kitchen/cooking_machines/cereal.dm
@@ -11,7 +11,12 @@
 
 /obj/machinery/cooker/cereal/change_product_strings(atom/movable/product, atom/movable/origin)
 	. = ..()
-	product.SetName("box of [product.name]")
+	var/product_name = ""
+	if(thing_inside_parent)
+		product_name = "[thing_inside_parent.name] cereal"
+	else
+		product_name = product.name
+	product.SetName("box of [product_name]")
 	return product
 
 /obj/machinery/cooker/cereal/change_product_appearance(obj/item/weapon/reagent_containers/food/snacks/variable/cereal/product, atom/movable/origin)
@@ -28,10 +33,25 @@
 
 	product.overlays += background
 
-	var/image/food_image = image(origin.icon, origin.icon_state)
+	var/image/food_image
+	if(istype(thing_inside_parent, /obj/item/organ/internal))
+		food_image = image(thing_inside_parent.icon, thing_inside_parent.icon_state)
+	else if(istype(thing_inside_parent, /obj/item/organ/external))
+		var/obj/item/organ/external/E = thing_inside_parent
+		var/obj/item/weapon/reagent_containers/food/snacks/meat/human/snack = new E.food_organ_type(E)
+		food_image = image(snack.icon, snack.icon_state)
+		qdel(snack)
+		E = null
+	else
+		food_image = image(origin.icon, origin.icon_state)
 	food_image.color = origin.color
 	food_image.overlays += origin.overlays
-	food_image.transform *= 0.7
-	food_image.pixel_y = 2
+	if(istype(thing_inside_parent, /obj/item/organ/internal/brain))
+		food_image.transform *= 0.4
+	else if(istype(thing_inside_parent, /obj/item/organ/internal))
+		food_image.transform *= 0.7
+	else
+		food_image.transform *= 0.7
+		food_image.pixel_y = 2
 	product.overlays += food_image
 	return product

--- a/code/game/machinery/kitchen/microwave.dm
+++ b/code/game/machinery/kitchen/microwave.dm
@@ -46,6 +46,7 @@
 		// impure carbon. ~Z
 		acceptable_items |= /obj/item/weapon/holder
 		acceptable_items |= /obj/item/weapon/reagent_containers/food/snacks/grown
+		acceptable_items |= /obj/item/organ
 
 /*******************
 *   Item Adding

--- a/code/modules/organs/external/head.dm
+++ b/code/modules/organs/external/head.dm
@@ -27,6 +27,11 @@
 	var/forehead_graffiti
 	var/graffiti_style
 
+/obj/item/organ/external/head/organ_eated(mob/user)
+	. = ..()
+	var/obj/item/weapon/skull/SK = new /obj/item/weapon/skull(get_turf(src))
+	user.put_in_active_hand(SK)
+
 /obj/item/organ/external/head/examine(mob/user)
 	. = ..()
 

--- a/code/modules/organs/external/stump.dm
+++ b/code/modules/organs/external/stump.dm
@@ -2,6 +2,7 @@
 	name = "limb stump"
 	icon_name = ""
 	dislocated = -1
+	disable_food_organ = TRUE
 
 /obj/item/organ/external/stump/New(mob/living/carbon/holder, internal, obj/item/organ/external/limb)
 	if(istype(limb))

--- a/code/modules/organs/internal/_internal.dm
+++ b/code/modules/organs/internal/_internal.dm
@@ -2,6 +2,7 @@
 				INTERNAL ORGANS DEFINES
 ****************************************************/
 /obj/item/organ/internal
+	food_organ_type = /obj/item/weapon/reagent_containers/food/snacks/organ
 	var/dead_icon // Icon to use when the organ has died.
 	var/surface_accessible = FALSE
 	var/relative_size = 25   // Relative size of the organ. Roughly % of space they take in the target projection :D

--- a/code/modules/organs/organ.dm
+++ b/code/modules/organs/organ.dm
@@ -25,6 +25,9 @@ var/list/organ_cache = list()
 	var/max_damage             	  // Damage cap
 	var/rejecting                     // Is this organ already being rejected?
 
+	var/food_organ_type				  // path of food made from organ, ex.
+	var/obj/item/weapon/reagent_containers/food/snacks/food_organ
+	var/disable_food_organ = FALSE // used to override food_organ's creation and using
 	var/death_time
 
 
@@ -40,6 +43,9 @@ var/list/organ_cache = list()
 	return (damage >= min_broken_damage || (status & ORGAN_CUT_AWAY) || (status & ORGAN_BROKEN))
 
 /obj/item/organ/New(mob/living/carbon/holder)
+	if(food_organ_type && !disable_food_organ)
+		food_organ = new food_organ_type(src)
+
 	..(holder)
 
 	if(max_damage)
@@ -123,6 +129,9 @@ var/list/organ_cache = list()
 	if(damage >= max_damage)
 		die()
 
+	if(food_organ)
+		update_food_from_organ()
+
 /obj/item/organ/proc/is_preserved()
 	if(istype(loc,/obj/item/organ))
 		var/obj/item/organ/O = loc
@@ -133,6 +142,9 @@ var/list/organ_cache = list()
 /obj/item/organ/examine(mob/user)
 	. = ..()
 	. += "\n[show_decay_status(user)]"
+	if(get_dist(src, user) > 1)
+		return
+	. += food_organ.get_bitecount_examine()
 
 /obj/item/organ/proc/show_decay_status(mob/user)
 	if(status & ORGAN_DEAD)
@@ -275,31 +287,35 @@ var/list/organ_cache = list()
 		set_dna(owner.dna)
 	return 1
 
+/obj/item/organ/proc/organ_eated(mob/user)
+	qdel(src)
+
+/obj/item/organ/proc/update_food_from_organ()
+	food_organ.SetName(name)
+	food_organ.appearance = src
+	reagents.trans_to(food_organ, reagents.total_volume)
+	if(fingerprints)
+		food_organ.fingerprints = fingerprints.Copy()
+	if(fingerprintshidden)
+		food_organ.fingerprintshidden = fingerprintshidden.Copy()
+	if(fingerprintslast)
+		food_organ.fingerprintslast = fingerprintslast
+
 /obj/item/organ/attack(mob/target, mob/user)
 	if(status & ORGAN_ROBOTIC || !istype(target) || !istype(user) || (user != target && user.a_intent == I_HELP))
 		return ..()
 
-	if(alert("Do you really want to use this organ as food? It will be useless for anything else afterwards.",,"Ew, no.","Bon appetit!") == "Ew, no.")
-		to_chat(user, SPAN_NOTICE("You successfully repress your cannibalistic tendencies."))
-		return
+	if(food_organ.bitecount == 0)
+		if(alert("Do you really want to use this organ as food? It will be useless for anything else afterwards.",,"Ew, no.","Bon appetit!") == "Ew, no.")
+			to_chat(user, SPAN_NOTICE("You successfully repress your cannibalistic tendencies."))
+			return
+		update_food_from_organ()
 
 	if(QDELETED(src))
 		return
 
-	user.drop_from_inventory(src)
-	var/obj/item/weapon/reagent_containers/food/snacks/organ/O = new(get_turf(src))
-	O.SetName(name)
-	O.appearance = src
-	reagents.trans_to(O, reagents.total_volume)
-	if(fingerprints)
-		O.fingerprints = fingerprints.Copy()
-	if(fingerprintshidden)
-		O.fingerprintshidden = fingerprintshidden.Copy()
-	if(fingerprintslast)
-		O.fingerprintslast = fingerprintslast
-	user.put_in_active_hand(O)
-	qdel(src)
-	target.attackby(O, user)
+	die()
+	target.attackby(src.food_organ, user)
 
 /obj/item/organ/proc/can_feel_pain()
 	return (!BP_IS_ROBOTIC(src) && (!species || !(species.species_flags & SPECIES_FLAG_NO_PAIN)))

--- a/code/modules/reagents/reagent_containers/food/snacks.dm
+++ b/code/modules/reagents/reagent_containers/food/snacks.dm
@@ -32,6 +32,10 @@
 				M.put_in_hands(TrashItem)
 			else if(istype(trash,/obj/item))
 				M.put_in_hands(trash)
+		if(istype(src.loc, /obj/item/organ))
+			var/obj/item/organ/O = src.loc
+			if(!QDELETED(O))
+				O.organ_eated(M)
 		qdel(src)
 	return
 
@@ -102,18 +106,21 @@
 
 	return 0
 
+/obj/item/weapon/reagent_containers/food/snacks/proc/get_bitecount_examine()
+	if (bitecount==0)
+		return
+	else if (bitecount==1)
+		return "\n<span class='notice'>\The [src] was bitten by someone!</span>"
+	else if (bitecount<=3)
+		return "\n<span class='notice'>\The [src] was bitten [bitecount] time\s!</span>"
+	else
+		return "\n<span class='notice'>\The [src] was bitten multiple times!</span>"
+
 /obj/item/weapon/reagent_containers/food/snacks/examine(mob/user)
 	. = ..()
 	if(get_dist(src, user) > 1)
 		return
-	if (bitecount==0)
-		return
-	else if (bitecount==1)
-		. += "\n<span class='notice'>\The [src] was bitten by someone!</span>"
-	else if (bitecount<=3)
-		. += "\n<span class='notice'>\The [src] was bitten [bitecount] time\s!</span>"
-	else
-		. += "\n<span class='notice'>\The [src] was bitten multiple times!</span>"
+	. += get_bitecount_examine()
 
 /obj/item/weapon/reagent_containers/food/snacks/attackby(obj/item/weapon/W as obj, mob/user as mob)
 	if(istype(W,/obj/item/weapon/storage))


### PR DESCRIPTION
Теперь вместо создания нового орган-еда-предмета, можно использовать уже существующий орган.
internal орган - получает food/snacks/organ, что означает, что это уже готовый продукт
external орган - получает food/snacks/meat/human, что означает, что из external органов можно создавать блюда (например, мясной пирог)
Так же задел работу микроволновки и рецептов, что бы то, что выше могло сработать.
Улучшил опыт взаимодействия для пожирания органа, теперь нужно только один раз подтвердить свое желание съесть орган.
Добавил в examine надписи о том сколько раз откусили орган.

close #1193

- [ ] Pull Request полностью завершен, мне не нужна помощь чтобы его закончить.
- [x] Я внимательно прочитал все свои изменения и багов в них не нашел.
- [x] Я запускал сервер со своими изменениями локально и все протестировал.
- [x] Я ознакомился c [Guide to Contribute](https://github.com/ChaoticOnyx/OnyxBay/blob/dev/docs/contributing.md).