### PR TITLE
Removes that one little nasty bug preventing Brand Intelligence event from working at all

### DIFF
--- a/code/modules/events/brand_intelligence.dm
+++ b/code/modules/events/brand_intelligence.dm
@@ -20,7 +20,7 @@
 		kill()
 		return
 
-	originMachine = pick(vendingMachines)
+	originMachine = pick(vendingMachines).resolve()
 	vendingMachines.Remove(originMachine)
 	originMachine.shut_up = 0
 	originMachine.shoot_inventory = 1


### PR DESCRIPTION
- Исправлена ошибка в brand_intelligence.dm, из-за которой автоматы не ломались и генерировались сотни рантаймов в минуту, из-за чего сервер мог подтормаживать. Используйте викреференсы аккуратно, бля.

- [x] Pull Request полностью завершен, мне не нужна помощь чтобы его закончить.
- [x] Я внимательно прочитал все свои изменения и багов в них не нашел.
- [x] Я запускал сервер со своими изменениями локально и все протестировал.
- [x] Я ознакомился c [Guide to Contribute](https://github.com/ChaoticOnyx/OnyxBay/blob/dev/docs/contributing.md).
