### PR TITLE
Removes lack of tool-belt holdable items

### DIFF
--- a/code/game/objects/items/weapons/storage/belt.dm
+++ b/code/game/objects/items/weapons/storage/belt.dm
@@ -59,7 +59,10 @@
 		/obj/item/taperoll,
 		/obj/item/weapon/extinguisher/mini,
 		/obj/item/weapon/marshalling_wand,
-		/obj/item/weapon/combotool/advtool
+		/obj/item/weapon/combotool/advtool,
+		/obj/item/device/geiger,
+		/obj/item/device/lightreplacer,
+		/obj/item/device/robotanalyzer
 		)
 
 


### PR DESCRIPTION
- В тулбелтах теперь можно хранить счётчики Гейгера, лайтреплейсеры и роботанализеры;

- [x] Pull Request полностью завершен, мне не нужна помощь чтобы его закончить.
- [x] Я внимательно прочитал все свои изменения и багов в них не нашел.
- [ ] Я запускал сервер со своими изменениями локально и все протестировал.
- [x] Я ознакомился c [Guide to Contribute](https://github.com/ChaoticOnyx/OnyxBay/blob/dev/docs/contributing.md).
