### PR TITLE
fix(storage): alt+click interaction w/ locked storages

### DIFF
--- a/code/game/objects/items/weapons/storage/secure.dm
+++ b/code/game/objects/items/weapons/storage/secure.dm
@@ -73,7 +73,13 @@
 
 /obj/item/weapon/storage/secure/MouseDrop(over_object, src_location, over_location)
 	if(locked)
-		src.add_fingerprint(usr)
+		add_fingerprint(usr)
+		return
+	..()
+
+/obj/item/weapon/storage/secure/AltClick(mob/usr)
+	if(locked)
+		add_fingerprint(usr)
 		return
 	..()
 

--- a/code/game/objects/items/weapons/storage/storage.dm
+++ b/code/game/objects/items/weapons/storage/storage.dm
@@ -55,7 +55,7 @@
 				if(BP_L_HAND)
 					usr.put_in_l_hand(src)
 
-/obj/item/weapon/storage/AltClick(var/mob/usr)
+/obj/item/weapon/storage/AltClick(mob/usr)
 	if(!canremove)
 		return
 


### PR DESCRIPTION
- Исправлена возможность открывать закрытые сторейджи с помощью alt+click;

- [x] Pull Request полностью завершен, мне не нужна помощь чтобы его закончить.
- [x] Я внимательно прочитал все свои изменения и багов в них не нашел.
- [x] Я запускал сервер со своими изменениями локально и все протестировал.
- [x] Я ознакомился c [Guide to Contribute](https://github.com/ChaoticOnyx/OnyxBay/blob/dev/docs/contributing.md).
