### PR TITLE
Кнопка для закрытия игрового окна

### DIFF
--- a/code/modules/admin/admin.dm
+++ b/code/modules/admin/admin.dm
@@ -82,6 +82,7 @@ var/global/floorIsLava = 0
 
 	if(M.client)
 		body += "| <A HREF='?src=\ref[src];sendtoprison=\ref[M]'>Prison</A> | "
+		body += "| <A HREF='?src=\ref[src];blind=\ref[M]'>Blind</A> | "	
 		var/muted = M.client.prefs.muted
 		body += {"<br><b>Mute: </b>
 			\[<A href='?src=\ref[src];mute=\ref[M];mute_type=[MUTE_IC]'><font color='[(muted & MUTE_IC)?"red":"blue"]'>IC</font></a> |

--- a/code/modules/admin/topic.dm
+++ b/code/modules/admin/topic.dm
@@ -1123,6 +1123,17 @@
 		to_chat(M, "<span class='warning'>You have been sent to the prison station!</span>")
 		log_and_message_admins("sent [key_name_admin(M)] to the prison station.")
 
+	else if(href_list["blind"])
+		if(!check_rights(R_ADMIN))
+			return
+
+		var/mob/M = locate(href_list["blind"])
+		if(!ismob(M) || !M.client)
+			return
+
+		M.client.view = M.client.view == world.view ? -1 : world.view
+		log_and_message_admins("[M.client.view == world.view ? "opened" : "closed"] the game window for [key_name_admin(M)]")
+
 	else if(href_list["tdome1"])
 		if(!check_rights(R_FUN))	return
 


### PR DESCRIPTION
Совместно с Фрогой было замечено, что игнорирование игроками сообщений педалей успешно лечится отключением игрового окна. Незаменимая фича при общении с новичками, которые нарушают правила и при этом не замечают стучащегося к нему админа. 

<details>
<summary>Пример того, как это выглядит</summary>

![image](https://user-images.githubusercontent.com/59123747/120039828-3408d000-c00e-11eb-9026-0ec2debe01aa.png)

</details>

<details>
<summary>Чейнджлог</summary>

```yml
🆑
admin: В Player Panel добавлена кнопка, позволяющая закрыть игровое окно для игрока.
/🆑
```

</details>


- [x] Pull Request полностью завершен, мне не нужна помощь чтобы его закончить.
- [x] Я внимательно прочитал все свои изменения и багов в них не нашел.
- [x] Я запускал сервер со своими изменениями локально и все протестировал.
- [x] Я ознакомился c [Guide to Contribute](https://github.com/ChaoticOnyx/OnyxBay/blob/dev/docs/contributing.md).
