### PR TITLE
Стены больше не прячут мехов навечно

### DIFF
--- a/code/game/turfs/simulated/floor.dm
+++ b/code/game/turfs/simulated/floor.dm
@@ -83,9 +83,7 @@
 		update_icon(1)
 
 /turf/simulated/floor/levelupdate()
-	for(var/obj/O in src)
-		O.hide(O.hides_under_flooring() && src.flooring)
-
+	..()
 	if(flooring)
 		layer = TURF_LAYER
 	else

--- a/code/game/turfs/turf.dm
+++ b/code/game/turfs/turf.dm
@@ -158,6 +158,10 @@ var/const/enterloopsanity = 100
 			M.inertia_dir = 0
 			M.make_floating(0) //we know we're not on solid ground so skip the checks to save a bit of processing
 
+	if (isobj(A))
+		var/obj/O = A
+		O.hide(O.hides_under_flooring() && !is_plating())
+
 /turf/proc/adjacent_fire_act(turf/simulated/floor/source, temperature, volume)
 	return
 


### PR DESCRIPTION
При создании стены, мы прячем всё `obj` под ней через set_invisibility(). Если стену удалить (т.е. заменить на пол), то мы раскрываем объекты (кроме тех, что спрятаны в полу). Однако, если объект сам сдвинется с тайла со стеной, мы не раскроем его. Добавил этот же код в Entered() для базового класса `turf`.

Проверил для каргопаровозика, мехов, smuggler's satchel (которые в полу прячутся, для них должно было остаться, как есть). 

closes #4023
closes #3651

- [x] Pull Request полностью завершен, мне не нужна помощь чтобы его закончить.
- [x] Я внимательно прочитал все свои изменения и багов в них не нашел.
- [x] Я запускал сервер со своими изменениями локально и все протестировал.
- [x] Я ознакомился c [Guide to Contribute](https://github.com/ChaoticOnyx/OnyxBay/blob/dev/docs/contributing.md).
