### PR TITLE
Removes get_wounds() getting called when the Storyteller's off

### DIFF
--- a/code/modules/storyteller/metrics/wounds_metrics.dm
+++ b/code/modules/storyteller/metrics/wounds_metrics.dm
@@ -1,4 +1,7 @@
 /datum/controller/subsystem/storyteller/proc/report_wound(mob/victim, type, severity)
+	if(!config.storyteller)
+		return
+
 	ASSERT(istype(victim)) 	     // not used yet, keep for the future
 	ASSERT(istext(type) && type) // not used yet, keep for the future
 	ASSERT(isnum(severity) && severity)


### PR DESCRIPTION
- При выключенном сторителлере больше не будут вылезать тысячи рантаймов, связаных с get_wounds(). 

- [x] Pull Request полностью завершен, мне не нужна помощь чтобы его закончить.
- [x] Я внимательно прочитал все свои изменения и багов в них не нашел.
- [x] Я запускал сервер со своими изменениями локально и все протестировал.
- [x] Я ознакомился c [Guide to Contribute](https://github.com/ChaoticOnyx/OnyxBay/blob/dev/docs/contributing.md).
