### PR TITLE
Dreamchecker: operator 'in'

### DIFF
--- a/code/_helpers/icons.dm
+++ b/code/_helpers/icons.dm
@@ -749,7 +749,7 @@ proc // Creates a single icon from a given /atom or /image.  Only the first argu
 				curblend = BLEND_OVERLAY
 				add = icon(I:icon, I:icon_state, I:dir)
 			else // 'I' is an appearance object.
-				if(istype(A,/obj/machinery/atmospherics) && I in A.underlays)
+				if(istype(A,/obj/machinery/atmospherics) && (I in A.underlays))
 					var/image/Im = I
 					add = getFlatIcon(new /image(I), Im.dir, curicon, curstate, curblend, 1)
 				else

--- a/code/_onclick/click.dm
+++ b/code/_onclick/click.dm
@@ -232,7 +232,7 @@
 	A.ShiftClick(src)
 	return
 /atom/proc/ShiftClick(mob/user)
-	if(user.client && src in view(user.client.eye))
+	if(user.client && (src in view(user.client.eye)))
 		user.examinate(src)
 
 	return

--- a/code/datums/extensions/multitool/items/cable.dm
+++ b/code/datums/extensions/multitool/items/cable.dm
@@ -18,7 +18,7 @@
 
 /datum/extension/interactive/multitool/items/cable/on_topic(href, href_list, user)
 	var/obj/item/stack/cable_coil/cable_coil = holder
-	if(href_list["select_color"] && href_list["select_color"] in possible_cable_coil_colours)
+	if(href_list["select_color"] && (href_list["select_color"] in possible_cable_coil_colours))
 		cable_coil.set_cable_color(href_list["select_color"], user)
 		return MT_REFRESH
 

--- a/code/game/antagonist/antagonist_factions.dm
+++ b/code/game/antagonist/antagonist_factions.dm
@@ -2,7 +2,7 @@
 	set name = "Convert Bourgeoise"
 	set category = "Abilities"
 
-	if(!M in able_mobs_in_oview(src))
+	if(!(M in able_mobs_in_oview(src)))
 		return
 	if(!M.mind || !M.client)
 		return
@@ -48,7 +48,7 @@
 	set name = "Convert Recidivist"
 	set category = "Abilities"
 
-	if(!M in able_mobs_in_oview(src))
+	if(!(M in able_mobs_in_oview(src)))
 		return
 	if(!M.mind || !M.client)
 		return

--- a/code/game/dna/genes/gene.dm
+++ b/code/game/dna/genes/gene.dm
@@ -27,7 +27,7 @@
 * Is the gene active in this mob's DNA?
 */
 /datum/dna/gene/proc/is_active(mob/M)
-	return M.active_genes && type in M.active_genes
+	return (M.active_genes && (type in M.active_genes))
 
 // Return 1 if we can activate.
 // HANDLE MUTCHK_FORCED HERE!

--- a/code/game/gamemodes/events.dm
+++ b/code/game/gamemodes/events.dm
@@ -42,7 +42,7 @@ var/hadevent    = 0
 
 	var/list/vents = list()
 	for(var/obj/machinery/atmospherics/unary/vent_pump/temp_vent in SSmachines.machinery)
-		if(!temp_vent.welded && temp_vent.network && temp_vent.loc.z in GLOB.using_map.station_levels)
+		if(!temp_vent.welded && temp_vent.network && (temp_vent.loc.z in GLOB.using_map.station_levels))
 			if(temp_vent.network.normal_members.len > 50) // Stops Aliens getting stuck in small networks. See: Security, Virology
 				vents += temp_vent
 

--- a/code/game/gamemodes/malfunction/newmalf_ability_trees/tree_networking.dm
+++ b/code/game/gamemodes/malfunction/newmalf_ability_trees/tree_networking.dm
@@ -206,7 +206,7 @@
 	sleep(1 MINUTE)
 	// Hack all APCs, including those built during hack sequence.
 	for(var/obj/machinery/power/apc/A in SSmachines.machinery)
-		if((!A.hacker || A.hacker != src) && !A.aidisabled && A.z in GLOB.using_map.station_levels)
+		if((!A.hacker || A.hacker != src) && !A.aidisabled && (A.z in GLOB.using_map.station_levels))
 			A.ai_hack(src)
 
 	log_ability_use(user, "system override (FINISHED)")

--- a/code/game/gamemodes/vampire/vampire_powers.dm
+++ b/code/game/gamemodes/vampire/vampire_powers.dm
@@ -1,6 +1,6 @@
 // Contains all /mob/procs that relate to vampire.
 /mob/living/carbon/human/AltClickOn(atom/A)
-	if(mind && mind.vampire && istype(A , /turf/simulated/floor) && /mob/living/carbon/human/proc/vampire_veilstep in verbs)
+	if(mind && mind.vampire && istype(A , /turf/simulated/floor) && (/mob/living/carbon/human/proc/vampire_veilstep in verbs))
 		vampire_veilstep(A)
 	..()
 

--- a/code/game/machinery/Sleeper.dm
+++ b/code/game/machinery/Sleeper.dm
@@ -208,7 +208,7 @@
 				return TOPIC_REFRESH
 	if(href_list["stasis"])
 		var/nstasis = text2num(href_list["stasis"])
-		if(stasis != nstasis && nstasis in stasis_settings)
+		if(stasis != nstasis && (nstasis in stasis_settings))
 			stasis = text2num(href_list["stasis"])
 			return TOPIC_REFRESH
 

--- a/code/game/machinery/camera/tracking.dm
+++ b/code/game/machinery/camera/tracking.dm
@@ -6,7 +6,7 @@
 /mob/living/silicon/ai/var/stored_locations[0]
 
 /proc/InvalidPlayerTurf(turf/T as turf)
-	return !(T && T.z in GLOB.using_map.player_levels)
+	return !(T && (T.z in GLOB.using_map.player_levels))
 
 /mob/living/silicon/ai/proc/get_camera_list()
 	if(src.stat == 2)

--- a/code/game/machinery/telecomms/traffic_control.dm
+++ b/code/game/machinery/telecomms/traffic_control.dm
@@ -52,7 +52,7 @@
 
 				for(var/mob/M in viewingcode)
 
-					if( (M.machine == src && M in view(1, src) ) || issilicon(M))
+					if( (M.machine == src && (M in view(1, src) )) || issilicon(M))
 						winset(M, "tcscode", "is-disabled=true")
 						winset(M, "tcscode", "text=\"[showcode]\"")
 					else

--- a/code/game/mecha/mecha.dm
+++ b/code/game/mecha/mecha.dm
@@ -1057,7 +1057,7 @@
 	return
 
 /obj/mecha/proc/moved_inside(mob/living/carbon/human/H as mob)
-	if(H && H.client && H in range(1))
+	if(H && H.client && (H in range(1)))
 		H.reset_view(src)
 		/*
 		H.client.perspective = EYE_PERSPECTIVE

--- a/code/game/mecha/working/working.dm
+++ b/code/game/mecha/working/working.dm
@@ -29,7 +29,7 @@
 	..()
 	if(href_list["drop_from_cargo"])
 		var/obj/O = locate(href_list["drop_from_cargo"])
-		if(O && O in src.cargo)
+		if(O && (O in src.cargo))
 			src.occupant_message("<span class='notice'>You unload [O].</span>")
 			O.loc = get_turf(src)
 			src.cargo -= O

--- a/code/game/objects/items/devices/PDA/PDA.dm
+++ b/code/game/objects/items/devices/PDA/PDA.dm
@@ -372,7 +372,7 @@ var/global/list/obj/item/device/pda/PDAs = list()
 	var/auto_update = 1
 	if(mode in no_auto_update)
 		auto_update = 0
-	if(old_ui && (mode == lastmode && ui_tick % 5 && mode in update_every_five))
+	if(old_ui && (mode == lastmode && ui_tick % 5 && (mode in update_every_five)))
 		return
 
 	lastmode = mode

--- a/code/game/objects/items/devices/radio/radio.dm
+++ b/code/game/objects/items/devices/radio/radio.dm
@@ -382,7 +382,7 @@
 			R.receive_signal(signal)
 
 		// Receiving code can be located in Telecommunications.dm
-		return signal.data["done"] && position.z in signal.data["level"]
+		return (signal.data["done"] && (position.z in signal.data["level"]))
 
 
   /* ###### Intercoms and station-bounced radios ###### */
@@ -434,7 +434,7 @@
 
 	sleep(rand(10,25)) // wait a little...
 
-	if(signal.data["done"] && position.z in signal.data["level"])
+	if(signal.data["done"] && (position.z in signal.data["level"]))
 		// we're done here.
 		return 1
 

--- a/code/game/objects/items/weapons/storage/wallets.dm
+++ b/code/game/objects/items/weapons/storage/wallets.dm
@@ -71,7 +71,7 @@
 	overlays.Cut()
 	if(front_id)
 		var/tiny_state = "id-generic"
-		if("id-"+front_id.icon_state in icon_states(icon))
+		if(("id-"+front_id.icon_state) in icon_states(icon))
 			tiny_state = "id-"+front_id.icon_state
 		var/image/tiny_image = new /image(icon, icon_state = tiny_state)
 		tiny_image.appearance_flags = RESET_COLOR

--- a/code/game/objects/items/weapons/tanks/tanks.dm
+++ b/code/game/objects/items/weapons/tanks/tanks.dm
@@ -258,7 +258,7 @@ var/list/global/tank_gauge_cache = list()
 		else if(src in location)		// or if tank is in the mobs possession
 			if(!location.internal)		// and they do not have any active internals
 				mask_check = 1
-		else if(istype(loc, /obj/item/weapon/rig) && loc in location)	// or the rig is in the mobs possession
+		else if(istype(loc, /obj/item/weapon/rig) && (loc in location))	// or the rig is in the mobs possession
 			if(!location.internal)		// and they do not have any active internals
 				mask_check = 1
 

--- a/code/game/objects/structures/transit_tubes.dm
+++ b/code/game/objects/structures/transit_tubes.dm
@@ -120,7 +120,7 @@ obj/structure/ex_act(severity)
 			if(pod.contents.len)
 				to_chat(AM, "<span class='notice'>The pod is already occupied.</span>")
 				return
-			else if(!pod.moving && pod.dir in directions())
+			else if(!pod.moving && (pod.dir in directions()))
 				AM.loc = pod
 				return
 
@@ -128,7 +128,7 @@ obj/structure/ex_act(severity)
 /obj/structure/transit_tube/station/attack_hand(mob/user as mob)
 	if(!pod_moving)
 		for(var/obj/structure/transit_tube_pod/pod in loc)
-			if(!pod.moving && pod.dir in directions())
+			if(!pod.moving && (pod.dir in directions()))
 				if(icon_state == "closed")
 					open_animation()
 
@@ -157,7 +157,7 @@ obj/structure/ex_act(severity)
 
 /obj/structure/transit_tube/station/proc/launch_pod()
 	for(var/obj/structure/transit_tube_pod/pod in loc)
-		if(!pod.moving && pod.dir in directions())
+		if(!pod.moving && (pod.dir in directions()))
 			spawn(5)
 				pod_moving = 1
 				close_animation()

--- a/code/modules/admin/verbs/diagnostics.dm
+++ b/code/modules/admin/verbs/diagnostics.dm
@@ -17,7 +17,7 @@
 	var/inactive_on_main_station = 0
 	for(var/zone/zone in SSair.zones)
 		var/turf/simulated/turf = locate() in zone.contents
-		if(turf && turf.z in GLOB.using_map.station_levels)
+		if(turf && (turf.z in GLOB.using_map.station_levels))
 			if(zone.needs_update)
 				active_on_main_station++
 			else

--- a/code/modules/admin/verbs/mapping.dm
+++ b/code/modules/admin/verbs/mapping.dm
@@ -90,7 +90,7 @@ var/intercom_range_display_status = 0
 			if(!(locate(/obj/structure/grille,T)))
 				var/window_check = 0
 				for(var/obj/structure/window/W in T)
-					if (W.dir == turn(C1.dir,180) || W.dir in list(5,6,9,10) )
+					if (W.dir == turn(C1.dir,180) || (W.dir in list(5,6,9,10)) )
 						window_check = 1
 						break
 				if(!window_check)

--- a/code/modules/client/preference_setup/preference_setup.dm
+++ b/code/modules/client/preference_setup/preference_setup.dm
@@ -118,7 +118,7 @@ var/const/CHARACTER_PREFERENCE_INPUT_TITLE = "Character Preference"
 
 	if(href_list["category"])
 		var/category = locate(href_list["category"])
-		if(category && category in categories)
+		if(category && (category in categories))
 			selected_category = category
 		. = 1
 

--- a/code/modules/economy/Accounts_DB.dm
+++ b/code/modules/economy/Accounts_DB.dm
@@ -18,7 +18,7 @@
 			return 0
 		if(access_cent_captain in held_card.access)
 			return 2
-		else if(access_hop in held_card.access || access_captain in held_card.access)
+		else if((access_hop in held_card.access) || (access_captain in held_card.access))
 			return 1
 
 	proc/create_transation(target, reason, amount)

--- a/code/modules/economy/EFTPOS.dm
+++ b/code/modules/economy/EFTPOS.dm
@@ -209,7 +209,7 @@
 				var/obj/item/I = usr.get_active_hand()
 				if (istype(I, /obj/item/weapon/card))
 					var/obj/item/weapon/card/id/C = I
-					if(access_cent_captain in C.access || access_hop in C.access || access_captain in C.access)
+					if((access_cent_captain in C.access) || (access_hop in C.access) || (access_captain in C.access))
 						access_code = 0
 						to_chat(usr, "\icon[src]<span class='info'>Access code reset to 0.</span>")
 				else if (istype(I, /obj/item/weapon/card/emag))

--- a/code/modules/events/spider_infestation.dm
+++ b/code/modules/events/spider_infestation.dm
@@ -16,7 +16,7 @@
 /datum/event/spider_infestation/start()
 	var/list/vents = list()
 	for(var/obj/machinery/atmospherics/unary/vent_pump/temp_vent in world)
-		if(!temp_vent.welded && temp_vent.network && temp_vent.loc.z in affecting_z)
+		if(!temp_vent.welded && temp_vent.network && (temp_vent.loc.z in affecting_z))
 			if(temp_vent.network.normal_members.len > 50)
 				vents += temp_vent
 

--- a/code/modules/mob/language/language.dm
+++ b/code/modules/mob/language/language.dm
@@ -166,7 +166,7 @@
 	if (only_species_language && speaking != all_languages[species_language])
 		return 0
 
-	return (speaking.can_speak_special(src) && (universal_speak || (speaking && speaking.flags & INNATE) || speaking in src.languages))
+	return (speaking.can_speak_special(src) && (universal_speak || (speaking && speaking.flags & INNATE) || (speaking in src.languages)))
 
 /mob/proc/get_language_prefix()
 	return get_prefix_key(/decl/prefix/language)

--- a/code/modules/mob/living/carbon/human/body_build.dm
+++ b/code/modules/mob/living/carbon/human/body_build.dm
@@ -33,7 +33,7 @@ var/global/datum/body_build/default_body_build = new
 
 /datum/body_build/proc/get_mob_icon(slot, icon_state)
 	var/icon/I
-	if(!slot in default_onmob_slots)
+	if(!(slot in default_onmob_slots))
 		to_world_log("##ERROR. Wrong sprite group for mob icon \"[slot]\"")
 		return I // Nonexistent slot, just give 'em an empty icon
 	for(var/datum/body_build/BB in list(src, default_body_build))

--- a/code/modules/mob/living/carbon/human/say.dm
+++ b/code/modules/mob/living/carbon/human/say.dm
@@ -222,7 +222,7 @@
 	var/needs_assist = 0
 	var/can_speak_assist = 0
 
-	if(species && speaking.name in species.assisted_langs)
+	if(species && (speaking.name in species.assisted_langs))
 		needs_assist = 1
 		for(var/obj/item/organ/internal/I in src.internal_organs)
 			if((speaking in I.assists_languages) && (I.is_usable()))

--- a/code/modules/mob/living/carbon/human/species/xenomorphs/alien_powers.dm
+++ b/code/modules/mob/living/carbon/human/species/xenomorphs/alien_powers.dm
@@ -151,7 +151,7 @@
 	set desc = "Drench an object in acid, destroying it over time."
 	set category = "Abilities"
 
-	if(!O in oview(1))
+	if(!(O in oview(1)))
 		to_chat(src, "<span class='alium'>[O] is too far away.</span>")
 		return
 

--- a/code/modules/mob/living/silicon/robot/robot.dm
+++ b/code/modules/mob/living/silicon/robot/robot.dm
@@ -245,7 +245,7 @@
 		if(custom_sprite && CUSTOM_ITEM_ROBOTS)
 			var/sprite_state = GLOB.robot_custom_icons[ckey]
 			var/list/valid_states = icon_states(CUSTOM_ITEM_ROBOTS)
-			if(sprite_state && sprite_state in valid_states)
+			if(sprite_state && (sprite_state in valid_states))
 				module_sprites["Custom"] = sprite_state
 				icon = CUSTOM_ITEM_ROBOTS
 				icontype = "Custom"

--- a/code/modules/mob/living/simple_animal/hostile/bear.dm
+++ b/code/modules/mob/living/simple_animal/hostile/bear.dm
@@ -56,7 +56,7 @@
 			stop_automated_movement = 1
 			stance_step++
 			if(stance_step >= 10) //rests for 10 ticks
-				if(target_mob && target_mob in ListTargets(10))
+				if(target_mob && (target_mob in ListTargets(10)))
 					stance = HOSTILE_STANCE_ATTACK //If the mob he was chasing is still nearby, resume the attack, otherwise go idle.
 				else
 					stance = HOSTILE_STANCE_IDLE
@@ -64,7 +64,7 @@
 		if(HOSTILE_STANCE_ALERT)
 			stop_automated_movement = 1
 			var/found_mob = 0
-			if(target_mob && target_mob in ListTargets(10))
+			if(target_mob && (target_mob in ListTargets(10)))
 				if(!(SA_attackable(target_mob)))
 					stance_step = max(0, stance_step) //If we have not seen a mob in a while, the stance_step will be negative, we need to reset it to 0 as soon as we see a mob again.
 					stance_step++

--- a/code/modules/mob/living/simple_animal/parrot.dm
+++ b/code/modules/mob/living/simple_animal/parrot.dm
@@ -410,11 +410,11 @@
 					return
 			return
 
-		if(parrot_interest && parrot_interest in view(src))
+		if(parrot_interest && (parrot_interest in view(src)))
 			parrot_state = PARROT_SWOOP | PARROT_STEAL
 			return
 
-		if(parrot_perch && parrot_perch in view(src))
+		if(parrot_perch && (parrot_perch in view(src)))
 			parrot_state = PARROT_SWOOP | PARROT_RETURN
 			return
 

--- a/code/modules/modular_computers/file_system/programs/engineering/atmos_control.dm
+++ b/code/modules/modular_computers/file_system/programs/engineering/atmos_control.dm
@@ -38,7 +38,7 @@
 		for(var/obj/machinery/alarm/alarm in SSmachines.machinery)
 			if(!(alarm.z in GLOB.using_map.station_levels))
 				continue
-			if(alarm.alarm_id && alarm.alarm_id in monitored_alarm_ids)
+			if(alarm.alarm_id && (alarm.alarm_id in monitored_alarm_ids))
 				monitored_alarms += alarm
 		// machines may not yet be ordered at this point
 		monitored_alarms = dd_sortedObjectList(monitored_alarms)

--- a/code/modules/organs/external/_external.dm
+++ b/code/modules/organs/external/_external.dm
@@ -907,7 +907,7 @@ Note that amputating the affected organ does in fact remove the infection from t
 		holder = owner
 	if(!holder)
 		return
-	if (holder.handcuffed && body_part in list(ARM_LEFT, ARM_RIGHT, HAND_LEFT, HAND_RIGHT))
+	if (holder.handcuffed && (body_part in list(ARM_LEFT, ARM_RIGHT, HAND_LEFT, HAND_RIGHT)))
 		holder.visible_message(\
 			"\The [holder.handcuffed.name] falls off of [holder.name].",\
 			"\The [holder.handcuffed.name] falls off you.")

--- a/code/modules/overmap/spacetravel.dm
+++ b/code/modules/overmap/spacetravel.dm
@@ -23,7 +23,7 @@ var/list/cached_space = list()
 /obj/effect/overmap/sector/temporary/proc/can_die(mob/observer)
 	testing("Checking if sector at [map_z[1]] can die.")
 	for(var/mob/M in GLOB.player_list)
-		if(M != observer && M.z in map_z)
+		if(M != observer && (M.z in map_z))
 			testing("There are people on it.")
 			return 0
 	return 1

--- a/code/modules/paperwork/stamps.dm
+++ b/code/modules/paperwork/stamps.dm
@@ -78,7 +78,7 @@
 
 	var/input_stamp = input(user, "Choose a stamp to disguise as.", "Choose a stamp.") in show_stamps
 
-	if(user && src in user.contents)
+	if(user && (src in user.contents))
 
 		var/obj/item/weapon/stamp/chosen_stamp = stamps[capitalize(input_stamp)]
 

--- a/code/modules/psychotronics/psychoscope.dm
+++ b/code/modules/psychotronics/psychoscope.dm
@@ -83,7 +83,7 @@
 		for(var/neuromod_reward in neuromod_rewards)
 			var/datum/neuromod/N = neuromod_reward
 
-			if(!N || neuromod_reward in scanned[lifeform_type]["opened_neuromods"])
+			if(!N || (neuromod_reward in scanned[lifeform_type]["opened_neuromods"]))
 				continue
 
 			var/opened = prob(initial(N.chance))

--- a/code/modules/recycling/sortingmachinery.dm
+++ b/code/modules/recycling/sortingmachinery.dm
@@ -371,7 +371,7 @@
 	openwindow(user)
 
 /obj/item/device/destTagger/OnTopic(user, href_list, state)
-	if(href_list["nextTag"] && href_list["nextTag"] in GLOB.tagger_locations)
+	if(href_list["nextTag"] && (href_list["nextTag"] in GLOB.tagger_locations))
 		src.currTag = href_list["nextTag"]
 		. = TOPIC_REFRESH
 	if(href_list["nextTag"] == "CUSTOM")

--- a/code/modules/scripting/IDE.dm
+++ b/code/modules/scripting/IDE.dm
@@ -1,7 +1,7 @@
 client/verb/tcssave()
 	set hidden = 1
 	if(mob.machine || issilicon(mob))
-		if((istype(mob.machine, /obj/machinery/computer/telecomms/traffic) && mob.machine in view(1, mob)) || issilicon(mob))
+		if((istype(mob.machine, /obj/machinery/computer/telecomms/traffic) && (mob.machine in view(1, mob))) || issilicon(mob))
 			var/obj/machinery/computer/telecomms/traffic/Machine = mob.machine
 			if(Machine.editingcode != mob)
 				return
@@ -28,7 +28,7 @@ client/verb/tcssave()
 client/verb/tcscompile()
 	set hidden = 1
 	if(mob.machine || issilicon(mob))
-		if((istype(mob.machine, /obj/machinery/computer/telecomms/traffic) && mob.machine in view(1, mob)) || (issilicon(mob) && istype(mob.machine, /obj/machinery/computer/telecomms/traffic) ))
+		if((istype(mob.machine, /obj/machinery/computer/telecomms/traffic) && (mob.machine in view(1, mob))) || (issilicon(mob) && istype(mob.machine, /obj/machinery/computer/telecomms/traffic) ))
 			var/obj/machinery/computer/telecomms/traffic/Machine = mob.machine
 			if(Machine.editingcode != mob)
 				return
@@ -79,7 +79,7 @@ client/verb/tcscompile()
 client/verb/tcsrun()
 	set hidden = 1
 	if(mob.machine || issilicon(mob))
-		if((istype(mob.machine, /obj/machinery/computer/telecomms/traffic) && mob.machine in view(1, mob)) || (issilicon(mob) && istype(mob.machine, /obj/machinery/computer/telecomms/traffic) ))
+		if((istype(mob.machine, /obj/machinery/computer/telecomms/traffic) && (mob.machine in view(1, mob))) || (issilicon(mob) && istype(mob.machine, /obj/machinery/computer/telecomms/traffic) ))
 			var/obj/machinery/computer/telecomms/traffic/Machine = mob.machine
 			if(Machine.editingcode != mob)
 				return
@@ -145,7 +145,7 @@ client/verb/tcsrun()
 client/verb/exittcs()
 	set hidden = 1
 	if(mob.machine || issilicon(mob))
-		if((istype(mob.machine, /obj/machinery/computer/telecomms/traffic) && mob.machine in view(1, mob)) || (issilicon(mob) && istype(mob.machine, /obj/machinery/computer/telecomms/traffic) ))
+		if((istype(mob.machine, /obj/machinery/computer/telecomms/traffic) && (mob.machine in view(1, mob))) || (issilicon(mob) && istype(mob.machine, /obj/machinery/computer/telecomms/traffic) ))
 			var/obj/machinery/computer/telecomms/traffic/Machine = mob.machine
 			if(Machine.editingcode == mob)
 				Machine.storedcode = "[winget(mob, "tcscode", "text")]"
@@ -157,7 +157,7 @@ client/verb/exittcs()
 client/verb/tcsrevert()
 	set hidden = 1
 	if(mob.machine || issilicon(mob))
-		if((istype(mob.machine, /obj/machinery/computer/telecomms/traffic) && mob.machine in view(1, mob)) || (issilicon(mob) && istype(mob.machine, /obj/machinery/computer/telecomms/traffic) ))
+		if((istype(mob.machine, /obj/machinery/computer/telecomms/traffic) && (mob.machine in view(1, mob))) || (issilicon(mob) && istype(mob.machine, /obj/machinery/computer/telecomms/traffic) ))
 			var/obj/machinery/computer/telecomms/traffic/Machine = mob.machine
 			if(Machine.editingcode != mob)
 				return
@@ -186,7 +186,7 @@ client/verb/tcsrevert()
 client/verb/tcsclearmem()
 	set hidden = 1
 	if(mob.machine || issilicon(mob))
-		if((istype(mob.machine, /obj/machinery/computer/telecomms/traffic) && mob.machine in view(1, mob)) || (issilicon(mob) && istype(mob.machine, /obj/machinery/computer/telecomms/traffic) ))
+		if((istype(mob.machine, /obj/machinery/computer/telecomms/traffic) && (mob.machine in view(1, mob))) || (issilicon(mob) && istype(mob.machine, /obj/machinery/computer/telecomms/traffic) ))
 			var/obj/machinery/computer/telecomms/traffic/Machine = mob.machine
 			if(Machine.editingcode != mob)
 				return

--- a/code/modules/spells/spell_code.dm
+++ b/code/modules/spells/spell_code.dm
@@ -296,7 +296,7 @@ var/list/spells = typesof(/spell) //needed for the badmin verb for now
 
 	var/list/valid_targets = view_or_range(range, holder, selection_type)
 	for(var/target in targets)
-		if(!target in valid_targets)
+		if(!(target in valid_targets))
 			return 0
 	return 1
 

--- a/code/modules/xenoarcheaology/finds/special.dm
+++ b/code/modules/xenoarcheaology/finds/special.dm
@@ -131,7 +131,7 @@
 
 /obj/item/weapon/vampiric/hear_talk(mob/M as mob, text)
 	..()
-	if(world.time - last_bloodcall >= bloodcall_interval && M in view(7, src))
+	if(world.time - last_bloodcall >= bloodcall_interval && (M in view(7, src)))
 		bloodcall(M)
 
 /obj/item/weapon/vampiric/proc/bloodcall(mob/living/carbon/human/M)


### PR DESCRIPTION
Убираем двусмысленность у оператора `in` в билде. 
`A && B in C` -> `A && (B in C)`
`!A in B` -> `!(A in B)`

Поправило примерно пятьдесят три проблемы, на которые указывал сам дримчекер. 

- [x] Pull Request полностью завершен, мне не нужна помощь чтобы его закончить.
- [x] Я внимательно прочитал все свои изменения и багов в них не нашел.
- [ ] Я запускал сервер со своими изменениями локально и все протестировал.
- [x] Я ознакомился c [Guide to Contribute](https://github.com/ChaoticOnyx/OnyxBay/blob/dev/docs/contributing.md).
