### PR TITLE
Removes absence of #3267

### DIFF
--- a/code/modules/clothing/shoes/magboots.dm
+++ b/code/modules/clothing/shoes/magboots.dm
@@ -42,7 +42,7 @@
 	user.update_inv_shoes()	//so our mob-overlays update
 	user.update_action_buttons()
 	user.update_floating()
-	user.update_inventory_slowdown()
+	user.update_equipment_slowdown()
 
 /obj/item/clothing/shoes/magboots/mob_can_equip(mob/user)
 	var/mob/living/carbon/human/H = user

--- a/code/modules/clothing/shoes/magboots.dm
+++ b/code/modules/clothing/shoes/magboots.dm
@@ -42,6 +42,7 @@
 	user.update_inv_shoes()	//so our mob-overlays update
 	user.update_action_buttons()
 	user.update_floating()
+	user.update_inventory_slowdown()
 
 /obj/item/clothing/shoes/magboots/mob_can_equip(mob/user)
 	var/mob/living/carbon/human/H = user

--- a/code/modules/mob/inventory.dm
+++ b/code/modules/mob/inventory.dm
@@ -301,5 +301,5 @@ var/list/slot_equipment_priority = list( \
 	if(A && (l_hand == A || r_hand == A))
 		return TRUE
 
-/mob/proc/update_inventory_slowdown()
+/mob/proc/update_equipment_slowdown()
 	return

--- a/code/modules/mob/inventory.dm
+++ b/code/modules/mob/inventory.dm
@@ -300,3 +300,6 @@ var/list/slot_equipment_priority = list( \
 /mob/proc/is_item_in_hands(atom/A)
 	if(A && (l_hand == A || r_hand == A))
 		return TRUE
+
+/mob/proc/update_inventory_slowdown()
+	return

--- a/code/modules/mob/living/carbon/human/human.dm
+++ b/code/modules/mob/living/carbon/human/human.dm
@@ -8,6 +8,7 @@
 	throw_range = 4
 	var/candrop = 1
 
+	var/equipment_slowdown = -1
 	var/list/hud_list[10]
 	var/embedded_flag	  //To check if we've need to roll for damage on movement while an item is imbedded in us.
 	var/obj/item/weapon/rig/wearing_rig // This is very not good, but it's much much better than calling get_rig() every update_canmove() call.

--- a/code/modules/mob/living/carbon/human/human_movement.dm
+++ b/code/modules/mob/living/carbon/human/human_movement.dm
@@ -1,9 +1,6 @@
 /mob/living/carbon/human/movement_delay()
 	var/tally = ..()
 
-	if(species.slowdown)
-		tally += species.slowdown
-
 	tally += species.handle_movement_delay_special(src)
 
 	if(istype(loc, /turf/space))
@@ -12,11 +9,21 @@
 	if(embedded_flag || (stomach_contents && stomach_contents.len))
 		handle_embedded_and_stomach_objects() //Moving with objects stuck in you can cause bad times.
 
-	if(CE_SPEEDBOOST in chem_effects)
-		return -1
+	for(var/E in chem_effects)
+		switch(E)
+			if(CE_SPEEDBOOST)
+				return -1
+			if(CE_SLOWDOWN)
+				tally += chem_effects[CE_SLOWDOWN]
 
-	if(CE_SLOWDOWN in chem_effects)
-		tally += chem_effects[CE_SLOWDOWN]
+	var/human_delay = config.human_delay
+
+	for(var/M in mutations)
+		switch(M)
+			if(mRun)
+				return human_delay
+			if(MUTATION_FAT)
+				tally += 1.5
 
 	for(var/datum/modifier/M in modifiers)
 		if(!isnull(M.haste) && M.haste == TRUE)
@@ -24,64 +31,24 @@
 		if(!isnull(M.slowdown))
 			tally += M.slowdown
 
-	var/health_deficiency = (maxHealth - health)
-	if(health_deficiency >= 40)
-		tally += (health_deficiency / 25)
+	if(species.slowdown)
+		tally += species.slowdown
 
-	if(can_feel_pain())
-		if(get_shock() >= 10)
-			tally += (get_shock() / 10) //pain shouldn't slow you down if you can't even feel it
+	if(aiming)
+		tally += aiming.movement_tally // Iron sights make you slower, it's a well-known fact.
 
-	if(istype(buckled, /obj/structure/bed/chair/wheelchair))
-		for(var/organ_name in list(BP_L_HAND, BP_R_HAND, BP_L_ARM, BP_R_ARM))
-			var/obj/item/organ/external/E = get_organ(organ_name)
-			if(!E || E.is_stump())
-				tally += 4
-			else if(E.splinted)
-				tally += 0.5
-			else if(E.status & ORGAN_BROKEN)
-				tally += 1.5
-	else
-		var/total_item_slowdown = -1
-		for(var/slot = slot_first to slot_last)
-			var/obj/item/I = get_equipped_item(slot)
-			if(I)
-				var/item_slowdown = 0
-				item_slowdown += I.slowdown_general
-				item_slowdown += I.slowdown_per_slot[slot]
-				item_slowdown += I.slowdown_accessory
-
-				if(item_slowdown >= 0)
-					var/size_mod = 0
-					if(!(mob_size == MOB_MEDIUM))
-						size_mod = log(2, mob_size / MOB_MEDIUM)
-					if(species.strength + size_mod + 1 > 0)
-						item_slowdown = item_slowdown / (species.strength + size_mod + 1)
-					else
-						item_slowdown = item_slowdown - species.strength - size_mod
-				total_item_slowdown += max(item_slowdown, 0)
-		tally += round(total_item_slowdown)
-
-		for(var/organ_name in list(BP_L_LEG, BP_R_LEG, BP_L_FOOT, BP_R_FOOT))
-			var/obj/item/organ/external/E = get_organ(organ_name)
-			if(!E || E.is_stump())
-				tally += 4
-			else if(E.splinted)
-				tally += 0.5
-			else if(E.status & ORGAN_BROKEN)
-				tally += 1.5
-
-	if(aiming && aiming.aiming_at)
-		tally += 5 // Iron sights make you slower, it's a well-known fact.
-
-	if(MUTATION_FAT in mutations)
-		tally += 1.5
-	if (bodytemperature < 283.222)
+	if(bodytemperature < 283.222)
 		tally += (283.222 - bodytemperature) / 10 * 1.75
 
 	tally += blocking * 1.5
 
-	tally += max(2 * stance_damage, 0) //damaged/missing feet or legs is slow
+	var/health_deficiency = (maxHealth - health)
+	if(health_deficiency >= 40)
+		tally += (health_deficiency / 25)
+
+	var/shock = get_shock()
+	if(shock >= 10)
+		tally += (shock / 10) //pain shouldn't slow you down if you can't even feel it
 
 	if(!isSynthetic(src))	// are you hungry? I think yes
 		var/nut_level = nutrition / 100
@@ -91,10 +58,20 @@
 			if(450 to INFINITY)
 				tally += nut_level - 4.5
 
-	if(mRun in mutations)
-		tally = 0
+	tally += equipment_slowdown
 
-	return (tally+config.human_delay)
+	var/list/organ_list = list(BP_L_LEG, BP_R_LEG, BP_L_FOOT, BP_R_FOOT)  // if character use legs
+	if(istype(buckled, /obj/structure/bed/chair/wheelchair))              // if character buckled into wheelchair
+		organ_list = list(BP_L_HAND, BP_R_HAND, BP_L_ARM, BP_R_ARM)
+
+	for(var/organ_name in organ_list)
+		var/obj/item/organ/external/E = get_organ(organ_name)
+		if(!E)
+			tally += 4
+		else
+			tally += E.movement_tally
+
+	return (tally + human_delay)
 
 /mob/living/carbon/human/Allow_Spacemove(check_drift = 0)
 	//Can we act?

--- a/code/modules/mob/living/carbon/human/inventory.dm
+++ b/code/modules/mob/living/carbon/human/inventory.dm
@@ -217,6 +217,7 @@ This saves us from having to call add_fingerprint() any time something is put in
 	else
 		return 0
 
+	update_inventory_slowdown()
 	update_action_buttons()
 	return 1
 
@@ -367,7 +368,28 @@ This saves us from having to call add_fingerprint() any time something is put in
 	if(old_item)
 		qdel(old_item)
 
+	update_inventory_slowdown()
+
 	return 1
+
+/mob/living/carbon/human/update_inventory_slowdown()
+	equipment_slowdown = -1
+	for(var/slot = slot_first to slot_last)
+		var/obj/item/I = get_equipped_item(slot)
+		if(I)
+			var/item_slowdown = 0
+			item_slowdown += I.slowdown_general
+			item_slowdown += I.slowdown_per_slot[slot]
+			item_slowdown += I.slowdown_accessory
+			if(item_slowdown >= 0)
+				var/size_mod = 0
+				if(!(mob_size == MOB_MEDIUM))
+					size_mod = log(2, mob_size / MOB_MEDIUM)
+				if(species.strength + size_mod + 1 > 0)
+					item_slowdown = item_slowdown / (species.strength + size_mod + 1)
+				else
+					item_slowdown = item_slowdown - species.strength - size_mod
+			equipment_slowdown += item_slowdown
 
 //Checks if a given slot can be accessed at this time, either to equip or unequip I
 /mob/living/carbon/human/slot_is_accessible(slot, obj/item/I, mob/user=null)

--- a/code/modules/mob/living/carbon/human/inventory.dm
+++ b/code/modules/mob/living/carbon/human/inventory.dm
@@ -217,7 +217,7 @@ This saves us from having to call add_fingerprint() any time something is put in
 	else
 		return 0
 
-	update_inventory_slowdown()
+	update_equipment_slowdown()
 	update_action_buttons()
 	return 1
 
@@ -368,11 +368,11 @@ This saves us from having to call add_fingerprint() any time something is put in
 	if(old_item)
 		qdel(old_item)
 
-	update_inventory_slowdown()
+	update_equipment_slowdown()
 
 	return 1
 
-/mob/living/carbon/human/update_inventory_slowdown()
+/mob/living/carbon/human/update_equipment_slowdown()
 	equipment_slowdown = -1
 	for(var/slot = slot_first to slot_last)
 		var/obj/item/I = get_equipped_item(slot)

--- a/code/modules/organs/external/_external.dm
+++ b/code/modules/organs/external/_external.dm
@@ -27,6 +27,13 @@
 	var/full_pain = 0                  // Overall pain including damages.
 	var/pain_disability_threshold      // Point at which a limb becomes unusable due to pain.
 
+	// Movement delay vars.
+	var/movement_tally    = 0          // Defines movement speed
+	var/damage_multiplier = 0.5        // Default damage multiplier
+	var/stumped_tally     = 8          // 4.0  tally if limb stmuped
+	var/splinted_tally    = 1          // 0.5 tally if limb splinted
+	var/broken_tally      = 3          // 1.5 tally if limb broken
+
 	// A bitfield for a collection of limb behavior flags.
 	var/limb_flags = ORGAN_FLAG_CAN_AMPUTATE | ORGAN_FLAG_CAN_BREAK
 
@@ -841,6 +848,7 @@ Note that amputating the affected organ does in fact remove the infection from t
 				stump.robotize()
 			stump.wounds |= W
 			victim.organs |= stump
+			movement_tally += stumped_tally * damage_multiplier
 			if(disintegrate != DROPLIMB_BURN)
 				stump.sever_artery()
 			stump.update_damages()
@@ -1011,6 +1019,7 @@ obj/item/organ/external/proc/remove_clamps()
 
 	playsound(src.loc, "fracture", 100, 1, -2)
 	status |= ORGAN_BROKEN
+	movement_tally += broken_tally * damage_multiplier
 
 	//Kinda difficult to keep standing when your leg's gettin' wrecked, eh?
 	if(limb_flags & ORGAN_FLAG_CAN_STAND)
@@ -1037,11 +1046,13 @@ obj/item/organ/external/proc/remove_clamps()
 		return 0	//will just immediately fracture again
 
 	status &= ~ORGAN_BROKEN
+	movement_tally -= broken_tally * damage_multiplier
 	return 1
 
 /obj/item/organ/external/proc/apply_splint(atom/movable/splint)
 	if(!splinted)
 		splinted = splint
+		movement_tally += splinted_tally * damage_multiplier
 		if(!applied_pressure)
 			applied_pressure = splint
 		return 1
@@ -1054,6 +1065,7 @@ obj/item/organ/external/proc/remove_clamps()
 		if(applied_pressure == splinted)
 			applied_pressure = null
 		splinted = null
+		movement_tally -= splinted_tally * damage_multiplier
 		return 1
 	return 0
 

--- a/code/modules/projectiles/targeting/targeting_overlay.dm
+++ b/code/modules/projectiles/targeting/targeting_overlay.dm
@@ -11,6 +11,7 @@
 	simulated = 0
 	mouse_opacity = 0
 
+	var/movement_tally = 0     // Movement slow if aiming
 	var/mob/living/aiming_at   // Who are we currently targeting, if anyone?
 	var/obj/item/aiming_with   // What are we targeting with?
 	var/mob/living/owner       // Who do we belong to?
@@ -174,6 +175,7 @@ obj/aiming_overlay/proc/update_aiming_deferred()
 			playsound(get_turf(owner), 'sound/weapons/TargetOn.ogg', 50,1)
 
 		aiming_at.aimed |= src
+		movement_tally = 5
 		toggle_active(1)
 		update_icon()
 		lock_time = world.time + 35
@@ -228,6 +230,7 @@ obj/aiming_overlay/proc/update_aiming_deferred()
 		GLOB.destroyed_event.unregister(aiming_at, src)
 		aiming_at.aimed -= src
 		aiming_at = null
+		movement_tally = 0
 
 	aiming_with = null
 	loc = null


### PR DESCRIPTION
**В случае принятия награду отсылать HentaiStorm. Пиздюли, если всё сломается - тоже.**
Отличия от оригинального ПРа #3267:
- Пофикшено отсутствие замедления от включения магбутсов;
- Убрано ненужное вычисление замедления от stance_damage. Оно и так накидывается от movement_tally конечности, вычисление от stance_damage фактически его дублирует, из-за чего замедление при переломах доходит до абсурда;

Изменения:
- Заменены местами и отсортированы по приоритетам почти все блоки
- Итерации списков теперь в одном блоке
- Ретурнящие конструкции подняты к верху
- stance_damage перенесен из общего блока в элс коляски

close #1956

- [x] Pull Request полностью завершен, мне не нужна помощь чтобы его закончить.
- [x] Я внимательно прочитал все свои изменения и багов в них не нашел.
- [x] Я запускал сервер со своими изменениями локально и все протестировал.
- [x] Я ознакомился c [Guide to Contribute](https://github.com/ChaoticOnyx/OnyxBay/blob/dev/docs/contributing.md).
