### PR TITLE
fix(atmospherics control)

### DIFF
--- a/code/modules/modular_computers/file_system/programs/engineering/atmos_control.dm
+++ b/code/modules/modular_computers/file_system/programs/engineering/atmos_control.dm
@@ -58,11 +58,25 @@
 /datum/nano_module/atmos_control/ui_interact(mob/user, ui_key = "main", datum/nanoui/ui = null, force_open = 1, master_ui = null, datum/topic_state/state = GLOB.default_state)
 	var/list/data = host.initial_data()
 	var/alarms[0]
+	var/alarmsAlert[0]
+	var/alarmsDanger[0]
 
 	// TODO: Move these to a cache, similar to cameras
 	for(var/obj/machinery/alarm/alarm in (monitored_alarms.len ? monitored_alarms : SSmachines.machinery))
-		alarms[++alarms.len] = list("name" = sanitize(alarm.name), "ref"= "\ref[alarm]", "danger" = max(alarm.danger_level, alarm.alarm_area.atmosalm))
-	data["alarms"] = alarms
+		var/Z = get_host_z()
+		if ((!monitored_alarms.len) && (!Z || !AreConnectedZLevels(Z, alarm.z)))
+			continue
+		var/danger_level = max(alarm.danger_level, alarm.alarm_area.atmosalm)
+		if(danger_level == 2)
+			alarmsAlert[++alarmsAlert.len] = list("name" = sanitize(alarm.name), "ref"= "\ref[alarm]", "danger" = danger_level)
+		else if(danger_level == 1)
+			alarmsDanger[++alarmsDanger.len] = list("name" = sanitize(alarm.name), "ref"= "\ref[alarm]", "danger" = danger_level)
+		else
+			alarms[++alarms.len] = list("name" = sanitize(alarm.name), "ref"= "\ref[alarm]", "danger" = danger_level)
+
+	data["alarms"] = sortByKey(alarms, "name")
+	data["alarmsAlert"] = sortByKey(alarmsAlert, "name")
+	data["alarmsDanger"] = sortByKey(alarmsDanger, "name")
 
 	ui = SSnano.try_update_ui(user, src, ui_key, ui, data, force_open)
 	if(!ui)

--- a/nano/templates/atmos_control.tmpl
+++ b/nano/templates/atmos_control.tmpl
@@ -1,5 +1,15 @@
 <div class='item'>
+	{{for data.alarmsAlert}}
+        {{:helper.link(value.name, null, {'alarm' : value.ref}, null, 'redButton')}}
+    {{/for}}
+</div>
+<div class='item'>
+    {{for data.alarmsDanger}}
+        {{:helper.link(value.name, null, {'alarm' : value.ref}, null, 'yellowButton')}}
+    {{/for}}
+</div>
+<div class='item'>
     {{for data.alarms}}
-        {{:helper.link(value.name, null, {'alarm' : value.ref}, null, value.danger == 2 ? 'redButton' : (value.danger == 1 ? 'yellowButton' : null))}}
+        {{:helper.link(value.name, null, {'alarm' : value.ref}, null, null)}}
     {{/for}}
 </div>


### PR DESCRIPTION
- Программа Atmospherics Control теперь показывает панельки только с соединённых З-левелов (основной этаж и гетто);
- Список в Atmospherics Control сортируется в алфавитном порядке;
- В Atmospherics Control тревоги выводятся выше всего остального;

- [x] Pull Request полностью завершен, мне не нужна помощь чтобы его закончить.
- [x] Я внимательно прочитал все свои изменения и багов в них не нашел.
- [x] Я запускал сервер со своими изменениями локально и все протестировал.
- [x] Я ознакомился c [Guide to Contribute](https://github.com/ChaoticOnyx/OnyxBay/blob/dev/docs/contributing.md).
