### PR TITLE
Removes lack of savefile-related PRs

### DIFF
--- a/code/_helpers/logging.dm
+++ b/code/_helpers/logging.dm
@@ -49,7 +49,7 @@
 		WRITE_FILE(GLOB.world_common_log, "\[[time_stamp()]] [game_id] [type]: [message][log_end]")
 
 	var/rendered = "<span class=\"log_message\"><span class=\"prefix\">[type] LOG:</span> <span class=\"message\">[message]</span></span>"
-	if(notify_admin)
+	if(notify_admin && SScharacter_setup.initialized) // Checking SScharacter_setup early so won't cycle through all the admins
 		for(var/client/C in GLOB.admins)
 			if(!req_pref || (C.get_preference_value(req_pref) == GLOB.PREF_SHOW))
 				to_chat(C, rendered)

--- a/code/datums/browser.dm
+++ b/code/datums/browser.dm
@@ -19,16 +19,16 @@
 /datum/browser/New(nuser, nwindow_id, ntitle = 0, nwidth = 0, nheight = 0, atom/nref = null)
 	user = nuser
 	window_id = nwindow_id
-	if (ntitle)
+	if(ntitle)
 		title = format_text(ntitle)
-	if (nwidth)
+	if(nwidth)
 		width = nwidth
-	if (nheight)
+	if(nheight)
 		height = nheight
-	if (nref)
+	if(nref)
 		ref = nref
 	// If a client exists, but they have disabled fancy windowing, disable it!
-	if(user && user.client && user.client.get_preference_value(/datum/client_preference/browser_style) == GLOB.PREF_PLAIN)
+	if(user?.client?.get_preference_value(/datum/client_preference/browser_style) == GLOB.PREF_PLAIN)
 		return
 	add_stylesheet("common", 'html/browser/common.css') // this CSS sheet is common to all UIs
 
@@ -115,7 +115,7 @@
 
 /datum/browser/proc/open(use_onclose = 1)
 	var/window_size = ""
-	if (width && height)
+	if(width && height)
 		window_size = "size=[width]x[height];"
 	show_browser(user, get_content(), "window=[window_id];[window_size][window_options]")
 	winset(user, "mapwindow.map", "focus=true")
@@ -123,12 +123,18 @@
 		onclose(user, window_id, ref)
 
 /datum/browser/proc/update(force_open = 0, use_onclose = 1)
+	if(!user)
+		qdel(src)
+		return
 	if(force_open)
 		open(use_onclose)
 	else
 		send_output(user, get_content(), "[window_id].browser")
 
 /datum/browser/proc/close()
+	if(!user)
+		qdel(src)
+		return
 	close_browser(user, "window=[window_id]")
 	winset(user, "mapwindow.map", "focus=true")
 	qdel(src)

--- a/code/datums/browser.dm
+++ b/code/datums/browser.dm
@@ -123,21 +123,13 @@
 		onclose(user, window_id, ref)
 
 /datum/browser/proc/update(force_open = 0, use_onclose = 1)
-	if(!user)
-		qdel(src)
-		return
 	if(force_open)
 		open(use_onclose)
 	else
 		send_output(user, get_content(), "[window_id].browser")
 
 /datum/browser/proc/close()
-	if(!user)
-		qdel(src)
-		return
 	close_browser(user, "window=[window_id]")
-	winset(user, "mapwindow.map", "focus=true")
-	qdel(src)
 
 /datum/browser/Destroy()
 	ref = null
@@ -183,7 +175,11 @@
 	if(ref)
 		param = "\ref[ref]"
 
-	winset(user, windowid, "on-close=\".windowclose [param]\"")
+	addtimer(CALLBACK(user, /mob/proc/post_onclose, windowid, param), 2)
+
+/mob/proc/post_onclose(windowid, param)
+	if(client)
+		winset(src, windowid, "on-close=\".windowclose [param]\"")
 
 //	log_debug("OnClose [user]: [windowid] : ["on-close=\".windowclose [param]\""]")
 

--- a/code/datums/movement/mob.dm
+++ b/code/datums/movement/mob.dm
@@ -249,6 +249,8 @@
 
 	step(mob, direction)
 
+	if(!mob)
+		return // If the mob gets deleted on move (e.g. Entered, whatever), it wipes this reference on us in Destroy (and we should be aborting all action anyway).
 	// Something with pulling things
 	var/extra_delay = HandleGrabs(direction, old_turf)
 	mob.addMoveCooldown(extra_delay)

--- a/code/modules/client/client_procs.dm
+++ b/code/modules/client/client_procs.dm
@@ -252,11 +252,6 @@
 			sleep(2) // wait a bit more, possibly fixes hardware mode not re-activating right
 			winset(src, null, "command=\".configure graphics-hwmode on\"")
 
-	log_client_to_db()
-	SSdonations.log_client_to_db(src)
-	SSdonations.update_donator(src)
-	SSdonations.update_donator_items(src)
-
 	send_resources()
 
 	if(prefs.lastchangelog != changelog_hash) //bolds the changelog button on the interface so we know there are updates.

--- a/code/modules/client/client_procs.dm
+++ b/code/modules/client/client_procs.dm
@@ -252,6 +252,11 @@
 			sleep(2) // wait a bit more, possibly fixes hardware mode not re-activating right
 			winset(src, null, "command=\".configure graphics-hwmode on\"")
 
+	log_client_to_db()
+	SSdonations.log_client_to_db(src)
+	SSdonations.update_donator(src)
+	SSdonations.update_donator_items(src)
+
 	send_resources()
 
 	if(prefs.lastchangelog != changelog_hash) //bolds the changelog button on the interface so we know there are updates.

--- a/code/modules/client/preference_setup/global/05_settings.dm
+++ b/code/modules/client/preference_setup/global/05_settings.dm
@@ -82,15 +82,18 @@
 	return ..()
 
 /client/proc/get_preference_value(preference)
-	if (!prefs)
+	if(!SScharacter_setup.initialized)
+		return // Too early to use any preferences
+
+	if(!prefs)
 		log_error("[ckey]'s preferences did not load. Trying to fix.")
 		prefs = SScharacter_setup.preferences_datums[ckey]
 
-	if (!prefs)
+	if(!prefs)
 		log_error("[ckey]'s preferences are broken. Creating new one.")
 		prefs = new /datum/preferences(src)
 
-	if (!prefs)
+	if(!prefs)
 		CRASH("Can't create preferences for [ckey].")
 
 	var/datum/client_preference/cp = get_client_preference(preference)

--- a/code/modules/client/preference_setup/global/preferences.dm
+++ b/code/modules/client/preference_setup/global/preferences.dm
@@ -97,7 +97,8 @@ var/global/list/_client_preferences_by_type
 
 /datum/client_preference/play_lobby_music/changed(mob/preference_mob, new_value)
 	if(new_value == GLOB.PREF_YES)
-		GLOB.using_map.lobby_music.play_to(preference_mob)
+		if(isnewplayer(preference_mob))
+			GLOB.using_map.lobby_music.play_to(preference_mob)
 	else
 		sound_to(preference_mob, sound(null, repeat = 0, wait = 0, volume = 85, channel = 1))
 

--- a/code/modules/client/preferences.dm
+++ b/code/modules/client/preferences.dm
@@ -66,7 +66,7 @@
 	var/stage = "pre"
 
 	try
-		var/pref_path = get_path(client_ckey, "player_preferences")
+		var/pref_path = get_path(client_ckey, "preferences")
 
 		if(!fexists(pref_path))
 			stage = "migrate"
@@ -89,7 +89,7 @@
 	// - legacy saves were only made on the current map
 	// - a maximum of 40 slots were used
 
-	var/legacy_pref_path = get_path(client.ckey, "preferences", "sav")
+	var/legacy_pref_path = "data/player_saves/[copytext(client.ckey, 1, 2)]/[client.ckey]/preferences.sav"
 	if(!fexists(legacy_pref_path))
 		return 0
 
@@ -444,6 +444,11 @@
 	set waitfor = 0
 	if(!client)
 		return
+
+	client.log_client_to_db()
+	SSdonations.log_client_to_db(client)
+	SSdonations.update_donator(client)
+	SSdonations.update_donator_items(client)
 
 	if(client.get_preference_value(/datum/client_preference/chat_position) == GLOB.PREF_YES)
 		client.update_chat_position(TRUE)

--- a/code/modules/client/preferences.dm
+++ b/code/modules/client/preferences.dm
@@ -445,11 +445,6 @@
 	if(!client)
 		return
 
-	client.log_client_to_db()
-	SSdonations.log_client_to_db(client)
-	SSdonations.update_donator(client)
-	SSdonations.update_donator_items(client)
-
 	if(client.get_preference_value(/datum/client_preference/chat_position) == GLOB.PREF_YES)
 		client.update_chat_position(TRUE)
 

--- a/code/modules/client/preferences_persist.dm
+++ b/code/modules/client/preferences_persist.dm
@@ -1,7 +1,7 @@
 #define PREF_SER_VERSION 1
 
-/datum/preferences/proc/get_path(ckey, record_key, extension="json")
-	return "data/player_saves/[copytext(ckey,1,2)]/[ckey]/[record_key].[extension]"
+/datum/preferences/proc/get_path(ckey, record_key, extension = "json")
+	return "data/players/[ckey]/[record_key].[extension]"
 
 // Returns null if there's no record file. Crashes on other error conditions.
 /datum/preferences/proc/load_pref_record(record_key)
@@ -39,7 +39,7 @@
 /datum/preferences/proc/load_preferences()
 	var/datum/pref_record_reader/R = load_pref_record("player_preferences")
 	if(!R)
-		R = new /datum/pref_record_reader/null(PREF_SER_VERSION)
+		R = new /datum/pref_record_reader/null_reader(PREF_SER_VERSION)
 	player_setup.load_preferences(R)
 
 /datum/preferences/proc/save_preferences()
@@ -62,17 +62,17 @@
 
 	if(slot == SAVE_RESET)
 		// If we're resetting, set everything to null. Sanitization will clean it up
-		var/datum/pref_record_reader/null/R = new(PREF_SER_VERSION)
+		var/datum/pref_record_reader/null_reader/R = new(PREF_SER_VERSION)
 		player_setup.load_character(R)
 	else
 		var/datum/pref_record_reader/R = load_pref_record(get_slot_key(slot))
 		if(!R)
-			R = new /datum/pref_record_reader/null(PREF_SER_VERSION)
+			R = new /datum/pref_record_reader/null_reader(PREF_SER_VERSION)
 		player_setup.load_character(R)
 
 	update_preview_icon()
 
-/datum/preferences/proc/save_character(override_key=null)
+/datum/preferences/proc/save_character(override_key = null)
 	var/datum/pref_record_writer/json_list/W = new(PREF_SER_VERSION)
 	player_setup.save_character(W)
 

--- a/code/modules/client/preferences_storage.dm
+++ b/code/modules/client/preferences_storage.dm
@@ -57,16 +57,16 @@
 
 // Null preference reader
 // Returns null for all keys; used when initializing records
-/datum/pref_record_reader/null
+/datum/pref_record_reader/null_reader
 	var/version
 
-/datum/pref_record_reader/null/New(version)
+/datum/pref_record_reader/null_reader/New(version)
 	src.version = version
 
-/datum/pref_record_reader/null/get_version()
+/datum/pref_record_reader/null_reader/get_version()
 	return version
 
-/datum/pref_record_reader/null/read(key)
+/datum/pref_record_reader/null_reader/read(key)
 	return null
 
 
@@ -77,7 +77,7 @@
 
 /datum/pref_record_writer/json_list/New(version)
 	ASSERT(isnum(version))
-	data = list("__VERSION"=version)
+	data = list("__VERSION" = version)
 
 /datum/pref_record_writer/json_list/write(key, val)
 	data[key] = val

--- a/code/modules/donations/donator.dm
+++ b/code/modules/donations/donator.dm
@@ -29,11 +29,15 @@
 	var/list/items = new
 
 /datum/donator_info/proc/on_patreon_tier_loaded(client/C)
+	if(!SScharacter_setup.initialized)
+		return
 	var/choosen_ooc_patreon_tier = C.get_preference_value(/datum/client_preference/ooc_name_color)
-	if (!patreon_tier_available(choosen_ooc_patreon_tier))
+	if(!patreon_tier_available(choosen_ooc_patreon_tier))
 		C.set_preference(/datum/client_preference/ooc_name_color, patron_type)
 
 /datum/donator_info/proc/get_decorated_ooc_name(client/C)
+	if(!SScharacter_setup.initialized)
+		return C.key
 	var/choosen_ooc_patreon_tier = C.get_preference_value(/datum/client_preference/ooc_name_color)
 	if(choosen_ooc_patreon_tier == PATREON_NONE)
 		return C.key

--- a/code/modules/mob/living/silicon/pai/personality.dm
+++ b/code/modules/mob/living/silicon/pai/personality.dm
@@ -8,7 +8,7 @@
 */
 
 /datum/paiCandidate/proc/savefile_path(client/user)
-	return "data/player_saves/[copytext(user.ckey, 1, 2)]/[user.ckey]/pai.sav"
+	return "data/players/[user.ckey]/pai.sav"
 
 /datum/paiCandidate/proc/savefile_save(client/user)
 	if(IsGuestKey(user.key))

--- a/maps/exodus/exodus_define.dm
+++ b/maps/exodus/exodus_define.dm
@@ -37,6 +37,3 @@
 	new /datum/random_map/automata/cave_system(null, 1, 1, 6, 255, 255) // Create the mining Z-level.
 	new /datum/random_map/noise/ore(null, 1, 1, 6, 255, 255)         // Create the mining ore distribution map.
 	return 1
-
-/datum/map/exodus/preferences_key()
-	return "exodus"

--- a/maps/~mapsystem/map_preferences.dm
+++ b/maps/~mapsystem/map_preferences.dm
@@ -3,7 +3,7 @@
 
 /datum/map/proc/preferences_key()
 	// Must be a filename-safe string. In future if map paths get funky, do some sanitization here.
-	return path
+	return "default"
 
 // Procs for loading legacy savefile preferences
 /datum/map/proc/character_save_path(slot)


### PR DESCRIPTION
- Окончательно (_наверное_) допилена новая система сохранений;
- Сохранения игроков теперь лежат не в /data/player_saves, а в data/players;
- Персонажи со всех имеющихся сейчас карт имеют постфикс "default" (character_default_1.json). В будущем можно выставлять картам кастомные постфиксы для отдельных сохранений;
- Попутно слегка задеты браузеры, окошки должны зависать реже;
- Исправлены не замеченные в предыдущих ПРах вызовы get_preference_value() до инициализации SScharacter_setup;

- [x] Pull Request полностью завершен, мне не нужна помощь чтобы его закончить.
- [x] Я внимательно прочитал все свои изменения и багов в них не нашел.
- [x] Я запускал сервер со своими изменениями локально и все протестировал.
- [x] Я ознакомился c [Guide to Contribute](https://github.com/ChaoticOnyx/OnyxBay/blob/dev/docs/contributing.md).
