### PR TITLE
Фикс рантайма у вируса

### DIFF
--- a/code/modules/virus2/effects/common.dm
+++ b/code/modules/virus2/effects/common.dm
@@ -33,7 +33,7 @@
 	name = "[initial(R.name)][initial(name)]"
 
 /datum/disease2/effect/adaptation_chem/change_parent()
-	parent_disease.antigen = null
+	parent_disease.antigen = list()
 
 /datum/disease2/effect/adaptation_chem/activate(mob/living/carbon/human/mob)
 	if (mob.reagents.get_reagent_amount(data) > multiplier)
@@ -86,7 +86,7 @@
 	badness = VIRUS_COMMON
 
 /datum/disease2/effect/adaptation_damage/change_parent()
-	parent_disease.antigen = null
+	parent_disease.antigen = list()
 
 /datum/disease2/effect/adaptation_damage/activate(mob/living/carbon/human/mob)
 	for(var/obj/item/organ/external/E in mob.organs)
@@ -102,7 +102,7 @@
 	badness = VIRUS_COMMON
 
 /datum/disease2/effect/adaptation_rads/change_parent()
-	parent_disease.antigen = null
+	parent_disease.antigen = list()
 
 /datum/disease2/effect/adaptation_rads/activate(mob/living/carbon/human/mob)
 	if(mob.radiation > 10*multiplier)

--- a/code/modules/virus2/effects/mutation.dm
+++ b/code/modules/virus2/effects/mutation.dm
@@ -58,7 +58,7 @@
 	name = "[H.real_name] [initial(name)]"
 
 /datum/disease2/effect/adaptation_kill/change_parent()
-	parent_disease.antigen = null
+	parent_disease.antigen = list()
 
 /datum/disease2/effect/adaptation_kill/activate(mob/living/carbon/human/mob)
 	var/mob/living/carbon/human/H = data


### PR DESCRIPTION
`Runtime in viruses.dm, line 46: Cannot read 0.len`
Из-за занулления листа `antigen` проверка в файле viruses.dm ломалась к чертям, не давая вирусу умереть, если тот должен был.
Возможно, но не обещаю, это пофиксит спавн миллиард вирусов. 
Но вот это `Skipped 6053 runtimes in viruses.dm,46.` точно никуда не годится.

- [x] Pull Request полностью завершен, мне не нужна помощь чтобы его закончить.
- [x] Я внимательно прочитал все свои изменения и багов в них не нашел.
- [x] Я запускал сервер со своими изменениями локально и все протестировал.
- [x] Я ознакомился c [Guide to Contribute](https://github.com/ChaoticOnyx/OnyxBay/blob/dev/docs/contributing.md).
