### PR TITLE
Doors can be interacted with by clicking on turf

### DIFF
--- a/code/_onclick/ai.dm
+++ b/code/_onclick/ai.dm
@@ -215,35 +215,35 @@
 		eyeobj.face_atom(A)
 
 
-//QOL feature, clicking on turf can toogle doors
+// QOL feature, clicking on turf can toogle doors
 /turf/attack_ai(mob/user)
 	user.setClickCooldown(DEFAULT_QUICK_COOLDOWN)
-	//QOL feature, clicking on turf can toogle doors
-	var/obj/machinery/door/airlock/AL = locate(/obj/machinery/door/airlock) in src.contents
+	// QOL feature, clicking on turf can toogle doors
+	var/obj/machinery/door/airlock/AL = locate(/obj/machinery/door/airlock) in contents
 	if(AL)
 		AL.attack_hand(user)
 		return TRUE
-	var/obj/machinery/door/firedoor/FD = locate(/obj/machinery/door/firedoor) in src.contents
+	var/obj/machinery/door/firedoor/FD = locate(/obj/machinery/door/firedoor) in contents
 	if(FD)
 		FD.attack_hand(user)
 		return TRUE
 
-/turf/AICtrlClick(var/mob/user)
-	var/obj/machinery/door/airlock/AL = locate(/obj/machinery/door/airlock) in src.contents
+/turf/AICtrlClick(mob/user)
+	var/obj/machinery/door/airlock/AL = locate(/obj/machinery/door/airlock) in contents
 	if(AL)
 		AL.AICtrlClick(user)
 		return
 	return ..()
 
-/turf/AIAltClick(var/mob/user)
-	var/obj/machinery/door/airlock/AL = locate(/obj/machinery/door/airlock) in src.contents
+/turf/AIAltClick(mob/user)
+	var/obj/machinery/door/airlock/AL = locate(/obj/machinery/door/airlock) in contents
 	if(AL)
 		AL.AIAltClick(user)
 		return
 	return ..()
 
-/turf/AIShiftClick(var/mob/user)
-	var/obj/machinery/door/airlock/AL = locate(/obj/machinery/door/airlock) in src.contents
+/turf/AIShiftClick(mob/user)
+	var/obj/machinery/door/airlock/AL = locate(/obj/machinery/door/airlock) in contents
 	if(AL)
 		AL.AIShiftClick(user)
 		return

--- a/code/_onclick/ai.dm
+++ b/code/_onclick/ai.dm
@@ -213,3 +213,38 @@
 /mob/living/silicon/ai/face_atom(atom/A)
 	if(eyeobj)
 		eyeobj.face_atom(A)
+
+
+//QOL feature, clicking on turf can toogle doors
+/turf/attack_ai(mob/user)
+	user.setClickCooldown(DEFAULT_QUICK_COOLDOWN)
+	//QOL feature, clicking on turf can toogle doors
+	var/obj/machinery/door/airlock/AL = locate(/obj/machinery/door/airlock) in src.contents
+	if(AL)
+		AL.attack_hand(user)
+		return TRUE
+	var/obj/machinery/door/firedoor/FD = locate(/obj/machinery/door/firedoor) in src.contents
+	if(FD)
+		FD.attack_hand(user)
+		return TRUE
+
+/turf/AICtrlClick(var/mob/user)
+	var/obj/machinery/door/airlock/AL = locate(/obj/machinery/door/airlock) in src.contents
+	if(AL)
+		AL.AICtrlClick(user)
+		return
+	return ..()
+
+/turf/AIAltClick(var/mob/user)
+	var/obj/machinery/door/airlock/AL = locate(/obj/machinery/door/airlock) in src.contents
+	if(AL)
+		AL.AIAltClick(user)
+		return
+	return ..()
+
+/turf/AIShiftClick(var/mob/user)
+	var/obj/machinery/door/airlock/AL = locate(/obj/machinery/door/airlock) in src.contents
+	if(AL)
+		AL.AIShiftClick(user)
+		return
+	return ..() 

--- a/code/_onclick/ai.dm
+++ b/code/_onclick/ai.dm
@@ -247,4 +247,4 @@
 	if(AL)
 		AL.AIShiftClick(user)
 		return
-	return ..() 
+	return ..()

--- a/code/_onclick/cyborg.dm
+++ b/code/_onclick/cyborg.dm
@@ -174,4 +174,4 @@
 	AIAltClick(user)
 
 /turf/BorgShiftClick(var/mob/living/silicon/robot/user)
-	AIShiftClick(user) 
+	AIShiftClick(user)

--- a/code/_onclick/cyborg.dm
+++ b/code/_onclick/cyborg.dm
@@ -165,3 +165,13 @@
 /atom/proc/attack_robot(mob/user as mob)
 	attack_ai(user)
 	return
+
+//QOL feature, clicking on turf can toogle doors
+/turf/BorgCtrlClick(var/mob/living/silicon/robot/user)
+	AICtrlClick(user)
+
+/turf/BorgAltClick(var/mob/living/silicon/robot/user)
+	AIAltClick(user)
+
+/turf/BorgShiftClick(var/mob/living/silicon/robot/user)
+	AIShiftClick(user) 

--- a/code/_onclick/cyborg.dm
+++ b/code/_onclick/cyborg.dm
@@ -166,12 +166,12 @@
 	attack_ai(user)
 	return
 
-//QOL feature, clicking on turf can toogle doors
-/turf/BorgCtrlClick(var/mob/living/silicon/robot/user)
+// QOL feature, clicking on turf can toogle doors
+/turf/BorgCtrlClick(mob/living/silicon/robot/user)
 	AICtrlClick(user)
 
-/turf/BorgAltClick(var/mob/living/silicon/robot/user)
+/turf/BorgAltClick(mob/living/silicon/robot/user)
 	AIAltClick(user)
 
-/turf/BorgShiftClick(var/mob/living/silicon/robot/user)
+/turf/BorgShiftClick(mob/living/silicon/robot/user)
 	AIShiftClick(user)

--- a/code/game/turfs/turf.dm
+++ b/code/game/turfs/turf.dm
@@ -70,12 +70,12 @@
 
 /turf/attack_hand(mob/user)
 	user.setClickCooldown(DEFAULT_QUICK_COOLDOWN)
-	//QOL feature, clicking on turf can toogle doors
-	var/obj/machinery/door/airlock/AL = locate(/obj/machinery/door/airlock) in src.contents
+	// QOL feature, clicking on turf can toogle doors
+	var/obj/machinery/door/airlock/AL = locate(/obj/machinery/door/airlock) in contents
 	if(AL)
 		AL.attack_hand(user)
 		return TRUE
-	var/obj/machinery/door/firedoor/FD = locate(/obj/machinery/door/firedoor) in src.contents
+	var/obj/machinery/door/firedoor/FD = locate(/obj/machinery/door/firedoor) in contents
 	if(FD)
 		FD.attack_hand(user)
 		return TRUE

--- a/code/game/turfs/turf.dm
+++ b/code/game/turfs/turf.dm
@@ -70,6 +70,15 @@
 
 /turf/attack_hand(mob/user)
 	user.setClickCooldown(DEFAULT_QUICK_COOLDOWN)
+	//QOL feature, clicking on turf can toogle doors
+	var/obj/machinery/door/airlock/AL = locate(/obj/machinery/door/airlock) in src.contents
+	if(AL)
+		AL.attack_hand(user)
+		return TRUE
+	var/obj/machinery/door/firedoor/FD = locate(/obj/machinery/door/firedoor) in src.contents
+	if(FD)
+		FD.attack_hand(user)
+		return TRUE
 
 	if(user.restrained())
 		return 0


### PR DESCRIPTION
Двери можно открыть кликая на турф а не на иконку двери

<details>
<summary>Чейнджлог</summary>

```yml
🆑
rscadd: Двери теперь можно открывать кликая на тайл где находится дверь.
/🆑
```
</details>

- [x] Pull Request полностью завершен, мне не нужна помощь чтобы его закончить.
- [x] Я внимательно прочитал все свои изменения и багов в них не нашел.
- [x] Я запускал сервер со своими изменениями локально и все протестировал.
- [x] Я ознакомился c [Guide to Contribute](https://github.com/ChaoticOnyx/OnyxBay/blob/dev/docs/contributing.md).
