### PR TITLE
Стан-перчаточное

### DIFF
--- a/baystation12.dme
+++ b/baystation12.dme
@@ -1371,6 +1371,7 @@
 #include "code\modules\clothing\gloves\boxing.dm"
 #include "code\modules\clothing\gloves\color.dm"
 #include "code\modules\clothing\gloves\miscellaneous.dm"
+#include "code\modules\clothing\gloves\stun.dm"
 #include "code\modules\clothing\head\beanies.dm"
 #include "code\modules\clothing\head\collectable.dm"
 #include "code\modules\clothing\head\hardhat.dm"

--- a/code/_onclick/other_mobs.dm
+++ b/code/_onclick/other_mobs.dm
@@ -16,7 +16,7 @@
 		return
 
 	// Special glove functions:
-	// If the gloves do anything, have them return 1 to stop
+	// If the gloves do anything, have them return TRUE to stop
 	// normal attack_hand() here.
 	var/obj/item/clothing/gloves/G = gloves // not typecast specifically enough in defines
 	if(istype(G) && G.Touch(A,1))

--- a/code/modules/clothing/clothing.dm
+++ b/code/modules/clothing/clothing.dm
@@ -209,9 +209,8 @@ BLIND     // can't see anything
 	w_class = ITEM_SIZE_SMALL
 	icon = 'icons/obj/clothing/gloves.dmi'
 	siemens_coefficient = 0.75
-	var/wired = 0
-	var/obj/item/weapon/cell/cell = 0
-	var/clipped = 0
+	var/wired = FALSE
+	var/clipped = FALSE
 	var/obj/item/clothing/ring/ring = null		//Covered ring
 	var/mob/living/carbon/human/wearer = null	//Used for covered rings when dropping
 	body_parts_covered = HANDS
@@ -227,17 +226,19 @@ BLIND     // can't see anything
 	. = ..()
 
 /obj/item/clothing/gloves/update_clothing_icon()
-	if (ismob(src.loc))
+	if(ismob(src.loc))
 		var/mob/M = src.loc
 		M.update_inv_gloves()
 
-/obj/item/clothing/gloves/emp_act(severity)
-	if(cell)
-		//why is this not part of the powercell code?
-		cell.charge -= 1000 / severity
-		if (cell.charge < 0)
-			cell.charge = 0
-	..()
+/obj/item/clothing/gloves/update_icon(needs_updating=FALSE)
+	if(!needs_updating)
+		..()
+		return
+
+	overlays.Cut()
+
+	if(wired)
+		overlays += image(icon, "gloves_wire")
 
 /obj/item/clothing/gloves/get_fibers()
 	return "material from a pair of [name]."
@@ -247,25 +248,50 @@ BLIND     // can't see anything
 	return 0 // return 1 to cancel attack_hand()
 
 /obj/item/clothing/gloves/attackby(obj/item/weapon/W, mob/user)
-	if(istype(W, /obj/item/weapon/wirecutters) || istype(W, /obj/item/weapon/scalpel))
-		if (clipped)
-			to_chat(user, "<span class='notice'>\The [src] have already been modified!</span>")
+	if(isWirecutter(W) || istype(W, /obj/item/weapon/scalpel))
+		if(wired)
+			wired = FALSE
+			update_icon(TRUE)
+			new /obj/item/stack/cable_coil(user.loc, 15, color)
+			playsound(src.loc, 'sound/items/Wirecutter.ogg', 100, 1)
+			to_chat(user, SPAN("notice", "You remove the wires from \the [src]."))
+			return
+
+		if(clipped)
+			to_chat(user, SPAN("notice", "\The [src] have already been modified!"))
 			update_icon()
 			return
 
 		playsound(src.loc, 'sound/items/Wirecutter.ogg', 100, 1)
-		user.visible_message("<span class='warning'>\The [user] modifies \the [src] with \the [W].</span>","<span class='warning'>You modify \the [src] with \the [W].</span>")
+		user.visible_message(SPAN("warning", "\The [user] modifies \the [src] with \the [W]."), SPAN("warning", "You modify \the [src] with \the [W]."))
 
 		cut_fingertops() // apply change, so relevant xenos can wear these
+		return
+
+	if(isCoil(W) && !wired)
+		if(istype(src, /obj/item/clothing/gloves/rig))
+			to_chat(user, SPAN("notice", "That definitely won't work."))
+			return
+		var/obj/item/stack/cable_coil/C = W
+		if(C.use(15))
+			wired = TRUE
+			update_icon(TRUE)
+			user.visible_message(SPAN("warning", "\The [user] attaches some wires to \the [W]."), SPAN("notice", "You attach some wires to \the [src]."))
+			return
+
+	if(istype(W, /obj/item/weapon/tape_roll) && wired)
+		user.visible_message(SPAN("warning", "\The [user] secures the wires on \the [src] with \the [W]."), SPAN("notice", "You secure the wires on \the [src] with \the [W]."))
+		user.drop_from_inventory(src)
+		new /obj/item/clothing/gloves/stun(src.loc, src)
 		return
 
 // Applies "clipped" and removes relevant restricted species from the list,
 // making them wearable by the specified species, does nothing if already cut
 /obj/item/clothing/gloves/proc/cut_fingertops()
-	if (clipped)
+	if(clipped)
 		return
 
-	clipped = 1
+	clipped = TRUE
 	name = "modified [name]"
 	desc = "[desc]<br>They have been modified to accommodate a different shape."
 	if("exclude" in species_restricted)

--- a/code/modules/clothing/clothing.dm
+++ b/code/modules/clothing/clothing.dm
@@ -210,6 +210,7 @@ BLIND     // can't see anything
 	icon = 'icons/obj/clothing/gloves.dmi'
 	siemens_coefficient = 0.75
 	var/wired = FALSE
+	var/wire_color
 	var/clipped = FALSE
 	var/obj/item/clothing/ring/ring = null		//Covered ring
 	var/mob/living/carbon/human/wearer = null	//Used for covered rings when dropping
@@ -244,14 +245,14 @@ BLIND     // can't see anything
 
 // Called just before an attack_hand(), in mob/UnarmedAttack()
 /obj/item/clothing/gloves/proc/Touch(atom/A, proximity)
-	return 0 // return 1 to cancel attack_hand()
+	return FALSE // return TRUE to cancel attack_hand()
 
 /obj/item/clothing/gloves/attackby(obj/item/weapon/W, mob/user)
 	if(isWirecutter(W) || istype(W, /obj/item/weapon/scalpel))
 		if(wired)
 			wired = FALSE
 			update_icon(TRUE)
-			new /obj/item/stack/cable_coil(user.loc, 15, color)
+			new /obj/item/stack/cable_coil(user.loc, 15, wire_color)
 			playsound(src.loc, 'sound/items/Wirecutter.ogg', 100, 1)
 			to_chat(user, SPAN("notice", "You remove the wires from \the [src]."))
 			return
@@ -274,6 +275,7 @@ BLIND     // can't see anything
 		var/obj/item/stack/cable_coil/C = W
 		if(C.use(15))
 			wired = TRUE
+			wire_color = C.color
 			update_icon(TRUE)
 			user.visible_message(SPAN("warning", "\The [user] attaches some wires to \the [W]."), SPAN("notice", "You attach some wires to \the [src]."))
 			return

--- a/code/modules/clothing/clothing.dm
+++ b/code/modules/clothing/clothing.dm
@@ -232,8 +232,7 @@ BLIND     // can't see anything
 
 /obj/item/clothing/gloves/update_icon(needs_updating=FALSE)
 	if(!needs_updating)
-		..()
-		return
+		return ..()
 
 	overlays.Cut()
 

--- a/code/modules/clothing/gloves/boxing.dm
+++ b/code/modules/clothing/gloves/boxing.dm
@@ -5,10 +5,10 @@
 	armor = list(melee = 15, bullet = 10, laser = 10, energy = 5, bomb = 0, bio = 0, rad = 0)
 
 /obj/item/clothing/gloves/boxing/attackby(obj/item/weapon/W, mob/user)
-	if(isWirecutter(W) || istype(W, /obj/item/weapon/scalpel))
-		to_chat(user, "<span class='notice'>That won't work.</span>")//Nope
-	else
-		..()
+	if(isWirecutter(W) || istype(W, /obj/item/weapon/scalpel) || isCoil(W))
+		to_chat(user, SPAN("notice", "That won't work."))//Nope
+		return
+	..()
 
 /obj/item/clothing/gloves/boxing/green
 	icon_state = "boxinggreen"

--- a/code/modules/clothing/gloves/stun.dm
+++ b/code/modules/clothing/gloves/stun.dm
@@ -1,0 +1,134 @@
+// Stun gloves. ~TheUnknownOne
+
+/obj/item/clothing/gloves/stun
+	name = "stun gloves"
+	desc = "A pair of gloves with some wires with exposed ends at the fingers taped to them."
+	icon_state = "black"
+	wired = TRUE
+	var/obj/item/clothing/gloves/base_gloves
+	var/agonyforce = 50
+	var/attack_cost = 50
+	var/obj/item/weapon/cell/device/bcell
+
+/obj/item/clothing/gloves/stun/Initialize(loc, obj/item/clothing/gloves/G)
+	..()
+	if(!istype(G))
+		return
+	base_gloves = G
+	if(base_gloves.clipped)
+		cut_fingertops()
+	appearance = base_gloves.appearance
+	name = "stun gloves"
+	desc = "[desc]<br>They have some wires with exposed ends at the fingers taped to them."
+	siemens_coefficient = base_gloves.siemens_coefficient
+	armor = base_gloves.armor
+	base_gloves.forceMove(src)
+
+/obj/item/clothing/gloves/stun/update_icon(needs_updating=FALSE)
+	..()
+	if(bcell)
+		overlays += image(icon, "gloves_cell")
+
+/obj/item/clothing/gloves/stun/examine()
+	. = ..()
+	if(!bcell)
+		. += "<br>\The [src] have no power cell installed."
+	else
+		. += "<br>\The [src] are [round(bcell.percent())]% charged."
+
+/obj/item/clothing/gloves/stun/attackby(obj/item/weapon/W, mob/user)
+	if(isWirecutter(W))
+		playsound(src.loc, 'sound/items/Wirecutter.ogg', 100, 1)
+		if(bcell)
+			to_chat(user, SPAN("notice", "You carefully disconnect \the [bcell] from the wires on \the [src]."))
+			user.put_in_hands(bcell)
+			bcell = null
+			update_icon(TRUE)
+			return
+
+		user.visible_message(SPAN("warning", "\The [user] cuts the tape and the wires from \the [src] with \the [W]."), SPAN("notice", "You cut the tape and the wires from \the [src] with \the [W]."))
+		if(!base_gloves)
+			qdel(src)
+		base_gloves.wired = FALSE
+		base_gloves.update_icon(TRUE)
+		new /obj/item/stack/cable_coil(user.loc, 15, color)
+		user.drop_from_inventory(base_gloves)
+		qdel(src)
+		return
+
+	if(istype(W, /obj/item/weapon/cell/device))
+		insert_cell(W, user)
+		return
+
+/obj/item/clothing/gloves/stun/proc/insert_cell(obj/item/weapon/cell/device/DC, mob/user)
+	if(!istype(DC))
+		return
+	if(bcell)
+		to_chat(user, SPAN("notice", "The [src] already have \the [bcell] installed."))
+		return
+	if(user.unEquip(DC))
+		to_chat(user, SPAN("notice", "You connect \the [DC] to the wires on \the [src]."))
+		bcell = DC
+		bcell.forceMove(src)
+		update_icon(TRUE)
+
+/obj/item/clothing/gloves/stun/emp_act(severity)
+	if(bcell)
+		bcell.charge -= 100 / severity
+		if (bcell.charge < 0)
+			bcell.charge = 0
+	..()
+
+/obj/item/clothing/gloves/stun/Touch(atom/A, proximity)
+	if(!proximity || !bcell)
+		return 0
+
+	if(ishuman(A) && ishuman(src.loc))
+		var/mob/living/carbon/human/user = src.loc
+		var/mob/living/carbon/human/victim = A
+		if(user.a_intent != I_HURT)
+			return 0
+		stun_attack(user, victim)
+		return 1
+	return 0
+
+/obj/item/clothing/gloves/stun/proc/check_aim(zone)
+	var/restricted_bps = list(BP_R_LEG, BP_L_LEG, BP_R_FOOT, BP_L_FOOT)
+	check_zone(zone)
+	if(zone in restricted_bps)
+		zone = BP_GROIN // To avoid stunning people with one stun attack
+	return zone
+
+/obj/item/clothing/gloves/stun/proc/stun_attack(mob/living/carbon/human/user, mob/living/carbon/human/victim)
+	if(!istype(user) || !istype(victim))
+		return
+
+	var/aim = check_aim(user.zone_sel.selecting)
+	var/obj/item/organ/external/affecting = victim.get_organ(aim)
+	if(!affecting)
+		to_chat(user, SPAN("warning", "\The [victim] is missing that bodypart!"))
+		return
+
+	user.do_attack_animation(victim)
+	if(!bcell.checked_use(attack_cost))
+		user.visible_message(SPAN("danger", "\The [user] grips \the [victim]'s [affecting.name] but nothing happens!"), SPAN("danger", "You grip \the [victim]'s [affecting.name] but your [src] aren't activating!"))
+		return
+
+	var/datum/effect/effect/system/spark_spread/s = new /datum/effect/effect/system/spark_spread
+	s.set_up(5, 1, victim)
+	s.start()
+
+	victim.stun_effect_act(0, agonyforce, aim, src)
+	victim.forcesay(GLOB.hit_appends)
+	user.visible_message(SPAN("danger", "\The [user] grips \the [victim]'s [affecting.name] and sparks emit from their gloves!"))
+	to_chat(victim, SPAN("warning", "You feel a shock coming from \the [user]'s gloves!"))
+
+	var/self_shock_chance = 5
+	if(MUTATION_CLUMSY in user.mutations)
+		self_shock_chance = 50
+	if(prob(self_shock_chance) && siemens_coefficient > 0)
+		var/self_agony = agonyforce * siemens_coefficient
+		user.stun_effect_act(0, self_agony, pick(BP_R_HAND, BP_L_HAND), src)
+		user.visible_message(SPAN("danger", "\The [user] accidentally shocks themself with their [src]!"), SPAN("danger", "You accidentally shock yourself with your [src]!"))
+
+	msg_admin_attack("[key_name(user)] stun gripped [key_name(victim)] with the [src].")

--- a/code/modules/clothing/gloves/stun.dm
+++ b/code/modules/clothing/gloves/stun.dm
@@ -25,6 +25,11 @@
 	armor = base_gloves.armor
 	base_gloves.forceMove(src)
 
+/obj/item/clothing/gloves/stun/Destroy()
+	QDEL_NULL(bcell)
+	QDEL_NULL(base_gloves)
+	return ..()
+
 /obj/item/clothing/gloves/stun/update_icon(needs_updating=FALSE)
 	..()
 	if(bcell)
@@ -54,6 +59,7 @@
 		base_gloves.update_icon(TRUE)
 		new /obj/item/stack/cable_coil(user.loc, 15, wire_color)
 		user.drop_from_inventory(base_gloves)
+		base_gloves = null
 		qdel(src)
 		return
 

--- a/code/modules/clothing/gloves/stun.dm
+++ b/code/modules/clothing/gloves/stun.dm
@@ -11,7 +11,7 @@
 	var/obj/item/weapon/cell/device/bcell
 
 /obj/item/clothing/gloves/stun/Initialize(loc, obj/item/clothing/gloves/G)
-	..()
+	. = ..()
 	if(!istype(G))
 		return
 	base_gloves = G
@@ -75,7 +75,7 @@
 /obj/item/clothing/gloves/stun/emp_act(severity)
 	if(bcell)
 		bcell.charge -= 100 / severity
-		if (bcell.charge < 0)
+		if(bcell.charge < 0)
 			bcell.charge = 0
 	..()
 

--- a/code/modules/clothing/gloves/stun.dm
+++ b/code/modules/clothing/gloves/stun.dm
@@ -86,7 +86,7 @@
 	if(ishuman(A) && ishuman(src.loc))
 		var/mob/living/carbon/human/user = src.loc
 		var/mob/living/carbon/human/victim = A
-		if(user.a_intent != I_HURT)
+		if(user.a_intent != I_DISARM)
 			return 0
 		stun_attack(user, victim)
 		return 1

--- a/code/modules/mob/living/carbon/human/species/species.dm
+++ b/code/modules/mob/living/carbon/human/species/species.dm
@@ -366,6 +366,9 @@ The slots that you can use are found in items_clothing.dm and are the inventory 
 			if(target.a_intent == I_HELP)
 				H.visible_message("<span class='notice'>[H] and [target] shake hands!</span>", \
 								"<span class='notice'>You shake [target]'s hand!</span>")
+				if(istype(H.gloves, /obj/item/clothing/gloves/stun))
+					var/obj/item/clothing/gloves/stun/SG = H.gloves
+					SG.stun_attack(H, target)
 			else
 				H.visible_message("<span class='warning'>[target] refuses to shake [H]'s hand!</span>", \
 								"<span class='warning'>[target] refuses to shake your hand!</span>")


### PR DESCRIPTION
- Добавлены стан-перчатки. Они делаются из любых перчаток (кроме боксёрских) добавлением 15 проводов и закреплением их изолентой. Получившиеся стан-перчатки наследуют некоторые свойства у оригинала.
- Для работы стан-перчаткам нужна девайс-батарейка - одна атака стоит 50 заряда. Установленную в перчатки батарейку можно снять кусачками.
- Для атаки стан-перчатками нужно нажать на человека дизармом, имея надетые стан-перчатки с достаточным зарядом батарейки. Болевая сила атаки немного слабее станпрода, а атака сопровождается видимыми искрами. Стан-атаки нельзя направлять в ноги и пятки, чтобы нельзя было уложить здорового человека одной атакой.
- Успешное рукопожатие, инициированное носителем стан-перчаток, исполняет стан-атаку над вторым человеком.
- Стан-атака имеет небольшой шанс (5% для обычных людей, 50% если кламзи) также шокировать носителя стан-перчаток. Болевая сила, применяющаяся к носителю, в этом случае зависит от коэффициента Сименса его перчаток - полная изоляция полностью защищает от этого эффекта.
- Успешные стан-атаки логируются в аттаклогах.
- Стан-перчатки можно вернуть в свой прежний вид, использовав на них кусачки, когда батарея не установлена. Провода выпадают. Незакреплённые изолентой провода на перчатках также можно срезать. (да, их ещё можно срезать скальпелем. почему нет?)
- Местами небольшой рефакторинг (1/0 на TRUE/FALSE и \<span> на SPAN())

ПР сделан по иссую:
close #2187 

- [x] Pull Request полностью завершен, мне не нужна помощь чтобы его закончить.
- [x] Я внимательно прочитал все свои изменения и багов в них не нашел.
- [x] Я запускал сервер со своими изменениями локально и все протестировал.
- [x] Я ознакомился c [Guide to Contribute](https://github.com/ChaoticOnyx/OnyxBay/blob/dev/docs/contributing.md).