### PR TITLE
experimental(auxtools): adds auxtools support

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -1,0 +1,18 @@
+{
+    "version": "0.2.0",
+    "configurations": [
+            {
+                "type": "byond",
+                "request": "launch",
+                "name": "DS Debug",
+                "dmb": "${workspaceFolder}/${command:CurrentDMB}"
+            },
+            {
+                "type": "byond",
+                "request": "launch",
+                "name": "Build & DS Debug",
+                "preLaunchTask": "dm: build - ${command:CurrentDME}",
+                "dmb": "${workspaceFolder}/${command:CurrentDMB}"
+        }
+    ]
+}

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,9 @@
+{
+	// Lets you preview .dmi files in the editor
+	"workbench.editorAssociations": [
+		{
+				"filenamePattern": "*.dmi",
+				"viewType": "imagePreview.previewEditor"
+		}
+	]
+}

--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -2,14 +2,16 @@
 	"version": "2.0.0",
 	"tasks": [
 		{
-			"label": "Run test server",
-			"group": "test",
-			"command": "DreamDaemon",
-			"args": [
-				"${workspaceRoot}/baystation12.dmb",
-				"-invisible",
-				"-verbose"
-			]
+			"type": "dreammaker",
+			"dme": "baystation12.dme",
+			"problemMatcher": [
+				"$dreammaker"
+			],
+			"group": {
+				"kind": "build",
+				"isDefault": true
+			},
+			"label": "dm: build - baystation12.dme"
 		}
 	]
 }

--- a/SpacemanDMM.toml
+++ b/SpacemanDMM.toml
@@ -1,2 +1,5 @@
 [langserver]
 dreamchecker = true
+
+[debugger]
+engine = "auxtools"

--- a/baystation12.dme
+++ b/baystation12.dme
@@ -87,6 +87,7 @@
 #include "code\_helpers\areas.dm"
 #include "code\_helpers\atmospherics.dm"
 #include "code\_helpers\atom_movables.dm"
+#include "code\_helpers\auxtools.dm"
 #include "code\_helpers\builtin_proc_callers.dm"
 #include "code\_helpers\cmp.dm"
 #include "code\_helpers\files.dm"

--- a/code/__defines/_compile_options.dm
+++ b/code/__defines/_compile_options.dm
@@ -1,2 +1,3 @@
-#define BACKGROUND_ENABLED 0    // The default value for all uses of set background. Set background can cause gradual lag and is recommended you only turn this on if necessary.
-								// 1 will enable set background. 0 will disable set background.
+// The default value for all uses of set background. Set background can cause gradual lag and is recommended you only turn this on if necessary.
+// 1 will enable set background. 0 will disable set background.
+#define BACKGROUND_ENABLED 0

--- a/code/_helpers/auxtools.dm
+++ b/code/_helpers/auxtools.dm
@@ -1,0 +1,21 @@
+var/auxtools_debug_server = world.GetConfig("env", "AUXTOOLS_DEBUG_DLL")
+
+/proc/enable_debugging(mode, port)
+	CRASH("auxtools not loaded")
+
+/proc/auxtools_stack_trace(msg)
+	CRASH(msg)
+
+/proc/auxtools_expr_stub()
+	return
+
+/hook/startup/proc/auxtools_init()
+	if (global.auxtools_debug_server)
+		call(global.auxtools_debug_server, "auxtools_init")()
+		enable_debugging()
+	return TRUE
+
+/hook/shutdown/proc/auxtools_shutdown()
+	if (global.auxtools_debug_server)
+		call(global.auxtools_debug_server, "auxtools_shutdown")()
+	return TRUE


### PR DESCRIPTION
nuff said

Имплементирует поддержку [auxtools](https://github.com/willox/auxtools) которая будет полезна для отладки в VSC с помощью SpaceDMM.
Работает при запуске F5 при скомпилированном билде. На живом сервере использоваться, собственно, не будет.

Он уже ловит ошибки которые "приостанавливают" игру, так что не удивляйтесь если ваша игра зависнет. Вам просто надо нажать на кнопочку продолжить в вискоде.

Список текущих ошибок которые выявились с начала локального раунда.
```
Debug Server: "Pausing execution (reason: Runtime(\"code/modules/admin/banjob_iaa.dm:178:Assertion Failed: establish_db_connection()\"))"
Debug Server: "Pausing execution (reason: Runtime(\"Shuttle \\\"Creaker\\\" could not find its starting location.\"))"
Debug Server: "Pausing execution (reason: Runtime(\"bad client\"))"
```
Текущий список фич найдёте по ссылке выше в [описании](https://github.com/willox/auxtools#features).

- [X] Pull Request полностью завершен, мне не нужна помощь чтобы его закончить.
- [X] Я внимательно прочитал все свои изменения и багов в них не нашел.
- [X] Я запускал сервер со своими изменениями локально и все протестировал.
- [X] Я ознакомился c [Guide to Contribute](https://github.com/ChaoticOnyx/OnyxBay/blob/dev/docs/contributing.md).
