### PR TITLE
feat(roundend) add show report verb

### DIFF
--- a/code/_helpers/roundend.dm
+++ b/code/_helpers/roundend.dm
@@ -220,6 +220,12 @@ GLOBAL_LIST_EMPTY(common_report)
 	R.Grant(C.mob)
 	to_chat(C,"<a href='?src=\ref[R];report=1'>Show roundend report again</a>")
 
+/mob/verb/show_round_end()
+	set name = "Show roundend report"
+	set category = "OOC"
+	if(SSticker.end_game_state != END_GAME_NOT_OVER && GLOB.common_report)
+		SSticker.show_roundend_report(usr.client, TRUE)
+
 /datum/action/report
 	name = "Show roundend report"
 	button_icon_state = "round_end"


### PR DESCRIPTION
Добавлен верб, который позволяет любому мобу открыть репорт, в конце сессии.

По второму параметру в show_roundend_report сложно, но мне кажется, что будет нормально в случае, если игрок еще не генерировал репорт.

- [x] Pull Request полностью завершен, мне не нужна помощь чтобы его закончить.
- [x] Я внимательно прочитал все свои изменения и багов в них не нашел.
- [ ] Я запускал сервер со своими изменениями локально и все протестировал.
- [x] Я ознакомился c [Guide to Contribute](https://github.com/ChaoticOnyx/OnyxBay/blob/dev/docs/contributing.md).