### PR TITLE
Removes the bug allowing to make mechas and trains invisible

### DIFF
--- a/code/game/mecha/mecha.dm
+++ b/code/game/mecha/mecha.dm
@@ -250,6 +250,9 @@
 		radio.talk_into(M, text)
 	return
 
+/obj/mecha/hides_inside_walls() // Won't let us hide piloted mechas inside walls, the simpliest way for now (and probably for ages)
+	return occupant ? 0 : 1
+
 ////////////////////////////
 ///// Action processing ////
 ////////////////////////////

--- a/code/game/objects/objs.dm
+++ b/code/game/objects/objs.dm
@@ -112,6 +112,9 @@
 /obj/proc/hides_under_flooring()
 	return level == 1
 
+/obj/proc/hides_inside_walls()
+	return 1
+
 /obj/proc/hear_talk(mob/M as mob, text, verb, datum/language/speaking)
 	if(talking_atom)
 		talking_atom.catchMessage(text, M)

--- a/code/game/turfs/simulated/walls.dm
+++ b/code/game/turfs/simulated/walls.dm
@@ -46,7 +46,7 @@
 // Walls always hide the stuff below them.
 /turf/simulated/wall/levelupdate()
 	for(var/obj/O in src)
-		O.hide(1)
+		O.hide(O.hides_inside_walls())
 
 /turf/simulated/wall/protects_atom(atom/A)
 	var/obj/O = A

--- a/code/modules/vehicles/vehicle.dm
+++ b/code/modules/vehicles/vehicle.dm
@@ -163,6 +163,9 @@
 	if(load == .)
 		unload(.)
 
+/obj/vehicle/hides_inside_walls()
+	return istype(load, /mob/living) ? 0 : 1
+
 //-------------------------------------------
 // Vehicle procs
 //-------------------------------------------


### PR DESCRIPTION
- Экзоскелеты и транспорт (i.e. карговозики) больше не прячутся в стенах, если ими кто-то управляет.

- [x] Pull Request полностью завершен, мне не нужна помощь чтобы его закончить.
- [x] Я внимательно прочитал все свои изменения и багов в них не нашел.
- [x] Я запускал сервер со своими изменениями локально и все протестировал.
- [x] Я ознакомился c [Guide to Contribute](https://github.com/ChaoticOnyx/OnyxBay/blob/dev/docs/contributing.md).
