### PR TITLE
update ablative armor

### DIFF
--- a/code/modules/clothing/suits/armor.dm
+++ b/code/modules/clothing/suits/armor.dm
@@ -183,7 +183,7 @@
 	if(istype(damage_source, /obj/item/projectile/energy) || istype(damage_source, /obj/item/projectile/beam))
 		var/obj/item/projectile/P = damage_source
 
-		var/reflectchance = 40 - round(damage/3)
+		var/reflectchance = 100 - damage
 		if(!(def_zone in list(BP_CHEST, BP_GROIN))) //not changing this so arm and leg shots reflect, gives some incentive to not aim center-mass
 			reflectchance /= 2
 		if(P.starting && prob(reflectchance))

--- a/code/modules/clothing/suits/armor.dm
+++ b/code/modules/clothing/suits/armor.dm
@@ -184,7 +184,13 @@
 		var/obj/item/projectile/P = damage_source
 
 		var/reflectchance = 100 - damage
-		if(!(def_zone in list(BP_CHEST, BP_GROIN))) //not changing this so arm and leg shots reflect, gives some incentive to not aim center-mass
+		var/def_list = list(BP_CHEST, BP_GROIN)
+
+		var/mob/living/carbon/human/H = user
+		if(H && istype(H.head, /obj/item/clothing/head/helmet/ablative))
+			def_list += BP_HEAD
+
+		if(!(def_zone in def_list)) //not changing this so arm and leg shots reflect, gives some incentive to not aim center-mass
 			reflectchance /= 2
 		if(P.starting && prob(reflectchance))
 			visible_message("<span class='danger'>\The [user]'s [src.name] reflects [attack_text]!</span>")


### PR DESCRIPTION
Увеличивает шанс на рефлект луча/пучка брони почти в два раза
Формула нового шанса: (100 - урон)%
Старая: (40 - урон/3)%

- Пример лазерного карабина с лучевым режимом:
По новой формуле: 100 - 50 = 50%
По старой формуле: 40 - 50/3 = 23% 
- Пример лазерного карабина с режимом пучка:
По новой формуле: 100 - 60 = 40%
По старой формуле: 40 - 60/3 = 20% 

ТАКЖЕ: Рефлект головы повышен до процентажа груди, при надетом шлеме

✅ Pull Request полностью завершен, мне не нужна помощь чтобы его закончить.
✅ Я внимательно прочитал все свои изменения и багов в них не нашел.
✅ Я запускал сервер со своими изменениями локально и все протестировал.
✅ Я ознакомился c [Guide to Contribute](https://github.com/ChaoticOnyx/OnyxBay/blob/dev/docs/contributing.md).
