### PR TITLE
feat(storyteller): add more roles to storyteller

### DIFF
--- a/baystation12.dme
+++ b/baystation12.dme
@@ -97,6 +97,7 @@
 #include "code\_helpers\global_access.dm"
 #include "code\_helpers\global_lists.dm"
 #include "code\_helpers\icons.dm"
+#include "code\_helpers\input.dm"
 #include "code\_helpers\json.dm"
 #include "code\_helpers\lists.dm"
 #include "code\_helpers\logging.dm"

--- a/code/_helpers/input.dm
+++ b/code/_helpers/input.dm
@@ -1,6 +1,7 @@
 
 /datum/__alert_timeout_processor/proc/process(recipient, message, title, timeout, button1, button2, button3)
-	spawn(timeout) del(src) // make this proc die if src dies
+	spawn(timeout)
+		del(src) // make this proc die if src dies
 	return alert(recipient, message, title, button1, button2, button3)
 
 /proc/alert_timeout(recipient, message, title, timeout, button1, button2, button3)

--- a/code/_helpers/input.dm
+++ b/code/_helpers/input.dm
@@ -1,0 +1,8 @@
+
+/datum/__alert_timeout_processor/proc/process(recipient, message, title, timeout, button1, button2, button3)
+	spawn(timeout) del(src) // make this proc die if src dies
+	return alert(recipient, message, title, button1, button2, button3)
+
+/proc/alert_timeout(recipient, message, title, timeout, button1, button2, button3)
+	var/datum/__alert_timeout_processor/processor = new()
+	return processor.process(recipient, message, title, timeout, button1, button2, button3)

--- a/code/game/antagonist/alien/borer.dm
+++ b/code/game/antagonist/alien/borer.dm
@@ -4,7 +4,7 @@ GLOBAL_DATUM_INIT(borers, /datum/antagonist/xenos/borer, new)
 	id = MODE_BORER
 	role_text = "Cortical Borer"
 	role_text_plural = "Cortical Borers"
-	mob_path = /mob/living/simple_animal/borer
+	mob_path = /mob/living/simple_animal/borer/initial
 	welcome_text = "Use your Infest power to crawl into the ear of a host and fuse with their brain. You can only take control temporarily, and at risk of hurting your host, so be clever and careful; your host is encouraged to help you however they can. Talk to your fellow borers with :x."
 	antag_indicator = "hudborer"
 	antaghud_indicator = "hudborer"
@@ -23,8 +23,6 @@ GLOBAL_DATUM_INIT(borers, /datum/antagonist/xenos/borer, new)
 	return "<a href='?src=\ref[src];move_to_spawn=\ref[player.current]'>\[put in host\]</a>"
 
 /datum/antagonist/xenos/borer/create_objectives(datum/mind/player)
-	if(!..())
-		return
 	player.objectives += new /datum/objective/borer_survive()
 	player.objectives += new /datum/objective/borer_reproduce()
 	player.objectives += new /datum/objective/escape()
@@ -34,7 +32,7 @@ GLOBAL_DATUM_INIT(borers, /datum/antagonist/xenos/borer, new)
 	if(istype(borer))
 		var/mob/living/carbon/human/host
 		for(var/mob/living/carbon/human/H in SSmobs.mob_list)
-			if(H.stat != DEAD && !H.has_brain_worms())
+			if(H.mind && H.stat != DEAD && !H.has_brain_worms())
 				var/obj/item/organ/external/head = H.get_organ(BP_HEAD)
 				if(head && !BP_IS_ROBOTIC(head))
 					host = H
@@ -44,7 +42,7 @@ GLOBAL_DATUM_INIT(borers, /datum/antagonist/xenos/borer, new)
 			if(head)
 				borer.host = host
 				head.implants += borer
-				borer.forceMove(head)
+				borer.forceMove(host)
 				if(!borer.host_brain)
 					borer.host_brain = new(borer)
 				borer.host_brain.SetName(host.name)

--- a/code/game/antagonist/antagonist.dm
+++ b/code/game/antagonist/antagonist.dm
@@ -222,11 +222,6 @@
 
 	return 1
 
-/proc/alert_timeout(recipient, message, title, timeout, button1, button2, button3)
-	src = new /datum()  // make this proc die if src dies
-	spawn(timeout) del(src)
-	return alert(recipient, message, title, button1, button2, button3)
-
 /datum/antagonist/proc/draft_antagonist(datum/mind/player)
 	//Check if the player can join in this antag role, or if the player has already been given an antag role.
 	if(!can_become_antag(player))

--- a/code/game/antagonist/antagonist.dm
+++ b/code/game/antagonist/antagonist.dm
@@ -222,6 +222,11 @@
 
 	return 1
 
+/proc/alert_timeout(recipient, message, title, timeout, button1, button2, button3)
+	src = new /datum()  // make this proc die if src dies
+	spawn(timeout) del(src)
+	return alert(recipient, message, title, button1, button2, button3)
+
 /datum/antagonist/proc/draft_antagonist(datum/mind/player)
 	//Check if the player can join in this antag role, or if the player has already been given an antag role.
 	if(!can_become_antag(player))
@@ -234,8 +239,16 @@
 		log_debug_verbose("[player.key] was selected for [role_text] by lottery, but they have not joined the game.")
 		return 0
 	if(GAME_STATE >= RUNLEVEL_GAME && (isghostmind(player) || isnewplayer(player.current)) && !(player in SSticker.antag_pool))
-		log_debug_verbose("[player.key] was selected for [role_text] by lottery, but they are a ghost not in the antag pool.")
-		return 0
+		var/answer = alert_timeout(
+			recipient = player.current,
+			message = "You was selected for role [role_text] by lottery. Are you ready to play it?", 
+			title = "Do you want to play [role_text]?",
+			timeout = 100,
+			button1 = "Yes",
+			button2 = "No")
+		if(answer != "Yes")
+			log_debug_verbose("[player.key] was selected for [role_text] by lottery, but they denied it.")
+			return 0
 
 	pending_antagonists |= player
 	log_debug_verbose("[player.key] has been selected for [role_text] by lottery.")

--- a/code/game/antagonist/antagonist.dm
+++ b/code/game/antagonist/antagonist.dm
@@ -236,7 +236,7 @@
 	if(GAME_STATE >= RUNLEVEL_GAME && (isghostmind(player) || isnewplayer(player.current)) && !(player in SSticker.antag_pool))
 		var/answer = alert_timeout(
 			recipient = player.current,
-			message = "You was selected for role [role_text] by lottery. Are you ready to play it?", 
+			message = "You were selected for role [role_text] by lottery. Are you ready to play it?", 
 			title = "Do you want to play [role_text]?",
 			timeout = 100,
 			button1 = "Yes",

--- a/code/game/antagonist/antagonist_add.dm
+++ b/code/game/antagonist/antagonist_add.dm
@@ -8,7 +8,7 @@
 		player.assigned_role = role_text
 	player.special_role = role_text
 
-	if(isghostmind(player))
+	if(isghostmind(player) || isnewplayer(player.current))
 		create_default(player.current)
 	else
 		create_antagonist(player, move_to_spawn, do_not_announce, preserve_appearance)

--- a/code/game/gamemodes/game_mode.dm
+++ b/code/game/gamemodes/game_mode.dm
@@ -325,8 +325,6 @@ var/global/list/additional_antag_types = list()
 		for(var/mob/player in GLOB.player_list)
 			if(!player.client)
 				continue
-			if(istype(player, /mob/new_player))
-				continue
 			if(!antag_id || (antag_id in player.client.prefs.be_special_role))
 				log_debug("[player.key] had [antag_id] enabled, so we are drafting them.")
 				candidates += player.mind

--- a/code/modules/mob/living/simple_animal/borer/borer.dm
+++ b/code/modules/mob/living/simple_animal/borer/borer.dm
@@ -38,14 +38,14 @@
 	var/controlling                         // Used in human death check.
 	var/docile = 0                          // Sugar can stop borers from acting.
 	var/has_reproduced
-	var/roundstart
+	var/initial
 
-/mob/living/simple_animal/borer/roundstart
-	roundstart = 1
+/mob/living/simple_animal/borer/initial
+	initial = 1
 
 /mob/living/simple_animal/borer/Login()
 	..()
-	if(mind)
+	if(!initial)
 		GLOB.borers.add_antagonist(mind)
 
 /mob/living/simple_animal/borer/New(atom/newloc, gen=1)
@@ -57,7 +57,7 @@
 
 	generation = gen
 	truename = "[borer_names[min(generation, borer_names.len)]] [random_id("borer[generation]", 1000, 9999)]"
-	if(!roundstart) request_player()
+	if(!initial) request_player()
 
 /mob/living/simple_animal/borer/Life()
 

--- a/code/modules/mob/living/simple_animal/borer/borer.dm
+++ b/code/modules/mob/living/simple_animal/borer/borer.dm
@@ -57,7 +57,8 @@
 
 	generation = gen
 	truename = "[borer_names[min(generation, borer_names.len)]] [random_id("borer[generation]", 1000, 9999)]"
-	if(!initial) request_player()
+	if(!initial)
+		request_player()
 
 /mob/living/simple_animal/borer/Life()
 

--- a/code/modules/storyteller/characters/support.dm
+++ b/code/modules/storyteller/characters/support.dm
@@ -12,6 +12,7 @@
 
 /datum/storyteller_character/support/process_new_cycle_start()
 	..()
+
 	USE_METRIC(/storyteller_metric/station_characters_count, station_characters_count)
 	USE_METRIC(/storyteller_metric/security_manpower, security_manpower)
 	USE_METRIC(/storyteller_metric/is_storyteller_random, is_storyteller_random)
@@ -32,17 +33,26 @@
 
 	_log_debug("Security Advantage: [security_advantage]")
 	var/balancing_is_needed = security_advantage > 5
-	if (balancing_is_needed)
-		_log_debug("Balancing is needed due high security advantage")
 
-	while (balancing_is_needed) // balancing
+	var/minutes_to_next_cycle = 15 + rand(0, 10)
+
+	if(balancing_is_needed)
+		_log_debug("Balancing is needed due to high security advantage")
+		minutes_to_next_cycle = 1
+
 		var/list/triggers = new
-		triggers[/storyteller_trigger/spawn_antagonist/traitor] = 8
+		triggers[/storyteller_trigger/spawn_antagonist/traitor] = 65
+		triggers[/storyteller_trigger/spawn_antagonist/vampire] = 10
+		triggers[/storyteller_trigger/spawn_antagonist/borer] = 5
 
-		if (security_advantage > 10)
-			triggers[/storyteller_trigger/spawn_antagonist/changeling] = 4
+		if(security_advantage > 10)
+			triggers[/storyteller_trigger/spawn_antagonist/changeling] = 40
 		else
-			triggers[/storyteller_trigger/spawn_antagonist/changeling] = 1
+			triggers[/storyteller_trigger/spawn_antagonist/changeling] = 10
+
+		if(security_advantage > 20)
+			triggers[/storyteller_trigger/spawn_antagonist/ninja] = 80
+			triggers[/storyteller_trigger/spawn_antagonist/wizard] = 80
 
 		var/choosen_trigger
 		var/result
@@ -50,24 +60,11 @@
 			choosen_trigger = pickweight(triggers)
 			result = _run_trigger(choosen_trigger)
 			triggers.Remove(choosen_trigger)
-		while (!result && triggers.len)
+		while(!result && triggers.len)
 
 		if(!result)
 			_log_debug("Triggers don't work! We can't fix the balance :(")
-			break
-
-		if (choosen_trigger == /storyteller_trigger/spawn_antagonist/traitor)
-			security_advantage -= 4
-		else
-			security_advantage -= 8
-
-		if (security_advantage <= 5)
-			balancing_is_needed = FALSE
-
-	if (balancing_is_needed)
-		_log_debug("Security Advantage after balancing: [security_advantage]")
-
-	var/minutes_to_next_cycle = 15 + rand(0, 10)
+	
 	_log_debug("Time to next cycle: [minutes_to_next_cycle] minutes" )
 
 	return minutes_to_next_cycle MINUTES

--- a/code/modules/storyteller/characters/support.dm
+++ b/code/modules/storyteller/characters/support.dm
@@ -60,7 +60,7 @@
 			choosen_trigger = pickweight(triggers)
 			result = _run_trigger(choosen_trigger)
 			triggers.Remove(choosen_trigger)
-		while(!result && triggers.len)
+		while(!result && length(triggers))
 
 		if(!result)
 			_log_debug("Triggers don't work! We can't fix the balance :(")

--- a/code/modules/storyteller/metrics/common_metrics.dm
+++ b/code/modules/storyteller/metrics/common_metrics.dm
@@ -70,50 +70,47 @@
 	return security_manpower
 
 
+/proc/antagonist_to_danger(antagonist_id)
+	switch(antagonist_id)
+		if(MODE_ERT)           return -6
+		if(MODE_LOYALIST)      return -2
+		if(MODE_BORER)         return 2
+		if(MODE_REVOLUTIONARY) return 2
+		if(MODE_COMMANDO)      return 4
+		if(MODE_TRAITOR)       return 4
+		if(MODE_CULTIST)       return 4
+		if(MODE_RENEGADE)      return 4
+		if(MODE_RAIDER)        return 4
+		if(MODE_NUKE)          return 4
+		if(MODE_DEATHSQUAD)    return 6
+		if(MODE_CHANGELING)    return 8
+		if(MODE_NINJA)         return 12
+		if(MODE_WIZARD)        return 16
+		if(MODE_BLOB)          return 24
+		if(MODE_MALFUNCTION)   return 24
+	return 0
+
 /storyteller_metric/antagonists_danger
 	name = "Danger by Antagonists"
 
 /storyteller_metric/antagonists_danger/_evaluate()
 	var/antagonists_danger = 0
 
-	for (var/role_id in GLOB.all_antag_types_)
+	for(var/role_id in GLOB.all_antag_types_)
 		var/datum/antagonist/antag = GLOB.all_antag_types_[role_id]
-		var/add_danger = 0
-		switch (role_id)
-			if (MODE_ERT)           add_danger = -6
-			if (MODE_LOYALIST)      add_danger = -2
-			if (MODE_BORER)         add_danger = 2
-			if (MODE_REVOLUTIONARY) add_danger = 2
-			if (MODE_COMMANDO)      add_danger = 4
-			if (MODE_TRAITOR)       add_danger = 4
-			if (MODE_CULTIST)       add_danger = 4
-			if (MODE_RENEGADE)      add_danger = 4
-			if (MODE_RAIDER)        add_danger = 4
-			if (MODE_NUKE)          add_danger = 4
-			if (MODE_DEATHSQUAD)    add_danger = 6
-			if (MODE_CHANGELING)    add_danger = 8
-			if (MODE_NINJA)         add_danger = 12
-			if (MODE_WIZARD)        add_danger = 16
-			if (MODE_BLOB)          add_danger = 24
-			if (MODE_MALFUNCTION)   add_danger = 24
-
-			// if ("god cultist") - /datum/antagonist/godcultist
-			// if ("xenomorph") - /datum/antagonist/xenos
-			// if ("actor") - /datum/antagonist/actor
-			// if ("deity") - /datum/antagonist/deity
-
+		var/add_danger = antagonist_to_danger(role_id)
 		var/count = 0
-		for (var/datum/mind/M in antag.current_antagonists)
-			if (M.current)
+		for(var/datum/mind/M in antag.current_antagonists)
+			if(M.current)
 				var/mob/living/L = M.current
-				if (L.stat & DEAD)
+				if(L.stat & DEAD)
 					_log_debug("Dead antagonist: [L] ([role_id])")
 					continue
-				if (antag.station_crew_involved && M.is_brigged(0))
+				if(antag.station_crew_involved && M.is_brigged(0))
 					_log_debug("Brigged antagonist: [L] ([role_id])")
 					continue
 				count++
-		if (count)
+		if(count)
 			_log_debug("Add +[add_danger] for each [role_id] ([count] times)")
 			antagonists_danger += count * add_danger
 

--- a/code/modules/storyteller/storyteller.dm
+++ b/code/modules/storyteller/storyteller.dm
@@ -91,7 +91,8 @@ SUBSYSTEM_DEF(storyteller)
 	if (drop_data)
 		__ckey_to_ui_data[user.ckey] = list()
 	var/data = __ckey_to_ui_data[user.ckey]
-	data["storyteller"] = __get_params_for_ui(data["current_tab"])
+	if("current_tab" in data)
+		data["storyteller"] = __get_params_for_ui(data["current_tab"])
 	data["pregame"] = (GAME_STATE < RUNLEVEL_GAME)
 
 	var/ui_key = "storyteller_control_panel"

--- a/code/modules/storyteller/triggers/spawn_antagonists_triggers.dm
+++ b/code/modules/storyteller/triggers/spawn_antagonists_triggers.dm
@@ -14,8 +14,24 @@
 
 /storyteller_trigger/spawn_antagonist/traitor/New()
 	name = "Spawn Traitor"
-	antagonist_id = "traitor"
+	antagonist_id = MODE_TRAITOR
 
 /storyteller_trigger/spawn_antagonist/changeling/New()
 	name = "Spawn Changeling"
-	antagonist_id = "changeling"
+	antagonist_id = MODE_CHANGELING
+
+/storyteller_trigger/spawn_antagonist/vampire/New()
+	name = "Spawn Vampire"
+	antagonist_id = MODE_VAMPIRE
+
+/storyteller_trigger/spawn_antagonist/wizard/New()
+	name = "Spawn Wizard"
+	antagonist_id = MODE_WIZARD
+
+/storyteller_trigger/spawn_antagonist/ninja/New()
+	name = "Spawn Ninja"
+	antagonist_id = MODE_NINJA
+
+/storyteller_trigger/spawn_antagonist/borer/New()
+	name = "Spawn Borer"
+	antagonist_id = MODE_BORER


### PR DESCRIPTION
Добавляем больше ролей в сторителлера. Поправил рантайм при переключении вкладок панели управления сторителлером.

При спавне борера, мага и ниндзи сторителлер опрашивает гостов и игроков в лобби с соответствующим префенсом, хотят ли они быть ролью. Если игрок отклоняет или не отвечает в течение 10 секунд, то опрашивается следующий игрок.

Нужно еще допилить борерам перенос тушки КУДА-ТО - пока не придумал где их спавнить можно.

Еще при спавне из лобби остается висеть окно Declare из-за баги #5499.

close #1320

<details>
<summary>Чейнджлог</summary>

```yml
🆑
rscadd: Добавил сторителлеру возможность спавнить бореров, магов, ниндзю и вампиров.
/🆑
```

</details>


- [x] Pull Request полностью завершен, мне не нужна помощь чтобы его закончить.
- [x] Я внимательно прочитал все свои изменения и багов в них не нашел.
- [x] Я запускал сервер со своими изменениями локально и все протестировал.
- [x] Я ознакомился c [Guide to Contribute](https://github.com/ChaoticOnyx/OnyxBay/blob/dev/docs/contributing.md).
