### PR TITLE
fix(human): preserve implants on revive

### DIFF
--- a/code/modules/mob/living/carbon/human/species/species.dm
+++ b/code/modules/mob/living/carbon/human/species/species.dm
@@ -281,7 +281,8 @@ The slots that you can use are found in items_clothing.dm and are the inventory 
 /datum/species/proc/create_organs(mob/living/carbon/human/H) //Handles creation of mob organs.
 
 	H.mob_size = mob_size
-	var/list/obj/item/organ/internal/foreign_organs = list()
+	var/list/foreign_organs = list()
+	var/list/implants_from_external_organs = list()
 
 	for(var/obj/item/organ/external/E in H.contents)
 		for(var/obj/item/organ/internal/O in E.internal_organs)
@@ -289,6 +290,10 @@ The slots that you can use are found in items_clothing.dm and are the inventory 
 				E.internal_organs.Remove(O)
 				H.internal_organs.Remove(O)
 				foreign_organs |= O
+		if(E.implants.len)
+			implants_from_external_organs[E.organ_tag] = list()
+		for(var/I in E.implants)
+			implants_from_external_organs[E.organ_tag] += I
 
 	for(var/obj/item/organ/organ in H.contents)
 		if((organ in H.organs) || (organ in H.internal_organs))
@@ -336,8 +341,11 @@ The slots that you can use are found in items_clothing.dm and are the inventory 
 
 	H.sync_organ_dna()
 
-/datum/species/proc/hug(mob/living/carbon/human/H,mob/living/target)
+	for(var/obj/item/organ/external/E in H.contents)
+		if(E.organ_tag in implants_from_external_organs)
+			E.implants += implants_from_external_organs[E.organ_tag]
 
+/datum/species/proc/hug(mob/living/carbon/human/H, mob/living/target)
 	var/mob/living/carbon/human/V
 	if(istype(target,/mob/living/carbon/human))
 		V = target


### PR DESCRIPTION
Исправил удаление имплантов при ревайве - теперь они будут оставаться на месте. Внезапно, Борер - тоже имплант и при ревайве он ломался.

fix #5337

<details>
<summary>Чейнджлог</summary>

```yml
🆑
tweak: Теперь чудесные воскрешения и вылечивания не будут удалять импланты.
bugfix: Исправлен баг из-за которого после лечения ядром Ховерхеда пропадала возможность извлечь Борера хирургически.
/🆑
```

</details>

- [x] Pull Request полностью завершен, мне не нужна помощь чтобы его закончить.
- [x] Я внимательно прочитал все свои изменения и багов в них не нашел.
- [x] Я запускал сервер со своими изменениями локально и все протестировал.
- [x] Я ознакомился c [Guide to Contribute](https://github.com/ChaoticOnyx/OnyxBay/blob/dev/docs/contributing.md).
