### PR TITLE
Активное переключение индикатора набора текста

### DIFF
--- a/code/modules/client/client_defines.dm
+++ b/code/modules/client/client_defines.dm
@@ -62,3 +62,6 @@
 
 	//used for initial centering of saywindow
 	var/first_say = TRUE
+
+	//For tracking shift key (world.time)
+	var/shift_released_at = 0 

--- a/code/modules/client/client_procs.dm
+++ b/code/modules/client/client_procs.dm
@@ -584,3 +584,8 @@ client/verb/character_setup()
 
 		pct += delta
 		winset(src, "mainwindow.mainvsplit", "splitter=[pct]")
+
+/client/verb/release_shift()
+	set name = ".release_shift"
+
+	shift_released_at = world.time

--- a/code/modules/mob/typing_indicator.dm
+++ b/code/modules/mob/typing_indicator.dm
@@ -41,7 +41,9 @@ I IS TYPIN'!'
 	. = ..()
 
 /mob/proc/create_typing_indicator()
-	if(client && !stat && get_preference_value(/datum/client_preference/show_typing_indicator) == GLOB.PREF_SHOW)
+	if(!client || stat)
+		return
+	if((get_preference_value(/datum/client_preference/show_typing_indicator) == GLOB.PREF_SHOW) == (client.shift_released_at <= world.time - 2))
 		new /atom/movable/overlay/typing_indicator(get_turf(src), src)
 
 /mob/proc/remove_typing_indicator() // A bit excessive, but goes with the creation of the indicator I suppose

--- a/interface/skin.dmf
+++ b/interface/skin.dmf
@@ -218,6 +218,9 @@ macro "borghotkeymode"
 	elem 
 		name = "F12"
 		command = "F12"
+	elem 
+		name = "SHIFT+Up"
+		command = ".release_shift"
 
 macro "macro"
 	elem 
@@ -388,6 +391,9 @@ macro "macro"
 	elem 
 		name = "F12"
 		command = "F12"
+	elem 
+		name = "SHIFT+Up"
+		command = ".release_shift"
 
 macro "hotkeymode"
 	elem 
@@ -630,6 +636,9 @@ macro "hotkeymode"
 	elem 
 		name = "."
 		command = "move-down"
+	elem 
+		name = "SHIFT+Up"
+		command = ".release_shift"
 
 macro "borgmacro"
 	elem 
@@ -794,6 +803,9 @@ macro "borgmacro"
 	elem 
 		name = "F12"
 		command = "F12"
+	elem 
+		name = "SHIFT+Up"
+		command = ".release_shift"
 
 
 menu "menu"


### PR DESCRIPTION
Комбинация клавиш `Shift + F3` или `Shift + T` теперь инвертирует текущее состояние префа `Show Typing Indicator`. То есть, проще говоря, зажатый шифт при сэе скрывает, либо показывает индикатор набора текста, в зависимости от значения настройки. 

<h3>Зачем и нахуя?</h3>

К примеру вам захочется что-то передать в канал генокрадов, при этом не показывая окружающим, что вы что-то пишите. Или же если вы другой какой антагонист. Или же если вы хотите сказать что-то по рации, при этом не останавливая мимоидущего крокодила. Или же наоборот, хотите привлечь его внимание. С этой фичей вам не нужно будет постоянно залезать в настройки, чтобы скрыть/показать свой индикатор набора текста.

<h3>Что-то ещё?</h3>

Сделано с небольшим *костылем* с проверкой по времени в которое кнопка Shift перестала удерживаться. Уж простите, после принятия той фичи с форсеем недописанного текста теперь сам Say стало страшно трогать.

По сути, теперь при нажатии F3/T сбрасывается фокус с игры, из-за чего отслеживать активное состояние зажатой кнопки Shift стало нереально, поэтому использовал проверку по времени.

- [x] Pull Request полностью завершен, мне не нужна помощь чтобы его закончить.
- [x] Я внимательно прочитал все свои изменения и багов в них не нашел.
- [x] Я запускал сервер со своими изменениями локально и все протестировал.
- [x] Я ознакомился c [Guide to Contribute](https://github.com/ChaoticOnyx/OnyxBay/blob/dev/docs/contributing.md).
