### PR TITLE
tweak(antag appearance) fix ability to select xenos

### DIFF
--- a/code/game/antagonist/antagonist.dm
+++ b/code/game/antagonist/antagonist.dm
@@ -53,7 +53,7 @@
 	var/station_crew_involved = TRUE
 
 	// Used for setting appearance.
-	var/list/valid_species =       list(SPECIES_UNATHI,SPECIES_TAJARA,SPECIES_SKRELL,SPECIES_HUMAN,SPECIES_VOX)
+	var/list/valid_species = list(SPECIES_UNATHI,SPECIES_TAJARA,SPECIES_SKRELL,SPECIES_HUMAN,SPECIES_VOX)
 	var/min_player_age = 14
 
 	// Runtime vars.

--- a/code/game/antagonist/antagonist_update.dm
+++ b/code/game/antagonist/antagonist_update.dm
@@ -14,7 +14,7 @@
 	if(!preserve_appearance && (flags & ANTAG_SET_APPEARANCE))
 		spawn(3)
 			var/mob/living/carbon/human/H = player.current
-			if(istype(H)) H.change_appearance(APPEARANCE_ALL, H.loc, H, valid_species, state = GLOB.z_state)
+			if(istype(H)) H.change_appearance(APPEARANCE_ALL, H.loc, H, species_whitelist = valid_species, state = GLOB.z_state)
 	return player.current
 
 /datum/antagonist/proc/update_access(mob/living/player)

--- a/code/game/antagonist/outsider/commando.dm
+++ b/code/game/antagonist/outsider/commando.dm
@@ -10,6 +10,8 @@ GLOBAL_DATUM_INIT(commandos, /datum/antagonist/deathsquad/syndicate, new)
 	flags = ANTAG_RANDOM_EXCEPTED | ANTAG_CLEAR_EQUIPMENT | ANTAG_CHOOSE_NAME | ANTAG_OVERRIDE_JOB | ANTAG_SET_APPEARANCE
 	antaghud_indicator = "hudoperative"
 
+	valid_species = list(SPECIES_HUMAN) // Syndicate Comms don't like xenos.
+
 	hard_cap = 4
 	hard_cap_round = 8
 	initial_spawn_req = 4

--- a/code/game/antagonist/outsider/deathsquad.dm
+++ b/code/game/antagonist/outsider/deathsquad.dm
@@ -15,6 +15,8 @@ GLOBAL_DATUM_INIT(deathsquad, /datum/antagonist/deathsquad, new)
 	initial_spawn_req = 4
 	initial_spawn_target = 6
 
+	valid_species = list(SPECIES_HUMAN) // NT don't like xenos.
+
 	faction = "deathsquad"
 
 	var/deployed = 0

--- a/code/game/antagonist/outsider/ert.dm
+++ b/code/game/antagonist/outsider/ert.dm
@@ -18,6 +18,8 @@ GLOBAL_DATUM_INIT(ert, /datum/antagonist/ert, new)
 	flags = ANTAG_OVERRIDE_JOB | ANTAG_SET_APPEARANCE | ANTAG_HAS_LEADER | ANTAG_CHOOSE_NAME | ANTAG_RANDOM_EXCEPTED
 	antaghud_indicator = "hudloyalist"
 
+	valid_species = list(SPECIES_HUMAN) // NT don't like xenos.
+
 	hard_cap = 4
 	hard_cap_round = 6
 	initial_spawn_req = 3

--- a/code/game/antagonist/outsider/ninja.dm
+++ b/code/game/antagonist/outsider/ninja.dm
@@ -9,6 +9,7 @@ GLOBAL_DATUM_INIT(ninjas, /datum/antagonist/ninja, new)
 	flags = ANTAG_OVERRIDE_JOB | ANTAG_CLEAR_EQUIPMENT | ANTAG_CHOOSE_NAME | ANTAG_RANDSPAWN | ANTAG_VOTABLE | ANTAG_SET_APPEARANCE
 	antaghud_indicator = "hudninja"
 
+	valid_species = list(SPECIES_UNATHI, SPECIES_HUMAN) // Spider Clan don't like weakness.
 	initial_spawn_req = 1
 	initial_spawn_target = 1
 	hard_cap = 1

--- a/code/game/antagonist/outsider/raider.dm
+++ b/code/game/antagonist/outsider/raider.dm
@@ -11,6 +11,7 @@ GLOBAL_DATUM_INIT(raiders, /datum/antagonist/raider, new)
 	flags = ANTAG_OVERRIDE_MOB | ANTAG_OVERRIDE_JOB | ANTAG_CLEAR_EQUIPMENT | ANTAG_VOTABLE | ANTAG_HAS_LEADER
 	antaghud_indicator = "hudmutineer"
 
+	valid_species = list(SPECIES_VOX)
 	hard_cap = 5
 	hard_cap_round = 6
 	initial_spawn_req = 3


### PR DESCRIPTION
Разработчик забыл явно определить вайтлист рас, из-за этого можно было выбрать Алиумов при спавне ЕРТшником, так же исправил возможность выбрать воксов, алиумов, скреллочки и таярочки для ниндзи, и некоторые другие минорные фиксы.

![image](https://user-images.githubusercontent.com/63081538/109997751-93ae5280-7d21-11eb-860d-30d4d8e531c8.png)

~~А если бы не мех на Фловуи, я бы не заметил и не пофиксил этот баг, спасибо тебе, котик, люблю, целую~~
- [x] Pull Request полностью завершен, мне не нужна помощь чтобы его закончить.
- [x] Я внимательно прочитал все свои изменения и багов в них не нашел.
- [x] Я запускал сервер со своими изменениями локально и все протестировал.
- [x] Я ознакомился c [Guide to Contribute](https://github.com/ChaoticOnyx/OnyxBay/blob/dev/docs/contributing.md).
