### PR TITLE
Roundend runtime fix

### DIFF
--- a/code/_helpers/roundend.dm
+++ b/code/_helpers/roundend.dm
@@ -242,7 +242,7 @@ GLOBAL_LIST_EMPTY(common_report)
 	return "data/roundend_reports/[ckey].html"
 
 /datum/controller/subsystem/ticker/proc/show_roundend_report(client/C, previous = FALSE)
-	var/datum/browser/roundend_report = new(C, "roundend")
+	var/datum/browser/roundend_report = new(C.mob, "roundend")
 	roundend_report.width = 800
 	roundend_report.height = 600
 	var/content

--- a/code/datums/browser.dm
+++ b/code/datums/browser.dm
@@ -17,7 +17,6 @@
 
 
 /datum/browser/New(nuser, nwindow_id, ntitle = 0, nwidth = 0, nheight = 0, atom/nref = null)
-
 	user = nuser
 	window_id = nwindow_id
 	if (ntitle)


### PR DESCRIPTION
Фиксит это говно в конце раундов
```
[13:08:50] Runtime in browser.dm,32: undefined variable /client/var/client
[13:08:50] Runtime in browser.dm,32: undefined variable /client/var/client
[13:08:50] Runtime in browser.dm,32: undefined variable /client/var/client
[13:08:50] Runtime in browser.dm,32: undefined variable /client/var/client
[13:08:50] Runtime in browser.dm,32: undefined variable /client/var/client
```
- [x] Pull Request полностью завершен, мне не нужна помощь чтобы его закончить.
- [x] Я внимательно прочитал все свои изменения и багов в них не нашел.
- [x] Я запускал сервер со своими изменениями локально и все протестировал.
- [x] Я ознакомился c [Guide to Contribute](https://github.com/ChaoticOnyx/OnyxBay/blob/dev/docs/contributing.md).
