### PR TITLE
roundend logs fix

### DIFF
--- a/code/_helpers/roundend.dm
+++ b/code/_helpers/roundend.dm
@@ -213,7 +213,7 @@ GLOBAL_LIST_EMPTY(common_report)
 		show_roundend_report(C)
 		give_show_report_button(C)
 		CHECK_TICK
-
+	log_roundend(GLOB.common_report)
 
 /datum/controller/subsystem/ticker/proc/give_show_report_button(client/C)
 	var/datum/action/report/R = new
@@ -259,5 +259,4 @@ GLOBAL_LIST_EMPTY(common_report)
 	roundend_report.add_stylesheet("roundend", 'html/browser/roundend.css')
 	roundend_report.add_stylesheet("font-awesome", 'html/font-awesome/css/all.min.css')
 	to_chat(C, content)
-	log_roundend(GLOB.common_report)
 	roundend_report.open(FALSE)


### PR DESCRIPTION
Было(2 игрока на серве):
![изображение](https://user-images.githubusercontent.com/42303535/114832970-c430e400-9dd7-11eb-9eab-1f2d4f92f063.png)

Стало(2 игрока на серве):
![изображение](https://user-images.githubusercontent.com/42303535/114833073-ddd22b80-9dd7-11eb-9d80-3c67ce9fe49c.png)

Вынес команду для логирования так что-бы она срабатывала ОДИН раз, а не столько же сколько игроков
close #4907 
- [x] Pull Request полностью завершен, мне не нужна помощь чтобы его закончить.
- [x] Я внимательно прочитал все свои изменения и багов в них не нашел.
- [x] Я запускал сервер со своими изменениями локально и все протестировал.
- [x] Я ознакомился c [Guide to Contribute](https://github.com/ChaoticOnyx/OnyxBay/blob/dev/docs/contributing.md).
