### PR TITLE
Removes incorrect Initialize() usage for chem dispensers, grenades and ecig cratridges 

### DIFF
--- a/code/game/objects/items/weapons/ecigs.dm
+++ b/code/game/objects/items/weapons/ecigs.dm
@@ -209,10 +209,6 @@ obj/item/clothing/mask/smokable/ecig/deluxe/examine(mob/user)
 	volume = 20
 	atom_flags = ATOM_FLAG_OPEN_CONTAINER
 
-/obj/item/weapon/reagent_containers/ecig_cartridge/Initialize()
-	. = ..()
-	create_reagents(volume)
-
 /obj/item/weapon/reagent_containers/ecig_cartridge/examine(mob/user as mob)//to see how much left
 	. = ..()
 	. += "\nThe cartridge has [reagents.total_volume] units of liquid remaining."

--- a/code/game/objects/items/weapons/ecigs.dm
+++ b/code/game/objects/items/weapons/ecigs.dm
@@ -210,6 +210,7 @@ obj/item/clothing/mask/smokable/ecig/deluxe/examine(mob/user)
 	atom_flags = ATOM_FLAG_OPEN_CONTAINER
 
 /obj/item/weapon/reagent_containers/ecig_cartridge/Initialize()
+	. = ..()
 	create_reagents(volume)
 
 /obj/item/weapon/reagent_containers/ecig_cartridge/examine(mob/user as mob)//to see how much left

--- a/code/game/objects/items/weapons/grenades/chem_grenade.dm
+++ b/code/game/objects/items/weapons/grenades/chem_grenade.dm
@@ -16,6 +16,7 @@
 	var/affected_area = 3
 
 /obj/item/weapon/grenade/chem_grenade/Initialize()
+	. = ..()
 	create_reagents(1000)
 
 /obj/item/weapon/grenade/chem_grenade/attack_self(mob/user as mob)
@@ -297,4 +298,3 @@
 	beakers += B1
 	beakers += B2
 	icon_state = initial(icon_state) +"_locked"
-

--- a/code/modules/reagents/dispenser/dispenser2.dm
+++ b/code/modules/reagents/dispenser/dispenser2.dm
@@ -21,9 +21,8 @@
 	anchored = 1
 	obj_flags = OBJ_FLAG_ANCHORABLE
 
-/obj/machinery/chemical_dispenser/New()
-	..()
-
+/obj/machinery/chemical_dispenser/Initialize()
+	. = ..()
 	if(spawn_cartridges)
 		for(var/type in spawn_cartridges)
 			add_cartridge(new type(src))

--- a/code/modules/reagents/reagent_containers.dm
+++ b/code/modules/reagents/reagent_containers.dm
@@ -14,7 +14,7 @@
 	set name = "Set transfer amount"
 	set category = "Object"
 	set src in usr
-	
+
 	var/N = input("Amount per transfer from this:","[src]") as null|anything in cached_number_list_decode(possible_transfer_amounts)
 	if(N)
 		amount_per_transfer_from_this = N


### PR DESCRIPTION
- Fixes bad Initialize() for: chemical dispensers, chem grenades, ecig cartridges;

- [x] Pull Request полностью завершен, мне не нужна помощь чтобы его закончить.
- [x] Я внимательно прочитал все свои изменения и багов в них не нашел.
- [x] Я запускал сервер со своими изменениями локально и все протестировал.
- [x] Я ознакомился c [Guide to Contribute](https://github.com/ChaoticOnyx/OnyxBay/blob/dev/docs/contributing.md).
