### PR TITLE
Syndicate Cigarettes rework

### DIFF
--- a/code/game/objects/items/weapons/smokables/cigarettes.dm
+++ b/code/game/objects/items/weapons/smokables/cigarettes.dm
@@ -326,6 +326,22 @@
 	icon_state = "cigarelloOr"
 	filling = list(/datum/reagent/tobacco/fine = 6, /datum/reagent/drink/juice/orange = 2)
 
+////////////////////
+//SYNDI CIGARETTES//
+////////////////////
+/obj/item/clothing/mask/smokable/cigarette/syndi_cigs/
+	chem_volume = 15
+/obj/item/clothing/mask/smokable/cigarette/syndi_cigs/flash
+	atom_flags = ATOM_FLAG_NO_REACT
+	filling = list(/datum/reagent/aluminum = 5, /datum/reagent/potassium = 5, /datum/reagent/sulfur = 5)
+/obj/item/clothing/mask/smokable/cigarette/syndi_cigs/mind_breaker
+	filling = list(/datum/reagent/mindbreaker = 15)
+/obj/item/clothing/mask/smokable/cigarette/syndi_cigs/smoke
+	atom_flags = ATOM_FLAG_NO_REACT
+	filling = list(/datum/reagent/potassium = 5, /datum/reagent/sugar = 5, /datum/reagent/phosphorus = 5)
+/obj/item/clothing/mask/smokable/cigarette/syndi_cigs/tricordrazine
+	filling = list(/datum/reagent/tricordrazine = 15)
+
 ////////////
 // CIGARS //
 ////////////

--- a/code/game/objects/items/weapons/smokables/cigarettes.dm
+++ b/code/game/objects/items/weapons/smokables/cigarettes.dm
@@ -331,14 +331,18 @@
 ////////////////////
 /obj/item/clothing/mask/smokable/cigarette/syndi_cigs
 	chem_volume = 15
+
 /obj/item/clothing/mask/smokable/cigarette/syndi_cigs/flash
 	atom_flags = ATOM_FLAG_NO_REACT
 	filling = list(/datum/reagent/aluminum = 5, /datum/reagent/potassium = 5, /datum/reagent/sulfur = 5)
+
 /obj/item/clothing/mask/smokable/cigarette/syndi_cigs/mind_breaker
 	filling = list(/datum/reagent/mindbreaker = 15)
+
 /obj/item/clothing/mask/smokable/cigarette/syndi_cigs/smoke
 	atom_flags = ATOM_FLAG_NO_REACT
 	filling = list(/datum/reagent/potassium = 5, /datum/reagent/sugar = 5, /datum/reagent/phosphorus = 5)
+
 /obj/item/clothing/mask/smokable/cigarette/syndi_cigs/tricordrazine
 	filling = list(/datum/reagent/tricordrazine = 15)
 

--- a/code/game/objects/items/weapons/smokables/cigarettes.dm
+++ b/code/game/objects/items/weapons/smokables/cigarettes.dm
@@ -329,7 +329,7 @@
 ////////////////////
 //SYNDI CIGARETTES//
 ////////////////////
-/obj/item/clothing/mask/smokable/cigarette/syndi_cigs/
+/obj/item/clothing/mask/smokable/cigarette/syndi_cigs
 	chem_volume = 15
 /obj/item/clothing/mask/smokable/cigarette/syndi_cigs/flash
 	atom_flags = ATOM_FLAG_NO_REACT

--- a/code/game/objects/items/weapons/smokables/smokables.dm
+++ b/code/game/objects/items/weapons/smokables/smokables.dm
@@ -86,9 +86,9 @@
 
 /obj/item/clothing/mask/smokable/proc/light(atom/used_tool, mob/holder) // both arguments are optional
 	if(!src.lit)
-		src.lit = 1
-		if(istype(src,/obj/item/clothing/mask/smokable/cigarette/syndi_cigs))
-			atom_flags = 48
+		src.lit = TRUE
+		if(atom_flags & ATOM_FLAG_NO_REACT)
+			atom_flags &= ~ATOM_FLAG_NO_REACT
 
 		damtype = BURN
 		force = initial(force) + 2

--- a/code/game/objects/items/weapons/smokables/smokables.dm
+++ b/code/game/objects/items/weapons/smokables/smokables.dm
@@ -88,7 +88,7 @@
 	if(!src.lit)
 		src.lit = 1
 		if(istype(src,/obj/item/clothing/mask/smokable/cigarette/syndi_cigs))
-			atom_flags=48
+			atom_flags = 48
 
 		damtype = BURN
 		force = initial(force) + 2

--- a/code/game/objects/items/weapons/smokables/smokables.dm
+++ b/code/game/objects/items/weapons/smokables/smokables.dm
@@ -85,12 +85,12 @@
 #undef MIN_OXIDIZER_PRESSURE_TO_SMOKE
 
 /obj/item/clothing/mask/smokable/proc/light(atom/used_tool, mob/holder) // both arguments are optional
-  	if(src.lit)
-     	return
+	if(src.lit)
+		return
 
-  	src.lit = TRUE
-	if(atom_flags & ATOM_FLAG_NO_REACT)
-		atom_flags &= ~ATOM_FLAG_NO_REACT
+	src.lit = TRUE
+	if(src.atom_flags & ATOM_FLAG_NO_REACT)
+		src.atom_flags &= ~ATOM_FLAG_NO_REACT
 
 	damtype = BURN
 	force = initial(force) + 2

--- a/code/game/objects/items/weapons/smokables/smokables.dm
+++ b/code/game/objects/items/weapons/smokables/smokables.dm
@@ -85,36 +85,36 @@
 #undef MIN_OXIDIZER_PRESSURE_TO_SMOKE
 
 /obj/item/clothing/mask/smokable/proc/light(atom/used_tool, mob/holder) // both arguments are optional
-  if(src.lit)
-      return
+  	if(src.lit)
+     	return
 
-  src.lit = TRUE
-		if(atom_flags & ATOM_FLAG_NO_REACT)
-			atom_flags &= ~ATOM_FLAG_NO_REACT
+  	src.lit = TRUE
+	if(atom_flags & ATOM_FLAG_NO_REACT)
+		atom_flags &= ~ATOM_FLAG_NO_REACT
 
-		damtype = BURN
-		force = initial(force) + 2
+	damtype = BURN
+	force = initial(force) + 2
 
-		var/explosion_amount = 0
+	var/explosion_amount = 0
 
-		if(reagents.get_reagent_amount(/datum/reagent/toxin/plasma))
-			explosion_amount += reagents.get_reagent_amount(/datum/reagent/toxin/plasma)
-		if(reagents.get_reagent_amount(/datum/reagent/fuel))
-			explosion_amount += reagents.get_reagent_amount(/datum/reagent/fuel) / 2
+	if(reagents.get_reagent_amount(/datum/reagent/toxin/plasma))
+		explosion_amount += reagents.get_reagent_amount(/datum/reagent/toxin/plasma)
+	if(reagents.get_reagent_amount(/datum/reagent/fuel))
+		explosion_amount += reagents.get_reagent_amount(/datum/reagent/fuel) / 2
 
-		if(explosion_amount)
-			var/datum/effect/effect/system/reagents_explosion/e = new()
-			e.set_up(explosion_amount, src, 0, 0)
-			e.start()
-			qdel(src)
-			return
+	if(explosion_amount)
+		var/datum/effect/effect/system/reagents_explosion/e = new()
+		e.set_up(explosion_amount, src, 0, 0)
+		e.start()
+		qdel(src)
+		return
 
-		update_icon()
-		var/turf/T = get_turf(src)
-		T.visible_message(generate_lighting_message(used_tool, holder))
-		set_light(2, 0.25, "#e38f46")
-		smokeamount = reagents.total_volume / smoketime
-		START_PROCESSING(SSobj, src)
+	update_icon()
+	var/turf/T = get_turf(src)
+	T.visible_message(generate_lighting_message(used_tool, holder))
+	set_light(2, 0.25, "#e38f46")
+	smokeamount = reagents.total_volume / smoketime
+	START_PROCESSING(SSobj, src)
 
 /obj/item/clothing/mask/smokable/proc/die(nomessage = FALSE, nodestroy = FALSE)
 	set_light(0)

--- a/code/game/objects/items/weapons/smokables/smokables.dm
+++ b/code/game/objects/items/weapons/smokables/smokables.dm
@@ -87,6 +87,8 @@
 /obj/item/clothing/mask/smokable/proc/light(atom/used_tool, mob/holder) // both arguments are optional
 	if(!src.lit)
 		src.lit = 1
+		if(istype(src,/obj/item/clothing/mask/smokable/cigarette/syndi_cigs))
+			atom_flags=48
 
 		damtype = BURN
 		force = initial(force) + 2

--- a/code/game/objects/items/weapons/storage/fancy.dm
+++ b/code/game/objects/items/weapons/storage/fancy.dm
@@ -251,15 +251,15 @@
 	desc = "A ubiquitous brand of cigarettes, found in the facilities of every major spacefaring corporation in the universe. As mild and flavorless as it gets. 'F' has been scribbled on it."
 
 /obj/item/weapon/storage/fancy/cigarettes/syndi_cigs/smoke
-	startswith= list(/obj/item/clothing/mask/smokable/cigarette/syndi_cigs/smoke = 10)
+	startswith = list(/obj/item/clothing/mask/smokable/cigarette/syndi_cigs/smoke = 10)
 	desc = "A ubiquitous brand of cigarettes, found in the facilities of every major spacefaring corporation in the universe. As mild and flavorless as it gets. 'S' has been scribbled on it."
 
 /obj/item/weapon/storage/fancy/cigarettes/syndi_cigs/mind_breaker
-	startswith= list(/obj/item/clothing/mask/smokable/cigarette/syndi_cigs/mind_breaker = 10)
+	startswith = list(/obj/item/clothing/mask/smokable/cigarette/syndi_cigs/mind_breaker = 10)
 	desc = "A ubiquitous brand of cigarettes, found in the facilities of every major spacefaring corporation in the universe. As mild and flavorless as it gets. 'MB' has been scribbled on it."
 
 /obj/item/weapon/storage/fancy/cigarettes/syndi_cigs/tricordrazine
-	startswith= list(/obj/item/clothing/mask/smokable/cigarette/syndi_cigs/tricordrazine = 10)
+	startswith = list(/obj/item/clothing/mask/smokable/cigarette/syndi_cigs/tricordrazine = 10)
 	desc = "A ubiquitous brand of cigarettes, found in the facilities of every major spacefaring corporation in the universe. As mild and flavorless as it gets. 'T' has been scribbled on it."
 
 //cigarellos

--- a/code/game/objects/items/weapons/storage/fancy.dm
+++ b/code/game/objects/items/weapons/storage/fancy.dm
@@ -243,6 +243,25 @@
 	item_state = "Dpacket"
 	startswith = list(/obj/item/clothing/mask/smokable/cigarette/professionals = 10)
 
+////////////////////
+//SYNDI CIGARETTES//
+////////////////////
+/obj/item/weapon/storage/fancy/cigarettes/syndi_cigs/flash
+	startswith = list(/obj/item/clothing/mask/smokable/cigarette/syndi_cigs/flash = 10)
+	desc = "A ubiquitous brand of cigarettes, found in the facilities of every major spacefaring corporation in the universe. As mild and flavorless as it gets. 'F' has been scribbled on it."
+
+/obj/item/weapon/storage/fancy/cigarettes/syndi_cigs/smoke
+	startswith= list(/obj/item/clothing/mask/smokable/cigarette/syndi_cigs/smoke = 10)
+	desc = "A ubiquitous brand of cigarettes, found in the facilities of every major spacefaring corporation in the universe. As mild and flavorless as it gets. 'S' has been scribbled on it."
+
+/obj/item/weapon/storage/fancy/cigarettes/syndi_cigs/mind_breaker
+	startswith= list(/obj/item/clothing/mask/smokable/cigarette/syndi_cigs/mind_breaker = 10)
+	desc = "A ubiquitous brand of cigarettes, found in the facilities of every major spacefaring corporation in the universe. As mild and flavorless as it gets. 'MB' has been scribbled on it."
+
+/obj/item/weapon/storage/fancy/cigarettes/syndi_cigs/tricordrazine
+	startswith= list(/obj/item/clothing/mask/smokable/cigarette/syndi_cigs/tricordrazine = 10)
+	desc = "A ubiquitous brand of cigarettes, found in the facilities of every major spacefaring corporation in the universe. As mild and flavorless as it gets. 'T' has been scribbled on it."
+
 //cigarellos
 /obj/item/weapon/storage/fancy/cigarettes/cigarello
 	name = "pack of Trident Original cigars"

--- a/code/game/objects/items/weapons/storage/uplink_kits.dm
+++ b/code/game/objects/items/weapons/storage/uplink_kits.dm
@@ -143,30 +143,12 @@
 
 /obj/item/weapon/storage/box/syndie_kit/cigarette/New()
 	..()
-	var/obj/item/weapon/storage/fancy/cigarettes/pack
-	pack = new /obj/item/weapon/storage/fancy/cigarettes(src)
-	fill_cigarre_package(pack, list(/datum/reagent/aluminum = 1, /datum/reagent/potassium = 1, /datum/reagent/sulfur = 1))
-	pack.desc += " 'F' has been scribbled on it."
-
-	pack = new /obj/item/weapon/storage/fancy/cigarettes(src)
-	fill_cigarre_package(pack, list(/datum/reagent/aluminum = 1, /datum/reagent/potassium = 1, /datum/reagent/sulfur = 1))
-	pack.desc += " 'F' has been scribbled on it."
-
-	pack = new /obj/item/weapon/storage/fancy/cigarettes(src)
-	fill_cigarre_package(pack, list(/datum/reagent/potassium = 1, /datum/reagent/sugar = 1, /datum/reagent/phosphorus = 1))
-	pack.desc += " 'S' has been scribbled on it."
-
-	pack = new /obj/item/weapon/storage/fancy/cigarettes(src)
-	fill_cigarre_package(pack, list(/datum/reagent/potassium = 1, /datum/reagent/sugar = 1, /datum/reagent/phosphorus = 1))
-	pack.desc += " 'S' has been scribbled on it."
-
-	pack = new /obj/item/weapon/storage/fancy/cigarettes(src)
-	fill_cigarre_package(pack, list(/datum/reagent/dylovene = 1, /datum/reagent/silicon = 1, /datum/reagent/hydrazine = 1))
-	pack.desc += " 'MB' has been scribbled on it."
-
-	pack = new /obj/item/weapon/storage/fancy/cigarettes(src)
-	fill_cigarre_package(pack, list(/datum/reagent/tricordrazine = 4))
-	pack.desc += " 'T' has been scribbled on it."
+	new /obj/item/weapon/storage/fancy/cigarettes/syndi_cigs/flash(src)
+	new /obj/item/weapon/storage/fancy/cigarettes/syndi_cigs/flash(src)
+	new /obj/item/weapon/storage/fancy/cigarettes/syndi_cigs/smoke(src)
+	new /obj/item/weapon/storage/fancy/cigarettes/syndi_cigs/smoke(src)
+	new /obj/item/weapon/storage/fancy/cigarettes/syndi_cigs/mind_breaker(src)
+	new /obj/item/weapon/storage/fancy/cigarettes/syndi_cigs/tricordrazine(src)
 
 	new /obj/item/weapon/flame/lighter/zippo(src)
 

--- a/code/modules/reagents/Chemistry-Reagents/Chemistry-Reagents-Toxins.dm
+++ b/code/modules/reagents/Chemistry-Reagents/Chemistry-Reagents-Toxins.dm
@@ -61,7 +61,7 @@
 	description = "Plasma in its liquid form."
 	taste_mult = 1.5
 	reagent_state = LIQUID
-	color = "#ff3300"
+	color = "#e90eb8"
 	strength = 30
 	touch_met = 5
 	var/fire_mult = 5


### PR DESCRIPTION
1. Создан новый вид сигарет syndi_cigs с увеличенным chem_amount с 5 до 15 для хороших реакций(возможно изменение для баланса)
2. Создана ./syndi_cigs/flash. Сигарета флешка при закуривании(задержка до первой затяжки)и поджигании станит ~5 секунд(возможен ребаланс)
3. Создана ./syndi_cigs/smoke. Сигарета дымовуха при закуривании и поджигании создаёт пук дыма вокруг игрока(не очень полезна, но подойдёт при побеге в техах, закурил и в шкаф залез)
4. Создана ./syndi_cigs/mind_breaker. Сигарета наркоманов при закуривании и недлительном курении(хватает пару затяжек) начинаются глюки.
5. Создана ./syndi_cigs/tricordrazine. Сигарета лечилка, действует как tricordrazine...
6. В связи с моей кривозадостью созданы пачки для данных сигарет они абсолютно одинаковы кроме содержимого и описания(окончания)
7. Добавлен флаг ATOM_FLAG_NO_REACT для сигарет flash, smoke. Связано с тем что сразу при покупке сигарет они срабатывали
8. Дополнен обработчик зажигания сигарет согласно 7-му пункту. А точнее проверка на syndi_cigs и установка стандартного числа в поле "atom_flags"(было взято с других сигарет, проверялось через view variables)
9. Переделана покупка кита в аплинке
Примечания:
1. Все сигареты забиты под завязку

close #2048

- [x] Pull Request полностью завершен, мне не нужна помощь чтобы его закончить.
- [x] Я внимательно прочитал все свои изменения и багов в них не нашел.
- [x] Я запускал сервер со своими изменениями локально и все протестировал.
- [x] Я ознакомился c [Guide to Contribute](https://github.com/ChaoticOnyx/OnyxBay/blob/dev/docs/contributing.md).
