### PR TITLE
Преференсное

### DIFF
--- a/code/__defines/subsystems.dm
+++ b/code/__defines/subsystems.dm
@@ -25,14 +25,14 @@
 
 #define SS_INIT_GARBAGE          15
 #define SS_INIT_EAMS             14
-#define SS_INIT_DONATIONS        13
-#define SS_INIT_PLANTS           12
-#define SS_INIT_WARNINGS         11
-#define SS_INIT_ANTAGS           10
-#define SS_INIT_MISC             9
-#define SS_INIT_SKYBOX           8
-#define SS_INIT_MAPPING          7
-#define SS_INIT_CHAR_SETUP       6
+#define SS_INIT_CHAR_SETUP       13
+#define SS_INIT_DONATIONS        12
+#define SS_INIT_PLANTS           11
+#define SS_INIT_WARNINGS         10
+#define SS_INIT_ANTAGS           9
+#define SS_INIT_MISC             8
+#define SS_INIT_SKYBOX           7
+#define SS_INIT_MAPPING          6
 #define SS_INIT_OPEN_SPACE       5
 #define SS_INIT_CIRCUIT          4
 #define SS_INIT_ATOMS            3

--- a/code/controllers/subsystems/initialization/character_setup.dm
+++ b/code/controllers/subsystems/initialization/character_setup.dm
@@ -17,11 +17,15 @@ SUBSYSTEM_DEF(character_setup)
 		var/datum/preferences/prefs = prefs_awaiting_setup[prefs_awaiting_setup.len]
 		prefs_awaiting_setup.len--
 		prefs.setup()
+
+	// get_preference_value() requires value 'initialized' to be set TRUE.
+	// If we don't do it now - following deferred_login() will fail.
+	. = ..()
+
 	while(newplayers_requiring_init.len)
 		var/mob/new_player/new_player = newplayers_requiring_init[newplayers_requiring_init.len]
 		newplayers_requiring_init.len--
 		new_player.deferred_login()
-	. = ..()
 
 /datum/controller/subsystem/character_setup/fire(resumed = FALSE)
 	while(save_queue.len)

--- a/code/modules/client/preference_setup/global/05_settings.dm
+++ b/code/modules/client/preference_setup/global/05_settings.dm
@@ -83,7 +83,8 @@
 
 /client/proc/get_preference_value(preference)
 	if(!SScharacter_setup.initialized)
-		return // Too early to use any preferences
+		// Too early to use any preferences
+		CRASH("Trying to get [ckey]'s preferences before the subsystem's initialization.")
 
 	if(!prefs)
 		log_error("[ckey]'s preferences did not load. Trying to fix.")


### PR DESCRIPTION
Преференсы отказывались загружаться из-за того - что в `get_preference_value` у нас, в отличии от бэя, осталась проверка на инициализированность подсистемы. Перенёс установку флага и приоритет системы на чуть раньше и добавил краш в проверку.

возможно fixes #5510 

```yml
🆑
bugfix: Исправлена проблема с загрузкой преференсов.
/🆑
```


- [x] Pull Request полностью завершен, мне не нужна помощь чтобы его закончить.
- [x] Я внимательно прочитал все свои изменения и багов в них не нашел.
- [x] Я запускал сервер со своими изменениями локально и все протестировал.
- [x] Я ознакомился c [Guide to Contribute](https://github.com/ChaoticOnyx/OnyxBay/blob/dev/docs/contributing.md).
