### PR TITLE
Мобы в шкафах не слышат глобальных анонсов

### DIFF
--- a/code/procs/announce.dm
+++ b/code/procs/announce.dm
@@ -40,7 +40,7 @@
 
 	var/msg = FormMessage(message, message_title)
 	for(var/mob/M in GLOB.player_list)
-		if((M.z in (zlevels | GLOB.using_map.admin_levels)) && !istype(M,/mob/new_player) && !isdeaf(M))
+		if(should_recieve_announce(M, zlevels))
 			M.playsound_local(M.loc, pick('sound/signals/anounce1.ogg', 'sound/signals/anounce2.ogg', 'sound/signals/anounce3.ogg'), 75)
 
 			spawn (2)
@@ -54,6 +54,18 @@
 
 	if(log)
 		log_game("[key_name(usr)] has made \a [announcement_type]: [message_title] - [message] - [announcer]", notify_admin = TRUE)
+
+proc/should_recieve_announce(mob/M, list/contact_levels)
+	if (istype(M,/mob/new_player) || isdeaf(M))
+		return 0
+	if (M.z in (contact_levels | GLOB.using_map.admin_levels))
+		return 1
+	var/turf/loc_turf = get_turf(M.loc) // for mobs in lockers, sleepers, etc.
+	if (!loc_turf)
+		return 0
+	if (loc_turf.z in (contact_levels | GLOB.using_map.admin_levels))
+		return 1
+	return 0
 
 datum/announcement/proc/FormMessage(message as text, message_title as text)
 	. = "<h2 class='alert'>[message_title]</h2>"


### PR DESCRIPTION
Проблема: я сидел в шкафу, не услышал анонса о радиационной угрозе и помер от радиации. Другие анонсы из шкафов тоже не слышно.
Почему так: сейчас анонс рассылается всем мобам, у которых z-уровень соответствует станции. У мобов в шкафах z-уровень выставляется в 0 и я не вижу легкого способа это поправить и не поломать всё. Для мобов в контейнерах текущий контейнер записывается в `loc`, поэтому перед анонсом можем проверить `get_turf(loc).z` у моба. 

- [x] Pull Request полностью завершен, мне не нужна помощь чтобы его закончить.
- [x] Я внимательно прочитал все свои изменения и багов в них не нашел.
- [x] Я запускал сервер со своими изменениями локально и все протестировал.
- [x] Я ознакомился c [Guide to Contribute](https://github.com/ChaoticOnyx/OnyxBay/blob/dev/docs/contributing.md).
