### PR TITLE
fix(arithrazine): prothesis damage from arithrazine

### DIFF
--- a/code/modules/mob/living/carbon/human/human_damage.dm
+++ b/code/modules/mob/living/carbon/human/human_damage.dm
@@ -355,6 +355,21 @@ In most cases it makes more sense to use apply_damage() instead! And make sure t
 
 	updatehealth()
 
+// damage ONE organic external organ, organ gets randomly selected from all damagable
+/mob/living/carbon/human/proc/take_organic_organ_damage(brute, burn)
+	var/list/organic_organs = list()
+
+	for(var/obj/item/organ/external/organ in get_damageable_organs())
+		if(!BP_IS_ROBOTIC(organ))
+			organic_organs += organ
+
+	if(organic_organs.len == 0) return
+
+	var/obj/item/organ/external/damaged_organ = pick(organic_organs)
+	if(damaged_organ.take_external_damage(brute, burn))
+		BITSET(hud_updateflag, HEALTH_HUD)
+
+	updatehealth()
 
 //Heal MANY external organs, in random order
 /mob/living/carbon/human/heal_overall_damage(brute, burn)

--- a/code/modules/reagents/Chemistry-Reagents/Chemistry-Reagents-Medicine.dm
+++ b/code/modules/reagents/Chemistry-Reagents/Chemistry-Reagents-Medicine.dm
@@ -593,7 +593,11 @@
 	M.radiation = max(M.radiation - 70 * removed, 0)
 	M.adjustToxLoss(-10 * removed)
 	if(prob(60))
-		M.take_organ_damage(4 * removed, 0)
+		if(istype(M, /mob/living/carbon/human))
+			var/mob/living/carbon/human/human = M
+			human.take_organic_organ_damage(4 * removed, 0)
+		else
+			M.take_organ_damage(4 * removed, 0)
 
 /datum/reagent/spaceacillin
 	name = "Spaceacillin"

--- a/code/modules/reagents/Chemistry-Reagents/Chemistry-Reagents-Medicine.dm
+++ b/code/modules/reagents/Chemistry-Reagents/Chemistry-Reagents-Medicine.dm
@@ -593,7 +593,7 @@
 	M.radiation = max(M.radiation - 70 * removed, 0)
 	M.adjustToxLoss(-10 * removed)
 	if(prob(60))
-		if(istype(M, /mob/living/carbon/human))
+		if(ishuman(M))
 			var/mob/living/carbon/human/human = M
 			human.take_organic_organ_damage(4 * removed, 0)
 		else


### PR DESCRIPTION
Добавил новый прок для human'ов, который позволяет нанести дамаг рандомной органической конечности (не протезу). Также добавил этот прок в метаболизм аритразина, чтобы он не наносил дамаг протезам. Фолбэк к mob/living/carbon на всякий случай оставил.

![Screenshot_6](https://user-images.githubusercontent.com/38394905/113207429-ce60c780-929a-11eb-9b2e-a9c667d3e0aa.png)

fix #4731

- [x] Pull Request полностью завершен, мне не нужна помощь чтобы его закончить.
- [x] Я внимательно прочитал все свои изменения и багов в них не нашел.
- [x] Я запускал сервер со своими изменениями локально и все протестировал.
- [x] Я ознакомился c [Guide to Contribute](https://github.com/ChaoticOnyx/OnyxBay/blob/dev/docs/contributing.md).