### PR TITLE
Лолконвертное

### DIFF
--- a/code/game/antagonist/station/cultist.dm
+++ b/code/game/antagonist/station/cultist.dm
@@ -156,16 +156,6 @@ GLOBAL_DATUM_INIT(cult, /datum/antagonist/cultist, new)
 		for(var/mob/observer/ghost/D in SSmobs.mob_list)
 			add_ghost_magic(D)
 
-/datum/antagonist/cultist/proc/offer_uncult(mob/M)
-	if(!iscultist(M) || !M.mind)
-		return
-
-	to_chat(M, "<span class='cult'>Do you want to abandon the cult of Nar'Sie? <a href='?src=\ref[src];confirmleave=1'>ACCEPT</a></span>")
-
-/datum/antagonist/cultist/Topic(href, href_list)
-	if(href_list["confirmleave"])
-		GLOB.cult.remove_antagonist(usr.mind, 1)
-
 /datum/antagonist/cultist/proc/remove_cultiness(amount)
 	cult_rating = max(0, cult_rating - amount)
 

--- a/code/game/gamemodes/cult/runes.dm
+++ b/code/game/gamemodes/cult/runes.dm
@@ -194,34 +194,27 @@
 	target.visible_message("<span class='warning'>The markings below [target] glow a bloody red.</span>")
 
 	to_chat(target, "<span class='cult'>Your blood pulses. Your head throbs. The world goes red. All at once you are aware of a horrible, horrible truth. The veil of reality has been ripped away and in the festering wound left behind something sinister takes root.</span>")
-	if(!GLOB.cult.can_become_antag(target.mind, 1))
-		to_chat(target, "<span class='danger'>Are you going insane?</span>")
-	else
-		to_chat(target, "<span class='cult'>Do you want to join the cult of Nar'Sie? You can choose to ignore offer... <a href='?src=\ref[src];join=1'>Join the cult</a>.</span>")
 
 	spamcheck = 1
 	spawn(40)
 		spamcheck = 0
-		if(!iscultist(target) && target.loc == get_turf(src)) // They hesitated, resisted, or can't join, and they are still on the rune - burn them
+		if(!iscultist(target) && target.loc == get_turf(src) && GLOB.cult.can_become_antag(target.mind, 1))
+			GLOB.cult.add_antagonist(target.mind, ignore_role = 1, do_not_equip = 1)
+		else // They hesitated, resisted, or can't join, and they are still on the rune - damage them
 			if(target.stat == CONSCIOUS)
-				target.take_overall_damage(0, 10)
+				target.take_overall_damage(10, 0)
 				switch(target.getFireLoss())
 					if(0 to 25)
 						to_chat(target, "<span class='danger'>Your blood boils as you force yourself to resist the corruption invading every corner of your mind.</span>")
 					if(25 to 45)
 						to_chat(target, "<span class='danger'>Your blood boils and your body burns as the corruption further forces itself into your body and mind.</span>")
-						target.take_overall_damage(0, 3)
+						target.take_overall_damage(3, 5)
 					if(45 to 75)
 						to_chat(target, "<span class='danger'>You begin to hallucinate images of a dark and incomprehensible being and your entire body feels like its engulfed in flame as your mental defenses crumble.</span>")
-						target.take_overall_damage(0, 5)
+						target.take_overall_damage(5, 10)
 					if(75 to 100)
 						to_chat(target, "<span class='cult'>Your mind turns to ash as the burning flames engulf your very soul and images of an unspeakable horror begin to bombard the last remnants of mental resistance.</span>")
-						target.take_overall_damage(0, 10)
-
-/obj/effect/rune/convert/Topic(href, href_list)
-	if(href_list["join"])
-		if(usr.loc == loc && !iscultist(usr))
-			GLOB.cult.add_antagonist(usr.mind, ignore_role = 1, do_not_equip = 1)
+						target.take_overall_damage(10, 20)
 
 /obj/effect/rune/teleport
 	cultname = "teleport"

--- a/code/game/gamemodes/cult/runes.dm
+++ b/code/game/gamemodes/cult/runes.dm
@@ -193,10 +193,10 @@
 	speak_incantation(user, "Mah[pick("'","`")]weyh pleggh at e'ntrath!")
 	target.visible_message("<span class='warning'>The markings below [target] glow a bloody red.</span>")
 
-	to_chat(target, "<span class='cult'>Your blood pulses. Your head throbs. The world goes red. All at once you are aware of a horrible, horrible truth. The veil of reality has been ripped away and in the festering wound left behind something sinister takes root.</span>")
+	to_chat(target, SPAN_OCCULT("Your blood pulses. Your head throbs. The world goes red. All at once you are aware of a horrible, horrible truth. The veil of reality has been ripped away and in the festering wound left behind something sinister takes root."))
 
 	spamcheck = 1
-	spawn(40)
+	spawn(30)
 		spamcheck = 0
 		if(!iscultist(target) && target.loc == get_turf(src) && GLOB.cult.can_become_antag(target.mind, 1))
 			GLOB.cult.add_antagonist(target.mind, ignore_role = 1, do_not_equip = 1)
@@ -205,15 +205,15 @@
 				target.take_overall_damage(10, 0)
 				switch(target.getFireLoss())
 					if(0 to 25)
-						to_chat(target, "<span class='danger'>Your blood boils as you force yourself to resist the corruption invading every corner of your mind.</span>")
+						to_chat(target, SPAN_DANGER("Your blood boils as you force yourself to resist the corruption invading every corner of your mind."))
 					if(25 to 45)
-						to_chat(target, "<span class='danger'>Your blood boils and your body burns as the corruption further forces itself into your body and mind.</span>")
+						to_chat(target, SPAN_DANGER("Your blood boils and your body burns as the corruption further forces itself into your body and mind."))
 						target.take_overall_damage(3, 5)
 					if(45 to 75)
-						to_chat(target, "<span class='danger'>You begin to hallucinate images of a dark and incomprehensible being and your entire body feels like its engulfed in flame as your mental defenses crumble.</span>")
+						to_chat(target, SPAN_DANGER("You begin to hallucinate images of a dark and incomprehensible being and your entire body feels like its engulfed in flame as your mental defenses crumble."))
 						target.take_overall_damage(5, 10)
 					if(75 to 100)
-						to_chat(target, "<span class='cult'>Your mind turns to ash as the burning flames engulf your very soul and images of an unspeakable horror begin to bombard the last remnants of mental resistance.</span>")
+						to_chat(target, SPAN_OCCULT("Your mind turns to ash as the burning flames engulf your very soul and images of an unspeakable horror begin to bombard the last remnants of mental resistance."))
 						target.take_overall_damage(10, 20)
 
 /obj/effect/rune/teleport
@@ -433,7 +433,7 @@
 			T.holy = FALSE
 		else
 			T.cultify()
-		
+
 	var/area/A = get_area(src)
 	if(A && !isspace(A))
 		A.holy = FALSE

--- a/code/game/objects/items/weapons/weaponry.dm
+++ b/code/game/objects/items/weapons/weaponry.dm
@@ -21,22 +21,22 @@
 	//if(user != M)
 	if(M.mind && LAZYLEN(M.mind.learned_spells))
 		M.silence_spells(300) //30 seconds
-		to_chat(M, "<span class='danger'>You've been silenced!</span>")
+		to_chat(M, SPAN_DANGER("You've been silenced!"))
 		return
 
-	if (!user.IsAdvancedToolUser())
-		to_chat(user, "<span class='danger'>You don't have the dexterity to do this!</span>")
+	if(!user.IsAdvancedToolUser())
+		to_chat(user, SPAN_WARNING("You don't have the dexterity to do this!</span>"))
 		return
 
-	if ((MUTATION_CLUMSY in user.mutations) && prob(50))
-		to_chat(user, "<span class='danger'>The rod slips out of your hand and hits your head.</span>")
+	if((MUTATION_CLUMSY in user.mutations) && prob(50))
+		to_chat(user, SPAN_DANGER("The rod slips out of your hand and hits your head."))
 		user.take_organ_damage(10)
 		user.Paralyse(20)
 		return
 
 	if(GLOB.cult && iscultist(M))
-		M.visible_message("<span class='notice'>\The [user] waves \the [src] over \the [M]'s head.</span>")
-		GLOB.cult.offer_uncult(M)
+		M.visible_message(SPAN_NOTICE("\The [user] waves \the [src] over \the [M]'s head."))
+		GLOB.cult.remove_antagonist(usr.mind, 1)
 		return
 
 	..()

--- a/code/modules/reagents/Chemistry-Reagents/Chemistry-Reagents-Other.dm
+++ b/code/modules/reagents/Chemistry-Reagents/Chemistry-Reagents-Other.dm
@@ -181,10 +181,10 @@
 	if(ishuman(M)) // Any location
 		if(iscultist(M))
 			if(prob(10))
-				GLOB.cult.offer_uncult(M)
+				GLOB.cult.remove_antagonist(usr.mind, 1)
 			if(prob(2))
 				var/obj/effect/spider/spiderling/S = new /obj/effect/spider/spiderling(M.loc)
-				M.visible_message("<span class='warning'>\The [M] coughs up \the [S]!</span>")
+				M.visible_message(SPAN_WARNING("\The [M] coughs up \the [S]!</span>"))
 
 		if(M.mind && M.mind.vampire)
 			M.adjustFireLoss(6)


### PR DESCRIPTION
Возвращение нормального конверта, который не спрашивает игроков, желают ли они вылезти из своей чайной скорлупы. Нужна проверка на локалке с несколькими людьми, сложно потестить такое одному.
Также немного добавил брута и бёрна для тех, кто не может стать культистом.
close #1460 

<details>
<summary>Чейнджлог</summary>

```yml
🆑 KreeperHLC aka Голиаф
tweak: Возвращение конверта и анконверта без предложений это сделать.
/🆑
```

</details>

- [х] Pull Request полностью завершен, мне не нужна помощь чтобы его закончить.
- [х] Я внимательно прочитал все свои изменения и багов в них не нашел.
- [х] Я запускал сервер со своими изменениями локально и все протестировал.
- [] Я запускал сервер со своими изменениями локально с несколькими людьми и все протестировал.
- [х] Я ознакомился c [Guide to Contribute](https://github.com/ChaoticOnyx/OnyxBay/blob/dev/docs/contributing.md).
