### PR TITLE
ТобиБоёвочка - Артериальное

### DIFF
--- a/code/modules/organs/external/_external.dm
+++ b/code/modules/organs/external/_external.dm
@@ -465,15 +465,12 @@ This function completely restores a damaged organ to perfect condition.
 	..()
 
 /obj/item/organ/external/proc/createwound(type = CUT, damage, surgical)
-
 	if(damage <= 0)
 		return
-
 	//moved these before the open_wound check so that having many small wounds for example doesn't somehow protect you from taking internal damage (because of the return)
 	//Brute damage can possibly trigger an internal wound, too.
-	var/local_damage = brute_dam + burn_dam + damage
-	if(!surgical && (type in list(CUT, PIERCE, BRUISE)) && damage > 15 && local_damage > 30)
-
+	var/local_damage = brute_dam + burn_dam
+	if(!surgical && (type in list(CUT, PIERCE, BRUISE)) && damage > 15 && local_damage > min_broken_damage)
 		var/internal_damage
 		if(prob(damage/2) && sever_artery())
 			internal_damage = TRUE

--- a/code/modules/organs/external/_external.dm
+++ b/code/modules/organs/external/_external.dm
@@ -472,7 +472,7 @@ This function completely restores a damaged organ to perfect condition.
 	var/local_damage = brute_dam + burn_dam
 	if(!surgical && (type in list(CUT, PIERCE, BRUISE)) && damage > 15 && local_damage > min_broken_damage)
 		var/internal_damage
-		if(prob(damage/2) && sever_artery())
+		if(prob(ceil(damage/2)) && sever_artery())
 			internal_damage = TRUE
 		if(prob(ceil(damage/4)) && sever_tendon())
 			internal_damage = TRUE

--- a/code/modules/organs/external/head.dm
+++ b/code/modules/organs/external/head.dm
@@ -5,7 +5,7 @@
 	name = "head"
 	slot_flags = SLOT_BELT
 	max_damage = 75
-	min_broken_damage = 35
+	min_broken_damage = 40
 	w_class = ITEM_SIZE_NORMAL
 	body_part = HEAD
 	parent_organ = BP_CHEST

--- a/code/modules/organs/external/standard.dm
+++ b/code/modules/organs/external/standard.dm
@@ -68,7 +68,7 @@
 	amputation_point = "left shoulder"
 	tendon_name = "palmaris longus tendon"
 	artery_name = "basilic vein"
-	arterial_bleed_severity = 0.75
+	arterial_bleed_severity = 0.65
 	limb_flags = ORGAN_FLAG_CAN_AMPUTATE | ORGAN_FLAG_CAN_GRASP | ORGAN_FLAG_HAS_TENDON | ORGAN_FLAG_CAN_BREAK
 
 /obj/item/organ/external/arm/right
@@ -119,7 +119,7 @@
 	joint = "left ankle"
 	amputation_point = "left ankle"
 	tendon_name = "Achilles tendon"
-	arterial_bleed_severity = 0.5
+	arterial_bleed_severity = 0.45
 	limb_flags = ORGAN_FLAG_CAN_AMPUTATE | ORGAN_FLAG_CAN_STAND | ORGAN_FLAG_HAS_TENDON | ORGAN_FLAG_CAN_BREAK
 
 /obj/item/organ/external/foot/right
@@ -145,7 +145,7 @@
 	joint = "left wrist"
 	amputation_point = "left wrist"
 	tendon_name = "carpal ligament"
-	arterial_bleed_severity = 0.5
+	arterial_bleed_severity = 0.35
 	limb_flags = ORGAN_FLAG_CAN_AMPUTATE | ORGAN_FLAG_CAN_GRASP | ORGAN_FLAG_FINGERPRINT | ORGAN_FLAG_HAS_TENDON | ORGAN_FLAG_CAN_BREAK
 
 /obj/item/organ/external/hand/right

--- a/code/modules/projectiles/projectile/beams.dm
+++ b/code/modules/projectiles/projectile/beams.dm
@@ -179,6 +179,7 @@
 	agony = 40
 	tasing = 1
 	damage_type = STUN
+	penetration_modifier = 0
 
 	muzzle_type = /obj/effect/projectile/stun/muzzle
 	tracer_type = /obj/effect/projectile/stun/tracer
@@ -193,6 +194,7 @@
 	damage_type = ELECTROCUTE
 	damage = 10
 	agony  = 5
+	penetration_modifier = 0.1
 	fire_sound='sound/effects/weapons/energy/fire2.ogg'
 
 /obj/item/projectile/beam/stun/shock/heavy


### PR DESCRIPTION
- Опять переработан шанс на вызов артериального кровотечения. Раньше артерия могла прокнуть на всех органах после равного порога в 30 урона, теперь же порог зависит от органа. 20 у кистей, 25 у пяток, 30 у локтей, 40 у коленей, гроинов и голов, 45 у груди; порог теперь высчитывается не из имеющегося урона + нанесённого, а только из имеющегося. 
- Порог для перелома головы увеличен с 35 до 40 урона;
- Снижен модификатор артериального кровотечения для локтей (0.75 -> 0.65), пяток (0.5 -> 0.45), кистей (0.5 -> 0.35);
- Исправлено нанесения урона по органам станлучами и шоковыми лучами;

- [x] Pull Request полностью завершен, мне не нужна помощь чтобы его закончить.
- [x] Я внимательно прочитал все свои изменения и багов в них не нашел.
- [x] Я запускал сервер со своими изменениями локально и все протестировал.
- [x] Я ознакомился c [Guide to Contribute](https://github.com/ChaoticOnyx/OnyxBay/blob/dev/docs/contributing.md).
