### PR TITLE
Emote cyrillic workaround

### DIFF
--- a/code/_helpers/russian.dm
+++ b/code/_helpers/russian.dm
@@ -20,3 +20,9 @@ GLOBAL_LIST_INIT(rkeys, list(
 	if(t in GLOB.rkeys)
 		return GLOB.rkeys[t]
 	return t
+
+/proc/sanitize_cyrillic_string(text)
+	. = ""
+	for(var/i in 1 to length_char(text))
+		. += sanitize_cyrillic_char(copytext_char(text, i, i+1))
+	return .

--- a/code/modules/emotes/emote_mob.dm
+++ b/code/modules/emotes/emote_mob.dm
@@ -12,11 +12,6 @@
 		if (client && (client.prefs.muted & MUTE_IC))
 			to_chat(src, "<span class='warning'>You cannot send IC messages (muted).</span>")
 			return
-
-		if(act == "help")
-			to_chat(src,"<b>Usable emotes:</b> [english_list(usable_emotes)]")
-			return
-
 		if(!can_emote(m_type))
 			to_chat(src, "<span class='warning'>You cannot currently [m_type == AUDIBLE_MESSAGE ? "audibly" : "visually"] emote!</span>")
 			return
@@ -35,11 +30,17 @@
 				m_type = AUDIBLE_MESSAGE
 			return custom_emote(m_type, message)
 
-	var/splitpoint = findtext(act, " ")
+	var/splitpoint = findtext_char(act, " ")
 	if(splitpoint > 0)
 		var/tempstr = act
-		act = copytext(tempstr,1,splitpoint)
-		message = copytext(tempstr,splitpoint+1,0)
+		act = copytext_char(tempstr,1,splitpoint)
+		message = copytext_char(tempstr,splitpoint+1,0)
+
+	act = sanitize_cyrillic_string(act)
+
+	if(act == "help")
+		to_chat(src,"<b>Usable emotes:</b> [english_list(usable_emotes)]")
+		return
 
 	var/decl/emote/use_emote = usable_emotes[act]
 	if(!use_emote)


### PR DESCRIPTION
Эмотить можно используя русскую раскладку ("*тщв" == "*nod")

<details>
<summary>Чейнджлог</summary>

```yml
🆑
rscadd: Теперь использовать эмоуты можно и с русской раскладкой ("*тщв" == "*nod").
/🆑
```

</details>

- [x] Pull Request полностью завершен, мне не нужна помощь чтобы его закончить.
- [x] Я внимательно прочитал все свои изменения и багов в них не нашел.
- [x] Я запускал сервер со своими изменениями локально и все протестировал.
- [x] Я ознакомился c [Guide to Contribute](https://github.com/ChaoticOnyx/OnyxBay/blob/dev/docs/contributing.md).
