### PR TITLE
Removes lack of RPD disposal pipes

### DIFF
--- a/code/game/objects/items/weapons/backwear/rpd.dm
+++ b/code/game/objects/items/weapons/backwear/rpd.dm
@@ -14,7 +14,7 @@
 	matter = list(MATERIAL_STEEL = 1500, MATERIAL_GLASS = 500)
 
 /obj/item/weapon/backwear/powered/rpd/loaded
-	bcell = /obj/item/weapon/cell/standard
+	bcell = /obj/item/weapon/cell/high
 
 #define RPD_DISPENSE "dispense"
 #define RPD_WRENCH   "wrench"
@@ -155,6 +155,7 @@
 				O.update()
 				product = O
 			else if(selected.item_type == /obj/structure/disposalconstruct)
+				product = new selected.item_type()
 				var/datum/dispense_type/pipe/PD = selected
 				var/obj/structure/disposalconstruct/O = product
 				O.ptype = PD.pipe_type


### PR DESCRIPTION
```yml
🆑
bugfix: Исправлена невозможность печатать мусорные трубы с помощью РПД.
tweak: Стандартная батарейка с 250 заряда заменена на батарейку с 1000 заряда. Теперь заряда хватит не на 5 стандартных труб, а на 20.
/🆑
```

- [x] Pull Request полностью завершен, мне не нужна помощь чтобы его закончить.
- [x] Я внимательно прочитал все свои изменения и багов в них не нашел.
- [x] Я запускал сервер со своими изменениями локально и все протестировал.
- [x] Я ознакомился c [Guide to Contribute](https://github.com/ChaoticOnyx/OnyxBay/blob/dev/docs/contributing.md).
