### PR TITLE
Добавил бинты стандартному модулю киборга

### DIFF
--- a/code/modules/mob/living/silicon/robot/robot_modules.dm
+++ b/code/modules/mob/living/silicon/robot/robot_modules.dm
@@ -201,6 +201,16 @@ var/global/list/robot_modules = list(
 	src.modules += new /obj/item/weapon/soap/nanotrasen(src)
 	src.modules += new /obj/item/weapon/matter_decompiler(src)
 	src.emag = new /obj/item/weapon/melee/energy/sword/one_hand(src)
+
+	var/datum/matter_synth/medicine = new /datum/matter_synth/medicine(5000)
+	synths += medicine
+
+	var/obj/item/stack/medical/bruise_pack/B = new /obj/item/stack/medical/bruise_pack(src)
+	B.uses_charge = 1
+	B.charge_costs = list(1000)
+	B.synths = list(medicine)
+	modules += B
+	
 	..()
 
 /obj/item/weapon/robot_module/standard/respawn_consumable(mob/living/silicon/robot/R, amount)


### PR DESCRIPTION
Стандартный киборг казалось бы должен помогать во всём понемногу. Он может кое-как чистить, кое-как что-то даже чинить, может бить и калечить, может сканировать живых существ на наличие повреждений, но никак не может им помочь. Добавил ему в набор небольшое количество бинтов, в количестве всего пять штук. 

Не думаю, что это как-то сильно повлияет на баланс. 

- [x] Pull Request полностью завершен, мне не нужна помощь чтобы его закончить.
- [x] Я внимательно прочитал все свои изменения и багов в них не нашел.
- [x] Я запускал сервер со своими изменениями локально и все протестировал.
- [x] Я ознакомился c [Guide to Contribute](https://github.com/ChaoticOnyx/OnyxBay/blob/dev/docs/contributing.md).
