### PR TITLE
Фикс режимов освещения

### DIFF
--- a/code/__defines/lighting.dm
+++ b/code/__defines/lighting.dm
@@ -24,3 +24,8 @@
 		LIGHTING_SOFT_THRESHOLD, LIGHTING_SOFT_THRESHOLD, LIGHTING_SOFT_THRESHOLD, 0, \
 		0, 0, 0, 1           \
 	)
+
+#define LIGHTMODE_EMERGENCY "emergency_lighting"
+#define LIGHTMODE_EVACUATION "evacuation_lighting"
+#define LIGHTMODE_ALARM "alarm"
+#define LIGHTMODE_READY "ready"

--- a/code/controllers/evacuation/evacuation.dm
+++ b/code/controllers/evacuation/evacuation.dm
@@ -89,7 +89,7 @@ var/datum/evacuation_controller/evacuation_controller
 	state = EVAC_PREPPING
 
 	if(emergency_evacuation)
-		toggle_emergency_light()
+		toggle_emergency_light(TRUE)
 		if(!skip_announce)
 			GLOB.using_map.emergency_shuttle_called_announcement()
 	else
@@ -116,7 +116,7 @@ var/datum/evacuation_controller/evacuation_controller
 	if(emergency_evacuation)
 		evac_recalled.Announce(GLOB.using_map.emergency_shuttle_recall_message)
 		emergency_evacuation = 0
-		toggle_emergency_light()
+		toggle_emergency_light(FALSE)
 	else
 		priority_announcement.Announce(GLOB.using_map.shuttle_recall_message)
 
@@ -183,6 +183,6 @@ var/datum/evacuation_controller/evacuation_controller
 /datum/evacuation_controller/proc/should_call_autotransfer_vote()
 	return (state == EVAC_IDLE)
 
-/datum/evacuation_controller/proc/toggle_emergency_light()
+/datum/evacuation_controller/proc/toggle_emergency_light(state)
 	for(var/area/A in GLOB.hallway)
-		A.set_evacuation_lighting(emergency_evacuation)
+		A.set_lighting_mode(LIGHTMODE_EVACUATION, state)

--- a/code/game/area/Space Station 13 areas.dm
+++ b/code/game/area/Space Station 13 areas.dm
@@ -28,7 +28,8 @@ NOTE: there are two lists of areas in the end of this file: centcom and station 
 	luminosity = 0
 	mouse_opacity = 0
 	var/lightswitch = 1
-
+	var/lighting_mode = ""
+	var/list/enabled_lighting_modes = list()
 	var/eject = null
 
 	var/debug = 0

--- a/code/modules/power/apc.dm
+++ b/code/modules/power/apc.dm
@@ -836,7 +836,7 @@
 		var/new_power_light = (lighting >= POWERCHAN_ON)
 		if(area.power_light != new_power_light)
 			area.power_light = new_power_light
-			area.set_emergency_lighting(lighting == POWERCHAN_OFF_AUTO) //if lights go auto-off, emergency lights go on
+			area.set_lighting_mode(LIGHTMODE_EMERGENCY, lighting == POWERCHAN_OFF_AUTO) //if lights go auto-off, emergency lights go on
 
 		area.power_equip = (equipment >= POWERCHAN_ON)
 		area.power_environ = (environ >= POWERCHAN_ON)

--- a/code/modules/power/lighting.dm
+++ b/code/modules/power/lighting.dm
@@ -12,11 +12,6 @@
 #define LIGHT_BULB_TEMPERATURE 400 //K - used value for a 60W bulb
 #define LIGHTING_POWER_FACTOR 5		//5W per luminosity * range
 
-#define LIGHTMODE_EMERGENCY "emergency_lighting"
-#define LIGHTMODE_EVACUATION "evacuation_lighting"
-#define LIGHTMODE_ALARM "alarm"
-#define LIGHTMODE_READY "ready"
-
 /obj/machinery/light_construct
 	name = "light fixture frame"
 	desc = "A light fixture under construction."
@@ -302,35 +297,16 @@
 	return 1
 
 /obj/machinery/light/proc/set_mode(new_mode)
-	if(current_mode != new_mode)
+	if(current_mode == new_mode || !lightbulb)
+		return
+
+	if(new_mode in lightbulb.lighting_modes)
 		current_mode = new_mode
-		update_icon(0)
 
-/obj/machinery/light/proc/set_emergency_lighting(state as num)
-	if(state)
-		if(LIGHTMODE_EMERGENCY in lightbulb.lighting_modes)
-			set_mode(LIGHTMODE_EMERGENCY)
-			update_power_channel(ENVIRON)
-	else
-		if(current_mode == LIGHTMODE_EMERGENCY)
-			set_mode(null)
-			update_power_channel(initial(power_channel))
+	else if(new_mode == null)
+		current_mode = null
 
-/obj/machinery/light/proc/set_evacuation_lighting(state)
-	if(state)
-		if(LIGHTMODE_EVACUATION in lightbulb.lighting_modes)
-			set_mode(LIGHTMODE_EVACUATION)
-	else
-		if(current_mode == LIGHTMODE_EVACUATION)
-			set_mode(null)
-
-/obj/machinery/light/proc/set_alert_lighting(state as num)
-	if(state)
-		if(LIGHTMODE_ALARM in lightbulb.lighting_modes)
-			set_mode(LIGHTMODE_ALARM)
-	else
-		if(current_mode == LIGHTMODE_ALARM)
-			set_mode(null)
+	update_icon(0)
 
 // attempt to set the light's on/off status
 // will not switch on if broken/burned/empty
@@ -361,6 +337,11 @@
 /obj/machinery/light/proc/insert_bulb(obj/item/weapon/light/L)
 	L.forceMove(src)
 	lightbulb = L
+
+	var/area/A = get_area(src)
+	if(A && (A.lighting_mode in lightbulb.lighting_modes))
+		current_mode = A.lighting_mode
+
 	on = powered()
 	update_icon()
 
@@ -369,6 +350,7 @@
 	lightbulb.dropInto(loc)
 	lightbulb.update_icon()
 	lightbulb = null
+	current_mode = null
 	update_icon()
 
 /obj/machinery/light/attackby(obj/item/W, mob/user)
@@ -633,8 +615,8 @@
 	brightness_color = "#fffee0"
 	lighting_modes = list(
 		LIGHTMODE_EMERGENCY = list(l_range = 4, l_power = 1, l_color = "#da0205"),
-		LIGHTMODE_EVACUATION = list(l_color = "#bf0000"),
-		LIGHTMODE_ALARM = list(l_color = "#ff3333")
+		LIGHTMODE_EVACUATION = list(l_range = 7, l_power = 6, l_color = "#bf0000"),
+		LIGHTMODE_ALARM = list(l_range = 7, l_power = 6, l_color = "#ff3333")
 		)
 	sound_on = 'sound/machines/lightson.ogg'
 	random_tone = TRUE
@@ -678,8 +660,8 @@
 	brightness_color = "#a0a080"
 	lighting_modes = list(
 		LIGHTMODE_EMERGENCY = list(l_range = 3, l_power = 1, l_color = "#da0205"),
-		LIGHTMODE_EVACUATION = list(l_color = "#bf0000"),
-		LIGHTMODE_ALARM = list(l_color = "#ff3333")
+		LIGHTMODE_EVACUATION = list(l_range = 4, l_power = 4, l_color = "#bf0000"),
+		LIGHTMODE_ALARM = list(l_range = 4, l_power = 4, l_color = "#ff3333")
 		)
 	random_tone = TRUE
 


### PR DESCRIPTION
- Пофиксил ломающийся свет у лампочек в то время, когда у них выставлен особый режим освещения, вроде эвакуационного.
- Также теперь сохраняются режимы освещения при выставлении другого, так что быстрое включение/выключение пожарной сигнализации не уберёт эвакуационный режим освещения. <!-- Страдайте, сука. -->
- Также моргание лампочек при особом режиме перестает ломать их вовсе. Могло быть вызвано культо-магией или же синтетиками. 

fix #1807
Возможно были ещё репорты, но я не нашёл.

- [x] Pull Request полностью завершен, мне не нужна помощь чтобы его закончить.
- [x] Я внимательно прочитал все свои изменения и багов в них не нашел.
- [x] Я запускал сервер со своими изменениями локально и все протестировал.
- [x] Я ознакомился c [Guide to Contribute](https://github.com/ChaoticOnyx/OnyxBay/blob/dev/docs/contributing.md).
