### PR TITLE
Removes excessive lighttubes brightness

### DIFF
--- a/code/modules/power/lighting.dm
+++ b/code/modules/power/lighting.dm
@@ -273,6 +273,7 @@
 		TO.color = lightbulb.brightness_color
 		TO.layer = ABOVE_LIGHTING_LAYER
 		TO.plane = EFFECTS_ABOVE_LIGHTING_PLANE
+		TO.alpha = between(128, (lightbulb.brightness_power/6 * 255), 255)
 
 	if(on)
 		update_use_power(POWER_USE_ACTIVE)
@@ -282,6 +283,7 @@
 			changed = set_light(arglist(lightbulb.lighting_modes[current_mode]))
 			if(TO)
 				TO.color = lightbulb.lighting_modes[current_mode]["l_color"]
+				TO.alpha = between(128, (lightbulb.lighting_modes[current_mode]["l_power"]/6 * 255), 255) // Some fine tuning here
 		else
 			changed = set_light(lightbulb.brightness_range, lightbulb.brightness_power, lightbulb.brightness_color)
 


### PR DESCRIPTION
Подкрутил яркость оверлея у ламп с тусклым свечением. 

До:
![image](https://user-images.githubusercontent.com/45202681/117942195-9edabb80-b32c-11eb-81a4-fd4f970d1306.png)
После:
![image](https://user-images.githubusercontent.com/45202681/117942212-a1d5ac00-b32c-11eb-92fb-d0c823955f34.png)


- [x] Pull Request полностью завершен, мне не нужна помощь чтобы его закончить.
- [x] Я внимательно прочитал все свои изменения и багов в них не нашел.
- [x] Я запускал сервер со своими изменениями локально и все протестировал.
- [x] Я ознакомился c [Guide to Contribute](https://github.com/ChaoticOnyx/OnyxBay/blob/dev/docs/contributing.md).
