### PR TITLE
Делаем ивент с кражей денег жёстче

### DIFF
--- a/code/game/jobs/job/civilian.dm
+++ b/code/game/jobs/job/civilian.dm
@@ -192,3 +192,4 @@
 	access = list(access_merchant)
 	announced = FALSE
 	can_be_hired = FALSE
+	off_station = TRUE

--- a/code/game/jobs/job/job.dm
+++ b/code/game/jobs/job/job.dm
@@ -39,6 +39,7 @@
 
 	var/announced = TRUE                  //If their arrival is announced on radio
 	var/latejoin_at_spawnpoints           //If this job should use roundstart spawnpoints for latejoin (offstation jobs etc)
+	var/off_station = FALSE
 
 	var/hud_icon						  //icon used for Sec HUD overlay
 
@@ -92,7 +93,7 @@
 	var/species_modifier = economic_species_modifier[H.species.type]
 
 	var/money_amount = (rand(5,50) + rand(5, 50)) * loyalty * economic_modifier * species_modifier * GLOB.using_map.salary_modifier
-	var/datum/money_account/M = create_account(H.real_name, money_amount, null)
+	var/datum/money_account/M = create_account(H.real_name, money_amount, null, off_station)
 	if(H.mind)
 		var/remembered_info = ""
 		remembered_info += "<b>Your account number is:</b> #[M.account_number]<br>"

--- a/code/modules/economy/Accounts.dm
+++ b/code/modules/economy/Accounts.dm
@@ -6,6 +6,7 @@
 	var/money = 0
 	var/list/transaction_log = list()
 	var/suspended = 0
+	var/off_station = FALSE
 	var/security_level = 0	//0 - auto-identify from worn ID, require only account number
 							//1 - require manual login / account number and pin
 							//2 - require card and manual login
@@ -30,7 +31,7 @@
 	var/time = ""
 	var/source_terminal = ""
 
-/datum/transaction/New(_target, _purpose, _amount, _source)
+/datum/transaction/New(_target, _purpose, _amount, _source, _off_station)
 	..()
 	date = stationdate2text()
 	time = stationtime2text()
@@ -66,6 +67,7 @@
 	T.target_name = new_owner_name
 	T.purpose = "Account creation"
 	T.amount = starting_funds
+	M.off_station = _off_station
 	if(!source_db)
 		//set a random date, time and location some time over the past few decades
 		T.date = "[num2text(rand(1,31))] [pick("January","February","March","April","May","June","July","August","September","October","November","December")], [game_year-rand(8,18)]"

--- a/code/modules/economy/Accounts.dm
+++ b/code/modules/economy/Accounts.dm
@@ -31,7 +31,7 @@
 	var/time = ""
 	var/source_terminal = ""
 
-/datum/transaction/New(_target, _purpose, _amount, _source, _off_station)
+/datum/transaction/New(_target, _purpose, _amount, _source)
 	..()
 	date = stationdate2text()
 	time = stationtime2text()
@@ -54,7 +54,7 @@
 		R.Find(text)
 		amount = -text2num(R.match)
 
-/proc/create_account(new_owner_name = "Default user", starting_funds = 0, obj/machinery/computer/account_database/source_db)
+/proc/create_account(new_owner_name = "Default user", starting_funds = 0, obj/machinery/computer/account_database/source_db, _off_station)
 
 	//create a new account
 	var/datum/money_account/M = new()

--- a/code/modules/events/money_hacker.dm
+++ b/code/modules/events/money_hacker.dm
@@ -54,8 +54,10 @@
 		var/time = pick("", stationtime2text(), t2)
 
 		//create a taunting log entry
-		spawn(0)
-			for(var/datum/money_account/affected_account in affected_accounts)
+		spawn()
+			var/amount = rand(1, length(affected_accounts))
+			while(amount)
+				var/datum/money_account/affected_account = pick_n_take(affected_accounts)
 				var/datum/transaction/T = new()
 				T.target_name = target_name
 				T.purpose = purpose
@@ -64,6 +66,7 @@
 				T.time = time
 				T.source_terminal = pick("","[pick("Biesel","New Gibson")] GalaxyNet Terminal #[rand(111,999)]","your mums place","nantrasen high CommanD")
 				affected_account.do_transaction(T)
+				amount--
 
 	else
 		//crew wins

--- a/code/modules/events/money_hacker.dm
+++ b/code/modules/events/money_hacker.dm
@@ -1,25 +1,21 @@
 /var/global/account_hack_attempted = 0
 
 /datum/event/money_hacker
-	var/datum/money_account/affected_account
 	endWhen = 100
 	var/end_time
 
 /datum/event/money_hacker/setup()
 	end_time = world.time + 6000
 	if(all_money_accounts.len)
-		affected_account = pick(all_money_accounts)
-
 		account_hack_attempted = 1
 	else
 		kill()
 
 /datum/event/money_hacker/announce()
 	// Hide the account number for now since it's all you need to access a standard-security account. Change when that's no longer the case.
-	var/accnr_hidden = "***[copytext("[affected_account.account_number]", -3)]"
-	var/message = "A brute force hack has been detected (in progress since [stationtime2text()]). The target of the attack is: Financial account #[accnr_hidden], \
-	without intervention this attack will succeed in approximately 10 minutes. Required intervention: temporary suspension of affected accounts until the attack has ceased. \
-	Notifications will be sent as updates occur."
+	var/message = "A brute force hack has been detected (in progress since [stationtime2text()]). The target of the attack is: Financial accounts, \
+	without intervention this attack will succeed in approximately 10 minutes. Possible solutions: suspension of accounts, disabling NTnet server, \
+	increase account security level. Notifications will be sent as updates occur."
 	command_announcement.Announce(message, "[location_name()] Firewall Subroutines")
 
 
@@ -31,27 +27,43 @@
 
 /datum/event/money_hacker/end()
 	var/message
-	if(affected_account && !affected_account.suspended)
+
+	var/list/datum/money_account/affected_accounts = list()
+	for(var/datum/money_account/M in all_money_accounts)
+		if(M.suspended)
+			continue
+		if(M.security_level >= 1)
+			continue
+		if(M.off_station)
+			continue
+		if(M.money <= 0)
+			continue
+		affected_accounts |= M
+
+	if(ntnet_global?.check_function() && length(affected_accounts))
 		//hacker wins
 		message = "The hack attempt has succeeded."
 
-		//subtract the money
-		var/lost = affected_account.money * 0.8 + (rand(2,4) - 2) / 10
+		var/target_name = pick("","yo brotha from anotha motha","el Presidente","chieF smackDowN")
+		var/purpose = pick("Ne$ ---ount fu%ds init*&lisat@*n","PAY BACK YOUR MUM","Funds withdrawal","pWnAgE","l33t hax","liberationez")
+		var/d1 = "31 December, 1999"
+		var/d2 = "[num2text(rand(1,31))] [pick("January","February","March","April","May","June","July","August","September","October","November","December")], [rand(1000,3000)]"
+		var/date = pick("", stationdate2text(), d1, d2)
+		var/t1 = rand(0, 99999999)
+		var/t2 = "[round(t1 / 36000)+12]:[(t1 / 600 % 60) < 10 ? add_zero(t1 / 600 % 60, 1) : t1 / 600 % 60]"
+		var/time = pick("", stationtime2text(), t2)
 
 		//create a taunting log entry
-		var/datum/transaction/T = new()
-		T.target_name = pick("","yo brotha from anotha motha","el Presidente","chieF smackDowN")
-		T.purpose = pick("Ne$ ---ount fu%ds init*&lisat@*n","PAY BACK YOUR MUM","Funds withdrawal","pWnAgE","l33t hax","liberationez")
-		T.amount = -lost
-		var/date1 = "31 December, 1999"
-		var/date2 = "[num2text(rand(1,31))] [pick("January","February","March","April","May","June","July","August","September","October","November","December")], [rand(1000,3000)]"
-		T.date = pick("", stationdate2text(), date1, date2)
-		var/time1 = rand(0, 99999999)
-		var/time2 = "[round(time1 / 36000)+12]:[(time1 / 600 % 60) < 10 ? add_zero(time1 / 600 % 60, 1) : time1 / 600 % 60]"
-		T.time = pick("", stationtime2text(), time2)
-		T.source_terminal = pick("","[pick("Biesel","New Gibson")] GalaxyNet Terminal #[rand(111,999)]","your mums place","nantrasen high CommanD")
-
-		affected_account.do_transaction(T)
+		spawn(0)
+			for(var/datum/money_account/affected_account in affected_accounts)
+				var/datum/transaction/T = new()
+				T.target_name = target_name
+				T.purpose = purpose
+				T.amount = -affected_account.money
+				T.date = date
+				T.time = time
+				T.source_terminal = pick("","[pick("Biesel","New Gibson")] GalaxyNet Terminal #[rand(111,999)]","your mums place","nantrasen high CommanD")
+				affected_account.do_transaction(T)
 
 	else
 		//crew wins


### PR DESCRIPTION
Всем абсолютно похуй на этот ивент (ровно как и на деньги), потому я решил сделать его жестче. 

Теперь же хакер нацеливается на абсолютно **все** финансовые аккаунты станции, а не на какой-то один. 

Предотвратить кражу денег можно следующими способами:
1. Временная блокировка аккаунта через специальную консоль у главы персонала.
2. Повышение уровня безопасности аккаунта хотя бы до среднего.
3. Обналичивание всех денег со счета.
4. Временное отключение НТсервера - самый глобальный и, по идеи, наилучший вариант.

С этими изменениями, как мне кажется, люди будут создавать кое-какое, но всё же, движение в раунде. А при четвертом варианте решения проблемы многие программы будут недоступны, вроде сенсоров, что позволит антагам сделать свой ход.

- [x] Pull Request полностью завершен, мне не нужна помощь чтобы его закончить.
- [x] Я внимательно прочитал все свои изменения и багов в них не нашел.
- [x] Я запускал сервер со своими изменениями локально и все протестировал.
- [x] Я ознакомился c [Guide to Contribute](https://github.com/ChaoticOnyx/OnyxBay/blob/dev/docs/contributing.md).
