### PR TITLE
tweak(lights): tweaked frontier lights a bit

### DIFF
--- a/code/modules/power/lighting.dm
+++ b/code/modules/power/lighting.dm
@@ -735,11 +735,15 @@
 	name = "old light bulb"
 	desc = "Old type of light bulbs, almost not being used at the station."
 	base_state = "lold_bulb"
+	broken_chance = 1
+	b_max_bright = 0.8
+	b_outer_range = 6
 	b_color = "#ec8b2f"
 	random_tone = FALSE
 	tone_overlay = FALSE
 
 /obj/item/weapon/light/bulb/red
+	b_outer_range = 6
 	color = "#da0205"
 	b_color = "#da0205"
 	random_tone = FALSE


### PR DESCRIPTION
После обновы с софтдарком в дормы фронтира подселились негры и стали активно воровать уголь, из-за чего не было видно литтерали ничего дальше тайла. Повысил какие-то два параметра наскальным лампам, вроде стало лучше. Попутно понизил им шанс заспавниться сломанными (надеюсь) и слегка повысил радиус красным лампочкам в техах. Красные лампочки всё еще совершенно ничего не освещают, так что "дух техов" остается, но выглядит хоть немного приятнее.

Дормы до:
![Screenshot_23](https://user-images.githubusercontent.com/51989098/120983687-9ab28a00-c782-11eb-892c-f320d33485ba.png)
Домы после:
![Screenshot_25](https://user-images.githubusercontent.com/51989098/120983709-9f773e00-c782-11eb-8a6f-0598a6a56d59.png)



<details>
<summary>Чейнджлог</summary>

```yml
🆑
maptweak: Изменил освещение дорм фронтира на более яркое и приятное глазу. Слегка поднял радиус освещения мелких красных лампочек.
/🆑
```

</details>

- [x] Pull Request полностью завершен, мне не нужна помощь чтобы его закончить.
- [x] Я внимательно прочитал все свои изменения и багов в них не нашел.
- [x] Я запускал сервер со своими изменениями локально и все протестировал.
- [x] Я ознакомился c [Guide to Contribute](https://github.com/ChaoticOnyx/OnyxBay/blob/dev/docs/contributing.md).
