### PR TITLE
RUS-T engine reactions and controls fix

### DIFF
--- a/code/modules/power/fusion/core/core_control.dm
+++ b/code/modules/power/fusion/core/core_control.dm
@@ -168,4 +168,10 @@
 
 //Returns 1 if the machine can be interacted with via this console.
 /obj/machinery/computer/fusion_core_control/proc/check_core_status(obj/machinery/power/fusion_core/C)
+	if(isnull(C))
+		return
+	if(C.stat & BROKEN)
+		return
+	if(C.idle_power_usage > C.avail())
+		return
 	. = 1

--- a/code/modules/power/fusion/core/core_control.dm
+++ b/code/modules/power/fusion/core/core_control.dm
@@ -168,10 +168,4 @@
 
 //Returns 1 if the machine can be interacted with via this console.
 /obj/machinery/computer/fusion_core_control/proc/check_core_status(obj/machinery/power/fusion_core/C)
-	if(isnull(C))
-		return
-	if(C.stat & BROKEN)
-		return
-	if(C.idle_power_usage > C.avail())
-		return
 	. = 1

--- a/code/modules/power/fusion/fusion_reactions.dm
+++ b/code/modules/power/fusion/fusion_reactions.dm
@@ -50,7 +50,7 @@ proc/get_fusion_reaction(p_react, s_react, m_energy)
 	s_react = "hydrogen"
 	energy_consumption = 1
 	energy_production = 2
-	products = list("helium" = 1)
+	products = list("phoron" = 1)
 
 /decl/fusion_reaction/deuterium_deuterium
 	p_react = "deuterium"

--- a/code/modules/power/fusion/fusion_reactions.dm
+++ b/code/modules/power/fusion/fusion_reactions.dm
@@ -50,7 +50,7 @@ proc/get_fusion_reaction(p_react, s_react, m_energy)
 	s_react = "hydrogen"
 	energy_consumption = 1
 	energy_production = 2
-	products = list("helium" = 1)
+	products = list("phoron" = 1)
 
 /decl/fusion_reaction/deuterium_deuterium
 	p_react = "deuterium"
@@ -71,7 +71,7 @@ proc/get_fusion_reaction(p_react, s_react, m_energy)
 	s_react = "tritium"
 	energy_consumption = 1
 	energy_production = 1
-	products = list("helium" = 1)
+	products = list("oxygen" = 1)
 	instability = 0.5
 	radiation = 3
 

--- a/code/modules/power/fusion/fusion_reactions.dm
+++ b/code/modules/power/fusion/fusion_reactions.dm
@@ -50,7 +50,7 @@ proc/get_fusion_reaction(p_react, s_react, m_energy)
 	s_react = "hydrogen"
 	energy_consumption = 1
 	energy_production = 2
-	products = list("phoron" = 1)
+	products = list("helium" = 1)
 
 /decl/fusion_reaction/deuterium_deuterium
 	p_react = "deuterium"
@@ -71,7 +71,7 @@ proc/get_fusion_reaction(p_react, s_react, m_energy)
 	s_react = "tritium"
 	energy_consumption = 1
 	energy_production = 1
-	products = list("oxygen" = 1)
+	products = list("helium" = 1)
 	instability = 0.5
 	radiation = 3
 


### PR DESCRIPTION
Убрал проверку на поломку RUS-T (Его нельзя сломать), поменял несуществующие реагенты в реакциях на существующие(Откуда у нас в газах бор и бз, верно?). Это необходимый хотфикс, чтобы на данный момент получить хоть-какой то движок, чтобы в последствии его переписать(Полностью чужой код). 
Извиняюсь за три коммита, была проблема с логином. 

- [x] Pull Request полностью завершен, мне не нужна помощь чтобы его закончить.
- [x] Я внимательно прочитал все свои изменения и багов в них не нашел.
- [x] Я запускал сервер со своими изменениями локально и все протестировал.
- [x] Я ознакомился c [Guide to Contribute](https://github.com/ChaoticOnyx/OnyxBay/blob/dev/docs/contributing.md).
