### PR TITLE
Removes xenomorph's inability to strip people

### DIFF
--- a/code/modules/mob/living/carbon/alien/alien.dm
+++ b/code/modules/mob/living/carbon/alien/alien.dm
@@ -49,5 +49,5 @@
 /mob/living/carbon/alien/restrained()
 	return 0
 
-/mob/living/carbon/alien/show_inv(mob/user as mob)
+/mob/living/carbon/alien/show_inv(mob/user)
 	return //Consider adding cuffs and hats to this, for the sake of fun.

--- a/code/modules/mob/living/carbon/carbon.dm
+++ b/code/modules/mob/living/carbon/carbon.dm
@@ -424,7 +424,7 @@
 		return null
 	return species.default_language ? all_languages[species.default_language] : null
 
-/mob/living/carbon/show_inv(mob/user as mob)
+/mob/living/carbon/show_inv(mob/user)
 	user.set_machine(src)
 	var/dat = {"
 	<meta charset=\"utf-8\">

--- a/code/modules/mob/living/carbon/human/human.dm
+++ b/code/modules/mob/living/carbon/human/human.dm
@@ -235,7 +235,7 @@
 /mob/living/carbon/human/var/temperature_resistance = T0C+75
 
 /mob/living/carbon/human/show_inv(mob/user)
-	if(user.incapacitated() || !user.Adjacent(src) || !user.IsAdvancedToolUser())
+	if(user.incapacitated() || !user.Adjacent(src))
 		return
 	var/dat = "<B><HR><FONT size=3>[name]</FONT></B><BR><HR>"
 	var/firstline = TRUE

--- a/code/modules/mob/living/carbon/human/human.dm
+++ b/code/modules/mob/living/carbon/human/human.dm
@@ -237,6 +237,9 @@
 /mob/living/carbon/human/show_inv(mob/user)
 	if(user.incapacitated() || !user.Adjacent(src))
 		return
+	if(!user.IsAdvancedToolUser())
+		show_inv_reduced(user)
+		return
 	var/dat = "<B><HR><FONT size=3>[name]</FONT></B><BR><HR>"
 	var/firstline = TRUE
 	for(var/entry in species.hud.gear)
@@ -278,6 +281,39 @@
 		dat += "<BR><a href='?src=\ref[src];item=\ref[UW]'>Remove \the [UW]</a>"
 
 	dat += "<BR><A href='?src=\ref[src];item=splints'>Remove splints</A>"
+	dat += "<HR><A href='?src=\ref[src];refresh=1'>Refresh</A>"
+	dat += "<BR><A href='?src=\ref[user];inv_close=1'>Close</A>"
+
+	if(!user.show_inventory || user.show_inventory.user != user)
+		user.show_inventory = new /datum/browser(user, "mob[name]", "Inventory", 340, 560)
+		user.show_inventory.set_content(dat)
+	else
+		user.show_inventory.set_content(dat)
+		user.show_inventory.update()
+	return
+
+// Used when the user is not an advanced tool user (i.e. xenomorph)
+/mob/living/carbon/human/proc/show_inv_reduced(mob/user) // aka show_inv_to_a_moron
+	if(user.incapacitated() || !user.Adjacent(src))
+		return
+	var/dat = "<B><HR><FONT size=3>[name]</FONT></B><BR><HR>"
+	var/firstline = TRUE
+	for(var/entry in species.hud.gear)
+		var/list/slot_ref = species.hud.gear[entry]
+		if((slot_ref["slot"] in list(slot_l_store, slot_r_store, slot_w_uniform, slot_gloves, slot_shoes, slot_wear_id)))
+			continue
+		var/obj/item/thing_in_slot = get_equipped_item(slot_ref["slot"])
+		if(firstline)
+			firstline = FALSE
+		else
+			dat += "<BR>"
+		dat += "<B>[slot_ref["name"]]:</b> <a href='?src=\ref[src];item=[slot_ref["slot"]]'>[istype(thing_in_slot) ? thing_in_slot : "nothing"]</a>"
+	dat += "<HR>"
+
+	if(species.hud.has_hands)
+		dat += "<b>Left hand:</b> <A href='?src=\ref[src];item=[slot_l_hand]'>[istype(l_hand) ? l_hand : "nothing"]</A>"
+		dat += "<BR><b>Right hand:</b> <A href='?src=\ref[src];item=[slot_r_hand]'>[istype(r_hand) ? r_hand : "nothing"]</A>"
+
 	dat += "<HR><A href='?src=\ref[src];refresh=1'>Refresh</A>"
 	dat += "<BR><A href='?src=\ref[user];inv_close=1'>Close</A>"
 

--- a/code/modules/mob/living/simple_animal/hostile/facehugger.dm
+++ b/code/modules/mob/living/simple_animal/hostile/facehugger.dm
@@ -92,6 +92,10 @@
 	if(mask && !mask.knocked_out(H, dist = 0))
 		H.visible_message(SPAN("warning", "\The [src] tries to rip [H]'s [mask] off, but fails."))
 		return FALSE
+	var/obj/item/l_ear = H.get_equipped_item(slot_l_ear)
+	l_ear?.knocked_out(H, dist = 0)
+	var/obj/item/r_ear = H.get_equipped_item(slot_r_ear)
+	r_ear?.knocked_out(H, dist = 0)
 
 	var/obj/item/weapon/holder/facehugger/holder = new()
 	forceMove(holder)

--- a/code/modules/mob/mob.dm
+++ b/code/modules/mob/mob.dm
@@ -248,7 +248,7 @@
 				client.eye = loc
 	return
 
-/mob/proc/show_inv(mob/user as mob)
+/mob/proc/show_inv(mob/user)
 	return
 
 //mob verbs are faster than object verbs. See http://www.byond.com/forum/?post=1326139&page=2#comment8198716 for why this isn't atom/verb/examine()
@@ -528,14 +528,18 @@
 			return 1
 	return 0
 
-/mob/MouseDrop(mob/M as mob)
+/mob/MouseDrop(mob/M)
 	..()
-	if(M != usr) return
-	if(usr == src) return
-	if(!Adjacent(usr)) return
-	if(istype(M,/mob/living/silicon/ai)) return
+	if(M != usr)
+		return
+	if(usr == src)
+		return
+	if(!Adjacent(usr))
+		return
+	if(istype(M,/mob/living/silicon/ai))
+		return
 	show_inv(usr)
-	usr.show_inventory.open()
+	usr.show_inventory?.open()
 
 /mob/verb/stop_pulling()
 


### PR DESCRIPTION
```yml
🆑
tweak: Ксеноморфы теперь могут раздевать людей, но с ограничениями.
tweak: Лицехваты теперь скидывают не только шлемы и маски, но и предметы на ушах.
/🆑
```

- [x] Pull Request полностью завершен, мне не нужна помощь чтобы его закончить.
- [x] Я внимательно прочитал все свои изменения и багов в них не нашел.
- [x] Я запускал сервер со своими изменениями локально и все протестировал.
- [x] Я ознакомился c [Guide to Contribute](https://github.com/ChaoticOnyx/OnyxBay/blob/dev/docs/contributing.md).
