### PR TITLE
Позволяем призракам крутить стулья

### DIFF
--- a/code/game/area/Space Station 13 areas.dm
+++ b/code/game/area/Space Station 13 areas.dm
@@ -56,6 +56,7 @@ NOTE: there are two lists of areas in the end of this file: centcom and station 
 	var/list/forced_ambience = null
 	var/sound_env = STANDARD_STATION
 	var/turf/base_turf //The base turf type of the area, which can be used to override the z-level's base turf
+	var/holy = FALSE
 
 /*-----------------------------------------------------------------------------*/
 
@@ -109,6 +110,7 @@ area/space/atmosalert()
 /area/chapel
 	name = "\improper Chapel"
 	icon_state = "chapel"
+	holy = TRUE
 
 /area/centcom/specops
 	name = "\improper Centcom Special Ops"

--- a/code/game/gamemodes/cult/narsie.dm
+++ b/code/game/gamemodes/cult/narsie.dm
@@ -189,6 +189,11 @@ var/global/list/narsie_list = list()
 			var/turf/T = A
 			if(T.holy)
 				T.holy = 0 //Nar-Sie doesn't give a shit about sacred grounds.
+		
+			var/area/TA = get_area(T)
+			if(TA && !isspace(TA))
+				TA.holy = FALSE
+
 			T.cultify()
 
 /obj/singularity/narsie/proc/old_narsie(const/atom/A)

--- a/code/game/gamemodes/cult/narsie.dm
+++ b/code/game/gamemodes/cult/narsie.dm
@@ -188,7 +188,7 @@ var/global/list/narsie_list = list()
 		if (dist <= consume_range && !istype(A, /turf/space))
 			var/turf/T = A
 			if(T.holy)
-				T.holy = 0 //Nar-Sie doesn't give a shit about sacred grounds.
+				T.holy = FALSE //Nar-Sie doesn't give a shit about sacred grounds.
 		
 			var/area/TA = get_area(T)
 			if(TA && !isspace(TA))

--- a/code/game/gamemodes/cult/runes.dm
+++ b/code/game/gamemodes/cult/runes.dm
@@ -437,7 +437,7 @@
 	speak_incantation(user, "Ia! Ia! Zasan therium viortia!")
 	for(var/turf/T in range(1, src))
 		if(T.holy)
-			T.holy = 0
+			T.holy = FALSE
 		else
 			T.cultify()
 		
@@ -700,7 +700,7 @@
 			M.say("Ia! Ia! Zasan therium viortia! Razan gilamrua kioha!")
 		for(var/turf/T in range(5, src))
 			if(T.holy)
-				T.holy = 0
+				T.holy = FALSE
 			else
 				T.cultify()
 

--- a/code/game/gamemodes/cult/runes.dm
+++ b/code/game/gamemodes/cult/runes.dm
@@ -440,6 +440,11 @@
 			T.holy = 0
 		else
 			T.cultify()
+		
+	var/area/A = get_area(src)
+	if(A && !isspace(A))
+		A.holy = FALSE
+
 	visible_message("<span class='warning'>\The [src] embeds into the floor and walls around it, changing them!</span>", "You hear liquid flow.")
 	qdel(src)
 
@@ -698,6 +703,11 @@
 				T.holy = 0
 			else
 				T.cultify()
+
+	var/area/A = get_area(src)
+	if(A && !isspace(A))
+		A.holy = FALSE
+
 	visible_message("<span class='warning'>\The [src] embeds into the floor and walls around it, changing them!</span>", "You hear liquid flow.")
 	qdel(src)
 

--- a/code/game/objects/structures/stool_bed_chair_nest/chairs.dm
+++ b/code/game/objects/structures/stool_bed_chair_nest/chairs.dm
@@ -86,8 +86,9 @@
 		return
 
 	if(usr.stat == DEAD)
-		if(!round_is_spooky())
-			to_chat(src, "<span class='warning'>The veil is not thin enough for you to do that.</span>")
+		var/area/A = get_area(src)
+		if(A?.holy)
+			to_chat(usr, SPAN("warning", "\The [src] is on sacred ground, you cannot turn it."))
 			return
 	else if(usr.incapacitated())
 		return

--- a/code/game/turfs/simulated.dm
+++ b/code/game/turfs/simulated.dm
@@ -53,7 +53,7 @@
 /turf/simulated/New()
 	..()
 	if(istype(loc, /area/chapel))
-		holy = 1
+		holy = TRUE
 	levelupdate()
 
 /turf/simulated/Destroy()

--- a/code/game/turfs/turf.dm
+++ b/code/game/turfs/turf.dm
@@ -7,7 +7,7 @@
 
 	var/turf_flags
 
-	var/holy = 0
+	var/holy = FALSE
 
 	// Initial air contents (in moles)
 	var/list/initial_gas

--- a/code/modules/reagents/Chemistry-Reagents/Chemistry-Reagents-Other.dm
+++ b/code/modules/reagents/Chemistry-Reagents/Chemistry-Reagents-Other.dm
@@ -195,7 +195,7 @@
 					V.show_message(SPAN_WARNING("[M]'s skin sizzles and burns."), 1)
 /datum/reagent/water/holywater/touch_turf(turf/T)
 	if(volume >= 5)
-		T.holy = 1
+		T.holy = TRUE
 
 		var/area/A = get_area(T)
 		if(A && !isspace(A))

--- a/code/modules/reagents/Chemistry-Reagents/Chemistry-Reagents-Other.dm
+++ b/code/modules/reagents/Chemistry-Reagents/Chemistry-Reagents-Other.dm
@@ -196,7 +196,10 @@
 /datum/reagent/water/holywater/touch_turf(turf/T)
 	if(volume >= 5)
 		T.holy = 1
-	return
+
+		var/area/A = get_area(T)
+		if(A && !isspace(A))
+			A.holy = TRUE
 
 /datum/reagent/diethylamine
 	name = "Diethylamine"


### PR DESCRIPTION
Ну что тут сказать? Вперед гостчане!

Стулья нельзя крутить в священной зоне.
Зона становится священной после того, как кто-нибудь в ней осветит любой турф при помощи святой воды.
Зона перестает быть священной после осквернения (defile) культистами или же Нар-Си.

close #2969

- [x] Pull Request полностью завершен, мне не нужна помощь чтобы его закончить.
- [x] Я внимательно прочитал все свои изменения и багов в них не нашел.
- [x] Я запускал сервер со своими изменениями локально и все протестировал.
- [x] Я ознакомился c [Guide to Contribute](https://github.com/ChaoticOnyx/OnyxBay/blob/dev/docs/contributing.md).
