### PR TITLE
Задержка для Point-to

### DIFF
--- a/code/modules/mob/mob.dm
+++ b/code/modules/mob/mob.dm
@@ -278,6 +278,8 @@
 	set name = "Point To"
 	set category = "Object"
 
+	if(last_time_pointed_at + 2 SECONDS >= world.time)
+		return
 	if(!src || !isturf(src.loc) || !(A in view(src.loc)))
 		return 0
 	if(istype(A, /obj/effect/decal/point))
@@ -286,6 +288,8 @@
 	var/tile = get_turf(A)
 	if (!tile)
 		return 0
+
+	last_time_pointed_at = world.time
 
 	var/obj/P = new /obj/effect/decal/point(tile)
 	P.set_invisibility(invisibility)

--- a/code/modules/mob/mob_defines.dm
+++ b/code/modules/mob/mob_defines.dm
@@ -190,3 +190,5 @@
 	var/datum/browser/show_inventory
 
 	var/nabbing = 0  // Whether a creature with a CAN_NAB tag is grabbing normally or in nab mode.
+	
+	var/last_time_pointed_at = 0


### PR DESCRIPTION
ИтКупс добавил хоткей для поинт-ту, но не добавил ей задержку, из-за чего некоторые недобросовестные игроки пользуясь этим засирают всем чатик. 

<details>
<summary>Чейнджлог</summary>

```yml
🆑
tweak: Добавлена задержка для повторного использования Point-To.
/🆑
```

</details>

- [x] Pull Request полностью завершен, мне не нужна помощь чтобы его закончить.
- [x] Я внимательно прочитал все свои изменения и багов в них не нашел.
- [x] Я запускал сервер со своими изменениями локально и все протестировал.
- [x] Я ознакомился c [Guide to Contribute](https://github.com/ChaoticOnyx/OnyxBay/blob/dev/docs/contributing.md).
