### PR TITLE
Fixes everything

### DIFF
--- a/code/modules/client/client_defines.dm
+++ b/code/modules/client/client_defines.dm
@@ -27,7 +27,7 @@
 	changed to a URL at runtime (see client_procs.dm for procs that do this automatically). More information about how goofy this broken setting works at
 	http://www.byond.com/forum/post/1906517?page=2#comment23727144
 	*/
-	preload_rsc = 0
+	preload_rsc = 1
 
 	// * Sound stuff *
 	var/ambience_playing = null
@@ -64,4 +64,4 @@
 	var/first_say = TRUE
 
 	//For tracking shift key (world.time)
-	var/shift_released_at = 0 
+	var/shift_released_at = 0

--- a/code/modules/client/client_procs.dm
+++ b/code/modules/client/client_procs.dm
@@ -175,10 +175,12 @@
 		qdel(src)
 		return
 
+	/* Should be uncommented as soon as we manage to set a working resource URL. For now, messing with clients' preload_rsc at runtime may rain holy hell down upon us.
 	// Change the way they should download resources.
 	if(config.resource_urls && config.resource_urls.len)
 		src.preload_rsc = pick(config.resource_urls)
 	else src.preload_rsc = 1 // If config.resource_urls is not set, preload like normal.
+	*/
 
 	DIRECT_OUTPUT(src, "<span class='warning'>If the title screen is black and chat is broken, resources are still downloading. Please be patient until the title screen appears.</span>")
 	GLOB.clients += src


### PR DESCRIPTION
Теперь ресурсы грузятся во время подключения к серверу, а не подгружаются во время игры. Больше никаких фризов от стандартных песен из джукбокса, крашей от эмбиентов и пропадающих иконок. 
В теории, может решить проблему и с белыми окошками наноУИ.
После обновления игрокам рекомендуется почистить кэш бульонда. А желательно - чистить после каждого обновления.

- [x] Pull Request полностью завершен, мне не нужна помощь чтобы его закончить.
- [x] Я внимательно прочитал все свои изменения и багов в них не нашел.
- [x] Я запускал сервер со своими изменениями локально и все протестировал.
- [x] Я ознакомился c [Guide to Contribute](https://github.com/ChaoticOnyx/OnyxBay/blob/dev/docs/contributing.md).
