### PR TITLE
Removes some bugs, removes "non-alt" chat input

### DIFF
--- a/baystation12.dme
+++ b/baystation12.dme
@@ -1363,6 +1363,7 @@
 #include "code\modules\client\preferences_spawnpoints.dm"
 #include "code\modules\client\preferences_storage.dm"
 #include "code\modules\client\preferences_toggle.dm"
+#include "code\modules\client\tooltip.dm"
 #include "code\modules\client\ui_style.dm"
 #include "code\modules\client\preference_setup\_defines.dm"
 #include "code\modules\client\preference_setup\preference_setup.dm"

--- a/code/game/atoms.dm
+++ b/code/game/atoms.dm
@@ -561,3 +561,7 @@ its easier to just keep the beam vertical.
 		do_climb(target)
 	else
 		return ..()
+
+/atom/MouseEntered(location, control, params)
+	. = ..()
+	update_tooltip(usr, name)

--- a/code/game/sound.dm
+++ b/code/game/sound.dm
@@ -544,7 +544,10 @@ var/const/FALLOFF_SOUNDS = 0.5
 
 /client/proc/playtitlemusic()
 	if(get_preference_value(/datum/client_preference/play_lobby_music) == GLOB.PREF_YES)
-		GLOB.lobby_music.play_to(src)
+		if(isnewplayer(mob))
+			GLOB.lobby_music.play_to(src)
+	else
+		sound_to(src, sound(null, repeat = 0, wait = 0, volume = 85, channel = 1))
 
 /proc/get_rand_frequency()
 	return rand(32000, 55000) //Frequency stuff only works with 45kbps oggs.

--- a/code/modules/client/client_procs.dm
+++ b/code/modules/client/client_procs.dm
@@ -267,8 +267,6 @@
 	if(!winexists(src, "asset_cache_browser")) // The client is using a custom skin, tell them.
 		to_chat(src, "<span class='warning'>Unable to access asset cache browser, if you are using a custom skin file, please allow DS to download the updated version, if you are not, then make a bug report. This is not a critical issue but can cause issues with resource downloading, as it is impossible to know when extra resources arrived to you.</span>")
 
-	chatOutput.start()
-
 	if(prefs && !istype(mob, world.mob))
 		prefs.apply_post_login_preferences()
 
@@ -463,61 +461,17 @@
 	if(world.byond_version >= 511 && byond_version >= 511 && client_fps >= CLIENT_MIN_FPS && client_fps <= CLIENT_MAX_FPS)
 		vars["fps"] = prefs.clientfps
 
-/client/proc/update_chat_position(use_alternative)
-	var/input_height = 0
-	input_height = winget(src, "input", "size")
-	input_height = text2num(splittext(input_height, "x")[2])
-
-	// Hell
-
-	if (use_alternative == TRUE)
-		winset(src, "input_alt", "is-visible=true;is-disabled=false;is-default=true")
-		winset(src, "hotkey_toggle_alt", "is-visible=true;is-disabled=false;is-default=true")
-		winset(src, "saybutton_alt", "is-visible=true;is-disabled=false;is-default=true")
-
-		winset(src, "input", "is-visible=false;is-disabled=true;is-default=false")
-		winset(src, "hotkey_toggle", "is-visible=false;is-disabled=true;is-default=false")
-		winset(src, "saybutton", "is-visible=false;is-disabled=true;is-default=false")
-
-		var/current_size = splittext(winget(src, "outputwindow.output", "size"), "x")
-		var/new_size = "[current_size[1]]x[text2num(current_size[2]) - input_height]"
-		winset(src, "outputwindow.output", "size=[new_size]")
-		winset(src, "outputwindow.browseroutput", "size=[new_size]")
-
-		current_size = splittext(winget(src, "mainwindow.mainvsplit", "size"), "x")
-		new_size = "[current_size[1]]x[text2num(current_size[2]) + input_height]"
-		winset(src, "mainwindow.mainvsplit", "size=[new_size]")
-	else
-		winset(src, "input_alt", "is-visible=false;is-disabled=true;is-default=false")
-		winset(src, "hotkey_toggle_alt", "is-visible=false;is-disabled=true;is-default=false")
-		winset(src, "saybutton_alt", "is-visible=false;is-disabled=true;is-default=false")
-
-		winset(src, "input", "is-visible=true;is-disabled=false;is-default=true")
-		winset(src, "hotkey_toggle", "is-visible=true;is-disabled=false;is-default=true")
-		winset(src, "saybutton", "is-visible=true;is-disabled=false;is-default=true")
-
-		var/current_size = splittext(winget(src, "outputwindow.output", "size"), "x")
-		var/new_size = "[current_size[1]]x[text2num(current_size[2]) + input_height]"
-		winset(src, "outputwindow.output", "size=[new_size]")
-		winset(src, "outputwindow.browseroutput", "size=[new_size]")
-
-		current_size = splittext(winget(src, "mainwindow.mainvsplit", "size"), "x")
-		new_size = "[current_size[1]]x[text2num(current_size[2]) - input_height]"
-		winset(src, "mainwindow.mainvsplit", "size=[new_size]")
-	fit_viewport()
-
 /client/proc/toggle_fullscreen(new_value)
 	if((new_value == GLOB.PREF_BASIC) || (new_value == GLOB.PREF_FULL))
 		winset(src, "mainwindow", "is-maximized=false;can-resize=false;titlebar=false")
 		if(new_value == GLOB.PREF_FULL)
-			winset(src, "mainwindow", "menu=null;statusbar=false")
+			winset(src, "mainwindow", "menu=null")
 		winset(src, "mainwindow.mainvsplit", "pos=0x0")
 	else
 		winset(src, "mainwindow", "is-maximized=false;can-resize=true;titlebar=true")
-		winset(src, "mainwindow", "menu=menu;statusbar=true")
+		winset(src, "mainwindow", "menu=menu")
 		winset(src, "mainwindow.mainvsplit", "pos=3x0")
 	winset(src, "mainwindow", "is-maximized=true")
-	fit_viewport()
 
 /client/verb/fit_viewport()
 	set name = "Fit Viewport"

--- a/code/modules/client/client_procs.dm
+++ b/code/modules/client/client_procs.dm
@@ -260,24 +260,24 @@
 	send_resources()
 
 	if(prefs.lastchangelog != changelog_hash) //bolds the changelog button on the interface so we know there are updates.
-		to_chat(src, "<span class='info'>You have unread updates in the changelog.</span>")
+		to_chat(src, SPAN("info", "You have unread updates in the changelog."))
 		if(config.aggressive_changelog)
 			src.changes()
 
 	if(!winexists(src, "asset_cache_browser")) // The client is using a custom skin, tell them.
-		to_chat(src, "<span class='warning'>Unable to access asset cache browser, if you are using a custom skin file, please allow DS to download the updated version, if you are not, then make a bug report. This is not a critical issue but can cause issues with resource downloading, as it is impossible to know when extra resources arrived to you.</span>")
+		to_chat(src, SPAN("warning", "Unable to access asset cache browser, if you are using a custom skin file, please allow DS to download the updated version, if you are not, then make a bug report. This is not a critical issue but can cause issues with resource downloading, as it is impossible to know when extra resources arrived to you."))
 
 	if(prefs && !istype(mob, world.mob))
 		prefs.apply_post_login_preferences()
 
 	if(config.player_limit && is_player_rejected_by_player_limit(usr, ckey))
 		if(config.panic_address && TopicData != "redirect")
-			DIRECT_OUTPUT(src, SPAN_WARNING("<h1>This server is currently full and not accepting new connections. Sending you to [config.panic_server_name ? config.panic_server_name : config.panic_address]</h1>"))
+			DIRECT_OUTPUT(src, SPAN("warning", "<h1>This server is currently full and not accepting new connections. Sending you to [config.panic_server_name ? config.panic_server_name : config.panic_address]</h1>"))
 			winset(src, null, "command=.options")
 			send_link(src, "[config.panic_address]?redirect")
 
 		else
-			DIRECT_OUTPUT(src, SPAN_WARNING("<h1>This server is currently full and not accepting new connections.</h1>"))
+			DIRECT_OUTPUT(src, SPAN("warning", "<h1>This server is currently full and not accepting new connections.</h1>"))
 
 		log_admin("[ckey] tried to join but the server is full (player_limit=[config.player_limit])")
 		qdel(src)

--- a/code/modules/client/preference_setup/global/preferences.dm
+++ b/code/modules/client/preference_setup/global/preferences.dm
@@ -97,10 +97,10 @@ var/global/list/_client_preferences_by_type
 
 /datum/client_preference/play_lobby_music/changed(mob/preference_mob, new_value)
 	if(new_value == GLOB.PREF_YES)
-		if(isnewplayer(preference_mob))
-			GLOB.using_map.lobby_music.play_to(preference_mob)
+		if(isnewplayer(preference_mob) && preference_mob.client)
+			GLOB.lobby_music.play_to(preference_mob.client)
 	else
-		sound_to(preference_mob, sound(null, repeat = 0, wait = 0, volume = 85, channel = 1))
+		sound_to(preference_mob.client, sound(null, repeat = 0, wait = 0, volume = 85, channel = 1))
 
 /datum/client_preference/play_ambiance
 	description ="Play ambience"
@@ -249,17 +249,6 @@ var/global/list/_client_preferences_by_type
 		return
 	if(preference_mob.client)
 		preference_mob.client.toggle_fullscreen(new_value)
-
-/datum/client_preference/chat_position
-	description = "Use Alternative Chat Position"
-	key = "CHAT_ALT"
-	default_value = GLOB.PREF_NO
-
-/datum/client_preference/chat_position/changed(mob/preference_mob, new_value)
-	if(!SScharacter_setup.initialized)
-		return
-	if(preference_mob.client)
-		preference_mob.client.update_chat_position(new_value == GLOB.PREF_YES)
 
 /datum/client_preference/cinema_credits
 	description = "Show Cinema-like Credits At Round-end"

--- a/code/modules/client/preferences.dm
+++ b/code/modules/client/preferences.dm
@@ -445,8 +445,5 @@
 	if(!client)
 		return
 
-	if(client.get_preference_value(/datum/client_preference/chat_position) == GLOB.PREF_YES)
-		client.update_chat_position(TRUE)
-
 	if(client.get_preference_value(/datum/client_preference/fullscreen_mode) != GLOB.PREF_NO)
 		client.toggle_fullscreen(client.get_preference_value(/datum/client_preference/fullscreen_mode))

--- a/code/modules/client/tooltip.dm
+++ b/code/modules/client/tooltip.dm
@@ -1,0 +1,7 @@
+/client/var/tooltip_text = ""
+
+/proc/update_tooltip(mob/user, text)
+	if(user.client?.tooltip_text == text)
+		return
+	user.client.tooltip_text = text
+	winset(user.client, "mapwindow.tooltip", "text=[url_encode(text)]&is-visible=[!!text]")

--- a/code/modules/mob/living/carbon/human/human_species.dm
+++ b/code/modules/mob/living/carbon/human/human_species.dm
@@ -15,6 +15,9 @@
 /mob/living/carbon/human/dummy/mannequin/add_to_dead_mob_list()
 	return FALSE
 
+/mob/living/carbon/human/dummy/mannequin/update_deformities()
+	return // There's simply no need in extra processing
+
 /mob/living/carbon/human/dummy/mannequin/fully_replace_character_name(new_name)
 	..("[new_name] (mannequin)", FALSE)
 

--- a/code/modules/mob/living/silicon/robot/login.dm
+++ b/code/modules/mob/living/silicon/robot/login.dm
@@ -6,10 +6,10 @@
 	show_laws(0)
 
 	var/hotkey_mode = client.get_preference_value("DEFAULT_HOTKEY_MODE")
-	if (hotkey_mode == GLOB.PREF_NO)
-		winset(src, null, "mainwindow.macro=borgmacro hotkey_toggle.is-checked=false input.focus=true input.background-color=#d3b5b5")
-	else
+	if(hotkey_mode == GLOB.PREF_YES)
 		winset(src, null, "mainwindow.macro=borghotkeymode hotkey_toggle.is-checked=true input.focus=false input.background-color=#F0F0F0")
+	else
+		winset(src, null, "mainwindow.macro=borgmacro hotkey_toggle.is-checked=false input.focus=true input.background-color=#d3b5b5")
 
 
 	// Forces synths to select an icon relevant to their module

--- a/code/modules/mob/login.dm
+++ b/code/modules/mob/login.dm
@@ -84,7 +84,7 @@
 
 	//set macro to normal incase it was overriden (like cyborg currently does)
 	var/hotkey_mode = client.get_preference_value("DEFAULT_HOTKEY_MODE")
-	if (hotkey_mode == GLOB.PREF_NO)
-		winset(src, null, "mainwindow.macro=macro hotkey_toggle.is-checked=false input.focus=true")
-	else
+	if(hotkey_mode == GLOB.PREF_YES)
 		winset(src, null, "mainwindow.macro=hotkeymode hotkey_toggle.is-checked=true input.focus=false")
+	else
+		winset(src, null, "mainwindow.macro=macro hotkey_toggle.is-checked=false input.focus=true")

--- a/code/modules/mob/new_player/login.dm
+++ b/code/modules/mob/new_player/login.dm
@@ -70,3 +70,4 @@
 	if(client)
 		client.playtitlemusic()
 		client.prefs?.apply_post_login_preferences()
+		client.chatOutput.start()

--- a/code/modules/mob/new_player/login.dm
+++ b/code/modules/mob/new_player/login.dm
@@ -1,5 +1,5 @@
 /obj/screen/splash
-	name = "Baystation12"
+	name = "Chaotic Onyx"
 	desc = "This shouldn't be read."
 	screen_loc = "WEST,SOUTH"
 	icon = 'maps/exodus/exodus_lobby.dmi'
@@ -30,6 +30,9 @@
 		animate(src, alpha = 255, time = 30)
 	if(qdel_after)
 		QDEL_IN(src, 30)
+
+/obj/screen/splash/MouseEntered(location, control, params)
+	return // TODO: Replace /obj/screen/splash with somethig more sane
 
 /obj/screen/splash/Destroy()
 	if(holder)

--- a/interface/skin.dmf
+++ b/interface/skin.dmf
@@ -1135,7 +1135,7 @@ window "mainwindow"
 	elem "mainvsplit"
 		type = CHILD
 		pos = 3,0
-		size = 640x440
+		size = 634x440
 		anchor1 = 0,0
 		anchor2 = 100,100
 		saved-params = "splitter"
@@ -1168,6 +1168,17 @@ window "mapwindow"
 		saved-params = "icon-size;zoom-mode"
 		on-show = ".winset\"mainwindow.mainvsplit.left=mapwindow\""
 		on-hide = ".winset\"mainwindow.mainvsplit.left=\""
+	elem "tooltip"
+		type = LABEL
+		pos = 0,464
+		size = 280x16
+		anchor1 = 0,100
+		is-visible = false
+		text = ""
+		align = left
+		background-color = #272727
+		text-color = #ffffff
+		border = line
 
 window "outputwindow"
 	elem "outputwindow"

--- a/interface/skin.dmf
+++ b/interface/skin.dmf
@@ -392,7 +392,7 @@ macro "macro"
 		name = "F12"
 		command = "F12"
 	elem 
-		name = "SHIFT+Up"
+		name = "SHIFT+UP"
 		command = ".release_shift"
 
 macro "hotkeymode"
@@ -1114,64 +1114,33 @@ window "chemdispenser_reagents"
 window "mainwindow"
 	elem "mainwindow"
 		type = MAIN
-		pos = 372,0
-		size = 1001x739
+		pos = 281,0
+		size = 640x440
 		anchor1 = none
 		anchor2 = none
 		is-default = true
 		saved-params = "pos;size;is-minimized;is-maximized"
+		statusbar = false
 		icon = 'icons\\onyxlogo132x32.png'
 		macro = "macro"
 		menu = "menu"
 	elem "asset_cache_browser"
 		type = BROWSER
-		pos = 424,208
-		size = 1x1
+		pos = 0,0
+		size = 200x200
 		anchor1 = none
 		anchor2 = none
 		is-visible = false
 		saved-params = ""
 	elem "mainvsplit"
 		type = CHILD
-		pos = 0,0
-		size = 1001x720
+		pos = 3,0
+		size = 640x440
 		anchor1 = 0,0
 		anchor2 = 100,100
 		saved-params = "splitter"
 		right = "infowindow"
 		is-vert = true
-	elem "input"
-		type = INPUT
-		pos = 2,720
-		size = 878x20
-		anchor1 = 0,100
-		anchor2 = 100,100
-		background-color = #d3b5b5
-		is-default = true
-		border = sunken
-		saved-params = "command"
-		on-focus = ".add_typing_indicator"
-		on-blur = ".remove_typing_indicator"
-	elem "saybutton"
-		type = BUTTON
-		pos = 880,720
-		size = 40x20
-		anchor1 = 100,100
-		anchor2 = none
-		saved-params = "is-checked"
-		text = "Chat"
-		command = ".winset \"saybutton.is-checked=true?input.command=\"!Say \\\"\" macrobutton.is-checked=false:input.command=\""
-		button-type = pushbox
-	elem "hotkey_toggle"
-		type = BUTTON
-		pos = 920,720
-		size = 80x20
-		anchor1 = 100,100
-		anchor2 = none
-		saved-params = ""
-		text = "Hotkey Toggle"
-		command = ".winset \"mainwindow.macro!=macro ? mainwindow.macro=macro hotkey_toggle.is-checked=false input.focus=true : mainwindow.macro=hotkeymode hotkey_toggle.is-checked=true mapwindow.map.focus=true\""
-		button-type = pushbox
 
 window "mapwindow"
 	elem "mapwindow"
@@ -1203,7 +1172,7 @@ window "mapwindow"
 window "outputwindow"
 	elem "outputwindow"
 		type = MAIN
-		pos = 372,0
+		pos = 281,-30
 		size = 640x480
 		anchor1 = none
 		anchor2 = none
@@ -1214,55 +1183,50 @@ window "outputwindow"
 		can-minimize = false
 		can-resize = false
 		is-pane = true
+		outer-size = 654x494
 	elem "browseroutput"
 		type = BROWSER
 		pos = 0,0
-		size = 640x480
+		size = 640x456
 		anchor1 = 0,0
 		anchor2 = 100,100
 		background-color = #ffffff
 		is-visible = false
 		saved-params = ""
-		auto-format = false
 	elem "output"
 		type = OUTPUT
 		pos = 0,0
-		size = 640x480
+		size = 640x456
 		anchor1 = 0,0
 		anchor2 = 100,100
 		is-default = true
 		saved-params = ""
-	elem "saybutton_alt"
+	elem "saybutton"
 		type = BUTTON
-		pos = 519,459
+		pos = 519,460
 		size = 40x20
 		anchor1 = 100,100
 		anchor2 = none
-		is-visible = false
-		is-disabled = true
 		saved-params = "is-checked"
 		text = "Chat"
 		command = ".winset \"saybutton.is-checked=true?input.command=\"!say \\\"\" macrobutton.is-checked=false:input.command=\""
 		button-type = pushbox
-	elem "input_alt"
+	elem "input"
 		type = INPUT
-		pos = 1,459
+		pos = 1,460
 		size = 517x20
 		anchor1 = 0,100
 		anchor2 = 100,100
 		background-color = #d3b5b5
-		is-visible = false
-		is-disabled = true
+		is-default = true
 		border = sunken
 		saved-params = "command"
-	elem "hotkey_toggle_alt"
+	elem "hotkey_toggle"
 		type = BUTTON
-		pos = 560,459
+		pos = 560,460
 		size = 80x20
 		anchor1 = 100,100
 		anchor2 = none
-		is-visible = false
-		is-disabled = true
 		saved-params = ""
 		text = "Hotkey Toggle"
 		command = ".winset \"mainwindow.macro!=macro ? mainwindow.macro=macro hotkey_toggle.is-checked=false input.focus=true : mainwindow.macro=hotkeymode hotkey_toggle.is-checked=true mapwindow.map.focus=true\""
@@ -1281,7 +1245,7 @@ window "browserwindow"
 	elem "browser"
 		type = BROWSER
 		pos = 0,0
-		size = 640x499
+		size = 640x474
 		anchor1 = 0,0
 		anchor2 = 100,100
 		background-color = #ffffff
@@ -1391,23 +1355,18 @@ window "saywindow"
 		size = 300x90
 		anchor1 = none
 		anchor2 = none
-		background-color = none
 		is-visible = false
 		saved-params = "size;pos"
 		title = "say (text)"
 		statusbar = false
 		can-close = false
 		can-minimize = false
-		can-resize = true
-		outer-size = 308x117
-		inner-size = 300x90
 	elem "saywindow-button"
 		type = BUTTON
 		pos = 110,50
 		size = 80x25
 		anchor1 = 37,56
 		anchor2 = 63,83
-		background-color = none
 		border = line
 		saved-params = ""
 		text = "OK"
@@ -1418,7 +1377,6 @@ window "saywindow"
 		size = 280x20
 		anchor1 = 3,18
 		anchor2 = 96,40
-		is-default = false
 		border = sunken
 		saved-params = ""
 		command = "Say "


### PR DESCRIPTION
- Убрана опция "Use Alternative Chat Position", теперь альтернативная позиция (под чатом, а не под всем окном) - дефолтная. Игровая область стала больше, смотрится лучше и меньше риска, что БУОНД обосрётся при заходе на сервер. Единственный минус - старым пердунам придётся какое-то время привыкать к качеству.
- Убрана строка статуса. Та, что была под чатом. В современных реалиях толка от неё нет, большую часть времени в ней просто мигают сообщения о загрузке ресурсов. Да ещё и тёмным режимом не красится. В обмен получили, опять таки, больше игровой области на экране. Теперь можно спокойно ставить режим 64х64 и наслаждаться текстурками без растягиваний и замыливаний.
- Вместо неё добавлен компактный тултип-статусбар. В отличие от встроенной строки статуса, исчезает при наведении в пустую область, не показывает всякие ненужные пакости вроде скачки ресурсов, срабатывает мгновенно и имеет модную тёмную окраску.
- Исправлен баг с проигрыванием музыки в лобби.
- Исправлен иногда возникающий баг с превью персонажа в настройках - персонаж отображался как безглазый.
- Исправлен иногда возникающий баг с отваливающимся гунчатом. Он пытался загрузиться слишком рано, иногда - ещё до прогрузки преференсов и прочих нужных штук. Единственный минус - сам гунчат будет загружаться немножко позже, после инициализации SScharacter_setup. 
- Почищен skin.dmf. В теории, у Игоря теперь не должен проявляться баг с разрешением.

- [x] Pull Request полностью завершен, мне не нужна помощь чтобы его закончить.
- [x] Я внимательно прочитал все свои изменения и багов в них не нашел.
- [x] Я запускал сервер со своими изменениями локально и все протестировал.
- [x] Я ознакомился c [Guide to Contribute](https://github.com/ChaoticOnyx/OnyxBay/blob/dev/docs/contributing.md).
