### PR TITLE
Removes obsolescence of pulling

### DIFF
--- a/code/__defines/misc.dm
+++ b/code/__defines/misc.dm
@@ -243,3 +243,12 @@
 #define MOUSE_OPACITY_TRANSPARENT 0
 #define MOUSE_OPACITY_ICON 1
 #define MOUSE_OPACITY_OPAQUE 2
+
+//How pulling an object affects mob's movement speed.
+#define PULL_SLOWDOWN_WEIGHT   -1  // Default value, slowdown's handled by an object's w_class.
+#define PULL_SLOWDOWN_EXTREME 4.5
+#define PULL_SLOWDOWN_HEAVY   3.5
+#define PULL_SLOWDOWN_MEDIUM  2.5
+#define PULL_SLOWDOWN_LIGHT   1.5
+#define PULL_SLOWDOWN_TINY    0.5
+#define PULL_SLOWDOWN_NONE    0

--- a/code/game/machinery/vending.dm
+++ b/code/game/machinery/vending.dm
@@ -13,6 +13,7 @@
 	obj_flags = OBJ_FLAG_ANCHORABLE
 	clicksound = "button"
 	clickvol = 40
+	pull_slowdown = PULL_SLOWDOWN_HEAVY
 
 	var/max_health = 100
 	var/health = 100

--- a/code/game/objects/items/weapons/extinguisher.dm
+++ b/code/game/objects/items/weapons/extinguisher.dm
@@ -77,11 +77,20 @@
 	return ..()
 
 /obj/item/weapon/extinguisher/proc/propel_object(obj/O, mob/user, movementdirection)
-	if(O.anchored) return
+	if(O.anchored)
+		return
 
 	var/obj/structure/bed/chair/C
 	if(istype(O, /obj/structure/bed/chair))
 		C = O
+
+	var/area/A = get_area(src)
+	if(A.has_gravity) // No gravity? Your chair is a space ship then.
+		if(C?.foldable)
+			C.fold(null)
+			return
+		if(O.pull_slowdown > PULL_SLOWDOWN_MEDIUM)
+			return // Too much friction, not enough wheels
 
 	var/list/move_speed = list(1, 1, 1, 2, 2, 3)
 	for(var/i in 1 to 6)

--- a/code/game/objects/objs.dm
+++ b/code/game/objects/objs.dm
@@ -15,6 +15,7 @@
 	var/damtype = "brute"
 	var/armor_penetration = 0
 	var/anchor_fall = FALSE
+	var/pull_slowdown = PULL_SLOWDOWN_WEIGHT // How much it slows us down while we are pulling it
 
 /obj/Destroy()
 	var/obj/item/smallDelivery/delivery = loc

--- a/code/game/objects/structures.dm
+++ b/code/game/objects/structures.dm
@@ -2,6 +2,7 @@
 	icon = 'icons/obj/structures.dmi'
 	w_class = ITEM_SIZE_NO_CONTAINER
 	pull_sound = "pull_wood"
+	pull_slowdown = PULL_SLOWDOWN_MEDIUM
 
 	var/breakable
 	var/parts

--- a/code/game/objects/structures/crates_lockers/closets.dm
+++ b/code/game/objects/structures/crates_lockers/closets.dm
@@ -4,6 +4,7 @@
 	icon = 'icons/obj/closet.dmi'
 	icon_state = "closed"
 	pull_sound = "pull_closet"
+	pull_slowdown = PULL_SLOWDOWN_HEAVY
 	density = 1
 	w_class = ITEM_SIZE_NO_CONTAINER
 	layer = STRUCTURE_LAYER

--- a/code/game/objects/structures/crates_lockers/crates.dm
+++ b/code/game/objects/structures/crates_lockers/crates.dm
@@ -7,6 +7,7 @@ obj/structure/closet/crate
 	icon_closed = "crate"
 	atom_flags = ATOM_FLAG_CLIMBABLE
 	pull_sound = "pull_box"
+	pull_slowdown = PULL_SLOWDOWN_MEDIUM
 	setup = 0
 	open_delay = 3
 

--- a/code/game/objects/structures/crates_lockers/crates.dm
+++ b/code/game/objects/structures/crates_lockers/crates.dm
@@ -131,6 +131,7 @@ obj/structure/closet/crate
 	icon_state = "trashcart"
 	icon_opened = "trashcartopen"
 	icon_closed = "trashcart"
+	pull_slowdown = PULL_SLOWDOWN_LIGHT
 
 /obj/structure/closet/crate/medical
 	name = "medical crate"
@@ -364,6 +365,7 @@ obj/structure/closet/crate
 	close_sound = 'sound/items/Deconstruct.ogg'
 	req_access = list(access_mailsorting, access_xenobiology ,access_virology)
 	storage_types = CLOSET_STORAGE_ITEMS|CLOSET_STORAGE_MOBS
+	pull_slowdown = PULL_SLOWDOWN_LIGHT
 
 /obj/structure/closet/crate/secure/biohazard/blanks/WillContain()
 	return list(/mob/living/carbon/human/blank, /obj/item/usedcryobag)

--- a/code/game/objects/structures/crates_lockers/largecrate.dm
+++ b/code/game/objects/structures/crates_lockers/largecrate.dm
@@ -5,6 +5,7 @@
 	icon_state = "densecrate"
 	density = 1
 	atom_flags = ATOM_FLAG_CLIMBABLE
+	pull_slowdown = PULL_SLOWDOWN_HEAVY
 
 /obj/structure/largecrate/Initialize()
 	. = ..()

--- a/code/game/objects/structures/gas_stand.dm
+++ b/code/game/objects/structures/gas_stand.dm
@@ -3,6 +3,7 @@
 	icon = 'icons/obj/gas_stand.dmi'
 	desc = "Gas stand with retractable gas mask."
 	icon_state = "gas_stand_idle"
+	pull_slowdown = PULL_SLOWDOWN_TINY
 
 	var/obj/item/weapon/tank/tank
 	var/mob/living/carbon/breather

--- a/code/game/objects/structures/geltanks.dm
+++ b/code/game/objects/structures/geltanks.dm
@@ -6,6 +6,7 @@
 	density = 1
 	anchored = 0
 	pull_sound = "pull_machine"
+	pull_slowdown = PULL_SLOWDOWN_LIGHT
 	var/capacity_max = 300
 	var/capacity = 300
 	var/gel_type = "unknown"

--- a/code/game/objects/structures/girders.dm
+++ b/code/game/objects/structures/girders.dm
@@ -4,6 +4,7 @@
 	density = 1
 	layer = BELOW_OBJ_LAYER
 	w_class = ITEM_SIZE_NO_CONTAINER
+	pull_slowdown = PULL_SLOWDOWN_HEAVY
 	var/state = 0
 	var/max_health = 150
 	var/health = 150

--- a/code/game/objects/structures/iv_drip.dm
+++ b/code/game/objects/structures/iv_drip.dm
@@ -3,6 +3,7 @@
 	icon = 'icons/obj/iv_drip.dmi'
 	anchored = 0
 	density = 0
+	pull_slowdown = PULL_SLOWDOWN_TINY
 	var/mob/living/carbon/human/attached
 	var/mode = 1 // 1 is injecting, 0 is taking blood.
 	var/obj/item/weapon/reagent_containers/beaker

--- a/code/game/objects/structures/janicart.dm
+++ b/code/game/objects/structures/janicart.dm
@@ -6,6 +6,7 @@
 	anchored = 0
 	density = 1
 	atom_flags = ATOM_FLAG_OPEN_CONTAINER | ATOM_FLAG_CLIMBABLE
+	pull_slowdown = PULL_SLOWDOWN_LIGHT
 	//copypaste sorry
 	var/amount_per_transfer_from_this = 5 //shit I dunno, adding this so syringes stop runtime erroring. --NeoFite
 	var/obj/item/weapon/storage/bag/trash/mybag	= null

--- a/code/game/objects/structures/mop_bucket.dm
+++ b/code/game/objects/structures/mop_bucket.dm
@@ -7,6 +7,7 @@
 	w_class = ITEM_SIZE_NORMAL
 	atom_flags = ATOM_FLAG_CLIMBABLE
 	atom_flags = ATOM_FLAG_OPEN_CONTAINER
+	pull_slowdown = PULL_SLOWDOWN_TINY
 	var/amount_per_transfer_from_this = 5	//shit I dunno, adding this so syringes stop runtime erroring. --NeoFite
 
 

--- a/code/game/objects/structures/stasis_cage.dm
+++ b/code/game/objects/structures/stasis_cage.dm
@@ -4,6 +4,7 @@
 	icon = 'icons/obj/storage.dmi'
 	icon_state = "critter"
 	density = 1
+	pull_slowdown = PULL_SLOWDOWN_HEAVY
 
 	var/mob/living/simple_animal/contained
 

--- a/code/game/objects/structures/stool_bed_chair_nest/bed.dm
+++ b/code/game/objects/structures/stool_bed_chair_nest/bed.dm
@@ -216,14 +216,17 @@
 	icon_state = "rollerbed"
 	anchored = 0
 	buckle_pixel_shift = "x=0;y=6"
+	pull_slowdown = PULL_SLOWDOWN_TINY
 	var/bedtype = /obj/structure/bed/roller
 	var/rollertype = /obj/item/roller
 
 /obj/structure/bed/roller/adv
 	name = "advanced roller bed"
+	desc = "An advanced bed-on-wheels made for transporting medical patients with maximum speed."
 	icon_state = "rollerbedadv"
 	bedtype = /obj/structure/bed/roller/adv
 	rollertype = /obj/item/roller/adv
+	pull_slowdown = PULL_SLOWDOWN_NONE
 
 /obj/structure/bed/roller/update_icon()
 	return // Doesn't care about material or anything else.
@@ -330,6 +333,7 @@
 	icon_state = "wheelbed"
 	base_icon = "wheelbed"
 	buckle_pixel_shift = "x=0;y=3"
+	pull_slowdown = PULL_SLOWDOWN_LIGHT
 
 /obj/structure/bed/wheel/padded/New(newloc)
 	..(newloc, MATERIAL_PLASTIC, MATERIAL_COTTON)

--- a/code/game/objects/structures/stool_bed_chair_nest/chairs.dm
+++ b/code/game/objects/structures/stool_bed_chair_nest/chairs.dm
@@ -239,6 +239,7 @@
 	buckle_movable = 1
 	material_alteration = MATERIAL_ALTERATION_NONE
 	foldable = FALSE
+	pull_slowdown = PULL_SLOWDOWN_TINY
 
 /obj/structure/bed/chair/office/attackby(obj/item/weapon/W as obj, mob/user as mob)
 	if(istype(W,/obj/item/stack) || isWirecutter(W))

--- a/code/game/objects/structures/stool_bed_chair_nest/chairs.dm
+++ b/code/game/objects/structures/stool_bed_chair_nest/chairs.dm
@@ -7,6 +7,8 @@
 	buckle_dir = 0
 	buckle_lying = 0 //force people to sit up in chairs when buckled
 	buckle_pixel_shift = "x=0;y=0"
+	anchored = FALSE
+	pull_slowdown = PULL_SLOWDOWN_EXTREME
 	var/propelled = 0 // Check for fire-extinguisher-driven chairs
 	var/foldable = TRUE
 
@@ -156,7 +158,8 @@
 		fold(usr)
 
 /obj/structure/bed/chair/proc/fold(mob/user)
-	if(!foldable) return
+	if(!foldable)
+		return
 
 	var/list/collapse_message = list(SPAN_WARNING("\The [src.name] has collapsed!"), null)
 
@@ -177,7 +180,8 @@
 
 	visible_message(collapse_message[1], collapse_message[2])
 	var/obj/item/weapon/foldchair/O = new /obj/item/weapon/foldchair(get_turf(src))
-	if(user) O.add_fingerprint(user)
+	if(user)
+		O.add_fingerprint(user)
 	O.material = material
 	O.padding_material = padding_material
 	QDEL_IN(src, 0)
@@ -192,33 +196,34 @@
 	icon_state = "comfychair_preview"
 	base_icon = "comfychair"
 	foldable = FALSE
+	anchored = TRUE
 
-/obj/structure/bed/chair/comfy/brown/New(newloc,newmaterial)
+/obj/structure/bed/chair/comfy/brown/New(newloc, newmaterial)
 	..(newloc, MATERIAL_STEEL, MATERIAL_LEATHER)
 
-/obj/structure/bed/chair/comfy/red/New(newloc,newmaterial)
+/obj/structure/bed/chair/comfy/red/New(newloc, newmaterial)
 	..(newloc, MATERIAL_STEEL, MATERIAL_CARPET)
 
-/obj/structure/bed/chair/comfy/teal/New(newloc,newmaterial)
-	..(newloc, MATERIAL_STEEL,"teal")
+/obj/structure/bed/chair/comfy/teal/New(newloc, newmaterial)
+	..(newloc, MATERIAL_STEEL, "teal")
 
-/obj/structure/bed/chair/comfy/black/New(newloc,newmaterial)
-	..(newloc, MATERIAL_STEEL,"black")
+/obj/structure/bed/chair/comfy/black/New(newloc, newmaterial)
+	..(newloc, MATERIAL_STEEL, "black")
 
-/obj/structure/bed/chair/comfy/green/New(newloc,newmaterial)
-	..(newloc, MATERIAL_STEEL,"green")
+/obj/structure/bed/chair/comfy/green/New(newloc, newmaterial)
+	..(newloc, MATERIAL_STEEL, "green")
 
-/obj/structure/bed/chair/comfy/purp/New(newloc,newmaterial)
-	..(newloc, MATERIAL_STEEL,"purple")
+/obj/structure/bed/chair/comfy/purp/New(newloc, newmaterial)
+	..(newloc, MATERIAL_STEEL, "purple")
 
-/obj/structure/bed/chair/comfy/blue/New(newloc,newmaterial)
-	..(newloc, MATERIAL_STEEL,"blue")
+/obj/structure/bed/chair/comfy/blue/New(newloc, newmaterial)
+	..(newloc, MATERIAL_STEEL, "blue")
 
-/obj/structure/bed/chair/comfy/beige/New(newloc,newmaterial)
-	..(newloc, MATERIAL_STEEL,"beige")
+/obj/structure/bed/chair/comfy/beige/New(newloc, newmaterial)
+	..(newloc, MATERIAL_STEEL, "beige")
 
-/obj/structure/bed/chair/comfy/lime/New(newloc,newmaterial)
-	..(newloc, MATERIAL_STEEL,"lime")
+/obj/structure/bed/chair/comfy/lime/New(newloc, newmaterial)
+	..(newloc, MATERIAL_STEEL, "lime")
 
 /obj/structure/bed/chair/comfy/captain
 	name = "captain chair"
@@ -228,14 +233,14 @@
 	buckle_movable = 1
 
 /obj/structure/bed/chair/comfy/captain/New(newloc,newmaterial)
-	..(newloc, MATERIAL_STEEL,"black")
+	..(newloc, MATERIAL_STEEL, "black")
 
 /* ======================================================= */
 /* -------------------- Office Chairs -------------------- */
 /* ======================================================= */
 
 /obj/structure/bed/chair/office
-	anchored = 0
+	anchored = FALSE
 	buckle_movable = 1
 	material_alteration = MATERIAL_ALTERATION_NONE
 	foldable = FALSE
@@ -260,7 +265,8 @@
 
 /obj/structure/bed/chair/office/Bump(atom/A)
 	..()
-	if(!buckled_mob)	return
+	if(!buckled_mob)
+		return
 
 	if(propelled)
 		var/mob/living/occupant = unbuckle_mob()
@@ -321,6 +327,7 @@
 	icon_state = "shuttle_chair_preview"
 	material_alteration = MATERIAL_ALTERATION_NONE
 	foldable = FALSE
+	anchored = TRUE
 
 /obj/structure/bed/chair/shuttle/attackby(obj/item/weapon/W as obj, mob/user as mob)
 	if(istype(W,/obj/item/stack) || istype(W, /obj/item/weapon/wirecutters))
@@ -334,33 +341,33 @@
 	base_icon = "shuttle_chaired"
 	icon_state = "shuttle_chaired_preview"
 
-/obj/structure/bed/chair/shuttle/red/New(newloc,newmaterial)
+/obj/structure/bed/chair/shuttle/red/New(newloc, newmaterial)
 	..(newloc, MATERIAL_PLASTIC, MATERIAL_CARPET)
 
 // Colorful chairs
-/obj/structure/bed/chair/brown/New(newloc,newmaterial)
+/obj/structure/bed/chair/brown/New(newloc, newmaterial)
 	..(newloc, MATERIAL_STEEL, MATERIAL_LEATHER)
 
-/obj/structure/bed/chair/red/New(newloc,newmaterial)
+/obj/structure/bed/chair/red/New(newloc, newmaterial)
 	..(newloc, MATERIAL_STEEL, MATERIAL_CARPET)
 
-/obj/structure/bed/chair/teal/New(newloc,newmaterial)
+/obj/structure/bed/chair/teal/New(newloc, newmaterial)
 	..(newloc, MATERIAL_STEEL,"teal")
 
-/obj/structure/bed/chair/black/New(newloc,newmaterial)
+/obj/structure/bed/chair/black/New(newloc, newmaterial)
 	..(newloc, MATERIAL_STEEL,"black")
 
-/obj/structure/bed/chair/green/New(newloc,newmaterial)
+/obj/structure/bed/chair/green/New(newloc, newmaterial)
 	..(newloc, MATERIAL_STEEL,"green")
 
-/obj/structure/bed/chair/purp/New(newloc,newmaterial)
+/obj/structure/bed/chair/purp/New(newloc, newmaterial)
 	..(newloc, MATERIAL_STEEL,"purple")
 
-/obj/structure/bed/chair/blue/New(newloc,newmaterial)
+/obj/structure/bed/chair/blue/New(newloc, newmaterial)
 	..(newloc, MATERIAL_STEEL,"blue")
 
-/obj/structure/bed/chair/beige/New(newloc,newmaterial)
+/obj/structure/bed/chair/beige/New(newloc, newmaterial)
 	..(newloc, MATERIAL_STEEL,"beige")
 
-/obj/structure/bed/chair/lime/New(newloc,newmaterial)
+/obj/structure/bed/chair/lime/New(newloc, newmaterial)
 	..(newloc, MATERIAL_STEEL,"lime")

--- a/code/game/objects/structures/stool_bed_chair_nest/wheelchair.dm
+++ b/code/game/objects/structures/stool_bed_chair_nest/wheelchair.dm
@@ -6,6 +6,7 @@
 	buckle_movable = 1
 	movement_handlers = list(/datum/movement_handler/deny_multiz, /datum/movement_handler/delay = list(2), /datum/movement_handler/move_relay_self)
 	foldable = FALSE
+	pull_slowdown = PULL_SLOWDOWN_MEDIUM
 
 	var/driving = 0
 	var/mob/living/pulling = null

--- a/code/game/turfs/turf.dm
+++ b/code/game/turfs/turf.dm
@@ -86,6 +86,9 @@
 		M.start_pulling(t)
 	else
 		step(user.pulling, get_dir(user.pulling.loc, src))
+		if(isobj(user.pulling))
+			var/obj/O = user.pulling
+			user.setClickCooldown(DEFAULT_QUICK_COOLDOWN + O.pull_slowdown)
 	return 1
 
 /turf/attackby(obj/item/weapon/W as obj, mob/user as mob)

--- a/code/modules/mining/mine_items.dm
+++ b/code/modules/mining/mine_items.dm
@@ -277,6 +277,7 @@
 	density = 1
 	icon_opened = "miningcaropen"
 	icon_closed = "miningcar"
+	pull_slowdown = PULL_SLOWDOWN_LIGHT
 
 /**********************Pinpointer**********************/
 

--- a/code/modules/mining/satchel_ore_boxdm.dm
+++ b/code/modules/mining/satchel_ore_boxdm.dm
@@ -9,6 +9,7 @@
 	name = "ore box"
 	desc = "A heavy box used for storing ore."
 	density = 1
+	pull_slowdown = PULL_SLOWDOWN_HEAVY
 	var/last_update = 0
 	var/list/stored_ore = list()
 

--- a/code/modules/mob/living/living.dm
+++ b/code/modules/mob/living/living.dm
@@ -136,6 +136,7 @@
 		now_pushing = 0
 		spawn(0)
 			..()
+			var/saved_dir = AM.dir
 			if (!istype(AM, /atom/movable) || AM.anchored)
 				if(confused && prob(50) && m_intent == M_RUN && !lying)
 					var/obj/machinery/disposal/D = AM
@@ -172,6 +173,8 @@
 					for(var/obj/item/grab/G in M.grabbed_by)
 						step(G.assailant, get_dir(G.assailant, AM))
 						G.adjust_position()
+				if(saved_dir)
+					AM.set_dir(saved_dir)
 				now_pushing = 0
 
 /proc/swap_density_check(mob/swapper, mob/swapee)
@@ -186,7 +189,9 @@
 				return 1
 
 /mob/living/proc/can_swap_with(mob/living/tmob)
-	if(tmob.buckled || buckled)
+	if(!tmob)
+		return 0
+	if(tmob.buckled || buckled || tmob.anchored)
 		return 0
 	//BubbleWrap: people in handcuffs are always switched around as if they were on 'help' intent to prevent a person being pulled from being seperated from their puller
 	if(!(tmob.mob_always_swap || (tmob.a_intent == I_HELP || tmob.restrained()) && (a_intent == I_HELP || src.restrained())))
@@ -524,26 +529,40 @@
 	if(buckled)
 		return
 
-	if(restrained())
+	if(get_dist(src, pulling) > 1)
 		stop_pulling()
 
+	var/turf/old_loc = get_turf(src)
 
 	if(lying)
 		pull_sound = "pull_body"
 	else
 		pull_sound = null
 
+	. = ..()
+
+	if(. && pulling)
+		handle_pulling_after_move(old_loc)
+
+	if(s_active && !(s_active in contents) && get_turf(s_active) != get_turf(src))
+		s_active.close(src)
+
+	if(update_slimes)
+		for(var/mob/living/carbon/slime/M in view(1, src))
+			M.UpdateFeed()
+
+	/*
 	var/t7 = 1
 	if(restrained())
 		for(var/mob/living/M in range(src, 1))
-			if ((M.pulling == src && M.stat == 0 && !( M.restrained() )))
+			if(M.pulling == src && M.stat == 0 && !M.restrained())
 				t7 = null
-	if((t7 && (pulling && ((get_dist(src, pulling) <= 1 || pulling.loc == loc) && moving))))
+	if(t7 && (pulling && ((get_dist(src, pulling) <= 1 || pulling.loc == loc) && moving)))
 		var/turf/T = loc
 		. = ..()
 
 		if (pulling && pulling.loc)
-			if(!( isturf(pulling.loc) ))
+			if(!isturf(pulling.loc))
 				stop_pulling()
 				return
 
@@ -557,7 +576,7 @@
 			if((diag - 1) & diag)
 			else
 				diag = null
-			if((get_dist(src, pulling) > 1 || diag))
+			if(get_dist(src, pulling) > 1 || diag)
 				if(isliving(pulling))
 					var/mob/living/M = pulling
 					var/ok = 1
@@ -567,7 +586,6 @@
 							if(istype(G, /obj/item/grab))
 								for(var/mob/O in viewers(M, null))
 									O.show_message(text("<span class='warning'>[] has been pulled from []'s grip by []</span>", G.affecting, G.assailant, src), 1)
-								//G = null
 								qdel(G)
 						else
 							ok = 0
@@ -615,7 +633,7 @@
 						if(istype(pulling, /obj/structure/window))
 							var/obj/structure/window/W = pulling
 							if(W.is_full_window())
-								for(var/obj/structure/window/win in get_step(pulling,get_dir(pulling.loc, T)))
+								for(var/obj/structure/window/win in get_step(pulling, get_dir(pulling.loc, T)))
 									stop_pulling()
 					if(pulling)
 						step(pulling, get_dir(pulling.loc, T))
@@ -627,13 +645,105 @@
 	else
 		stop_pulling()
 		. = ..()
+	*/
 
-	if (s_active && !( s_active in contents ) && get_turf(s_active) != get_turf(src))	//check !( s_active in contents ) first so we hopefully don't have to call get_turf() so much.
-		s_active.close(src)
+/mob/living/proc/can_pull()
+	if(!moving)
+		return FALSE
+	if(pulling.anchored)
+		return FALSE
+	if(!isturf(pulling.loc))
+		return FALSE
+	if(restrained())
+		return FALSE
 
-	if(update_slimes)
-		for(var/mob/living/carbon/slime/M in view(1,src))
-			M.UpdateFeed()
+	if(get_dist(src, pulling) > 2)
+		return FALSE
+
+	if(pulling.z != z)
+		if(pulling.z < z)
+			return FALSE
+		var/turf/T = GetAbove(src)
+		if(!isopenspace(T))
+			return FALSE
+	return TRUE
+
+/mob/living/proc/handle_pulling_after_move(turf/old_loc)
+	if(!pulling)
+		return
+
+	if(!can_pull())
+		stop_pulling()
+		return
+
+	if(pulling.loc == loc || pulling.loc == old_loc)
+		return
+
+	if(!isliving(pulling))
+		step(pulling, get_dir(pulling.loc, old_loc))
+	else
+		var/mob/living/M = pulling
+		if(M.grabbed_by.len)
+			if(prob(75))
+				var/obj/item/grab/G = pick(M.grabbed_by)
+				if(istype(G))
+					M.visible_message(SPAN_WARNING("[G.affecting] has been pulled from [G.assailant]'s grip by [src]!"), SPAN_WARNING("[G.affecting] has been pulled from your grip by [src]!"))
+					qdel(G)
+		if(!M.grabbed_by.len)
+			M.handle_pull_damage(src)
+
+			var/atom/movable/t = M.pulling
+			M.stop_pulling()
+			step(M, get_dir(pulling.loc, old_loc))
+			if(t)
+				M.start_pulling(t)
+
+	handle_dir_after_pull()
+
+	if(m_intent == M_RUN && pulling.pull_sound && (world.time - last_pull_sound) > 1 SECOND)
+		last_pull_sound = world.time
+		playsound(pulling, pulling.pull_sound, rand(50, 75), TRUE)
+
+/mob/living/proc/handle_dir_after_pull()
+	if(!pulling)
+		return
+	if(isobj(pulling))
+		var/obj/O = pulling
+		// Hacky check to know if you can pass through the closet
+		if(istype(O, /obj/structure/closet) && !O.density)
+			return set_dir(get_dir(src, pulling))
+		if(O.pull_slowdown >= PULL_SLOWDOWN_MEDIUM)
+			return set_dir(get_dir(src, pulling))
+		else if(O.w_class >= ITEM_SIZE_HUGE)
+			return set_dir(get_dir(src, pulling))
+	if(isliving(pulling))
+		var/mob/living/L = pulling
+		// If pulled mob was bigger than us, we morelike will turn
+		// I made additional check in case if someone want a hand walk
+		if(L.mob_size > mob_size || L.lying)
+			return set_dir(get_dir(src, pulling))
+
+/mob/living/proc/handle_pull_damage(mob/living/puller)
+	var/area/A = get_area(src)
+	if(!A.has_gravity)
+		return
+	var/turf/location = get_turf(src)
+	if(lying && prob(getBruteLoss() / 6))
+		location.add_blood(src)
+		if(prob(25))
+			adjustBruteLoss(1)
+			visible_message(SPAN("danger", "\The [src]'s [src.isSynthetic() ? "state worsens": "wounds open more"] from being dragged!"))
+			. = TRUE
+	if(pull_damage())
+		if(prob(25))
+			adjustBruteLoss(2)
+			visible_message(SPAN("danger", "\The [src]'s [src.isSynthetic() ? "state worsens" : "wounds worsen"] terribly from being dragged!"))
+			location.add_blood(src)
+			if(ishuman(src))
+				var/mob/living/carbon/human/H = src
+				if(round(H.vessel.get_reagent_amount(/datum/reagent/blood)) > 0)
+					H.vessel.remove_reagent(/datum/reagent/blood, 1)
+			. = TRUE
 
 /mob/living/verb/resist()
 	set name = "Resist"

--- a/code/modules/mob/living/living.dm
+++ b/code/modules/mob/living/living.dm
@@ -551,102 +551,6 @@
 		for(var/mob/living/carbon/slime/M in view(1, src))
 			M.UpdateFeed()
 
-	/*
-	var/t7 = 1
-	if(restrained())
-		for(var/mob/living/M in range(src, 1))
-			if(M.pulling == src && M.stat == 0 && !M.restrained())
-				t7 = null
-	if(t7 && (pulling && ((get_dist(src, pulling) <= 1 || pulling.loc == loc) && moving)))
-		var/turf/T = loc
-		. = ..()
-
-		if (pulling && pulling.loc)
-			if(!isturf(pulling.loc))
-				stop_pulling()
-				return
-
-		/////
-		if(pulling && pulling.anchored)
-			stop_pulling()
-			return
-
-		if(!restrained())
-			var/diag = get_dir(src, pulling)
-			if((diag - 1) & diag)
-			else
-				diag = null
-			if(get_dist(src, pulling) > 1 || diag)
-				if(isliving(pulling))
-					var/mob/living/M = pulling
-					var/ok = 1
-					if(locate(/obj/item/grab, M.grabbed_by))
-						if(prob(75))
-							var/obj/item/grab/G = pick(M.grabbed_by)
-							if(istype(G, /obj/item/grab))
-								for(var/mob/O in viewers(M, null))
-									O.show_message(text("<span class='warning'>[] has been pulled from []'s grip by []</span>", G.affecting, G.assailant, src), 1)
-								qdel(G)
-						else
-							ok = 0
-						if(locate(/obj/item/grab, M.grabbed_by.len))
-							ok = 0
-					if(ok)
-						var/atom/movable/t = M.pulling
-						M.stop_pulling()
-
-						if(!istype(M.loc, /turf/space))
-							var/area/A = get_area(M)
-							if(A.has_gravity)
-								//this is the gay blood on floor shit -- Added back -- Skie
-								if(M.lying && (prob(M.getBruteLoss() / 6)))
-									var/turf/location = M.loc
-									if(istype(location, /turf/simulated))
-										location.add_blood(M)
-								//pull damage with injured people
-									if(prob(25))
-										M.adjustBruteLoss(1)
-										visible_message("<span class='danger'>\The [M]'s [M.isSynthetic() ? "state worsens": "wounds open more"] from being dragged!</span>")
-								if(M.pull_damage())
-									if(prob(25))
-										M.adjustBruteLoss(2)
-										visible_message("<span class='danger'>\The [M]'s [M.isSynthetic() ? "state" : "wounds"] worsen terribly from being dragged!</span>")
-										var/turf/location = M.loc
-										if(istype(location, /turf/simulated))
-											location.add_blood(M)
-											if(ishuman(M))
-												var/mob/living/carbon/human/H = M
-												var/blood_volume = round(H.vessel.get_reagent_amount(/datum/reagent/blood))
-												if(blood_volume > 0)
-													H.vessel.remove_reagent(/datum/reagent/blood, 1)
-
-
-						if(m_intent == M_RUN && pulling && pulling.pull_sound && (world.time - last_pull_sound) > 1 SECOND)
-							last_pull_sound = world.time
-							playsound(pulling, pulling.pull_sound, rand(50, 75), TRUE)
-
-						step(pulling, get_dir(pulling.loc, T))
-						if(t)
-							M.start_pulling(t)
-				else
-					if(pulling)
-						if(istype(pulling, /obj/structure/window))
-							var/obj/structure/window/W = pulling
-							if(W.is_full_window())
-								for(var/obj/structure/window/win in get_step(pulling, get_dir(pulling.loc, T)))
-									stop_pulling()
-					if(pulling)
-						step(pulling, get_dir(pulling.loc, T))
-
-						if(m_intent == M_RUN && pulling && pulling.pull_sound && (world.time - last_pull_sound) > 1 SECOND)
-							last_pull_sound = world.time
-							playsound(pulling, pulling.pull_sound, rand(50, 75), TRUE)
-
-	else
-		stop_pulling()
-		. = ..()
-	*/
-
 /mob/living/proc/can_pull()
 	if(!moving)
 		return FALSE
@@ -714,7 +618,7 @@
 			return set_dir(get_dir(src, pulling))
 		if(O.pull_slowdown >= PULL_SLOWDOWN_MEDIUM)
 			return set_dir(get_dir(src, pulling))
-		else if(O.w_class >= ITEM_SIZE_HUGE)
+		else if(O.pull_slowdown == PULL_SLOWDOWN_WEIGHT && O.w_class >= ITEM_SIZE_HUGE)
 			return set_dir(get_dir(src, pulling))
 	if(isliving(pulling))
 		var/mob/living/L = pulling

--- a/code/modules/mob/mob.dm
+++ b/code/modules/mob/mob.dm
@@ -169,7 +169,7 @@
 				. += O.pull_slowdown
 		else if(istype(pulling, /mob))
 			var/mob/M = pulling
-			. += max(0, M.mob_size) / MOB_MEDIUM
+			. += max(0, M.mob_size) / MOB_MEDIUM * (M.lying ? 2 : 0.5)
 		else
 			. += 1
 

--- a/code/modules/mob/mob.dm
+++ b/code/modules/mob/mob.dm
@@ -163,7 +163,10 @@
 	if(pulling)
 		if(istype(pulling, /obj))
 			var/obj/O = pulling
-			. += between(0, O.w_class, ITEM_SIZE_GARGANTUAN) / 5
+			if(O.pull_slowdown == PULL_SLOWDOWN_WEIGHT)
+				. += between(0, O.w_class, ITEM_SIZE_GARGANTUAN) / 5
+			else
+				. += O.pull_slowdown
 		else if(istype(pulling, /mob))
 			var/mob/M = pulling
 			. += max(0, M.mob_size) / MOB_MEDIUM

--- a/code/modules/mob/mob.dm
+++ b/code/modules/mob/mob.dm
@@ -161,17 +161,19 @@
 		. += 10 + (weakened * 2)
 
 	if(pulling)
-		if(istype(pulling, /obj))
-			var/obj/O = pulling
-			if(O.pull_slowdown == PULL_SLOWDOWN_WEIGHT)
-				. += between(0, O.w_class, ITEM_SIZE_GARGANTUAN) / 5
+		var/area/A = get_area(src)
+		if(A.has_gravity)
+			if(istype(pulling, /obj))
+				var/obj/O = pulling
+				if(O.pull_slowdown == PULL_SLOWDOWN_WEIGHT)
+					. += between(0, O.w_class, ITEM_SIZE_GARGANTUAN) / 5
+				else
+					. += O.pull_slowdown
+			else if(istype(pulling, /mob))
+				var/mob/M = pulling
+				. += max(0, M.mob_size) / MOB_MEDIUM * (M.lying ? 2 : 0.5)
 			else
-				. += O.pull_slowdown
-		else if(istype(pulling, /mob))
-			var/mob/M = pulling
-			. += max(0, M.mob_size) / MOB_MEDIUM * (M.lying ? 2 : 0.5)
-		else
-			. += 1
+				. += 1
 
 /mob/proc/Life()
 //	if(organStructure)

--- a/code/modules/reagents/reagent_dispenser.dm
+++ b/code/modules/reagents/reagent_dispenser.dm
@@ -7,6 +7,7 @@
 	density = 1
 	anchored = 0
 	pull_sound = "pull_machine"
+	pull_slowdown = PULL_SLOWDOWN_LIGHT
 
 	var/initial_capacity = 1000
 	var/initial_reagent_types  // A list of reagents and their ratio relative the initial capacity. list(/datum/reagent/water = 0.5) would fill the dispenser halfway to capacity.
@@ -263,6 +264,7 @@
 	amount_per_transfer_from_this = 10
 	initial_reagent_types = list(/datum/reagent/ethanol/beer = 1)
 	atom_flags = ATOM_FLAG_CLIMBABLE
+	pull_slowdown = PULL_SLOWDOWN_MEDIUM
 
 /obj/structure/reagent_dispensers/virusfood
 	name = "Virus Food Dispenser"

--- a/code/modules/synthesized_instruments/real_instruments/Piano/piano.dm
+++ b/code/modules/synthesized_instruments/real_instruments/Piano/piano.dm
@@ -3,4 +3,5 @@
 	desc = "A surprisingly high-tech piano with a digital display for modifying sound output"
 	icon_state = "piano"
 	path = /datum/instrument/piano
+	pull_slowdown = PULL_SLOWDOWN_HEAVY
 


### PR DESCRIPTION
_Тоби зарабастили замедлением от пулла каталки, инфа сото4ка._

- Переработано замедление от пулла:
- Пулл не замедляет в невесомости;
- Замедление от предметов остаётся прежним - оно зависит от w_class предмета;
- Замедление от структур переработано. Раньше оно было одинаковым у всех. Теперь - зависит от конкретной структуры. У большинства предметов замедление стало чуть больше, чем было раньше. Огромные объекты вроде ящиков для руды замедляют ещё сильнее. Структуры с колёсами (вроде кроватей на колёсиках и тележки уборщика) - меньше. Медицинская каталка - даёт крайне маленькое замедление, что делает её по-настоящему полезной. Улучшенная каталка из РнД - вовсе не замедляет.
- Немного изменено замедление от пулла мобов - в стоячем положении они замедляют вдвое меньше, чем раньше, в лежачем - вдвое сильнее.
- Портирован рефактор пулла с бея - у нас сейчас хтонический ужас с лесенками из восьми табов и переменными вроде "ok" и "t7". 
- Портирован (и модифицирован) поворот при пулле с бея. Если пуллить bulky-предметы, тяжёлые структуры или лежачих мобов - космонавтик будет идти спиной вперёд.
![reversepull](https://user-images.githubusercontent.com/45202681/113641963-84178600-96a0-11eb-9952-1b3ff430fe22.gif)
- Возвращена возможность пуллить обычные стулья. С очень сильным замедлением, конечно же.
 

- [x] Pull Request полностью завершен, мне не нужна помощь чтобы его закончить.
- [x] Я внимательно прочитал все свои изменения и багов в них не нашел.
- [x] Я запускал сервер со своими изменениями локально и все протестировал.
- [x] Я ознакомился c [Guide to Contribute](https://github.com/ChaoticOnyx/OnyxBay/blob/dev/docs/contributing.md).
