### PR TITLE
Фикс модуля интегралки Plant manipulation module

### DIFF
--- a/code/modules/integrated_electronics/subtypes/manipulation.dm
+++ b/code/modules/integrated_electronics/subtypes/manipulation.dm
@@ -276,6 +276,7 @@
 					TR.health = 0
 					if(TR.harvest)
 						TR.harvest = FALSE //To make sure they can't just put in another seed and insta-harvest it
+					TR.sampled = 0
 					qdel(TR.seed)
 					TR.seed = null
 				TR.weedlevel = 0 //Has a side effect of cleaning up those nasty weeds


### PR DESCRIPTION
### **Фикс:**
С посаженных растений в трее(tray) можно собирать образцы кусачками. С небольшим шансом при сборе, трей может получить флаг sampled = 1, который не позволит более собирать образцы с этого же растения. Этот флаг обычно сбрасывается, если растение по разным причинам уже не в трее(сбор, рубка топором). Проблема заключается в том, что при выкапывании растения с помощью Plant manipulation module интегрального принтера, флаг sampled не сбрасывается. Из-за этого, если посадить следующее растение, с него невозможно будет брать образцы.
Теперь флаг сбрасывается к 0, при использовании модуля в режиме выкапывания.


- [x] Pull Request полностью завершен, мне не нужна помощь чтобы его закончить.
- [x] Я внимательно прочитал все свои изменения и багов в них не нашел.
- [x] Я запускал сервер со своими изменениями локально и все протестировал.
- [x] Я ознакомился c [Guide to Contribute](https://github.com/ChaoticOnyx/OnyxBay/blob/dev/docs/contributing.md).
