### PR TITLE
tweak(storage): alt+clicks, usage by robots, background tile fixes

### DIFF
--- a/code/game/objects/items.dm
+++ b/code/game/objects/items.dm
@@ -89,25 +89,20 @@
 		pixel_y = rand(-randpixel, randpixel)
 
 /obj/item/Destroy()
-	qdel(hidden_uplink)
-	hidden_uplink = null
+	QDEL_NULL(hidden_uplink)
 	if(ismob(loc))
 		var/mob/m = loc
 		m.drop_from_inventory(src)
-		m.update_inv_r_hand()
-		m.update_inv_l_hand()
-		src.loc = null
 	if(maptext)
 		maptext = ""
+
 	if(istype(src.loc, /obj/item/weapon/storage))
-		var/obj/item/weapon/storage/storage = src.loc
-		storage.prepare_ui()
-		var/datum/storage_ui/s_ui = storage.storage_ui
-		if(s_ui)
-			s_ui.on_pre_remove(usr, src)
-		storage.contents -= src
-		storage.update_ui_after_item_removal()
-	return ..()
+		var/obj/item/weapon/storage/storage = loc // some ui cleanup needs to be done
+		storage.on_item_pre_deletion(src) // must be done before deletion
+		. = ..()
+		storage.on_item_post_deletion() // must be done after deletion
+	else
+		return ..()
 
 /obj/item/device
 	icon = 'icons/obj/device.dmi'

--- a/code/game/objects/items/stacks/medical.dm
+++ b/code/game/objects/items/stacks/medical.dm
@@ -41,8 +41,6 @@
 	amount -= used
 	if(get_amount() <= 0)
 		if(!stack_empty)
-			if(usr)
-				usr.remove_from_mob(src)
 			qdel(src) //should be safe to qdel immediately since if someone is still using this stack it will persist for a little while longer
 			return 1
 		else

--- a/code/game/objects/items/stacks/stack.dm
+++ b/code/game/objects/items/stacks/stack.dm
@@ -224,13 +224,11 @@
 	return 1
 
 /obj/item/stack/proc/use(used)
-	if (!can_use(used))
+	if(!can_use(used))
 		return 0
 	if(!uses_charge)
 		amount -= used
-		if (amount <= 0)
-			if(usr)
-				usr.remove_from_mob(src)
+		if(amount <= 0)
 			qdel(src) //should be safe to qdel immediately since if someone is still using this stack it will persist for a little while longer
 		return 1
 	else

--- a/code/game/objects/items/weapons/storage/storage_ui/default.dm
+++ b/code/game/objects/items/weapons/storage/storage_ui/default.dm
@@ -73,22 +73,24 @@
 	user.s_active = null
 
 /datum/storage_ui/default/on_insertion(mob/user)
-	if(user.s_active)
-		user.s_active.show_to(user)
+	for(var/mob/M in range(1, storage.loc))
+		if(M.s_active == storage)
+			M.s_active.show_to(M)
 
 /datum/storage_ui/default/on_pre_remove(mob/user, obj/item/W)
 	for(var/mob/M in range(1, storage.loc))
-		if (M.s_active == storage)
-			if (M.client)
+		if(M.s_active == storage)
+			if(M.client)
 				M.client.screen -= W
 
 /datum/storage_ui/default/on_post_remove(mob/user)
-	if(user.s_active)
-		user.s_active.show_to(user)
+	for(var/mob/M in range(1, storage.loc))
+		if(M.s_active == storage)
+			M.s_active.show_to(M)
 
 /datum/storage_ui/default/on_hand_attack(mob/user)
-	for(var/mob/M in range(1))
-		if (M.s_active == storage)
+	for(var/mob/M in range(1, storage.loc))
+		if(M.s_active == storage)
 			storage.close(M)
 
 /datum/storage_ui/default/show_to(mob/user)


### PR DESCRIPTION
- Исправлены остающиеся в УИ инвентарей (рюкзаки, коробки, etc.) фантомные бэкграунды после удаления предмета (складывание стаков, взрыв гранат, etc.);
- Инвентари теперь можно открывать с помощью alt+click;
- Киборги теперь могут открывать инвентари. Класть внутрь модули и вытаскивать вещи, конечно же, нельзя;
- Инструменты детектива теперь могут взаимодействовать с рюкзаками, коробками, etc. если интент - не help;

- [x] Pull Request полностью завершен, мне не нужна помощь чтобы его закончить.
- [x] Я внимательно прочитал все свои изменения и багов в них не нашел.
- [x] Я запускал сервер со своими изменениями локально и все протестировал.
- [x] Я ознакомился c [Guide to Contribute](https://github.com/ChaoticOnyx/OnyxBay/blob/dev/docs/contributing.md).
