### PR TITLE
Прикрутил эмоуты к сейлогам в Individual Round Logs

### DIFF
--- a/code/modules/admin/verbs/individual_logging.dm
+++ b/code/modules/admin/verbs/individual_logging.dm
@@ -19,4 +19,6 @@
 		for(var/entry in M.logging[type])
 			dat += "<font size=2px>[entry]: [M.logging[type][entry]]</font><hr>"
 
-	show_browser(usr, dat, "window=invidual_logging;size=600x480")
+	var/datum/browser/popup = new(M, "individual_logging_panel", "Individual logging panel", 600, 480)
+	popup.set_content(dat)
+	popup.open()

--- a/code/modules/emotes/emote_mob.dm
+++ b/code/modules/emotes/emote_mob.dm
@@ -128,6 +128,8 @@
 
 	if (message)
 		log_emote("[name]/[key] : [message]")
+		log_message(input, INDIVIDUAL_SAY_LOG, "\[EMOTE\]")
+
 	//do not show NPC animal emotes to ghosts, it turns into hellscape
 	var/check_ghosts = client ? /datum/client_preference/ghost_sight : null
 	if(m_type == VISIBLE_MESSAGE)

--- a/code/modules/mob/mob_helpers.dm
+++ b/code/modules/mob/mob_helpers.dm
@@ -290,14 +290,14 @@ It's fairly easy to fix if dealing with single letters but not so much with comp
 		p=p+n_mod
 	return sanitize(t)
 
-/mob/proc/log_message(message, message_type)
+/mob/proc/log_message(message, message_type, message_tag)
 	if(!LAZYLEN(message) || !message_type)
 		return
 
 	if(!islist(logging[message_type]))
 		logging[message_type] = list()
 
-	var/list/timestamped_message = list("[LAZYLEN(logging[message_type]) + 1]\[[time_stamp()]\] [key_name(src)]" = message)
+	var/list/timestamped_message = list("[LAZYLEN(logging[message_type]) + 1]\[[time_stamp()]\] [message_tag] [key_name(src)]" = message)
 
 	logging[message_type] += timestamped_message
 


### PR DESCRIPTION
Ну а также перевёл само окошко в фэйковые нанохуи

<details>
  <summary>Окошко</summary>
  
![image](https://user-images.githubusercontent.com/59123747/117358576-ff966e00-aebe-11eb-9ddb-d49ba01eb7e4.png)

</details>
 
close #4800 

🆑
tweak: Добавлено логирование эмоутов в Individual Round Logs.
/🆑

- [x] Pull Request полностью завершен, мне не нужна помощь чтобы его закончить.
- [x] Я внимательно прочитал все свои изменения и багов в них не нашел.
- [x] Я запускал сервер со своими изменениями локально и все протестировал.
- [x] Я ознакомился c [Guide to Contribute](https://github.com/ChaoticOnyx/OnyxBay/blob/dev/docs/contributing.md).
