### PR TITLE
фаст рэмбо анлоад магазина пистолета

### DIFF
--- a/code/modules/projectiles/guns/projectile.dm
+++ b/code/modules/projectiles/guns/projectile.dm
@@ -165,8 +165,14 @@
 		is_jammed = 0
 		playsound(src.loc, 'sound/weapons/flipblade.ogg', 50, 1)
 	if(ammo_magazine)
-		user.put_in_hands(ammo_magazine)
-		user.visible_message("[user] removes [ammo_magazine] from [src].", "<span class='notice'>You remove [ammo_magazine] from [src].</span>")
+		if(allow_dump)
+			user.drop_from_inventory(ammo_magazine)
+			user.visible_message("[user] ejects [ammo_magazine] from [src].",
+			SPAN_NOTICE("You eject [ammo_magazine] from [src]."))
+		else
+			user.put_in_hands(ammo_magazine)
+			user.visible_message("[user] removes [ammo_magazine] from [src].", 
+			SPAN_NOTICE("You remove [ammo_magazine] from [src]."))
 		playsound(src.loc, 'sound/weapons/empty.ogg', 50, 1)
 		ammo_magazine.update_icon()
 		ammo_magazine = null


### PR DESCRIPTION
4 сом ризон раньше даже селф аттак пистолета перекладывал магазин в свободную руку, заставляя переключатся на неё и выкидывать магаз на drop, дабы подать обратно уже новый

теперь можно эпично выкидывать пустой магазин после рэмбовской перестрелки единственным нажатием клавиши 

бонус поинты тому кто найдёт крутой sfx как магазин слайдит из пистолета

- [x] Pull Request полностью завершен, мне не нужна помощь чтобы его закончить.
- [x] Я внимательно прочитал все свои изменения и багов в них не нашел.
- [x] Я запускал сервер со своими изменениями локально и все протестировал.
- [x] Я ознакомился c [Guide to Contribute](https://github.com/ChaoticOnyx/OnyxBay/blob/dev/docs/contributing.md).
