### PR TITLE
fix(modular_computer): fix runtime on program's check if computer emagged

### DIFF
--- a/code/modules/modular_computers/file_system/program.dm
+++ b/code/modules/modular_computers/file_system/program.dm
@@ -130,8 +130,8 @@
 	if(!istype(user))
 		return 0
 
-	// allow to view programm if emagged
-	if(computer.computer_emagged)
+	// allow to view program if emagged
+	if(computer && computer.computer_emagged)
 		return 1
 
 	var/obj/item/weapon/card/id/I = user.GetIdCard()


### PR DESCRIPTION
Микрофикс рантайма

```
[17:13:26] Runtime in program.dm,134: Cannot read null.computer_emagged
  proc name: can run (/datum/computer_file/program/proc/can_run)
  usr: Milo Belikov (/mob/living/carbon/human) ([0x300018b]) (the floor) (172,121,2) (/turf/simulated/floor/tiled/white) (azeroender)
  usr.loc: The floor (/turf/simulated/floor/tiled/white) ([0x1017634]) (172,121,2) (/area/assembly/robotics)
```

fix #3827

- [x] Pull Request полностью завершен, мне не нужна помощь чтобы его закончить.
- [x] Я внимательно прочитал все свои изменения и багов в них не нашел.
- [x] Я запускал сервер со своими изменениями локально и все протестировал.
- [x] Я ознакомился c [Guide to Contribute](https://github.com/ChaoticOnyx/OnyxBay/blob/dev/docs/contributing.md).
