### PR TITLE
Точный point-to

### DIFF
--- a/code/modules/mob/mob.dm
+++ b/code/modules/mob/mob.dm
@@ -282,10 +282,9 @@
 
 	var/obj/P = new /obj/effect/decal/point(tile)
 	P.set_invisibility(invisibility)
-	spawn (20)
-		if(P)
-			qdel(P)	// qdel
-
+	P.pixel_x = A.pixel_x
+	P.pixel_y = A.pixel_y
+	QDEL_IN(P, 2 SECONDS)
 	face_atom(A)
 	return 1
 


### PR DESCRIPTION
Теперь `point-to` копирует `pixel_x` и `pixel_y` у атома, на который был указан.
"Зачем" показано на картинках ниже. 

![image](https://user-images.githubusercontent.com/59123747/113783765-ef169a80-973c-11eb-9c14-490dc2db9e02.png)
![image](https://user-images.githubusercontent.com/59123747/113783773-f178f480-973c-11eb-8e23-4a7935b2eaab.png)


- [x] Pull Request полностью завершен, мне не нужна помощь чтобы его закончить.
- [x] Я внимательно прочитал все свои изменения и багов в них не нашел.
- [x] Я запускал сервер со своими изменениями локально и все протестировал.
- [x] Я ознакомился c [Guide to Contribute](https://github.com/ChaoticOnyx/OnyxBay/blob/dev/docs/contributing.md).
