### PR TITLE
Removes meaninglessness from death alarms

### DIFF
--- a/code/game/objects/items/weapons/implants/implants/death_alarm.dm
+++ b/code/game/objects/items/weapons/implants/implants/death_alarm.dm
@@ -38,9 +38,9 @@
 	if(!t.requires_power) // We assume areas that don't use power are some sort of special zones
 		var/area/default = world.area
 		location = initial(default.name)
-	var/death_message = "Message from [name] acquired successful. [mobname] has died in [location]!"
+	var/death_message = "A message from [name] has been received. [mobname] has died in [location]!"
 	if(!cause)
-		death_message = "Message from [name] acquired successful. [mobname] has died-zzzzt in-in-in..."
+		death_message = "A message from [name] has been received. [mobname] has died-zzzzt in-in-in..."
 	STOP_PROCESSING(SSobj, src)
 
 	for(var/channel in list("Security", "Medical", "Command"))


### PR DESCRIPTION
- Исправлено сообщение при срабатывании Death Alarm implant'а;

🆑
SpellCheck: Исправлено сообщение при срабатывании Death Alarm implant'а.
/🆑

- [x] Pull Request полностью завершен, мне не нужна помощь чтобы его закончить.
- [x] Я внимательно прочитал все свои изменения и багов в них не нашел.
- [x] Я запускал сервер со своими изменениями локально и все протестировал.
- [x] Я ознакомился c [Guide to Contribute](https://github.com/ChaoticOnyx/OnyxBay/blob/dev/docs/contributing.md).
