### PR TITLE
Removes simplemorphs' immortality

### DIFF
--- a/code/modules/mob/living/simple_animal/hostile/alien.dm
+++ b/code/modules/mob/living/simple_animal/hostile/alien.dm
@@ -22,7 +22,7 @@
 	min_gas = null
 	max_gas = null
 	unsuitable_atoms_damage = 15
-	faction = "alien"
+	faction = "xenomorph"
 	environment_smash = 2
 	status_flags = CANPUSH
 	minbodytemp = 0
@@ -85,5 +85,5 @@
 	icon_state = "toxin"
 
 /mob/living/simple_animal/hostile/alien/death(gibbed, deathmessage, show_dead_message)
-	..(gibbed, deathmessage = "lets out a waning guttural screech, green blood bubbling from its maw...", show_dead_message)
+	. = ..(gibbed, "lets out a waning guttural screech, green blood bubbling from its maw...", show_dead_message)
 	playsound(src, 'sound/voice/hiss6.ogg', 100, 1)


### PR DESCRIPTION
```yml
🆑
bugfix: Ксеноморфы-мобы больше не бессмертные.
bugfix: Ксеноморфы-мобы теперь принадлежат фракции "xenomorph" и не будут нападать на лицехватов.
/🆑
```

- [x] Pull Request полностью завершен, мне не нужна помощь чтобы его закончить.
- [x] Я внимательно прочитал все свои изменения и багов в них не нашел.
- [x] Я запускал сервер со своими изменениями локально и все протестировал.
- [x] Я ознакомился c [Guide to Contribute](https://github.com/ChaoticOnyx/OnyxBay/blob/dev/docs/contributing.md).
