### PR TITLE
Removes instant crates and cryobags Toggle Open

### DIFF
--- a/code/game/objects/items/bodybag.dm
+++ b/code/game/objects/items/bodybag.dm
@@ -44,6 +44,7 @@
 	storage_capacity = (MOB_MEDIUM * 2) - 1
 	var/contains_body = 0
 	dremovable = 0
+	open_delay = 6
 
 /obj/structure/closet/body_bag/attackby(W as obj, mob/user as mob)
 	if (istype(W, /obj/item/weapon/pen))

--- a/code/game/objects/items/cryobag.dm
+++ b/code/game/objects/items/cryobag.dm
@@ -25,7 +25,7 @@
 
 	storage_types = CLOSET_STORAGE_MOBS
 	var/datum/gas_mixture/airtank
-	
+
 	var/syndi
 
 	var/stasis_power = 20
@@ -114,7 +114,7 @@
 	desc = "Pretty useless now.."
 	icon_state = "bodybag_used"
 	icon = 'icons/obj/cryobag.dmi'
-	
+
 /obj/item/bodybag/cryobag/syndi
 	name = "modified stasis bag"
 	icon = 'icons/obj/syndi_cryobag.dmi'
@@ -134,20 +134,20 @@
 	item_path = /obj/item/bodybag/cryobag/syndi
 	stasis_power = 10
 	degradation_time = 300
-	
+
 /obj/structure/closet/body_bag/cryobag/syndi/fold(user)
 	var/obj/item/bodybag/cryobag/syndi/folded = ..()
 	if(istype(folded))
 		folded.stasis_power = stasis_power
-		folded.color = color_saturation(get_saturation())	
-		
+		folded.color = color_saturation(get_saturation())
+
 /obj/structure/closet/body_bag/cryobag/syndi/Process()
 	..()
-	
+
 	var/mob/living/carbon/human/H = locate() in src
 	if(!H)
 		return PROCESS_KILL
-	
+
 	H.add_chemical_effect(CE_CRYO, 2)
 	H.add_chemical_effect(CE_STABLE)
 	H.add_chemical_effect(CE_OXYGENATED, 1)

--- a/code/game/objects/structures/crates_lockers/closets.dm
+++ b/code/game/objects/structures/crates_lockers/closets.dm
@@ -37,6 +37,8 @@
 	var/dremovable = 1	//	some closets' doors cannot be removed
 	var/nodoor = 0	// for crafting
 
+	var/open_delay = 0
+
 /obj/structure/closet/nodoor
 	nodoor = 1
 	opened = TRUE
@@ -487,10 +489,12 @@
 	if(!src.open())
 		to_chat(user, "<span class='notice'>It won't budge!</span>")
 
-/obj/structure/closet/attack_hand(mob/user as mob)
-	src.add_fingerprint(user)
-	src.toggle(user)
-	user.setClickCooldown(2)
+/obj/structure/closet/attack_hand(mob/user)
+	add_fingerprint(user)
+	user.setClickCooldown(max(2, open_delay))
+	if(open_delay && !do_after(user, open_delay))
+		return
+	toggle(user)
 
 // tk grab then use on self
 /obj/structure/closet/attack_self_tk(mob/user as mob)
@@ -513,8 +517,7 @@
 		return
 
 	if(ishuman(usr))
-		src.add_fingerprint(usr)
-		src.toggle(usr)
+		attack_hand(usr)
 	else
 		to_chat(usr, "<span class='warning'>This mob type can't use this verb.</span>")
 

--- a/code/game/objects/structures/crates_lockers/closets.dm
+++ b/code/game/objects/structures/crates_lockers/closets.dm
@@ -491,10 +491,16 @@
 
 /obj/structure/closet/attack_hand(mob/user)
 	add_fingerprint(user)
-	user.setClickCooldown(max(2, open_delay))
+	user.setClickCooldown(2)
+	if(in_use)
+		to_chat(user, SPAN("warning", "You can't do this right now."))
+		return
+	in_use = TRUE
 	if(open_delay && !do_after(user, open_delay))
+		in_use = FALSE
 		return
 	toggle(user)
+	in_use = FALSE
 
 // tk grab then use on self
 /obj/structure/closet/attack_self_tk(mob/user as mob)

--- a/code/game/objects/structures/crates_lockers/crates.dm
+++ b/code/game/objects/structures/crates_lockers/crates.dm
@@ -8,6 +8,7 @@ obj/structure/closet/crate
 	atom_flags = ATOM_FLAG_CLIMBABLE
 	pull_sound = "pull_box"
 	setup = 0
+	open_delay = 3
 
 	dremovable = 0
 


### PR DESCRIPTION
- Для открытия/закрытия ящиков (не шкафчиков) добавлена задержка в 0.3 секунды;
- Для открытия/закрытия мешков для трупов и криомешков добавлена задержка в 0.6 секунд;

Зачем? Дабы лысенькие мимокрокодилы в коридорах на лету не открывали ящики шахтёров и мешки медботов "ЧтОбЫ пОсМоТрЕтЬ".

- [x] Pull Request полностью завершен, мне не нужна помощь чтобы его закончить.
- [x] Я внимательно прочитал все свои изменения и багов в них не нашел.
- [x] Я запускал сервер со своими изменениями локально и все протестировал.
- [x] Я ознакомился c [Guide to Contribute](https://github.com/ChaoticOnyx/OnyxBay/blob/dev/docs/contributing.md).
