### PR TITLE
Removes the rest of new HUDs-related bugs

### DIFF
--- a/code/datums/uplink/devices and tools.dm
+++ b/code/datums/uplink/devices and tools.dm
@@ -86,7 +86,7 @@ datum/uplink_item/item/tools/cleaning_kit
 	path = /obj/item/weapon/storage/backpack/satchel/syndie_kit/space
 
 /datum/uplink_item/item/tools/thermal
-	name = "Thermal Imaging Glasses"
+	name = "Thermal Imaging Goggles"
 	item_cost = 24
 	path = /obj/item/clothing/glasses/hud/standard/thermal
 

--- a/code/datums/uplink/stealth_and_camouflage_items.dm
+++ b/code/datums/uplink/stealth_and_camouflage_items.dm
@@ -59,7 +59,8 @@
 */
 
 /datum/uplink_item/item/stealth_items/thermal
-	name = "Thermal Imaging Goggles"
+	name = "Chameleon Thermal Imaging Goggles"
+	desc = "These goggles contain a very special thermal imaging optical matrix that can change its color."
 	item_cost = 31
 	path = /obj/item/clothing/glasses/hud/standard/thermal/syndie
 

--- a/code/modules/supermatter/supermatter.dm
+++ b/code/modules/supermatter/supermatter.dm
@@ -384,13 +384,17 @@
 
 		env.merge(removed)
 
-	for(var/mob/living/carbon/human/l in view(src, min(7, round(sqrt(power/6))))) // If they can see it without mesons on.  Bad on them.
-		var/obj/item/organ/internal/eyes/E = l.internal_organs_by_name[BP_EYES]
-		var/obj/item/weapon/rig/r = l.back
-		if(E && !BP_IS_ROBOTIC(E) && !istype(l.glasses, /obj/item/clothing/glasses/hud/standard/meson)) //Synthetics eyes stop evil hallucination rays
-			if(!istype(r) || !istype(r.visor, /obj/item/rig_module/vision/meson) || !r.visor.active)
-				var/effect = max(0, min(200, power * config_hallucination_power * sqrt( 1 / max(1,get_dist(l, src)))) )
-				l.adjust_hallucination(effect, 0.25*effect)
+	for(var/mob/living/carbon/human/H in view(src, min(7, round(sqrt(power/6))))) // If they can see it without mesons on.  Bad on them.
+		var/obj/item/organ/internal/eyes/E = H.internal_organs_by_name[BP_EYES]
+		if(E && !BP_IS_ROBOTIC(E)) //Synthetics eyes stop evil hallucination rays
+			var/obj/item/clothing/glasses/hud/G = H.glasses
+			if(istype(G) && istype(G.matrix, /obj/item/device/hudmatrix/meson))
+				continue
+			var/obj/item/weapon/rig/R = H.back
+			if(istype(R) && istype(R.visor, /obj/item/rig_module/vision/meson) && R.visor.active)
+				continue
+			var/effect = max(0, min(200, power * config_hallucination_power * sqrt(1 / max(1, get_dist(H, src)))))
+			H.adjust_hallucination(effect, 0.25 * effect)
 
 	SSradiation.radiate(src, power * 1.5) //Better close those shutters!
 	power -= (power/DECAY_FACTOR)**3		//energy losses due to radiation

--- a/code/modules/xenoarcheaology/effect.dm
+++ b/code/modules/xenoarcheaology/effect.dm
@@ -142,7 +142,8 @@
 	if(istype(H.gloves,/obj/item/clothing/gloves/latex))
 		protected += 0.1
 
-	if(istype(H.glasses,/obj/item/clothing/glasses/hud/standard/science))
+	var/obj/item/clothing/glasses/hud/G = H.glasses
+	if(istype(G) && istype(G.matrix, /obj/item/device/hudmatrix/science))
 		protected += 0.1
 
 	return 1 - protected


### PR DESCRIPTION
Вроде как, больше ничего вылезти не должно.
- Исправлена защита от вызываемых материей галлюцинаций с помощью мезонов. Теперь мезонная матрица будет защищать от них, будучи установленной в любой корпус;
- Аналогичная хуйня с защитой от артефактов и научными ХУДами;
- Thermal Imaging Glasses в аплинке переименованы в Thermal Imaging Goggles;
- Исправлено название термалов-хамелеонов в аплинке;
- Добавлено описание для термалов-хамелеонов в аплинке;

- [x] Pull Request полностью завершен, мне не нужна помощь чтобы его закончить.
- [x] Я внимательно прочитал все свои изменения и багов в них не нашел.
- [x] Я запускал сервер со своими изменениями локально и все протестировал.
- [x] Я ознакомился c [Guide to Contribute](https://github.com/ChaoticOnyx/OnyxBay/blob/dev/docs/contributing.md).
