### PR TITLE
Removes lack of xenomorph tweaks

### DIFF
--- a/code/game/machinery/doors/simple.dm
+++ b/code/game/machinery/doors/simple.dm
@@ -238,14 +238,38 @@
 /obj/machinery/door/unpowered/simple/resin/New(newloc,material_name,complexity)
 	..(newloc, MATERIAL_RESIN, complexity)
 
-/obj/machinery/door/unpowered/simple/resin/attack_hand(mob/user)
-	if(istype(user, /mob/living/carbon/alien/larva))
-		return ..()
-	if(ishuman(user))
-		var/mob/living/carbon/human/H = user
+/obj/machinery/door/unpowered/simple/resin/allowed(mob/M)
+	if(istype(M, /mob/living/carbon/alien/larva))
+		return TRUE
+	if(ishuman(M))
+		var/mob/living/carbon/human/H = M
 		if(H.internal_organs_by_name[BP_HIVE])
-			return ..()
+			return TRUE
 	return FALSE
+
+/obj/machinery/door/unpowered/simple/resin/attackby(obj/item/I, mob/user) // It's much more simple that the other doors, no lock support etc.
+	add_fingerprint(user, 0, I)
+	if(istype(I, /obj/item/weapon) && user.a_intent == I_HURT)
+		var/obj/item/weapon/W = I
+		user.setClickCooldown(DEFAULT_ATTACK_COOLDOWN)
+		if(W.damtype == BRUTE || W.damtype == BURN)
+			user.do_attack_animation(src)
+			if(W.force < min_force)
+				user.visible_message(SPAN("danger", "\The [user] hits \the [src] with \the [W] with no visible effect."))
+			else
+				user.visible_message(SPAN("danger", "\The [user] forcefully strikes \the [src] with \the [W]!"))
+				playsound(loc, hitsound, 100, 1)
+				take_damage(W.force)
+			return
+
+	if(operating)
+		return
+
+	if(allowed(user))
+		if(density)
+			open()
+		else
+			close()
 
 /obj/machinery/door/unpowered/simple/cult/New(newloc,material_name,complexity)
 	..(newloc, MATERIAL_CULT, complexity)

--- a/code/modules/mob/living/carbon/alien/larva/larva.dm
+++ b/code/modules/mob/living/carbon/alien/larva/larva.dm
@@ -17,6 +17,7 @@
 	. = ..()
 	add_language("Xenomorph") //Bonus language.
 	internal_organs |= new /obj/item/organ/internal/xenos/hivenode(src)
+	verbs += /mob/living/carbon/proc/toggle_darksight
 
 /obj/structure/alien/egg/CanUseTopic(mob/user)
 	return isghost(user) ? STATUS_INTERACTIVE : STATUS_CLOSE
@@ -58,3 +59,7 @@
 	for(var/mob/observer/ghost/O in GLOB.ghost_mob_list)
 		if(O.client && !jobban_isbanned(O, MODE_XENOMORPH))
 			to_chat(O, SPAN("notice", "A new alien larva has been born! ([ghost_follow_link(src, O)]) (<a href='byond://?src=\ref[src];occupy=1'>OCCUPY</a>)"))
+
+/mob/living/carbon/alien/larva/update_living_sight()
+	..()
+	set_sight(sight|SEE_MOBS)

--- a/code/modules/mob/living/carbon/human/species/xenomorphs/alien_powers.dm
+++ b/code/modules/mob/living/carbon/human/species/xenomorphs/alien_powers.dm
@@ -307,7 +307,7 @@
 		if(M.stat == 2)
 			M.gib()
 
-/mob/living/carbon/human/proc/toggle_darksight()
+/mob/living/carbon/proc/toggle_darksight()
 	set category = "Abilities"
 	set name = "Toggle Darkvision"
 

--- a/code/modules/mob/living/carbon/human/species/xenomorphs/alien_species.dm
+++ b/code/modules/mob/living/carbon/human/species/xenomorphs/alien_species.dm
@@ -222,13 +222,13 @@
 
 	inherent_verbs = list(
 		/mob/living/proc/ventcrawl,
+		/mob/living/carbon/proc/toggle_darksight,
 		/mob/living/carbon/human/proc/regurgitate,
 		/mob/living/carbon/human/proc/plant,
 		/mob/living/carbon/human/proc/transfer_plasma,
 		/mob/living/carbon/human/proc/evolve,
 		/mob/living/carbon/human/proc/resin,
-		/mob/living/carbon/human/proc/corrosive_acid,
-		/mob/living/carbon/human/proc/toggle_darksight
+		/mob/living/carbon/human/proc/corrosive_acid
 		)
 
 /datum/species/xenos/drone/vile
@@ -240,6 +240,7 @@
 
 	inherent_verbs = list(
 		/mob/living/proc/ventcrawl,
+		/mob/living/carbon/proc/toggle_darksight,
 		/mob/living/carbon/human/proc/toggle_powers,
 		/mob/living/carbon/human/proc/toggle_acidspit,
 		/mob/living/carbon/human/proc/Spit,
@@ -248,8 +249,7 @@
 		/mob/living/carbon/human/proc/transfer_plasma,
 		/mob/living/carbon/human/proc/evolve,
 		/mob/living/carbon/human/proc/resin,
-		/mob/living/carbon/human/proc/corrosive_acid,
-		/mob/living/carbon/human/proc/toggle_darksight
+		/mob/living/carbon/human/proc/corrosive_acid
 		)
 
 /datum/species/xenos/hunter
@@ -276,6 +276,7 @@
 
 	inherent_verbs = list(
 		/mob/living/proc/ventcrawl,
+		/mob/living/carbon/proc/toggle_darksight,
 		/mob/living/carbon/human/proc/toggle_powers,
 		/mob/living/carbon/human/proc/toggle_tackle,
 		/mob/living/carbon/human/proc/toggle_leap,
@@ -283,8 +284,7 @@
 		/mob/living/carbon/human/proc/leap,
 		/mob/living/carbon/human/proc/gut,
 		/mob/living/carbon/human/proc/psychic_whisper,
-		/mob/living/carbon/human/proc/regurgitate,
-		/mob/living/carbon/human/proc/toggle_darksight
+		/mob/living/carbon/human/proc/regurgitate
 		)
 
 /datum/species/xenos/hunter/feral
@@ -321,6 +321,7 @@
 
 	inherent_verbs = list(
 		/mob/living/proc/ventcrawl,
+		/mob/living/carbon/proc/toggle_darksight,
 		/mob/living/carbon/human/proc/toggle_powers,
 		/mob/living/carbon/human/proc/toggle_tackle,
 		/mob/living/carbon/human/proc/toggle_neurotoxin,
@@ -329,8 +330,7 @@
 		/mob/living/carbon/human/proc/Spit,
 		/mob/living/carbon/human/proc/regurgitate,
 		/mob/living/carbon/human/proc/transfer_plasma,
-		/mob/living/carbon/human/proc/corrosive_acid,
-		/mob/living/carbon/human/proc/toggle_darksight
+		/mob/living/carbon/human/proc/corrosive_acid
 		)
 
 /datum/species/xenos/sentinel/primal
@@ -375,6 +375,7 @@
 
 	inherent_verbs = list(
 		/mob/living/proc/ventcrawl,
+		/mob/living/carbon/proc/toggle_darksight,
 		/mob/living/carbon/human/proc/toggle_powers,
 		/mob/living/carbon/human/proc/toggle_tackle,
 		/mob/living/carbon/human/proc/toggle_neurotoxin,
@@ -388,8 +389,7 @@
 		/mob/living/carbon/human/proc/plant,
 		/mob/living/carbon/human/proc/transfer_plasma,
 		/mob/living/carbon/human/proc/corrosive_acid,
-		/mob/living/carbon/human/proc/resin,
-		/mob/living/carbon/human/proc/toggle_darksight
+		/mob/living/carbon/human/proc/resin
 		)
 
 /datum/species/xenos/queen/handle_login_special(mob/living/carbon/human/H)

--- a/code/modules/organs/external/xenos.dm
+++ b/code/modules/organs/external/xenos.dm
@@ -119,6 +119,9 @@
 	limb_flags = ORGAN_FLAG_HEALS_OVERKILL
 	max_damage = 100
 
+/obj/item/organ/external/head/xeno/disfigure(type)
+	return // Lets just dont, kay?
+
 // Xenolimbs.
 /obj/item/organ/external/chest/xeno
 	dislocated = -1
@@ -222,4 +225,26 @@
 			owner.gib()
 			QDEL_NULL(src)
 			return PROCESS_KILL
+		else if(owner.can_feel_pain())
+			var/obj/item/organ/external/parent = owner.get_organ(parent_organ)
+			switch(growth)
+				if(230 to INFINITY)
+					if(prob(50))
+						owner.custom_pain("Something is just about to burst through your chest!", 60, affecting = parent)
+					owner.Weaken(10)
+					owner.Stun(10)
+					owner.make_jittery(100)
+				if(200 to 229)
+					if(prob(20))
+						owner.custom_pain("You feel like your chest is ripping apart!", 45, affecting = parent)
+				if(140 to 199)
+					if(prob(10))
+						owner.custom_pain("You feel a stabbing pain in your chest!", 15, affecting = parent)
+				if(70 to 139)
+					if(prob(5))
+						owner.custom_pain("You feel a stinging pain in your chest!", 5, affecting = parent)
+		else if(growth == 235)
+			to_chat(owner, SPAN("danger", "You feel like something is massacring your chest from the inside!"))
+			owner.Weaken(10)
+			owner.Stun(10)
 	..()


### PR DESCRIPTION
- Лица ксеноморфов больше нельзя сделать неузнаваемыми. Теперь - точно.
- Грудоломам добавлена способность Toggle Darksight.
- Люди больше не могут открывать двери ксеноморфов с помощью клика предметом.
- Добавлены эффекты от роста эмбриона ксеноморфа. Чем дольше растёт - тем больше космонавтик _познаёт боль_. Последние несколько секунд перед "вылуплением" жертва будет биться в конвульсиях.
- Теперь грудоломы могут видеть мобов через стены, как и взрослые ксеноморфы.

```yml
🆑
bugfix: Лица ксеноморфов больше нельзя сделать неузнаваемыми.
tweak: Грудоломам добавлена способность Toggle Darksight.
bugfix: Люди больше не могут открывать двери ксеноморфов с помощью клика предметом.
rscadd: Добавлены эффекты от роста эмбриона ксеноморфа.
tweak: Теперь грудоломы могут видеть мобов через стены, как и взрослые ксеноморфы.
/🆑
```

- [x] Pull Request полностью завершен, мне не нужна помощь чтобы его закончить.
- [x] Я внимательно прочитал все свои изменения и багов в них не нашел.
- [x] Я запускал сервер со своими изменениями локально и все протестировал.
- [x] Я ознакомился c [Guide to Contribute](https://github.com/ChaoticOnyx/OnyxBay/blob/dev/docs/contributing.md).
