### PR TITLE
Mecha tracking fix

### DIFF
--- a/code/game/mecha/combat/durand.dm
+++ b/code/game/mecha/combat/durand.dm
@@ -14,6 +14,8 @@
 	var/def_boost = 15
 	wreckage = /obj/effect/decal/mecha_wreckage/durand
 
+	create_tracker = 1
+
 /*
 /obj/mecha/combat/durand/Initialize()
 	..()

--- a/code/game/mecha/combat/gygax.dm
+++ b/code/game/mecha/combat/gygax.dm
@@ -16,6 +16,8 @@
 	internal_damage_threshold = 35
 	max_equip = 3
 
+	create_tracker = 1
+
 /obj/mecha/combat/gygax/dark
 	desc = "A lightweight exosuit used by Heavy Asset Protection. A significantly upgraded Gygax security mech."
 	name = "Dark Gygax"
@@ -29,6 +31,8 @@
 	wreckage = /obj/effect/decal/mecha_wreckage/gygax/dark
 	max_equip = 4
 	step_energy_drain = 5
+
+	create_tracker = 0
 
 /obj/mecha/combat/gygax/dark/Initialize()
 	. = .. ()

--- a/code/game/mecha/combat/honker.dm
+++ b/code/game/mecha/combat/honker.dm
@@ -16,6 +16,8 @@
 	max_equip = 3
 	var/squeak = 0
 
+	create_tracker = 1
+
 /obj/mecha/combat/honker/melee_action(target)
 	if(!melee_can_hit)
 		return

--- a/code/game/mecha/combat/honker.dm
+++ b/code/game/mecha/combat/honker.dm
@@ -16,7 +16,7 @@
 	max_equip = 3
 	var/squeak = 0
 
-	create_tracker = 1
+	create_tracker = 0
 
 /obj/mecha/combat/honker/melee_action(target)
 	if(!melee_can_hit)

--- a/code/game/mecha/combat/marauder.dm
+++ b/code/game/mecha/combat/marauder.dm
@@ -22,6 +22,8 @@
 	force = 45
 	max_equip = 4
 
+	create_tracker = 0
+
 /obj/mecha/combat/marauder/seraph
 	desc = "Heavy-duty, command-type exosuit. This is a custom model, utilized only by high-ranking military personnel."
 	name = "Seraph"
@@ -35,6 +37,8 @@
 	force = 55
 	max_equip = 5
 
+	create_tracker = 0
+
 /obj/mecha/combat/marauder/mauler
 	desc = "Heavy-duty, combat exosuit, developed off of the existing Marauder model."
 	name = "Mauler"
@@ -42,6 +46,8 @@
 	initial_icon = "mauler"
 	operation_req_access = list(access_syndicate)
 	wreckage = /obj/effect/decal/mecha_wreckage/mauler
+
+	create_tracker = 0
 
 /obj/mecha/combat/marauder/Initialize()
 	. = ..()

--- a/code/game/mecha/combat/phazon.dm
+++ b/code/game/mecha/combat/phazon.dm
@@ -20,6 +20,8 @@
 	var/phasing_energy_drain = 5 KILOWATTS
 	max_equip = 4
 
+	create_tracker = 0
+
 
 /obj/mecha/combat/phazon/Initialize()
 	. = ..()

--- a/code/game/mecha/equipment/tools/tools.dm
+++ b/code/game/mecha/equipment/tools/tools.dm
@@ -935,7 +935,7 @@
 
 //This is pretty much just for the death-ripley so that it is harmless
 /obj/item/mecha_parts/mecha_equipment/tool/safety_clamp
-	name = "\improper KILL CLAMP"
+	name = "\improper Kill Clamp"
 	icon_state = "mecha_clamp"
 	equip_cooldown = 15
 	energy_drain = 0

--- a/code/game/mecha/equipment/tools/tools.dm
+++ b/code/game/mecha/equipment/tools/tools.dm
@@ -935,7 +935,7 @@
 
 //This is pretty much just for the death-ripley so that it is harmless
 /obj/item/mecha_parts/mecha_equipment/tool/safety_clamp
-	name = "\improper Kill Clamp"
+	name = "\improper KILL CLAMP"
 	icon_state = "mecha_clamp"
 	equip_cooldown = 15
 	energy_drain = 0

--- a/code/game/mecha/mecha.dm
+++ b/code/game/mecha/mecha.dm
@@ -107,6 +107,11 @@
 	log_message("[src.name] created.")
 	loc.Entered(src)
 	mechas_list += src //global mech list
+
+	var/turf/T = get_turf(src)
+	if(isPlayerLevel(T.z) && src.create_tracker == 1)
+		new /obj/item/mecha_parts/mecha_tracking(src)
+
 	return
 
 /obj/mecha/Destroy()

--- a/code/game/mecha/mecha.dm
+++ b/code/game/mecha/mecha.dm
@@ -72,6 +72,7 @@
 	var/datum/global_iterator/pr_give_air //moves air from tank to cabin
 	var/datum/global_iterator/pr_internal_damage //processes internal damage
 
+	var/create_tracker // 1 - mecha can be tracked / 0 - mecha can not be tracked
 
 	var/wreckage
 

--- a/code/game/mecha/mecha.dm
+++ b/code/game/mecha/mecha.dm
@@ -72,7 +72,7 @@
 	var/datum/global_iterator/pr_give_air //moves air from tank to cabin
 	var/datum/global_iterator/pr_internal_damage //processes internal damage
 
-	var/create_tracker // 1 - mecha can be tracked / 0 - mecha can not be tracked
+	var/create_tracker
 
 	var/wreckage
 
@@ -109,7 +109,7 @@
 	mechas_list += src //global mech list
 
 	var/turf/T = get_turf(src)
-	if(isPlayerLevel(T.z) && src.create_tracker == 1)
+	if(isPlayerLevel(T.z) && src.create_tracker)
 		new /obj/item/mecha_parts/mecha_tracking(src)
 
 	return

--- a/code/game/mecha/mecha_control_console.dm
+++ b/code/game/mecha/mecha_control_console.dm
@@ -73,7 +73,7 @@
 
 	proc/get_mecha_info()
 		var/obj/mecha/M = src.loc
-		if(!in_mecha() || M.create_tracker==0)
+		if(!in_mecha())
 			return 0
 		var/cell_charge = M.get_charge()
 		var/answer = {"<b>Name:</b> [M.name]<br>

--- a/code/game/mecha/mecha_control_console.dm
+++ b/code/game/mecha/mecha_control_console.dm
@@ -72,9 +72,9 @@
 	origin_tech = list(TECH_DATA = 2, TECH_MAGNET = 2)
 
 	proc/get_mecha_info()
-		var/obj/mecha/M = src.loc
 		if(!in_mecha())
 			return 0
+		var/obj/mecha/M = src.loc
 		var/cell_charge = M.get_charge()
 		var/answer = {"<b>Name:</b> [M.name]<br>
 							<b>Integrity:</b> [M.health/initial(M.health)*100]%<br>

--- a/code/game/mecha/mecha_control_console.dm
+++ b/code/game/mecha/mecha_control_console.dm
@@ -85,7 +85,7 @@
 							<b>Active equipment:</b> [M.selected||"None"]"}
 		if(istype(M, /obj/mecha/working/ripley))
 			var/obj/mecha/working/ripley/RM = M
-			answer += "<b>Used cargo space:</b> [RM.cargo.len/RM.cargo_capacity*100]%<br>"
+			answer += "<br><b>Used cargo space:</b> [RM.cargo.len/RM.cargo_capacity*100]%<br>"
 
 		return answer
 

--- a/code/game/mecha/mecha_control_console.dm
+++ b/code/game/mecha/mecha_control_console.dm
@@ -72,9 +72,9 @@
 	origin_tech = list(TECH_DATA = 2, TECH_MAGNET = 2)
 
 	proc/get_mecha_info()
-		if(!in_mecha())
-			return 0
 		var/obj/mecha/M = src.loc
+		if(!in_mecha() || M.create_tracker==0)
+			return 0
 		var/cell_charge = M.get_charge()
 		var/answer = {"<b>Name:</b> [M.name]<br>
 							<b>Integrity:</b> [M.health/initial(M.health)*100]%<br>

--- a/code/game/mecha/medical/medical.dm
+++ b/code/game/mecha/medical/medical.dm
@@ -1,8 +1,5 @@
 /obj/mecha/medical/Initialize()
 	. = ..()
-	var/turf/T = get_turf(src)
-	if(isPlayerLevel(T.z))
-		new /obj/item/mecha_parts/mecha_tracking(src)
 
 
 /obj/mecha/medical/mechturn(direction)

--- a/code/game/mecha/medical/odysseus.dm
+++ b/code/game/mecha/medical/odysseus.dm
@@ -11,6 +11,8 @@
 	deflect_chance = 15
 	var/obj/item/clothing/glasses/hud/health/mech/hud
 
+	create_tracker = 1
+
 /obj/mecha/medical/odysseus/Initialize()
 	. = ..()
 	hud = new /obj/item/clothing/glasses/hud/health/mech(src)

--- a/code/game/mecha/working/hoverpod.dm
+++ b/code/game/mecha/working/hoverpod.dm
@@ -15,6 +15,8 @@
 	var/datum/effect/effect/system/trail/ion_trail
 	var/stabilization_enabled = 1
 
+	create_tracker = 1
+
 /obj/mecha/working/hoverpod/Initialize()
 	. = ..()
 	ion_trail = new /datum/effect/effect/system/trail/ion()
@@ -82,6 +84,8 @@
 	internal_damage_threshold = 35
 	cargo_capacity = 2
 	max_equip = 2
+
+	create_tracker = 1
 
 /obj/mecha/working/hoverpod/combatpod/Initialize()
 	. = ..()

--- a/code/game/mecha/working/hoverpod.dm
+++ b/code/game/mecha/working/hoverpod.dm
@@ -85,7 +85,7 @@
 	cargo_capacity = 2
 	max_equip = 2
 
-	create_tracker = 1
+	create_tracker = 0
 
 /obj/mecha/working/hoverpod/combatpod/Initialize()
 	. = ..()

--- a/code/game/mecha/working/ripley.dm
+++ b/code/game/mecha/working/ripley.dm
@@ -45,8 +45,8 @@
 	create_tracker = 1
 
 /obj/mecha/working/ripley/deathripley
-	desc = "Is that blood on its armor plating?"
-	name = "Death-Ripley"
+	desc = "OH SHIT IT'S THE DEATHSQUAD WE'RE ALL GONNA DIE!"
+	name = "DEATH-RIPLEY"
 	icon_state = "deathripley"
 	initial_icon = "deathripley"
 	step_in = 2
@@ -80,7 +80,5 @@
 	//Attach hydrolic clamp
 	var/obj/item/mecha_parts/mecha_equipment/tool/hydraulic_clamp/HC = new /obj/item/mecha_parts/mecha_equipment/tool/hydraulic_clamp
 	HC.attach(src)
-	/* for(var/obj/item/mecha_parts/mecha_tracking/B in src.contents)//Deletes the beacon so it can't be found easily
-		qdel (B) */
 
 

--- a/code/game/mecha/working/ripley.dm
+++ b/code/game/mecha/working/ripley.dm
@@ -45,8 +45,8 @@
 	create_tracker = 1
 
 /obj/mecha/working/ripley/deathripley
-	desc = "OH SHIT IT'S THE DEATHSQUAD WE'RE ALL GONNA DIE!"
-	name = "DEATH-RIPLEY"
+	desc = "Is that blood on its armor plating?"
+	name = "Death-Ripley"
 	icon_state = "deathripley"
 	initial_icon = "deathripley"
 	step_in = 2
@@ -80,7 +80,7 @@
 	//Attach hydrolic clamp
 	var/obj/item/mecha_parts/mecha_equipment/tool/hydraulic_clamp/HC = new /obj/item/mecha_parts/mecha_equipment/tool/hydraulic_clamp
 	HC.attach(src)
-	for(var/obj/item/mecha_parts/mecha_tracking/B in src.contents)//Deletes the beacon so it can't be found easily
-		qdel (B)
+	/* for(var/obj/item/mecha_parts/mecha_tracking/B in src.contents)//Deletes the beacon so it can't be found easily
+		qdel (B) */
 
 

--- a/code/game/mecha/working/ripley.dm
+++ b/code/game/mecha/working/ripley.dm
@@ -55,6 +55,8 @@
 	. = ..()
 	var/obj/item/mecha_parts/mecha_equipment/ME = new /obj/item/mecha_parts/mecha_equipment/tool/safety_clamp
 	ME.attach(src)
+	for(var/obj/item/mecha_parts/mecha_tracking/B in src.contents)//Deletes the beacon so it can't be found easily
+		qdel (B)
 	return
 
 /obj/mecha/working/ripley/mining

--- a/code/game/mecha/working/ripley.dm
+++ b/code/game/mecha/working/ripley.dm
@@ -10,6 +10,8 @@
 	cargo_capacity = 10
 	var/hides = 0
 
+	create_tracker = 1
+
 /obj/mecha/working/ripley/Destroy()
 	for(var/atom/movable/A in src.cargo)
 		A.loc = loc
@@ -40,6 +42,8 @@
 	damage_absorption = list("fire"=0.5,"bullet"=0.8,"bomb"=0.5)
 	wreckage = /obj/effect/decal/mecha_wreckage/ripley/firefighter
 
+	create_tracker = 1
+
 /obj/mecha/working/ripley/deathripley
 	desc = "OH SHIT IT'S THE DEATHSQUAD WE'RE ALL GONNA DIE!"
 	name = "DEATH-RIPLEY"
@@ -51,12 +55,12 @@
 	wreckage = /obj/effect/decal/mecha_wreckage/ripley/deathripley
 	step_energy_drain = 0
 
+	create_tracker = 0
+
 /obj/mecha/working/ripley/deathripley/Initialize()
 	. = ..()
 	var/obj/item/mecha_parts/mecha_equipment/ME = new /obj/item/mecha_parts/mecha_equipment/tool/safety_clamp
 	ME.attach(src)
-	for(var/obj/item/mecha_parts/mecha_tracking/B in src.contents)//Deletes the beacon so it can't be found easily
-		qdel (B)
 	return
 
 /obj/mecha/working/ripley/mining

--- a/code/game/mecha/working/working.dm
+++ b/code/game/mecha/working/working.dm
@@ -5,9 +5,6 @@
 
 /obj/mecha/working/Initialize()
 	. = ..()
-	var/turf/T = get_turf(src)
-	if(isPlayerLevel(T.z))
-		new /obj/item/mecha_parts/mecha_tracking(src)
 
 /obj/mecha/working/Destroy()
 	for(var/mob/M in src)

--- a/code/modules/research/mechfab_designs.dm
+++ b/code/modules/research/mechfab_designs.dm
@@ -521,14 +521,6 @@
 	materials = list(MATERIAL_STEEL = 10000, MATERIAL_GLASS = 15000, MATERIAL_DIAMOND = 10000)
 	build_path = /obj/item/borg/upgrade/syndicate
 
-/datum/design/item/mecha_tracking
-	name = "Tracking beacon"
-	build_type = MECHFAB
-	time = 5
-	materials = list(MATERIAL_STEEL = 500)
-	build_path = /obj/item/mecha_parts/mecha_tracking
-	category = "Misc"
-
 /datum/design/item/mecha
 	build_type = MECHFAB
 	category = "Exosuit Equipment"
@@ -540,11 +532,11 @@
 		desc = "Allows for the construction of \a '[item_name]' exosuit module."
 
 /datum/design/item/mecha/mecha_tracking
-	name = "Mecha tracking beacon"
+	name = "Tracking beacon"
 	id = "mecha_tracking"
 	build_path = /obj/item/mecha_parts/mecha_tracking
 	time = 5
-	materials = list(MATERIAL_STEEL = 200)
+	materials = list(MATERIAL_STEEL = 500)
 
 /datum/design/item/mecha/hydraulic_clamp
 	name = "Hydraulic clamp"

--- a/code/modules/research/mechfab_designs.dm
+++ b/code/modules/research/mechfab_designs.dm
@@ -521,6 +521,15 @@
 	materials = list(MATERIAL_STEEL = 10000, MATERIAL_GLASS = 15000, MATERIAL_DIAMOND = 10000)
 	build_path = /obj/item/borg/upgrade/syndicate
 
+
+/datum/design/item/mecha_tracking
+	name = "Tracking beacon"
+	id = "mecha_tracking"
+	build_path = /obj/item/mecha_parts/mecha_tracking
+	time = 5
+	materials = list(MATERIAL_STEEL = 500)
+	category = "Misc"
+
 /datum/design/item/mecha
 	build_type = MECHFAB
 	category = "Exosuit Equipment"
@@ -530,13 +539,6 @@
 /datum/design/item/mecha/AssembleDesignDesc()
 	if(!desc)
 		desc = "Allows for the construction of \a '[item_name]' exosuit module."
-
-/datum/design/item/mecha/mecha_tracking
-	name = "Tracking beacon"
-	id = "mecha_tracking"
-	build_path = /obj/item/mecha_parts/mecha_tracking
-	time = 5
-	materials = list(MATERIAL_STEEL = 500)
 
 /datum/design/item/mecha/hydraulic_clamp
 	name = "Hydraulic clamp"

--- a/code/modules/research/mechfab_designs.dm
+++ b/code/modules/research/mechfab_designs.dm
@@ -521,15 +521,6 @@
 	materials = list(MATERIAL_STEEL = 10000, MATERIAL_GLASS = 15000, MATERIAL_DIAMOND = 10000)
 	build_path = /obj/item/borg/upgrade/syndicate
 
-
-/datum/design/item/mecha_tracking
-	name = "Tracking beacon"
-	id = "mecha_tracking"
-	build_path = /obj/item/mecha_parts/mecha_tracking
-	time = 5
-	materials = list(MATERIAL_STEEL = 500)
-	category = "Misc"
-
 /datum/design/item/mecha
 	build_type = MECHFAB
 	category = "Exosuit Equipment"
@@ -539,6 +530,13 @@
 /datum/design/item/mecha/AssembleDesignDesc()
 	if(!desc)
 		desc = "Allows for the construction of \a '[item_name]' exosuit module."
+
+/datum/design/item/mecha/mecha_tracking
+	name = "Tracking beacon"
+	id = "mecha_tracking"
+	build_path = /obj/item/mecha_parts/mecha_tracking
+	time = 5
+	materials = list(MATERIAL_STEEL = 500)
 
 /datum/design/item/mecha/hydraulic_clamp
 	name = "Hydraulic clamp"

--- a/code/modules/research/mechfab_designs.dm
+++ b/code/modules/research/mechfab_designs.dm
@@ -522,7 +522,7 @@
 	build_path = /obj/item/borg/upgrade/syndicate
 
 /datum/design/item/mecha_tracking
-	name = "Exosuit tracking beacon"
+	name = "Tracking beacon"
 	build_type = MECHFAB
 	time = 5
 	materials = list(MATERIAL_STEEL = 500)
@@ -538,6 +538,13 @@
 /datum/design/item/mecha/AssembleDesignDesc()
 	if(!desc)
 		desc = "Allows for the construction of \a '[item_name]' exosuit module."
+
+/datum/design/item/mecha/mecha_tracking
+	name = "Mecha tracking beacon"
+	id = "mecha_tracking"
+	build_path = /obj/item/mecha_parts/mecha_tracking
+	time = 5
+	materials = list(MATERIAL_STEEL = 200)
 
 /datum/design/item/mecha/hydraulic_clamp
 	name = "Hydraulic clamp"


### PR DESCRIPTION
Глобальный фикс мехов.

Что сделано:
- Добавлен параметр create_tracker, который отвечает за создание маячка в мехе при его появлении в мире (т.е при постройке/генерации)..
- Исправлен UI у консоли РД. (до починки две строчки соединялись в одну) (фото прикреплено ниже)
- Маячок для отслеживания мехов можно сделать в Exosuit Fabricator за 500 стали.
- Мех появляется в консоли РД, если установить маячок.

![image](https://user-images.githubusercontent.com/47484306/116431538-8c528380-a850-11eb-9abe-990fa8322c72.png)
![image](https://user-images.githubusercontent.com/47484306/116431948-e8b5a300-a850-11eb-95f2-64c76953ea06.png)

```yml
🆑
bugfix: Исправлен UI консоли отслеживания мехов.
tweak: Маячок в дереликтовых мехах больше не создается.
rscadd: Маячок можно вновь создать в "Exosuit fabricator" за 500 ед. стали.
/🆑
```

P.S
Установку маячков на мехи геймдизайнеры смогут отрегулировать сами, если заменять ноль на единицу или единицу на ноль.
P.S.S
Извиняюсь за опечатки в описании комитов.

- [x] Pull Request полностью завершен, мне не нужна помощь чтобы его закончить.
- [x] Я внимательно прочитал все свои изменения и багов в них не нашел.
- [x] Я запускал сервер со своими изменениями локально и все протестировал.
- [x] Я ознакомился c [Guide to Contribute](https://github.com/ChaoticOnyx/OnyxBay/blob/dev/docs/contributing.md).
