### PR TITLE
Removes inability to ride chairs through doors

### DIFF
--- a/code/game/turfs/turf.dm
+++ b/code/game/turfs/turf.dm
@@ -70,15 +70,16 @@
 
 /turf/attack_hand(mob/user)
 	user.setClickCooldown(DEFAULT_QUICK_COOLDOWN)
-	// QOL feature, clicking on turf can toogle doors
-	var/obj/machinery/door/airlock/AL = locate(/obj/machinery/door/airlock) in contents
-	if(AL)
-		AL.attack_hand(user)
-		return TRUE
-	var/obj/machinery/door/firedoor/FD = locate(/obj/machinery/door/firedoor) in contents
-	if(FD)
-		FD.attack_hand(user)
-		return TRUE
+	if(!user.pulling)
+		// QOL feature, clicking on turf can toogle doors
+		var/obj/machinery/door/airlock/AL = locate(/obj/machinery/door/airlock) in contents
+		if(AL)
+			AL.attack_hand(user)
+			return TRUE
+		var/obj/machinery/door/firedoor/FD = locate(/obj/machinery/door/firedoor) in contents
+		if(FD)
+			FD.attack_hand(user)
+			return TRUE
 
 	if(user.restrained())
 		return 0


### PR DESCRIPTION
```yml
🆑
tweak: Больше нельзя закрывать двери кликом по полу, при этом пулля что-либо. Следовательно, снова можно кататься на стульях через двери. Или пихать в двери под током людей.
/🆑
```

- [x] Pull Request полностью завершен, мне не нужна помощь чтобы его закончить.
- [x] Я внимательно прочитал все свои изменения и багов в них не нашел.
- [x] Я запускал сервер со своими изменениями локально и все протестировал.
- [x] Я ознакомился c [Guide to Contribute](https://github.com/ChaoticOnyx/OnyxBay/blob/dev/docs/contributing.md).
