### PR TITLE
Removes get_turf() from all playsound calls

### DIFF
--- a/code/datums/trading/trade.dm
+++ b/code/datums/trading/trade.dm
@@ -257,7 +257,7 @@
 			return TRADER_FOUND_UNWANTED
 		. += get_value(offer) * mult
 
-	playsound(get_turf(offers[1]), 'sound/effects/teleport.ogg', 50, 1)
+	playsound(offers[1], 'sound/effects/teleport.ogg', 50, 1)
 	for(var/offer in offers)
 		qdel(offer)
 

--- a/code/game/gamemodes/cult/cult_structures.dm
+++ b/code/game/gamemodes/cult/cult_structures.dm
@@ -43,21 +43,21 @@
 				"You hear a tinkle of crystal shards"
 				)
 			user.do_attack_animation(src)
-			playsound(get_turf(src),get_sfx("window_breaking"), 75, 1)
+			playsound(src, get_sfx("window_breaking"), 75, 1)
 			isbroken = 1
 			set_density(0)
 			icon_state = "pylon-broken"
 			set_light(0)
 		else
 			to_chat(user, "You hit the pylon!")
-			playsound(get_turf(src), get_sfx("glass_hit"), 75, 1)
+			playsound(src, get_sfx("glass_hit"), 75, 1)
 	else
 		if(prob(damage * 2))
 			to_chat(user, "You pulverize what was left of the pylon!")
 			qdel(src)
 		else
 			to_chat(user, "You hit the pylon!")
-		playsound(get_turf(src), get_sfx("glass_hit"), 75, 1)
+		playsound(src, get_sfx("glass_hit"), 75, 1)
 
 
 /obj/structure/cult/pylon/proc/repair(mob/user as mob)

--- a/code/game/gamemodes/godmode/god_structures.dm
+++ b/code/game/gamemodes/godmode/god_structures.dm
@@ -42,7 +42,7 @@
 /obj/structure/deity/attackby(obj/item/W as obj, mob/user as mob)
 	user.setClickCooldown(DEFAULT_ATTACK_COOLDOWN)
 	user.do_attack_animation(src)
-	playsound(get_turf(src), get_sfx("glass_hit"), 50, 1)
+	playsound(src, get_sfx("glass_hit"), 50, 1)
 	user.visible_message(
 		"<span class='danger'>[user] hits \the [src] with \the [W]!</span>",
 		"<span class='danger'>You hit \the [src] with \the [W]!</span>",

--- a/code/game/machinery/kitchen/cooking_machines/_cooker.dm
+++ b/code/game/machinery/kitchen/cooking_machines/_cooker.dm
@@ -174,7 +174,7 @@
 
 				src.visible_message(SPAN_NOTICE("\The [src] pings!"))
 				if(cooked_sound)
-					playsound(get_turf(src), cooked_sound, 50, 1)
+					playsound(src, cooked_sound, 50, 1)
 		if(COOKED)
 			if(!can_burn_food)
 				eject()

--- a/code/game/objects/items/devices/chameleonholo.dm
+++ b/code/game/objects/items/devices/chameleonholo.dm
@@ -59,8 +59,8 @@
 	if(check_blacklist(target))
 		to_chat(user, SPAN("warning", "\The [src] is unable to scan \the [target]!"))
 		return
-	var/obj/object = target 
-	playsound(get_turf(src), 'sound/weapons/flash.ogg', 100, 1, -6)
+	var/obj/object = target
+	playsound(src, 'sound/weapons/flash.ogg', 100, 1, -6)
 	to_chat(user, SPAN("notice","Scanned \the [target]."))
 	saved_appearance = object.appearance
 	saved_dir = object.dir
@@ -70,7 +70,7 @@
 /obj/item/device/chameleonholo/proc/activate(obj/saved_item)
 	if(active || !saved_appearance)
 		return
-	playsound(get_turf(src), 'sound/effects/pop.ogg', 100, 1, -6)
+	playsound(src, 'sound/effects/pop.ogg', 100, 1, -6)
 	appearance = saved_appearance
 	dir = saved_dir
 	density = saved_density
@@ -80,7 +80,7 @@
 /obj/item/device/chameleonholo/proc/deactivate()
 	if (!active)
 		return
-	playsound(get_turf(src), 'sound/effects/pop.ogg', 100, 1, -6)
+	playsound(src, 'sound/effects/pop.ogg', 100, 1, -6)
 	appearance = initial(appearance)
 	dir = initial(dir)
 	density = initial(density)

--- a/code/game/objects/items/devices/chameleonproj.dm
+++ b/code/game/objects/items/devices/chameleonproj.dm
@@ -31,7 +31,7 @@
 	if(!proximity) return
 	if(!active_dummy)
 		if(istype(target,/obj/item) && !istype(target, /obj/item/weapon/disk/nuclear))
-			playsound(get_turf(src), 'sound/weapons/flash.ogg', 100, 1, -6)
+			playsound(src, 'sound/weapons/flash.ogg', 100, 1, -6)
 			to_chat(user, "<span class='notice'>Scanned [target].</span>")
 			saved_item = target.type
 			saved_icon = target.icon
@@ -42,7 +42,7 @@
 	if(!can_use || !saved_item) return
 	if(active_dummy)
 		eject_all()
-		playsound(get_turf(src), 'sound/effects/pop.ogg', 100, 1, -6)
+		playsound(src, 'sound/effects/pop.ogg', 100, 1, -6)
 		qdel(active_dummy)
 		active_dummy = null
 		to_chat(usr, "<span class='notice'>You deactivate the [src].</span>")
@@ -51,7 +51,7 @@
 		flick("emppulse",T)
 		QDEL_IN(T, 8)
 	else
-		playsound(get_turf(src), 'sound/effects/pop.ogg', 100, 1, -6)
+		playsound(src, 'sound/effects/pop.ogg', 100, 1, -6)
 		var/obj/O = new saved_item(src)
 		if(!O) return
 		var/obj/effect/dummy/chameleon/C = new /obj/effect/dummy/chameleon(usr.loc)

--- a/code/game/objects/items/devices/floor_painter.dm
+++ b/code/game/objects/items/devices/floor_painter.dm
@@ -112,7 +112,7 @@
 	if(decal_data["coloured"] && paint_colour)
 		painting_colour = paint_colour
 
-	playsound(get_turf(src), 'sound/effects/spray3.ogg', 30, 1, -6)
+	playsound(src, 'sound/effects/spray3.ogg', 30, 1, -6)
 	new painting_decal(F, painting_dir, painting_colour)
 
 /obj/item/device/floor_painter/attack_self(mob/user)

--- a/code/game/objects/items/devices/whistle.dm
+++ b/code/game/objects/items/devices/whistle.dm
@@ -32,11 +32,11 @@
 		return
 
 	if(isnull(insults))
-		playsound(get_turf(src), 'sound/voice/halt.ogg', 100, 1, vary = 0)
+		playsound(src, 'sound/voice/halt.ogg', 100, 1, vary = 0)
 		user.audible_message("<span class='warning'>[user]'s [name] rasps, \"[use_message]\"</span>", null, "<span class='warning'>\The [user] holds up \the [name].</span>")
 	else
 		if(insults > 0)
-			playsound(get_turf(src), 'sound/voice/binsult.ogg', 100, 1, vary = 0)
+			playsound(src, 'sound/voice/binsult.ogg', 100, 1, vary = 0)
 			// Yes, it used to show the transcription of the sound clip. That was a) inaccurate b) immature as shit.
 			user.audible_message("<span class='warning'>[user]'s [name] gurgles something indecipherable and deeply offensive.</span>", null, "<span class='warning'>\The [user] holds up \the [name].</span>")
 			insults--

--- a/code/game/objects/items/paintkit.dm
+++ b/code/game/objects/items/paintkit.dm
@@ -13,7 +13,7 @@
 
 /obj/item/device/kit/proc/use(amt, mob/user)
 	uses -= amt
-	playsound(get_turf(user), 'sound/items/Screwdriver.ogg', 50, 1)
+	playsound(user, 'sound/items/Screwdriver.ogg', 50, 1)
 	if(uses<1)
 		user.drop_item()
 		qdel(src)

--- a/code/game/objects/items/weapons/RCD.dm
+++ b/code/game/objects/items/weapons/RCD.dm
@@ -188,7 +188,7 @@
 			to_chat(user, "<span class='warning'>Insufficient resources.</span>")
 			return FALSE
 
-		playsound(get_turf(user), 'sound/machines/click.ogg', 50, 1)
+		playsound(user, 'sound/machines/click.ogg', 50, 1)
 		rcdm.work_message(target, user, rcd)
 
 		if(rcdm.delay)
@@ -197,7 +197,7 @@
 				return FALSE
 
 		rcdm.do_handle_work(target)
-		playsound(get_turf(user), 'sound/items/Deconstruct.ogg', 50, 1)
+		playsound(user, 'sound/items/Deconstruct.ogg', 50, 1)
 		return TRUE
 
 	return FALSE

--- a/code/game/objects/items/weapons/defib.dm
+++ b/code/game/objects/items/weapons/defib.dm
@@ -338,12 +338,12 @@
 	if(!do_after(user, 30, H))
 		return
 	user.visible_message("<span class='notice'>\The [user] places [src] on [H]'s chest.</span>", "<span class='warning'>You place [src] on [H]'s chest.</span>")
-	playsound(get_turf(src), 'sound/machines/defib_charge.ogg', 50, 0)
+	playsound(src, 'sound/machines/defib_charge.ogg', 50, 0)
 
 	var/error = can_defib(H)
 	if(error)
 		make_announcement(error, "warning")
-		playsound(get_turf(src), 'sound/machines/defib_failed.ogg', 50, 0)
+		playsound(src, 'sound/machines/defib_failed.ogg', 50, 0)
 		return
 
 	if(check_blood_level(H))
@@ -356,24 +356,24 @@
 	//deduct charge here, in case the base unit was EMPed or something during the delay time
 	if(!checked_use(chargecost))
 		make_announcement("buzzes, \"Insufficient charge.\"", "warning")
-		playsound(get_turf(src), 'sound/machines/defib_failed.ogg', 50, 0)
+		playsound(src, 'sound/machines/defib_failed.ogg', 50, 0)
 		return
 
 	H.visible_message("<span class='warning'>\The [H]'s body convulses a bit.</span>")
-	playsound(get_turf(src), 'sound/machines/defib_zap.ogg', 50, 1, -1)
+	playsound(src, 'sound/machines/defib_zap.ogg', 50, 1, -1)
 	set_cooldown(cooldowntime)
 
 	error = can_revive(H)
 	if(error)
 		make_announcement(error, "warning")
-		playsound(get_turf(src), 'sound/machines/defib_failed.ogg', 50, 0)
+		playsound(src, 'sound/machines/defib_failed.ogg', 50, 0)
 		return
 
 	H.apply_damage(burn_damage_amt, BURN, BP_CHEST)
 
 	//set oxyloss so that the patient is just barely in crit, if possible
 	make_announcement("pings, \"Resuscitation successful.\"", "notice")
-	playsound(get_turf(src), 'sound/machines/defib_success.ogg', 50, 0)
+	playsound(src, 'sound/machines/defib_success.ogg', 50, 0)
 	H.resuscitate()
 	var/obj/item/organ/internal/cell/potato = H.internal_organs_by_name[BP_CELL]
 	if(istype(potato) && potato.cell)
@@ -396,7 +396,7 @@
 		to_chat(user, "<span class='warning'>You can't do that while the safety is enabled.</span>")
 		return
 
-	playsound(get_turf(src), 'sound/machines/defib_charge.ogg', 50, 0)
+	playsound(src, 'sound/machines/defib_charge.ogg', 50, 0)
 	audible_message("<span class='warning'>\The [src] lets out a steadily rising hum...</span>")
 
 	if(!do_after(user, chargetime, H))
@@ -405,11 +405,11 @@
 	//deduct charge here, in case the base unit was EMPed or something during the delay time
 	if(!checked_use(chargecost))
 		make_announcement("buzzes, \"Insufficient charge.\"", "warning")
-		playsound(get_turf(src), 'sound/machines/defib_failed.ogg', 50, 0)
+		playsound(src, 'sound/machines/defib_failed.ogg', 50, 0)
 		return
 
 	user.visible_message("<span class='danger'><i>\The [user] shocks [H] with \the [src]!</i></span>", "<span class='warning'>You shock [H] with \the [src]!</span>")
-	playsound(get_turf(src), 'sound/machines/defib_zap.ogg', 100, 1, -1)
+	playsound(src, 'sound/machines/defib_zap.ogg', 100, 1, -1)
 	playsound(loc, 'sound/weapons/Egloves.ogg', 100, 1, -1)
 	set_cooldown(cooldowntime)
 
@@ -476,10 +476,10 @@
 		safety = new_safety
 		if(safety)
 			make_announcement("beeps, \"Safety protocols enabled!\"", "notice")
-			playsound(get_turf(src), 'sound/machines/defib_safetyon.ogg', 50, 0)
+			playsound(src, 'sound/machines/defib_safetyon.ogg', 50, 0)
 		else
 			make_announcement("beeps, \"Safety protocols disabled!\"", "warning")
-			playsound(get_turf(src), 'sound/machines/defib_safetyoff.ogg', 50, 0)
+			playsound(src, 'sound/machines/defib_safetyoff.ogg', 50, 0)
 		update_icon()
 	..()
 

--- a/code/game/objects/items/weapons/tanks/tanks.dm
+++ b/code/game/objects/items/weapons/tanks/tanks.dm
@@ -454,7 +454,7 @@ var/list/global/tank_gauge_cache = list()
 			if(!T)
 				return
 			T.assume_air(air_contents)
-			playsound(get_turf(src), 'sound/weapons/gunshot/shotgun.ogg', 20, 1)
+			playsound(src, 'sound/weapons/gunshot/shotgun.ogg', 20, 1)
 			visible_message("\icon[src] <span class='danger'>\The [src] flies apart!</span>", "<span class='warning'>You hear a bang!</span>")
 			T.hotspot_expose(air_contents.temperature, 70, 1)
 

--- a/code/game/objects/items/weapons/teleportation.dm
+++ b/code/game/objects/items/weapons/teleportation.dm
@@ -297,7 +297,7 @@ Frequency:
 		if(prob(50))
 			if(prob(50))
 				H.visible_message(SPAN_WARNING("The Vortex Manipulator violently shakes and extracts Space Carps from local bluespace anomaly!"))
-				playsound(get_turf(src), 'sound/effects/phasein.ogg', 50, 1)
+				playsound(src, 'sound/effects/phasein.ogg', 50, 1)
 				new /mob/living/simple_animal/hostile/carp(get_turf(src))
 				H.visible_message(SPAN_NOTICE("The Vortex Manipulator automatically initiates emergency area teleportation procedure."))
 				areateleport(H, 1)
@@ -306,7 +306,7 @@ Frequency:
 		else
 			if(prob(50))
 				H.visible_message(SPAN_WARNING("The Vortex Manipulator violently shakes and extracts Space Carps from local bluespace anomaly!"))
-				playsound(get_turf(src), 'sound/effects/phasein.ogg', 50, 1)
+				playsound(src, 'sound/effects/phasein.ogg', 50, 1)
 				new /mob/living/simple_animal/hostile/carp(get_turf(src))
 				var/temp_turf = get_turf(H)
 				H.visible_message(SPAN_NOTICE("The Vortex Manipulator suddenly teleports user to specific beacon for its own reasons."))
@@ -384,7 +384,7 @@ Frequency:
 		return
 	else if(prob(10))
 		H.visible_message(SPAN_WARNING("The Vortex Manipulator violently shakes and extracts Space Carps from local space-time anomaly!"))
-		playsound(get_turf(src), 'sound/effects/phasein.ogg', 50, 1)
+		playsound(src, 'sound/effects/phasein.ogg', 50, 1)
 		var/amount = rand(1,3)
 		for(var/i=0; i<amount; i++)
 			new /mob/living/simple_animal/hostile/carp(get_turf(src))
@@ -415,7 +415,7 @@ Frequency:
 				localteleport(M, 1)
 			return
 		localteleport(H, 1)
-	playsound(get_turf(src), "spark", 50, 1)
+	playsound(src, "spark", 50, 1)
 	var/datum/effect/effect/system/spark_spread/sparks = new /datum/effect/effect/system/spark_spread()
 	sparks.set_up(3, 0, get_turf(src))
 	sparks.start()
@@ -468,7 +468,7 @@ Frequency:
 	if(istype(vcell, /obj/item/weapon/cell/quantum))
 		var/obj/item/weapon/cell/quantum/Q = vcell
 		if(Q.partner)
-			playsound(get_turf(src), 'sound/effects/phasein.ogg', 50, 1)
+			playsound(src, 'sound/effects/phasein.ogg', 50, 1)
 			user.visible_message(SPAN_WARNING("The Vortex Manipulator turns into a potato!"))
 			new /obj/item/weapon/cell/potato(get_turf(src))
 			qdel(src)

--- a/code/game/objects/structures/bedsheet_bin.dm
+++ b/code/game/objects/structures/bedsheet_bin.dm
@@ -32,7 +32,7 @@ LINEN BINS
 
 /obj/item/weapon/bedsheet/AltClick()
 	if(src in oview(1))
-		playsound(get_turf(loc), "searching_clothes", 15, 1, -5)
+		playsound(loc, "searching_clothes", 15, 1, -5)
 		if(!folded)
 			folded = 1
 			icon_state = "sheet-folded"

--- a/code/game/objects/structures/curtains.dm
+++ b/code/game/objects/structures/curtains.dm
@@ -20,7 +20,7 @@
 		..(P, def_zone)
 
 /obj/structure/curtain/attack_hand(mob/user)
-	playsound(loc), "searching_clothes", 15, 1, -5)
+	playsound(loc, "searching_clothes", 15, 1, -5)
 	toggle()
 	..()
 

--- a/code/game/objects/structures/curtains.dm
+++ b/code/game/objects/structures/curtains.dm
@@ -20,7 +20,7 @@
 		..(P, def_zone)
 
 /obj/structure/curtain/attack_hand(mob/user)
-	playsound(get_turf(loc), "searching_clothes", 15, 1, -5)
+	playsound(loc), "searching_clothes", 15, 1, -5)
 	toggle()
 	..()
 

--- a/code/game/objects/structures/gas_stand.dm
+++ b/code/game/objects/structures/gas_stand.dm
@@ -107,7 +107,7 @@
 				if(breather.internals)
 					breather.internals.icon_state = "internal1"
 			valve_opened = TRUE
-			playsound(get_turf(src), 'sound/effects/internals.ogg', 100, 1)
+			playsound(src, 'sound/effects/internals.ogg', 100, 1)
 			update_icon()
 			START_PROCESSING(SSobj,src)
 

--- a/code/modules/admin/verbs/playsound.dm
+++ b/code/modules/admin/verbs/playsound.dm
@@ -26,7 +26,7 @@ var/list/sounds_cache = list()
 	if(!check_rights(R_SOUNDS))	return
 
 	log_admin("[key_name(src)] played a local sound [S]", location = src.mob, notify_admin = TRUE)
-	playsound(get_turf(src.mob), S, 50, 0, 0)
+	playsound(src.mob, S, 50, 0, 0)
 	feedback_add_details("admin_verb","PLS") //If you are copy-pasting this, ensure the 2nd parameter is unique to the new proc!
 
 

--- a/code/modules/clothing/shoes/magboots.dm
+++ b/code/modules/clothing/shoes/magboots.dm
@@ -38,7 +38,7 @@
 		set_slowdown()
 		force = 5
 		if(icon_base) icon_state = "[icon_base]1"
-		playsound(get_turf(src), 'sound/effects/magnetclamp.ogg', 20)
+		playsound(src, 'sound/effects/magnetclamp.ogg', 20)
 		to_chat(user, "You enable the [traction_system] traction system.")
 	user.update_inv_shoes()	//so our mob-overlays update
 	user.update_action_buttons()

--- a/code/modules/clothing/spacesuits/rig/modules/ninja.dm
+++ b/code/modules/clothing/spacesuits/rig/modules/ninja.dm
@@ -52,7 +52,7 @@
 		anim(get_turf(H), H, 'icons/effects/effects.dmi', "electricity",null,20,null)
 
 	// We still play the sound, even if not visibly uncloaking. Ninjas are not that stealthy.
-	playsound(get_turf(H), 'sound/effects/stealthoff.ogg', 75, 1)
+	playsound(H, 'sound/effects/stealthoff.ogg', 75, 1)
 
 
 /obj/item/rig_module/teleporter

--- a/code/modules/hydroponics/spreading/spreading.dm
+++ b/code/modules/hydroponics/spreading/spreading.dm
@@ -226,7 +226,7 @@
 		..()
 		var/damage = W.edge ? W.force : W.force / 2
 		adjust_health(-damage)
-		playsound(get_turf(src), W.hitsound, 100, 1)
+		playsound(src, W.hitsound, 100, 1)
 
 //handles being overrun by vines - note that attacker_parent may be null in some cases
 /obj/effect/vine/proc/vine_overrun(datum/seed/attacker_seed, obj/effect/vine/attacker_parent)

--- a/code/modules/hydroponics/trays/tray.dm
+++ b/code/modules/hydroponics/trays/tray.dm
@@ -516,7 +516,7 @@
 	else if(O.force && seed)
 		user.setClickCooldown(DEFAULT_ATTACK_COOLDOWN)
 		user.visible_message("<span class='danger'>\The [seed.display_name] has been attacked by [user] with \the [O]!</span>")
-		playsound(get_turf(src), O.hitsound, 100, 1)
+		playsound(src, O.hitsound, 100, 1)
 		if(!dead)
 			health -= O.force
 			check_health()

--- a/code/modules/integrated_electronics/core/assemblies.dm
+++ b/code/modules/integrated_electronics/core/assemblies.dm
@@ -623,7 +623,7 @@
 	if(isWrench(I) && istype(loc, /turf) && can_anchor)
 		if(do_after(user, time))
 			user.visible_message("\The [user] wrenches \the [src]'s anchoring bolts [anchored ? "back" : "into position"].")
-			playsound(get_turf(user), 'sound/items/Ratchet.ogg',50)
+			playsound(user, 'sound/items/Ratchet.ogg',50)
 			anchored = !anchored
 
 /obj/item/device/electronic_assembly/attackby(obj/item/I, mob/living/user)
@@ -691,7 +691,7 @@
 		user.drop_item(I)
 		I.forceMove(src)
 		battery = I
-		playsound(get_turf(src), 'sound/items/Deconstruct.ogg', 50, 1)
+		playsound(src, 'sound/items/Deconstruct.ogg', 50, 1)
 		to_chat(user, SPAN_NOTICE("You slot the [I] inside \the [src]'s power supplier."))
 		return TRUE
 

--- a/code/modules/integrated_electronics/subtypes/output.dm
+++ b/code/modules/integrated_electronics/subtypes/output.dm
@@ -157,7 +157,7 @@
 		if(!selected_sound)
 			return
 		vol = Clamp(vol, 0, 100)
-		playsound(get_turf(src), selected_sound, vol, freq, -1)
+		playsound(src, selected_sound, vol, freq, -1)
 		var/atom/A = get_object()
 		A.investigate_log("played a sound ([selected_sound]) as [type].", INVESTIGATE_CIRCUIT)
 

--- a/code/modules/mob/grab/nab/grab_nab.dm
+++ b/code/modules/mob/grab/nab/grab_nab.dm
@@ -88,7 +88,7 @@
 		G.affecting.visible_message("<span class='danger'>[G.assailant]'s spikes dig in painfully!</span>")
 	else
 		G.affecting.apply_damage(attack_damage, BRUTE, hit_zone, armor,, "crushing")
-	playsound(get_turf(G.assailant), 'sound/weapons/bite.ogg', 25, 1, -1)
+	playsound(G.assailant, 'sound/weapons/bite.ogg', 25, 1, -1)
 
 	admin_attack_log(G.assailant, G.affecting, "Crushed their victim.", "Was crushed.", "crushed")
 
@@ -101,6 +101,6 @@
 
 	G.affecting.apply_damage(attack_damage, BRUTE, hit_zone, armor, DAM_SHARP|DAM_EDGE, "mandibles")
 	G.affecting.visible_message("<span class='danger'>[G.assailant] chews on [G.affecting]'s [damaging.name]!</span>")
-	playsound(get_turf(G.assailant), 'sound/weapons/bite.ogg', 25, 1, -1)
+	playsound(G.assailant, 'sound/weapons/bite.ogg', 25, 1, -1)
 
 	admin_attack_log(G.assailant, G.affecting, "Chews their victim.", "Was chewed.", "chewed")

--- a/code/modules/mob/living/deity/phenomena/conjuration.dm
+++ b/code/modules/mob/living/deity/phenomena/conjuration.dm
@@ -77,7 +77,7 @@
 /datum/phenomena/banishing_smite/activate(mob/living/L, mob/living/deity/user)
 	..()
 	L.take_overall_damage(rand(5,30),0,0,0,"blunt intrument") //Actual spell does 5d10 but maaaybe too much.
-	playsound(get_turf(L), 'sound/effects/bamf.ogg', 100, 1)
+	playsound(L, 'sound/effects/bamf.ogg', 100, 1)
 	to_chat(L, "<span class='danger'>Something hard hits you!</span>")
 	if(L.health < L.maxHealth/2) //If it reduces past 50%
 		var/obj/effect/rift/R = new(get_turf(L))

--- a/code/modules/mob/living/living.dm
+++ b/code/modules/mob/living/living.dm
@@ -142,7 +142,7 @@
 					var/obj/machinery/disposal/D = AM
 					if(istype(D) && !(D.stat & BROKEN))
 						Weaken(6)
-						playsound(get_turf(AM), 'sound/effects/clang.ogg', 75)
+						playsound(AM, 'sound/effects/clang.ogg', 75)
 						visible_message(SPAN_WARNING("[src] falls into \the [AM]!"), SPAN_WARNING("You fall into \the [AM]!"))
 						if (client)
 							client.perspective = EYE_PERSPECTIVE

--- a/code/modules/mob/living/simple_animal/hostile/maneater.dm
+++ b/code/modules/mob/living/simple_animal/hostile/maneater.dm
@@ -56,7 +56,7 @@
 		return null // Don't just return 0 or i'll beat you with a stick
 	. = ..()
 	if(.)
-		playsound(get_turf(src), 'sound/voice/MEraaargh.ogg', 70, 1)
+		playsound(src, 'sound/voice/MEraaargh.ogg', 70, 1)
 		custom_emote(1, "roars at [.]")
 
 /mob/living/simple_animal/hostile/maneater/AttackingTarget()

--- a/code/modules/mob/transform_procs.dm
+++ b/code/modules/mob/transform_procs.dm
@@ -329,4 +329,4 @@
 	src.does_not_breathe = TRUE
 	verbs += /mob/living/proc/breath_death
 	verbs += /mob/living/proc/consume
-	playsound(get_turf(src), 'sound/hallucinations/wail.ogg', 20, 1)
+	playsound(src, 'sound/hallucinations/wail.ogg', 20, 1)

--- a/code/modules/power/apc.dm
+++ b/code/modules/power/apc.dm
@@ -673,7 +673,7 @@
 						to_chat(user, "<span class='warning'>There's a nasty sound and \the [src] goes cold...</span>")
 						set_broken(TRUE)
 				queue_icon_update()
-		playsound(get_turf(src), 'sound/effects/fighting/smash.ogg', 75, 1)
+		playsound(src, 'sound/effects/fighting/smash.ogg', 75, 1)
 
 // attack with hand - remove cell (if cover open) or interact with the APC
 

--- a/code/modules/power/port_gen.dm
+++ b/code/modules/power/port_gen.dm
@@ -492,10 +492,10 @@
 		if(R.standard_pour_into(src,user))
 			if(reagents.has_reagent("vodka"))
 				audible_message("<span class='notice'>[src] blips happily</span>")
-				playsound(get_turf(src),'sound/machines/synth_yes.ogg', 50, 0)
+				playsound(src,'sound/machines/synth_yes.ogg', 50, 0)
 			else
 				audible_message("<span class='warning'>[src] blips in disappointment</span>")
-				playsound(get_turf(src), 'sound/machines/synth_no.ogg', 50, 0)
+				playsound(src, 'sound/machines/synth_no.ogg', 50, 0)
 		return
 	..()
 

--- a/code/modules/power/smes.dm
+++ b/code/modules/power/smes.dm
@@ -339,7 +339,7 @@
 				to_chat(user, "<span class='warning'>You must remove the floor plating first.</span>")
 			else
 				to_chat(user, "<span class='notice'>You begin to cut the cables...</span>")
-				playsound(get_turf(src), 'sound/items/Deconstruct.ogg', 50, 1)
+				playsound(src, 'sound/items/Deconstruct.ogg', 50, 1)
 				if(do_after(user, 50, src))
 					if (prob(50) && electrocute_mob(usr, term.powernet, term))
 						var/datum/effect/effect/system/spark_spread/s = new /datum/effect/effect/system/spark_spread

--- a/code/modules/power/smes_construction.dm
+++ b/code/modules/power/smes_construction.dm
@@ -365,7 +365,7 @@
 				to_chat(user, "<span class='warning'>You have to disassemble the terminal first!</span>")
 				return
 
-			playsound(get_turf(src), 'sound/items/Crowbar.ogg', 50, 1)
+			playsound(src, 'sound/items/Crowbar.ogg', 50, 1)
 			to_chat(user, "<span class='warning'>You begin to disassemble the [src]!</span>")
 			if (do_after(usr, 50 * cur_coils, src)) // More coils = takes longer to disassemble. It's complex so largest one with 6 coils will take 30s
 

--- a/code/modules/projectiles/targeting/targeting_overlay.dm
+++ b/code/modules/projectiles/targeting/targeting_overlay.dm
@@ -172,7 +172,7 @@ obj/aiming_overlay/proc/update_aiming_deferred()
 		aiming_with = thing
 		aiming_at = target
 		if(istype(aiming_with, /obj/item/weapon/gun))
-			playsound(get_turf(owner), 'sound/weapons/TargetOn.ogg', 50,1)
+			playsound(owner, 'sound/weapons/TargetOn.ogg', 50,1)
 
 		aiming_at.aimed |= src
 		movement_tally = 5
@@ -220,7 +220,7 @@ obj/aiming_overlay/proc/update_aiming_deferred()
 	if(!aiming_with || !aiming_at)
 		return
 	if(istype(aiming_with, /obj/item/weapon/gun))
-		playsound(get_turf(owner), 'sound/weapons/TargetOff.ogg', 50,1)
+		playsound(owner, 'sound/weapons/TargetOff.ogg', 50,1)
 	if(!no_message)
 		owner.visible_message("<span class='notice'>\The [owner] lowers \the [aiming_with].</span>")
 

--- a/code/modules/reagents/Chemistry-Recipes.dm
+++ b/code/modules/reagents/Chemistry-Recipes.dm
@@ -937,7 +937,7 @@
 
 /datum/chemical_reaction/slime/bork/on_reaction(datum/reagents/holder)
 	var/list/borks = typesof(/obj/item/weapon/reagent_containers/food/snacks) - /obj/item/weapon/reagent_containers/food/snacks
-	playsound(get_turf(holder.my_atom), 'sound/effects/phasein.ogg', 100, 1)
+	playsound(holder.my_atom, 'sound/effects/phasein.ogg', 100, 1)
 	for(var/mob/living/carbon/human/M in viewers(get_turf(holder.my_atom), null))
 		if(M.eyecheck() < FLASH_PROTECTION_MODERATE)
 			M.flash_eyes()
@@ -973,7 +973,7 @@
 	set waitfor = 0
 	..()
 	sleep(50)
-	playsound(get_turf(holder.my_atom), 'sound/effects/phasein.ogg', 100, 1)
+	playsound(holder.my_atom, 'sound/effects/phasein.ogg', 100, 1)
 	for(var/mob/living/M in range (get_turf(holder.my_atom), 7))
 		M.bodytemperature -= 140
 		to_chat(M, "<span class='warning'>You feel a chill!</span>")

--- a/code/modules/spells/contracts.dm
+++ b/code/modules/spells/contracts.dm
@@ -124,7 +124,7 @@
 		return 1
 	else if(ispath(path,/obj))
 		new path(get_turf(user.loc))
-		playsound(get_turf(usr),'sound/effects/phasein.ogg',50,1)
+		playsound(usr, 'sound/effects/phasein.ogg', 50, 1)
 		return 1
 
 /obj/item/weapon/contract/boon/wizard

--- a/code/modules/spells/general/area_teleport.dm
+++ b/code/modules/spells/general/area_teleport.dm
@@ -32,7 +32,7 @@
 	return list(teleportlocs[thearea])
 
 /spell/area_teleport/cast(area/thearea, mob/user)
-	playsound(get_turf(user),cast_sound,50,1)
+	playsound(user,cast_sound,50,1)
 	if(!istype(thearea))
 		if(istype(thearea, /list))
 			thearea = thearea[1]

--- a/code/modules/spells/spell_code.dm
+++ b/code/modules/spells/spell_code.dm
@@ -186,7 +186,7 @@ var/list/spells = typesof(/spell) //needed for the badmin verb for now
 
 /spell/proc/after_cast(list/targets)
 	if(cast_sound)
-		playsound(get_turf(holder),cast_sound,50,1)
+		playsound(holder, cast_sound, 50, 1)
 	for(var/atom/target in targets)
 		var/location = get_turf(target)
 		if(istype(target,/mob/living) && message)

--- a/code/modules/spells/spellbook.dm
+++ b/code/modules/spells/spellbook.dm
@@ -213,7 +213,7 @@ var/list/artefact_feedback = list(/obj/structure/closet/wizard/armor = 		"HS",
 					uses -= spellbook.spells[path]
 					spellbook.max_uses -= spellbook.spells[path]
 					//finally give it a bit of an oomf
-					playsound(get_turf(user),'sound/effects/phasein.ogg',50,1)
+					playsound(user,'sound/effects/phasein.ogg',50,1)
 		. = TOPIC_REFRESH
 
 	else if(href_list["reset"])

--- a/code/modules/spells/targeted/shapeshift.dm
+++ b/code/modules/spells/targeted/shapeshift.dm
@@ -81,7 +81,7 @@
 		target.mind.transfer_to(transformer)
 	else
 		transformer.key = target.key
-	playsound(get_turf(target), revert_sound, 50, 1)
+	playsound(target, revert_sound, 50, 1)
 	transformer.forceMove(get_turf(target))
 	remove_target(target)
 	qdel(target)


### PR DESCRIPTION
Зачем? А потому что playsound и так вызывает get_turf.
https://github.com/ChaoticOnyx/OnyxBay/blob/2ce3db507abfb5bb33c7a89215908edcf8681e4c/code/game/sound.dm#L446

- [x] Pull Request полностью завершен, мне не нужна помощь чтобы его закончить.
- [x] Я внимательно прочитал все свои изменения и багов в них не нашел.
- [x] Я запускал сервер со своими изменениями локально и все протестировал.
- [x] Я ознакомился c [Guide to Contribute](https://github.com/ChaoticOnyx/OnyxBay/blob/dev/docs/contributing.md).
