### PR TITLE
tweak(storyteller): don't fire storyteller on evacuation

### DIFF
--- a/code/modules/storyteller/storyteller.dm
+++ b/code/modules/storyteller/storyteller.dm
@@ -48,9 +48,16 @@ SUBSYSTEM_DEF(storyteller)
 	_log_debug("ROUND STATISTICS END")
 
 /datum/controller/subsystem/storyteller/fire(resumed = FALSE)
-	if (__storyteller_tick == -1) // first tick is called with default 'wait', we need our tick with our value of 'wait'
+	if(__storyteller_tick == -1) // first tick is called with default 'wait', we need our tick with our value of 'wait'
 		__storyteller_tick = 0
 		return
+	
+	ASSERT(evacuation_controller)
+	if(evacuation_controller.is_evacuating())
+		_log_debug("Skip cycle due to evacuation. The next try is scheduled for 1 minute")
+		wait = 1 MINUTE
+		return
+
 	__storyteller_tick++
 	_log_debug("Process new cycle start")
 	var/time_to_next_cycle = __character.process_new_cycle_start()


### PR DESCRIPTION
Убрал сторителлеру срабатывания во время эвакуации

fix #2810

<details>
<summary>Чейнджлог</summary>

```yml
🆑
tweak: Сторителлер больше не будет срабатывать во время эвакуации.
/🆑
```

</details>

- [x] Pull Request полностью завершен, мне не нужна помощь чтобы его закончить.
- [x] Я внимательно прочитал все свои изменения и багов в них не нашел.
- [x] Я запускал сервер со своими изменениями локально и все протестировал.
- [x] Я ознакомился c [Guide to Contribute](https://github.com/ChaoticOnyx/OnyxBay/blob/dev/docs/contributing.md).
