### PR TITLE
Починил анимацию атаки для водителя карго-паровоза

### DIFF
--- a/code/game/objects/buckling.dm
+++ b/code/game/objects/buckling.dm
@@ -55,11 +55,14 @@
 
 /obj/proc/post_buckle_mob(mob/living/M)
 	if(buckle_pixel_shift)
-		if(M == buckled_mob)
-			var/list/pixel_shift = cached_key_number_decode(buckle_pixel_shift)
-			animate(M, pixel_x = M.default_pixel_x + pixel_shift["x"], pixel_y = M.default_pixel_y + pixel_shift["y"], 4, 1, LINEAR_EASING)
+		var/list/pixel_shift = cached_key_number_decode(buckle_pixel_shift)
+		if(M == buckled_mob)	
+			M.default_pixel_y = M.default_pixel_y + pixel_shift["y"]
+			M.default_pixel_x = M.default_pixel_x + pixel_shift["x"]
 		else
-			animate(M, pixel_x = M.default_pixel_x, pixel_y = M.default_pixel_y, 4, 1, LINEAR_EASING)
+			M.default_pixel_x = M.default_pixel_x - pixel_shift["x"]
+			M.default_pixel_y = M.default_pixel_y - pixel_shift["y"]
+		animate(M, pixel_x = M.default_pixel_x, pixel_y = M.default_pixel_y, time = 1, loop = 1, easing = LINEAR_EASING)
 
 /obj/proc/user_buckle_mob(mob/living/M, mob/user)
 	if(isanimal(user) || istype(M, /mob/living/simple_animal/hostile))


### PR DESCRIPTION
Затрагивает структуры, на которые можно садить людей (карго-паровоз, кровати...). Для них задан `pixel_shift` - координаты, на которые нужно сдвинуть иконку прицепленного моба. До этого PR `pixel_shift` модифицировал только текущий сдвиг (`pixel_x`,`pixel_y`) моба и не трогал дефолтный сдвиг `default_pixel_x`, `default_pixel_y`. Из-за этого некоторые анимации, завязанные на дефолтные сдвиг могли просирать текущий сдвиг.

Еще заметил, что сейчас анимация buckle/unbuckle для таких структур долгая, сделал быстрее.

close #4024

- [x] Pull Request полностью завершен, мне не нужна помощь чтобы его закончить.
- [x] Я внимательно прочитал все свои изменения и багов в них не нашел.
- [x] Я запускал сервер со своими изменениями локально и все протестировал.
- [x] Я ознакомился c [Guide to Contribute](https://github.com/ChaoticOnyx/OnyxBay/blob/dev/docs/contributing.md).
