### PR TITLE
Removes light tube lamps pixel shift

### DIFF
--- a/code/modules/power/lighting.dm
+++ b/code/modules/power/lighting.dm
@@ -148,7 +148,7 @@
 	var/flickering = 0
 	var/light_type = /obj/item/weapon/light/tube		// the type of light item
 	var/construct_type = /obj/machinery/light_construct
-	var/pixel_shift = 2
+	var/pixel_shift = 0
 
 	var/datum/effect/effect/system/spark_spread/s = new /datum/effect/effect/system/spark_spread
 
@@ -243,15 +243,16 @@
 
 /obj/machinery/light/update_icon(trigger = 1)
 	overlays.Cut()
-	switch(dir)
-		if(NORTH)
-			pixel_y = pixel_shift
-		if(SOUTH)
-			pixel_y = -pixel_shift
-		if(EAST)
-			pixel_x = pixel_shift
-		if(WEST)
-			pixel_x = -pixel_shift
+	if(pixel_shift)
+		switch(dir)
+			if(NORTH)
+				pixel_y = pixel_shift
+			if(SOUTH)
+				pixel_y = -pixel_shift
+			if(EAST)
+				pixel_x = pixel_shift
+			if(WEST)
+				pixel_x = -pixel_shift
 
 	switch(get_status())		// set icon_states
 		if(LIGHT_OK)


### PR DESCRIPTION
- Убран сдвиг обычных светильников (с трубками) из https://github.com/ChaoticOnyx/OnyxBay/pull/5059
Под некоторыми углами оно выглядит слишком уж ужасно. Надо будет в будущем подкрутить систему видимости, тогда можно будет и вернуть.

- [x] Pull Request полностью завершен, мне не нужна помощь чтобы его закончить.
- [x] Я внимательно прочитал все свои изменения и багов в них не нашел.
- [x] Я запускал сервер со своими изменениями локально и все протестировал.
- [x] Я ознакомился c [Guide to Contribute](https://github.com/ChaoticOnyx/OnyxBay/blob/dev/docs/contributing.md).
