### PR TITLE
AIs and Cyborgs can't interact with kitchen stuff

### DIFF
--- a/code/game/machinery/kitchen/cooking_machines/_cooker.dm
+++ b/code/game/machinery/kitchen/cooking_machines/_cooker.dm
@@ -249,6 +249,9 @@
 
 	..()
 
+/obj/machinery/cooker/attack_ai()
+	return
+
 /obj/machinery/cooker/proc/hurt_big_mob(mob/living/victim, mob/user)
 	to_chat(user, SPAN_WARNING("That's not going to fit."))
 	return


### PR DESCRIPTION
Борги более не могут удаленно взаимодействовать с кухонными приборами и доставать из них предметы, телепортируя их.

close #5332 

<details>
<summary>Чейнджлог</summary>

```yml
🆑
bugfix: ИИ и киборги более не могут взаимодействовать с кухонными приборами удаленно.
/🆑
```

</details>

- [x] Pull Request полностью завершен, мне не нужна помощь чтобы его закончить.
- [x] Я внимательно прочитал все свои изменения и багов в них не нашел.
- [ ] Я запускал сервер со своими изменениями локально и все протестировал.
- [x] Я ознакомился c [Guide to Contribute](https://github.com/ChaoticOnyx/OnyxBay/blob/dev/docs/contributing.md).
