### PR TITLE
Removes lack of proper movement thingies

### DIFF
--- a/code/datums/movement/movement.dm
+++ b/code/datums/movement/movement.dm
@@ -77,7 +77,7 @@ if(LAZYLEN(movement_handlers) && ispath(movement_handlers[1])) { \
 
 // If is_external is explicitly set then use that, otherwise if the mover isn't the host assume it's external
 #define SET_MOVER(X) X = X || src
-#define SET_IS_EXTERNAL(X) is_external = isnull(is_external) ? (mover != src) : is_external
+#define SET_IS_EXTERNAL(X) is_external = isnull(is_external) ? (X != src) : is_external
 
 /atom/movable/proc/DoMove(var/direction, var/mob/mover, var/is_external)
 	INIT_MOVEMENT_HANDLERS

--- a/code/game/objects/effects/chem/foam.dm
+++ b/code/game/objects/effects/chem/foam.dm
@@ -77,7 +77,7 @@
 		return
 	if(istype(AM, /mob/living))
 		var/mob/living/M = AM
-		M.slip("the foam", 6)
+		M.slip("the foam", 3)
 
 /datum/effect/effect/system/foam_spread
 	var/amount = 5				// the size of the foam spread.

--- a/code/game/objects/items/devices/PDA/PDA.dm
+++ b/code/game/objects/items/devices/PDA/PDA.dm
@@ -1376,12 +1376,12 @@ var/global/list/obj/item/device/pda/PDAs = list()
 	return ..()
 
 /obj/item/device/pda/clown/Crossed(AM as mob|obj) //Clown PDA is slippery.
-	if (istype(AM, /mob/living))
+	if(istype(AM, /mob/living))
 		var/mob/living/M = AM
 
-		if(M.slip("the PDA",8) && M.real_name != src.owner && istype(src.cartridge, /obj/item/weapon/cartridge/clown))
-			if(src.cartridge.charges < 5)
-				src.cartridge.charges++
+		if(M.slip_on_obj(src, 3, 3) && M.real_name != owner && istype(cartridge, /obj/item/weapon/cartridge/clown))
+			if(cartridge.charges < 5)
+				cartridge.charges++
 
 /obj/item/device/pda/proc/available_pdas()
 	var/list/names = list()

--- a/code/game/objects/items/weapons/soap.dm
+++ b/code/game/objects/items/weapons/soap.dm
@@ -32,7 +32,7 @@
 		var/mob/living/M = AM
 		if(reagents.total_volume <= 0)
 			return
-		if(M.slip_on_obj(src, 3, 2))
+		if(M.slip_on_obj(src, 2, 2))
 			reagents.remove_any(3)
 
 /obj/item/weapon/soap/afterattack(atom/target, mob/user as mob, proximity)

--- a/code/game/turfs/simulated.dm
+++ b/code/game/turfs/simulated.dm
@@ -114,7 +114,7 @@
 
 				bloodDNA = null
 
-		if(src.wet)
+		if(wet)
 
 			if(M.buckled || (M.m_intent == M_WALK && prob(min(100, 100/(wet/10))) ) )
 				return
@@ -123,10 +123,10 @@
 			var/slip_stun = 3
 			var/floor_type = "wet"
 
-			if(2 <= src.wet) // Lube
+			if(wet >= 2) // Lube
 				floor_type = "slippery"
 				slip_dist = 4
-				slip_stun = 9
+				slip_stun = 6
 
 			if(M.slip("the [floor_type] floor", slip_stun))
 				for(var/i = 1 to slip_dist)

--- a/code/modules/ZAS/Airflow.dm
+++ b/code/modules/ZAS/Airflow.dm
@@ -18,7 +18,8 @@ Contains helper procs for airflow, handled in /connection_group.
 	if(lying)
 		return 0
 	to_chat(src, SPAN_WARNING("The sudden rush of air knocks you over!"))
-	Weaken(rand(1,2))
+	Weaken(rand(2, 3))
+	Stun(2)
 	last_airflow_stun = world.time
 
 /mob/living/silicon/airflow_stun()
@@ -89,11 +90,12 @@ Contains helper procs for airflow, handled in /connection_group.
 
 /atom/movable/Bump(atom/A)
 	if(airflow_speed > 0 && airflow_dest)
-		if(airborne_acceleration > 1)
-			airflow_hit(A)
-		else if(istype(src, /mob/living/carbon/human))
-			to_chat(src, "<span class='notice'>You are pinned against [A] by airflow!</span>")
-			airborne_acceleration = 0
+		if(!istype(A, /obj/item))
+			if(airborne_acceleration > 1)
+				airflow_hit(A)
+			else if(istype(src, /mob/living/carbon/human))
+				to_chat(src, SPAN("notice", "You are pinned against [A] by airflow!"))
+				airborne_acceleration = 0
 	else
 		airflow_speed = 0
 		airflow_time = 0

--- a/code/modules/hydroponics/grown_inedible.dm
+++ b/code/modules/hydroponics/grown_inedible.dm
@@ -64,4 +64,4 @@
 	if(!istype(M))
 		return
 	if(M.m_intent != M_WALK)
-		M.slip_on_obj(src, 3, 2)
+		M.slip_on_obj(src, 2, 2)

--- a/code/modules/mob/living/carbon/carbon.dm
+++ b/code/modules/mob/living/carbon/carbon.dm
@@ -398,7 +398,8 @@
 	stop_pulling()
 	to_chat(src, SPAN("warning", "You slipped on [slipped_on]!"))
 	playsound(src.loc, 'sound/misc/slip.ogg', 50, 1, -3)
-	Weaken(Floor(stun_duration/3))
+	Stun(Ceiling(stun_duration/3)) // At least 1 second of actual stun
+	Weaken(stun_duration)
 	return 1
 
 /mob/living/carbon/slip_on_obj(obj/slipped_on, stun_duration = 8, slip_dist = 0)

--- a/code/modules/mob/living/carbon/human/life.dm
+++ b/code/modules/mob/living/carbon/human/life.dm
@@ -90,7 +90,8 @@
 		update_canmove(TRUE) // Otherwise we'll have a 1 tick latency between actual getting-up and the animation update
 
 		if(!client && !mind)
-			species.handle_npc(src)
+			spawn()
+				species.handle_npc(src)
 
 		if(lying != lying_prev || hanging != hanging_prev)
 			update_icons() // So we update icons ONCE (hopefully) and AFTER all the status/organs updates


### PR DESCRIPTION
- Исправлена длительность опрокидывания (и добавлен стан) при поскальзывании (и от ветерка). Оно пострадало во время череды фиксов и сейчас то же мыло роняет буквально на 0 секунд.
- Исправлены столкновения с предметами во время утягивания атмосферой (во время разгерметизации, например). Больше никаких "You are pinned against the bullet casing by airflow! x15", а разгерметизации выглядят чутка зрелищнее.
- handle_npc() убран под spawn(), ибо там есть step(), замораживающий процесс на время перемещения.

```yml
🆑
tweak: Поскальзывание и сквозняк теперь роняют на большее время.
tweak: Предметы больше не блокируют друг друга и мобов при утягивании атмосферой.
/🆑
```

- [x] Pull Request полностью завершен, мне не нужна помощь чтобы его закончить.
- [x] Я внимательно прочитал все свои изменения и багов в них не нашел.
- [x] Я запускал сервер со своими изменениями локально и все протестировал.
- [x] Я ознакомился c [Guide to Contribute](https://github.com/ChaoticOnyx/OnyxBay/blob/dev/docs/contributing.md).
