### PR TITLE
госты видят чё за руны

### DIFF
--- a/code/game/gamemodes/cult/runes.dm
+++ b/code/game/gamemodes/cult/runes.dm
@@ -120,8 +120,8 @@
 			animate(src)
 
 /obj/effect/rune/examine(mob/user)
-	. = ..()
-	if(iscultist(user))
+	..()
+	if(iscultist(user) || isghost(user))
 		to_chat(user, "This is \a [cultname] rune.")
 
 /obj/effect/rune/attackby(obj/item/I, mob/living/user)


### PR DESCRIPTION
а раньше не видели

- экзамайн за госта показывает чё за культяпская руна
- принт описания руны в чат перенесён ниже (а не выше как было) самого экзамайна

скринов не будет

- [x] Pull Request полностью завершен, мне не нужна помощь чтобы его закончить.
- [x] Я внимательно прочитал все свои изменения и багов в них не нашел.
- [x] Я запускал сервер со своими изменениями локально и все протестировал.
- [x] Я ознакомился c [Guide to Contribute](https://github.com/ChaoticOnyx/OnyxBay/blob/dev/docs/contributing.md).
