### PR TITLE
Removes lack of saves on EoS

### DIFF
--- a/code/modules/client/preferences.dm
+++ b/code/modules/client/preferences.dm
@@ -103,11 +103,11 @@
 	player_setup.load_preferences(savefile_reader)
 	var/orig_slot = default_slot
 
-	S.cd = GLOB.using_map.character_load_path(S, slot)
+	S.cd = "/[GLOB.using_map.path]"
 	for(var/slot = 1 to 40)
 		if(!S.dir.Find("character[slot]"))
 			continue
-		S.cd = "/[GLOB.using_map.path]/character[slot]"
+		S.cd = GLOB.using_map.character_load_path(S, slot)
 		default_slot = slot
 		player_setup.load_character(savefile_reader)
 		save_character(override_key = "character_[GLOB.using_map.preferences_key()]_[slot]")

--- a/code/modules/client/preferences.dm
+++ b/code/modules/client/preferences.dm
@@ -103,14 +103,14 @@
 	player_setup.load_preferences(savefile_reader)
 	var/orig_slot = default_slot
 
-	S.cd = "/[GLOB.using_map.path]"
+	S.cd = GLOB.using_map.character_load_path(S, slot)
 	for(var/slot = 1 to 40)
 		if(!S.dir.Find("character[slot]"))
 			continue
 		S.cd = "/[GLOB.using_map.path]/character[slot]"
 		default_slot = slot
 		player_setup.load_character(savefile_reader)
-		save_character(override_key = "character_[GLOB.using_map.path]_[slot]")
+		save_character(override_key = "character_[GLOB.using_map.preferences_key()]_[slot]")
 		S.cd = "/[GLOB.using_map.path]"
 	S.cd = "/"
 


### PR DESCRIPTION
- Миграция сейвов на ЕоСе брала сейвы немножко не оттуда, откуда надо. Для восстановления сейвов нужно удалить все player_preferences.json, после чего запустить обновление и перезапустить сервер.

- [x] Pull Request полностью завершен, мне не нужна помощь чтобы его закончить.
- [x] Я внимательно прочитал все свои изменения и багов в них не нашел.
- [x] Я запускал сервер со своими изменениями локально и все протестировал.
- [x] Я ознакомился c [Guide to Contribute](https://github.com/ChaoticOnyx/OnyxBay/blob/dev/docs/contributing.md).
