### PR TITLE
Removes overpoweredness of .44 SPECs, tweaks damage values across the board

### DIFF
--- a/code/game/objects/items/weapons/cane.dm
+++ b/code/game/objects/items/weapons/cane.dm
@@ -5,7 +5,7 @@
 	icon_state = "cane"
 	item_state = "stick"
 	obj_flags = OBJ_FLAG_CONDUCTIBLE
-	force = 7.5
+	force = 8.5
 	throwforce = 7.0
 	mod_reach = 1.5
 	mod_weight = 1.0

--- a/code/game/objects/items/weapons/extinguisher.dm
+++ b/code/game/objects/items/weapons/extinguisher.dm
@@ -32,7 +32,7 @@
 	icon_state = "miniFE0"
 	item_state = "miniFE"
 	hitsound = null	//it is much lighter, after all.
-	force = 6.5
+	force = 7.5
 	throwforce = 2
 	mod_handy = 0.7
 	mod_weight = 0.65

--- a/code/game/objects/items/weapons/material/misc.dm
+++ b/code/game/objects/items/weapons/material/misc.dm
@@ -13,7 +13,7 @@
 	desc = "A very sharp axe blade upon a short fibremetal handle. It has a long history of chopping things, but now it is used for chopping wood."
 	icon = 'icons/obj/weapons.dmi'
 	icon_state = "hatchet"
-	force_const = 6.5
+	force_const = 7.5
 	thrown_force_const = 5
 	force_divisor = 0.125 // 7.5 with hardness 60 (steel)
 	thrown_force_divisor = 0.5 // 10 with weight 20 (steel)
@@ -70,7 +70,7 @@
 	icon = 'icons/obj/weapons.dmi'
 	icon_state = "hoe"
 	item_state = "hoe"
-	force_const = 5.0
+	force_const = 5.5
 	force_divisor = 0.125 // 2.5 with weight 20 (steel)
 	thrown_force_divisor = 0.25 // as above
 	w_class = ITEM_SIZE_SMALL

--- a/code/game/objects/items/weapons/mop.dm
+++ b/code/game/objects/items/weapons/mop.dm
@@ -3,7 +3,7 @@
 	name = "mop"
 	icon = 'icons/obj/janitor.dmi'
 	icon_state = "mop"
-	force = 7.5
+	force = 9.0
 	throwforce = 10.0
 	throw_speed = 5
 	throw_range = 10

--- a/code/game/objects/items/weapons/tools.dm
+++ b/code/game/objects/items/weapons/tools.dm
@@ -25,7 +25,7 @@
 	item_state = "wrench"
 	obj_flags = OBJ_FLAG_CONDUCTIBLE
 	slot_flags = SLOT_BELT
-	force = 8.0
+	force = 8.5
 	throwforce = 7.0
 	w_class = ITEM_SIZE_SMALL
 	mod_weight = 0.8
@@ -614,7 +614,7 @@
 	icon_state = "crowbar"
 	obj_flags = OBJ_FLAG_CONDUCTIBLE
 	slot_flags = SLOT_BELT
-	force = 9.5
+	force = 10.0
 	throwforce = 7.0
 	throw_range = 3
 	item_state = "crowbar"
@@ -636,7 +636,7 @@
 	desc = "A steel bar with a wedge. It comes in a variety of configurations - collect them all."
 	icon_state = "prybar"
 	item_state = "crowbar"
-	force = 6.5
+	force = 7.5
 	throwforce = 6.0
 	throw_range = 5
 	w_class = ITEM_SIZE_SMALL

--- a/code/modules/projectiles/projectile/beams.dm
+++ b/code/modules/projectiles/projectile/beams.dm
@@ -3,7 +3,7 @@
 	icon_state = "laser"
 	fire_sound = 'sound/effects/weapons/energy/fire8.ogg'
 	pass_flags = PASS_FLAG_TABLE | PASS_FLAG_GLASS | PASS_FLAG_GRILLE
-	damage = 40
+	damage = 35
 	damage_type = BURN
 	sharp = 1 //concentrated burns
 	check_armour = "laser"
@@ -30,14 +30,14 @@
 	damage = 25
 
 /obj/item/projectile/beam/midlaser
-	damage = 50
+	damage = 45
 	armor_penetration = 10
 
 /obj/item/projectile/beam/heavylaser
 	name = "heavy laser"
 	icon_state = "heavylaser"
 	fire_sound = 'sound/effects/weapons/energy/fire21.ogg'
-	damage = 60
+	damage = 55
 	armor_penetration = 30
 
 	muzzle_type = /obj/effect/projectile/laser/heavy/muzzle

--- a/code/modules/projectiles/projectile/bullets.dm
+++ b/code/modules/projectiles/projectile/bullets.dm
@@ -126,21 +126,21 @@
 /* short-casing projectiles, like the kind used in pistols or SMGs */
 
 /obj/item/projectile/bullet/pistol
-	damage = 25 //9mm, .38, etc
+	damage = 27.5 //9mm, .38, etc
 	armor_penetration = 13.5
 
 /obj/item/projectile/bullet/pistol/medium
-	damage = 26.5 //.45
+	damage = 30 //.45
 	armor_penetration = 14.5
 
 /obj/item/projectile/bullet/pistol/medium/smg
 	fire_sound = 'sound/weapons/gunshot/gunshot_smg.ogg'
-	damage = 28 //10mm
-	armor_penetration = 18
+	damage = 32.5 //10mm
+	armor_penetration = 19.5
 
 /obj/item/projectile/bullet/pistol/medium/revolver
 	fire_sound = 'sound/weapons/gun_revolver44.ogg'
-	damage = 30 //.44 magnum or something
+	damage = 37.5 //.44 magnum or something
 	armor_penetration = 20
 
 /obj/item/projectile/bullet/pistol/strong //matebas
@@ -173,7 +173,7 @@
 
 /obj/item/projectile/bullet/pistol/accelerated/c44
 	name = "accelerated bullet"
-	damage = 42.5 //.44 magnum + gauss
+	damage = 40 //.44 magnum + gauss
 	armor_penetration = 45
 	fire_sound = 'sound/weapons/gun_revolver44.ogg'
 


### PR DESCRIPTION
tl;dr очередная порция боёвочки, лёгкий бафф урона в целом, нерф лазеров и M2019;

- Урон .44 SPEC слегка уменьшен (42.5 -> 40);
- Урон .44 значительно увеличен (30 -> 37.5);
- Урон 10mm увеличен (28 -> 32.5), пробитие брони увеличено (18 -> 19.5);
- Урон .45 увеличен (26.5 -> 30);
- Урон 9mm и .38 увеличен (25 -> 27.5);
- Урон лучей маленьких лазеров уменьшен (40 -> 35);
- Урон лучей средних лазеров (карабин) уменьшен (50 -> 45);
- Урон лучей тяжёлых лазеров уменьшен (60 -> 55);
- Урон лазерных пучков не поменялся;
- Урон гаечного ключа увеличен (8 -> 8.5);
- Урон монтировки увеличен (9.5 -> 10);
- Урон маленькой монтировки (pry bar) увеличен (6.5 -> 7.5);
- Урон швабры увеличен (7.5 -> 9);
- Базовый урон топориков увеличен (6.5 -> 7.5). Урон обычного топорика (стального), следовательно, увеличился с 14 до 15;
- Базовый урон граблей увеличен (5 -> 5.5). Урон обычных граблей (стальных), следовательно, увеличился с 7.5 до 8;
- Урон маленького огнетушителя увеличен с 6.5 до 7.5;
- Урон трости увеличен с 7.5 до 8.5;

🆑
tweak: Изменён баланс оружия: [PR](https://github.com/ChaoticOnyx/OnyxBay/pull/4912)
/🆑

- [x] Pull Request полностью завершен, мне не нужна помощь чтобы его закончить.
- [x] Я внимательно прочитал все свои изменения и багов в них не нашел.
- [x] Я запускал сервер со своими изменениями локально и все протестировал.
- [x] Я ознакомился c [Guide to Contribute](https://github.com/ChaoticOnyx/OnyxBay/blob/dev/docs/contributing.md).
