### PR TITLE
Removes absence of pay-2-win zippos in loadout

### DIFF
--- a/baystation12.dme
+++ b/baystation12.dme
@@ -1349,6 +1349,7 @@
 #include "code\modules\client\preference_setup\loadout\lists\footwear.dm"
 #include "code\modules\client\preference_setup\loadout\lists\gloves.dm"
 #include "code\modules\client\preference_setup\loadout\lists\headwear.dm"
+#include "code\modules\client\preference_setup\loadout\lists\lighters.dm"
 #include "code\modules\client\preference_setup\loadout\lists\masks.dm"
 #include "code\modules\client\preference_setup\loadout\lists\misc.dm"
 #include "code\modules\client\preference_setup\loadout\lists\security.dm"

--- a/code/game/objects/items/weapons/lighters.dm
+++ b/code/game/objects/items/weapons/lighters.dm
@@ -320,7 +320,7 @@ CIGARETTES AND STUFF ARE IN 'SMOKABLES' FOLDER
 
 /obj/item/weapon/flame/lighter/zippo/eng
 	name = "\improper Engineering lighter"
-	desc = "Its owner must be trusted. Should be trusted. May be trusted. Probably. In fact, shouldn't."
+	desc = "Its owner must be trusted. Should be trusted. May be trusted. Probably. In fact, shouldn't be."
 	icon_state = "zippo-eng"
 
 /obj/item/weapon/flame/lighter/zippo/med

--- a/code/modules/client/preference_setup/loadout/lists/lighters.dm
+++ b/code/modules/client/preference_setup/loadout/lists/lighters.dm
@@ -20,111 +20,111 @@
 //
 
 /datum/gear/lighters/us
-	display_name = "\improper Democratic lighter"
+	display_name = "Democratic lighter"
 	path = /obj/item/weapon/flame/lighter/zippo/us
 	price = 7
 
 /datum/gear/lighters/third
-	display_name = "\improper Unethical lighter"
+	display_name = "Unethical lighter"
 	path = /obj/item/weapon/flame/lighter/zippo/third
 	price = 7
 
 /datum/gear/lighters/sov
-	display_name = "\improper Commie lighter"
+	display_name = "Commie lighter"
 	path = /obj/item/weapon/flame/lighter/zippo/sov
 	price = 7
 
 /datum/gear/lighters/nt
-	display_name = "\improper NanoTrasen lighter"
+	display_name = "NanoTrasen lighter"
 	path = /obj/item/weapon/flame/lighter/zippo/nt
 	price = 5
 
 /datum/gear/lighters/red
-	display_name = "red Zippo lighter"
+	display_name = "Red Zippo lighter"
 	path = /obj/item/weapon/flame/lighter/zippo/red
 	price = 5
 
 /datum/gear/lighters/black
-	display_name = "black Zippo lighter"
+	display_name = "Black Zippo lighter"
 	path = /obj/item/weapon/flame/lighter/zippo/black
 	price = 5
 
 /datum/gear/lighters/grav
-	display_name = "engraved Zippo lighter"
+	display_name = "Engraved Zippo lighter"
 	path = /obj/item/weapon/flame/lighter/zippo/grav
 	price = 5
 
 /datum/gear/lighters/rainbow
-	display_name = "rainbow Zippo lighter"
+	display_name = "Rainbow Zippo lighter"
 	path = /obj/item/weapon/flame/lighter/zippo/rainbow
 	price = 5
 
 /datum/gear/lighters/pt
-	display_name = "\improper T&P lighter"
+	display_name = "T&P lighter"
 	path = /obj/item/weapon/flame/lighter/zippo/pt
 	price = 7
 
 /datum/gear/lighters/onyx
-	display_name = "\improper Chaotic lighter"
+	display_name = "Chaotic lighter"
 	path = /obj/item/weapon/flame/lighter/zippo/onyx
 	price = 10
 
 /datum/gear/lighters/ablack
-	display_name = "\improper Tyranny lighter"
+	display_name = "Tyranny lighter"
 	path = /obj/item/weapon/flame/lighter/zippo/ablack
 	price = 7
 
 /datum/gear/lighters/agreen
-	display_name = "\improper Apple lighter"
+	display_name = "Apple lighter"
 	path = /obj/item/weapon/flame/lighter/zippo/agreen
 	price = 7
 
 /datum/gear/lighters/awhite
-	display_name = "\improper Extinguisher lighter"
+	display_name = "Extinguisher lighter"
 	path = /obj/item/weapon/flame/lighter/zippo/awhite
 	price = 7
 
 /datum/gear/lighters/diona
-	display_name = "\improper Diona lighter"
+	display_name = "Diona lighter"
 	path = /obj/item/weapon/flame/lighter/zippo/diona
 	price = 5
 
 /datum/gear/lighters/rasta
-	display_name = "improper Rasta lighter"
+	display_name = "Rasta lighter"
 	path = /obj/item/weapon/flame/lighter/zippo/rasta
 	price = 5
 
 /datum/gear/lighters/chrome
-	display_name = "chrome Zippo lighter"
+	display_name = "Chrome Zippo lighter"
 	path = /obj/item/weapon/flame/lighter/zippo/chrome
 	price = 5
 
 /datum/gear/lighters/nuke
-	display_name = "\improper nuclear authentication lighter"
+	display_name = "Nuclear Authentication Lighter"
 	path = /obj/item/weapon/flame/lighter/zippo/nuke
 	price = 7
 
 /datum/gear/lighters/eng
-	display_name = "\improper Engineering lighter"
+	display_name = "Engineering lighter"
 	path = /obj/item/weapon/flame/lighter/zippo/eng
 	price = 5
 
 /datum/gear/lighters/med
-	display_name = "\improper Medical lighter"
+	display_name = "Medical lighter"
 	path = /obj/item/weapon/flame/lighter/zippo/med
 	price = 5
 
 /datum/gear/lighters/sci
-	display_name = "\improper Science lighter"
+	display_name = "Science lighter"
 	path = /obj/item/weapon/flame/lighter/zippo/sci
 	price = 5
 
 /datum/gear/lighters/clown
-	display_name = "\improper Clown lighter"
+	display_name = "Clown lighter"
 	path = /obj/item/weapon/flame/lighter/zippo/clown
 	price = 7
 
 /datum/gear/lighters/pig
-	display_name = "\improper Piggie lighter"
+	display_name = "Piggie lighter"
 	path = /obj/item/weapon/flame/lighter/zippo/pig
 	price = 15

--- a/code/modules/client/preference_setup/loadout/lists/lighters.dm
+++ b/code/modules/client/preference_setup/loadout/lists/lighters.dm
@@ -1,0 +1,130 @@
+/datum/gear/lighters
+	cost = 2
+	sort_category = "Lighters"
+
+/datum/gear/lighters/matchbook
+	display_name = "matchbook"
+	path = /obj/item/weapon/storage/box/matches
+
+/datum/gear/lighters/lighter
+	display_name = "cheap lighter"
+	path = /obj/item/weapon/flame/lighter
+
+/datum/gear/lighters/zippo
+	display_name = "zippo"
+	path = /obj/item/weapon/flame/lighter/zippo
+	cost = 2
+
+//
+// Doner's shop
+//
+
+/datum/gear/lighters/us
+	display_name = "\improper Democratic lighter"
+	path = /obj/item/weapon/flame/lighter/zippo/us
+	price = 7
+
+/datum/gear/lighters/third
+	display_name = "\improper Unethical lighter"
+	path = /obj/item/weapon/flame/lighter/zippo/third
+	price = 7
+
+/datum/gear/lighters/sov
+	display_name = "\improper Commie lighter"
+	path = /obj/item/weapon/flame/lighter/zippo/sov
+	price = 7
+
+/datum/gear/lighters/nt
+	display_name = "\improper NanoTrasen lighter"
+	path = /obj/item/weapon/flame/lighter/zippo/nt
+	price = 5
+
+/datum/gear/lighters/red
+	display_name = "red Zippo lighter"
+	path = /obj/item/weapon/flame/lighter/zippo/red
+	price = 5
+
+/datum/gear/lighters/black
+	display_name = "black Zippo lighter"
+	path = /obj/item/weapon/flame/lighter/zippo/black
+	price = 5
+
+/datum/gear/lighters/grav
+	display_name = "engraved Zippo lighter"
+	path = /obj/item/weapon/flame/lighter/zippo/grav
+	price = 5
+
+/datum/gear/lighters/rainbow
+	display_name = "rainbow Zippo lighter"
+	path = /obj/item/weapon/flame/lighter/zippo/rainbow
+	price = 5
+
+/datum/gear/lighters/pt
+	display_name = "\improper T&P lighter"
+	path = /obj/item/weapon/flame/lighter/zippo/pt
+	price = 7
+
+/datum/gear/lighters/onyx
+	display_name = "\improper Chaotic lighter"
+	path = /obj/item/weapon/flame/lighter/zippo/onyx
+	price = 10
+
+/datum/gear/lighters/ablack
+	display_name = "\improper Tyranny lighter"
+	path = /obj/item/weapon/flame/lighter/zippo/ablack
+	price = 7
+
+/datum/gear/lighters/agreen
+	display_name = "\improper Apple lighter"
+	path = /obj/item/weapon/flame/lighter/zippo/agreen
+	price = 7
+
+/datum/gear/lighters/awhite
+	display_name = "\improper Extinguisher lighter"
+	path = /obj/item/weapon/flame/lighter/zippo/awhite
+	price = 7
+
+/datum/gear/lighters/diona
+	display_name = "\improper Diona lighter"
+	path = /obj/item/weapon/flame/lighter/zippo/diona
+	price = 5
+
+/datum/gear/lighters/rasta
+	display_name = "improper Rasta lighter"
+	path = /obj/item/weapon/flame/lighter/zippo/rasta
+	price = 5
+
+/datum/gear/lighters/chrome
+	display_name = "chrome Zippo lighter"
+	path = /obj/item/weapon/flame/lighter/zippo/chrome
+	price = 5
+
+/datum/gear/lighters/nuke
+	display_name = "\improper nuclear authentication lighter"
+	path = /obj/item/weapon/flame/lighter/zippo/nuke
+	price = 7
+
+/datum/gear/lighters/eng
+	display_name = "\improper Engineering lighter"
+	path = /obj/item/weapon/flame/lighter/zippo/eng
+	price = 5
+
+/datum/gear/lighters/med
+	display_name = "\improper Medical lighter"
+	path = /obj/item/weapon/flame/lighter/zippo/med
+	price = 5
+
+/datum/gear/lighters/sci
+	display_name = "\improper Science lighter"
+	path = /obj/item/weapon/flame/lighter/zippo/sci
+	price = 5
+
+/datum/gear/lighters/clown
+	display_name = "\improper Clown lighter"
+	path = /obj/item/weapon/flame/lighter/zippo/clown
+	price = 7
+
+/datum/gear/lighters/pig
+	display_name = "\improper Piggie lighter"
+	path = /obj/item/weapon/flame/lighter/zippo/pig
+	price = 15

--- a/code/modules/client/preference_setup/loadout/lists/lighters.dm
+++ b/code/modules/client/preference_setup/loadout/lists/lighters.dm
@@ -18,112 +18,112 @@
 // Doner's shop
 //
 
-/datum/gear/lighters/us
+/datum/gear/lighters/zippo/us
 	display_name = "Democratic lighter"
 	path = /obj/item/weapon/flame/lighter/zippo/us
 	price = 7
 
-/datum/gear/lighters/third
+/datum/gear/lighters/zippo/third
 	display_name = "Unethical lighter"
 	path = /obj/item/weapon/flame/lighter/zippo/third
 	price = 7
 
-/datum/gear/lighters/sov
+/datum/gear/lighters/zippo/sov
 	display_name = "Commie lighter"
 	path = /obj/item/weapon/flame/lighter/zippo/sov
 	price = 7
 
-/datum/gear/lighters/nt
+/datum/gear/lighters/zippo/nt
 	display_name = "NanoTrasen lighter"
 	path = /obj/item/weapon/flame/lighter/zippo/nt
 	price = 5
 
-/datum/gear/lighters/red
+/datum/gear/lighters/zippo/red
 	display_name = "Red Zippo lighter"
 	path = /obj/item/weapon/flame/lighter/zippo/red
 	price = 5
 
-/datum/gear/lighters/black
+/datum/gear/lighters/zippo/black
 	display_name = "Black Zippo lighter"
 	path = /obj/item/weapon/flame/lighter/zippo/black
 	price = 5
 
-/datum/gear/lighters/grav
+/datum/gear/lighters/zippo/grav
 	display_name = "Engraved Zippo lighter"
 	path = /obj/item/weapon/flame/lighter/zippo/grav
 	price = 5
 
-/datum/gear/lighters/rainbow
+/datum/gear/lighters/zippo/rainbow
 	display_name = "Rainbow Zippo lighter"
 	path = /obj/item/weapon/flame/lighter/zippo/rainbow
 	price = 5
 
-/datum/gear/lighters/pt
+/datum/gear/lighters/zippo/pt
 	display_name = "T&P lighter"
 	path = /obj/item/weapon/flame/lighter/zippo/pt
 	price = 7
 
-/datum/gear/lighters/onyx
+/datum/gear/lighters/zippo/onyx
 	display_name = "Chaotic lighter"
 	path = /obj/item/weapon/flame/lighter/zippo/onyx
 	price = 10
 
-/datum/gear/lighters/ablack
+/datum/gear/lighters/zippo/ablack
 	display_name = "Tyranny lighter"
 	path = /obj/item/weapon/flame/lighter/zippo/ablack
 	price = 7
 
-/datum/gear/lighters/agreen
+/datum/gear/lighters/zippo/agreen
 	display_name = "Apple lighter"
 	path = /obj/item/weapon/flame/lighter/zippo/agreen
 	price = 7
 
-/datum/gear/lighters/awhite
+/datum/gear/lighters/zippo/awhite
 	display_name = "Extinguisher lighter"
 	path = /obj/item/weapon/flame/lighter/zippo/awhite
 	price = 7
 
-/datum/gear/lighters/diona
+/datum/gear/lighters/zippo/diona
 	display_name = "Diona lighter"
 	path = /obj/item/weapon/flame/lighter/zippo/diona
 	price = 5
 
-/datum/gear/lighters/rasta
+/datum/gear/lighters/zippo/rasta
 	display_name = "Rasta lighter"
 	path = /obj/item/weapon/flame/lighter/zippo/rasta
 	price = 5
 
-/datum/gear/lighters/chrome
+/datum/gear/lighters/zippo/chrome
 	display_name = "Chrome Zippo lighter"
 	path = /obj/item/weapon/flame/lighter/zippo/chrome
 	price = 5
 
-/datum/gear/lighters/nuke
+/datum/gear/lighters/zippo/nuke
 	display_name = "Nuclear Authentication Lighter"
 	path = /obj/item/weapon/flame/lighter/zippo/nuke
 	price = 7
 
-/datum/gear/lighters/eng
+/datum/gear/lighters/zippo/eng
 	display_name = "Engineering lighter"
 	path = /obj/item/weapon/flame/lighter/zippo/eng
 	price = 5
 
-/datum/gear/lighters/med
+/datum/gear/lighters/zippo/med
 	display_name = "Medical lighter"
 	path = /obj/item/weapon/flame/lighter/zippo/med
 	price = 5
 
-/datum/gear/lighters/sci
+/datum/gear/lighters/zippo/sci
 	display_name = "Science lighter"
 	path = /obj/item/weapon/flame/lighter/zippo/sci
 	price = 5
 
-/datum/gear/lighters/clown
+/datum/gear/lighters/zippo/clown
 	display_name = "Clown lighter"
 	path = /obj/item/weapon/flame/lighter/zippo/clown
 	price = 7
 
-/datum/gear/lighters/pig
+/datum/gear/lighters/zippo/pig
 	display_name = "Piggie lighter"
 	path = /obj/item/weapon/flame/lighter/zippo/pig
 	price = 15

--- a/code/modules/client/preference_setup/loadout/lists/lighters.dm
+++ b/code/modules/client/preference_setup/loadout/lists/lighters.dm
@@ -1,5 +1,4 @@
 /datum/gear/lighters
-	cost = 2
 	sort_category = "Lighters"
 
 /datum/gear/lighters/matchbook

--- a/code/modules/client/preference_setup/loadout/lists/misc.dm
+++ b/code/modules/client/preference_setup/loadout/lists/misc.dm
@@ -78,19 +78,6 @@
 	display_name = "pipe, corn"
 	path = /obj/item/clothing/mask/smokable/pipe/cobpipe
 
-/datum/gear/matchbook
-	display_name = "matchbook"
-	path = /obj/item/weapon/storage/box/matches
-
-/datum/gear/lighter
-	display_name = "cheap lighter"
-	path = /obj/item/weapon/flame/lighter
-
-/datum/gear/zippo
-	display_name = "zippo"
-	path = /obj/item/weapon/flame/lighter/zippo
-	cost = 2
-
 /datum/gear/ashtray
 	display_name = "ashtray, plastic"
 	path = /obj/item/weapon/material/ashtray/plastic


### PR DESCRIPTION
- В лодаут добавлена куча зажигалок за опиксы;
- Все зажигалки (включая спички) вынесены в отдельную категорию лодаута;

![Lighters](https://user-images.githubusercontent.com/45202681/114817853-8edac500-9ddc-11eb-8b59-93eb3214720f.png)

🆑
rscadd: В лодаут добавлена куча зажигалок за опиксы.
/🆑

- [x] Pull Request полностью завершен, мне не нужна помощь чтобы его закончить.
- [x] Я внимательно прочитал все свои изменения и багов в них не нашел.
- [x] Я запускал сервер со своими изменениями локально и все протестировал.
- [x] Я ознакомился c [Guide to Contribute](https://github.com/ChaoticOnyx/OnyxBay/blob/dev/docs/contributing.md).
