### PR TITLE
Removes absence of randomly-colored lightbulbs

### DIFF
--- a/code/modules/power/lighting.dm
+++ b/code/modules/power/lighting.dm
@@ -606,6 +606,19 @@
 	var/brightness_color = "#ffffff"
 	var/list/lighting_modes = list()
 	var/sound_on
+	var/random_tone = FALSE
+	var/list/random_tone_options = list(
+		"#fffee0",
+		"#eafeff",
+		"#fefefe",
+		"#fef6ea"
+	)
+
+/obj/item/weapon/light/Initialize()
+	. = ..()
+	if(random_tone)
+		brightness_color = pick(random_tone_options)
+		update_icon()
 
 /obj/item/weapon/light/tube
 	name = "light tube"
@@ -624,6 +637,7 @@
 		LIGHTMODE_ALARM = list(l_color = "#ff3333")
 		)
 	sound_on = 'sound/machines/lightson.ogg'
+	random_tone = TRUE
 
 /obj/item/weapon/light/tube/large
 	w_class = ITEM_SIZE_SMALL
@@ -639,6 +653,7 @@
 	brightness_power = 7
 	brightness_color = "#33cccc"
 	matter = list(MATERIAL_STEEL = 60, MATERIAL_GLASS = 300)
+	random_tone = FALSE
 
 /obj/item/weapon/light/tube/quartz
 	name = "quartz light tube"
@@ -647,6 +662,7 @@
 	brightness_range = 7
 	brightness_power = 10
 	brightness_color = "#8A2BE2"
+	random_tone = FALSE
 
 /obj/item/weapon/light/bulb
 	name = "light bulb"
@@ -665,6 +681,7 @@
 		LIGHTMODE_EVACUATION = list(l_color = "#bf0000"),
 		LIGHTMODE_ALARM = list(l_color = "#ff3333")
 		)
+	random_tone = TRUE
 
 /obj/item/weapon/light/bulb/he
 	name = "high efficiency light bulb"
@@ -674,6 +691,7 @@
 	brightness_power = 5
 	brightness_color = "#33cccc"
 	matter = list(MATERIAL_STEEL = 30, MATERIAL_GLASS = 150)
+	random_tone = FALSE
 
 /obj/item/weapon/light/bulb/quartz
 	name = "quartz light bulb"
@@ -682,6 +700,7 @@
 	brightness_range = 4
 	brightness_power = 8
 	brightness_color = "#8A2BE2"
+	random_tone = FALSE
 
 /obj/item/weapon/light/bulb/old
 	name = "old light bulb"
@@ -690,10 +709,12 @@
 	brightness_range = 3
 	brightness_power = 3
 	brightness_color = "#ec8b2f"
+	random_tone = FALSE
 
 /obj/item/weapon/light/bulb/red
 	color = "#da0205"
 	brightness_color = "#da0205"
+	random_tone = FALSE
 
 /obj/item/weapon/light/bulb/red/readylight
 	brightness_range = 5
@@ -715,6 +736,7 @@
 	matter = list(MATERIAL_GLASS = 100)
 	brightness_range = 4
 	brightness_power = 4
+	random_tone = FALSE
 
 // update the icon state and description of the light
 /obj/item/weapon/light/update_icon()


### PR DESCRIPTION
- Добавлена небольшая рандомизация цвета для лампочек. Лампочки могут светить нормально, желтить или отдавать синим. Разница не слишком бросается в глаза, но освещение стало чутка более "живым".
![image](https://user-images.githubusercontent.com/45202681/104532982-acf92380-563b-11eb-9ac0-0b40d72e5ecc.png)


- [x] Pull Request полностью завершен, мне не нужна помощь чтобы его закончить.
- [x] Я внимательно прочитал все свои изменения и багов в них не нашел.
- [x] Я запускал сервер со своими изменениями локально и все протестировал.
- [x] Я ознакомился c [Guide to Contribute](https://github.com/ChaoticOnyx/OnyxBay/blob/dev/docs/contributing.md).
