### PR TITLE
tweak(portal) add 1 second timer to teleport all things on portal turf

### DIFF
--- a/code/game/objects/effects/portals.dm
+++ b/code/game/objects/effects/portals.dm
@@ -23,6 +23,11 @@
 /obj/effect/portal/Initialize(mapload, end, delete_after = 300, failure_rate)
 	. = ..()
 	setup_portal(end, delete_after, failure_rate)
+	addtimer(CALLBACK(src,/obj/effect/portal/proc/teleport_everything_on_portal), 1 SECOND)
+
+/obj/effect/portal/proc/teleport_everything_on_portal()
+	for(var/atom/movable/MV in get_turf(src))
+		teleport(MV)
 
 /obj/effect/portal/Destroy()
 	target = null


### PR DESCRIPTION
Добавил 1 секундный таймер, что бы человек сумел уйти с портала, по истечению этого таймера телепортирует все вещи на турфе портала.

close #3903

- [x] Pull Request полностью завершен, мне не нужна помощь чтобы его закончить.
- [x] Я внимательно прочитал все свои изменения и багов в них не нашел.
- [x] Я запускал сервер со своими изменениями локально и все протестировал.
- [x] Я ознакомился c [Guide to Contribute](https://github.com/ChaoticOnyx/OnyxBay/blob/dev/docs/contributing.md).
