### PR TITLE
Removes absence of bloodloss faint message looking like an emote

### DIFF
--- a/code/modules/organs/internal/brain.dm
+++ b/code/modules/organs/internal/brain.dm
@@ -189,9 +189,9 @@
 					if(!past_damage_threshold(6) && prob(damprob))
 						take_internal_damage(0.5)
 					if(!owner.paralysis && prob(15))
-						owner.Paralyse(3,5)
 						owner.visible_message("<B>[owner]</B> faints!", \
 											  SPAN("warning", "You feel extremely [pick("dizzy","woozy","faint")]..."))
+						owner.Paralyse(3,5)
 				if(-(INFINITY) to BLOOD_VOLUME_SURVIVE) // Also see heart.dm, being below this point puts you into cardiac arrest.
 					owner.eye_blurry = max(owner.eye_blurry, 6)
 					damprob = owner.chem_effects[CE_STABLE] ? 70 : 100

--- a/code/modules/organs/internal/brain.dm
+++ b/code/modules/organs/internal/brain.dm
@@ -190,7 +190,7 @@
 						take_internal_damage(0.5)
 					if(!owner.paralysis && prob(15))
 						owner.Paralyse(3,5)
-						owner.visible_message("[owner] faints!", \
+						owner.visible_message("<B>[owner]</B> faints!", \
 											  SPAN("warning", "You feel extremely [pick("dizzy","woozy","faint")]..."))
 				if(-(INFINITY) to BLOOD_VOLUME_SURVIVE) // Also see heart.dm, being below this point puts you into cardiac arrest.
 					owner.eye_blurry = max(owner.eye_blurry, 6)


### PR DESCRIPTION
Сообщения типа "John Doe faints!" теперь выглядят как "**John Doe** faints!" дабы выглядеть как эмоут. 

- [x] Pull Request полностью завершен, мне не нужна помощь чтобы его закончить.
- [x] Я внимательно прочитал все свои изменения и багов в них не нашел.
- [x] Я запускал сервер со своими изменениями локально и все протестировал.
- [x] Я ознакомился c [Guide to Contribute](https://github.com/ChaoticOnyx/OnyxBay/blob/dev/docs/contributing.md).
