### PR TITLE
fix(crates): add specific material to crates and some refactoring

### DIFF
--- a/code/game/objects/structures/crates_lockers/closets.dm
+++ b/code/game/objects/structures/crates_lockers/closets.dm
@@ -38,7 +38,7 @@
 	var/dremovable = TRUE	//	some closets' doors cannot be removed
 	var/nodoor = FALSE	// for crafting
 
-	var/open_delay = FALSE
+	var/open_delay = 0
 
 	var/material = /obj/item/stack/material/steel
 
@@ -438,7 +438,7 @@
 		broken = 1
 		src.update_icon()
 		multi.in_use=0
-		user.visible_message(SPAN_WARNING("[user] [locked?"locks":"unlocks"] [name] with a multitool."), SPAN_WARNING("I [locked?"enable":"disable"] the locking modules."))
+		user.visible_message(SPAN_WARNING("[user] [locked ? "locks" : "unlocks"] [name] with a multitool."), SPAN_WARNING("I [locked ? "enable" : "disable"] the locking modules."))
 	else if(setup & CLOSET_HAS_LOCK)
 		src.togglelock(user, W)
 	else
@@ -448,7 +448,10 @@
 	if(!WT.remove_fuel(0,user))
 		to_chat(user, SPAN_NOTICE("You need more welding fuel to complete this task."))
 		return
-	new src.material(src.loc)
+	if(material != null)
+		new material(loc)
+	else
+		log_debug("\The [src] doesnt have material, this is bug", loc, type)
 	user.visible_message(SPAN_NOTICE("\The [src] has been cut apart by [user] with \the [WT]."), SPAN_NOTICE("You have cut \the [src] apart with \the [WT]."), "You hear welding.")
 	qdel(src)
 

--- a/code/game/objects/structures/crates_lockers/closets.dm
+++ b/code/game/objects/structures/crates_lockers/closets.dm
@@ -379,7 +379,7 @@
 			if(!cdoor)
 				return FALSE
 			if(remove_door())
-				user.visible_message(SPAN_NOTICE("[user] unscrewed [cdoor] from [src]."))
+				user.visible_message(SPAN("notice", "[user] unscrewed [cdoor] from [src]."))
 			return
 
 		if(istype(W, /obj/item/weapon/shield/closet) && dremovable && !cdoor)
@@ -493,7 +493,7 @@
 	add_fingerprint(user)
 	user.setClickCooldown(2)
 	if(in_use)
-		to_chat(user, SPAN_WARNING("You can't do this right now."))
+		to_chat(user, SPAN("warning", "You can't do this right now."))
 		return
 	in_use = TRUE
 	if(open_delay && !do_after(user, open_delay))

--- a/code/game/objects/structures/crates_lockers/closets.dm
+++ b/code/game/objects/structures/crates_lockers/closets.dm
@@ -5,7 +5,7 @@
 	icon_state = "closed"
 	pull_sound = "pull_closet"
 	pull_slowdown = PULL_SLOWDOWN_HEAVY
-	density = 1
+	density = TRUE
 	w_class = ITEM_SIZE_NO_CONTAINER
 	layer = STRUCTURE_LAYER
 
@@ -16,9 +16,9 @@
 	var/icon_broken = "spark"
 	var/icon_off
 
-	var/welded = 0
-	var/large = 1
-	var/wall_mounted = 0 //never solid (You can always pass over it)
+	var/welded = FALSE
+	var/large = TRUE
+	var/wall_mounted = FALSE //never solid (You can always pass over it)
 	var/health = 100
 	var/breakout = 0 //if someone is currently breaking out. mutex
 	var/storage_capacity = 2 * MOB_MEDIUM //This is so that someone can't pack hundreds of items in a locker/crate
@@ -35,15 +35,17 @@
 	var/locked = FALSE
 
 	var/obj/item/weapon/shield/closet/cdoor
-	var/dremovable = 1	//	some closets' doors cannot be removed
-	var/nodoor = 0	// for crafting
+	var/dremovable = TRUE	//	some closets' doors cannot be removed
+	var/nodoor = FALSE	// for crafting
 
-	var/open_delay = 0
+	var/open_delay = FALSE
+
+	var/material = /obj/item/stack/material/steel
 
 /obj/structure/closet/nodoor
-	nodoor = 1
+	nodoor = TRUE
 	opened = TRUE
-	density = 0
+	density = FALSE
 
 /obj/item/weapon/shield/closet
 	name = "closet door"
@@ -77,7 +79,7 @@
 	var/icon_locked
 	var/icon_off
 
-	var/lockable = 0
+	var/lockable = FALSE
 
 /obj/structure/closet/Initialize()
 	..()
@@ -111,7 +113,7 @@
 		ndoor.req_one_access = req_one_access
 
 		if((setup & CLOSET_HAS_LOCK))
-			ndoor.lockable = 1
+			ndoor.lockable = TRUE
 
 		ndoor.loc = src
 		cdoor = ndoor
@@ -146,20 +148,20 @@
 
 /obj/structure/closet/proc/can_open()
 	if((setup & CLOSET_HAS_LOCK) && locked)
-		return 0
+		return FALSE
 	if((setup & CLOSET_CAN_BE_WELDED) && welded)
-		return 0
+		return FALSE
 	if(dremovable && !cdoor)
-		return 0
-	return 1
+		return FALSE
+	return TRUE
 
 /obj/structure/closet/proc/can_close()
 	for(var/obj/structure/closet/closet in get_turf(src))
 		if(closet != src)
-			return 0
+			return FALSE
 	if(dremovable && !cdoor) // there's nothing to close
-		return 0
-	return 1
+		return FALSE
+	return TRUE
 
 /obj/structure/closet/proc/dump_contents()
 	for(var/mob/M in src)
@@ -184,34 +186,34 @@
 
 /obj/structure/closet/proc/open()
 	if(src.opened)
-		return 0
+		return FALSE
 
 	if(!src.can_open())
-		return 0
+		return FALSE
 
 	src.dump_contents()
 
-	src.opened = 1
+	src.opened = TRUE
 	playsound(src.loc, open_sound, 50, 1, -3)
-	density = 0
+	density = FALSE
 	update_icon()
-	return 1
+	return TRUE
 
 /obj/structure/closet/proc/close()
 	if(!src.opened)
-		return 0
+		return FALSE
 	if(!src.can_close())
-		return 0
+		return FALSE
 
 	store_contents()
-	src.opened = 0
+	src.opened = FALSE
 
 	playsound(src.loc, close_sound, 50, 0, -3)
-	density = 1
+	density = TRUE
 
 	update_icon()
 
-	return 1
+	return TRUE
 
 #define CLOSET_CHECK_TOO_BIG(x) (stored_units + . + x > storage_capacity)
 /obj/structure/closet/proc/store_items(stored_units)
@@ -288,16 +290,16 @@
 		return (I.w_class / 2)
 	if(istype(AM, /obj/structure) || istype(AM, /obj/machinery))
 		return MOB_LARGE
-	return 0
+	return FALSE
 
-/obj/structure/closet/proc/toggle(mob/user as mob)
+/obj/structure/closet/proc/toggle(mob/user)
 	if(locked)
 		togglelock(user)
 	else if(!(src.opened ? src.close() : src.open()))
 		if(dremovable && !cdoor)
-			to_chat(user, "<span class='notice'>There's no door to close!</span>")
+			to_chat(user, SPAN_NOTICE("There's no door to close!"))
 		else
-			to_chat(user, "<span class='notice'>It won't budge!</span>")
+			to_chat(user, SPAN_NOTICE("It won't budge!"))
 		update_icon()
 
 // this should probably use dump_contents()
@@ -346,14 +348,14 @@
 	else
 		break_open()
 
-/obj/structure/closet/attackby(obj/item/weapon/W as obj, mob/user as mob)
+/obj/structure/closet/attackby(obj/item/weapon/W, mob/user)
 	if(src.opened)
 		if(istype(W, /obj/item/grab))
 			var/obj/item/grab/G = W
 			src.MouseDrop_T(G.affecting, user)      //act like they were dragged onto the closet
-			return 0
+			return FALSE
 		if(istype(W,/obj/item/tk_grab))
-			return 0
+			return FALSE
 		if(isWelder(W))
 			var/obj/item/weapon/weldingtool/WT = W
 			if(WT.isOn())
@@ -364,31 +366,31 @@
 			var/turf/T = get_turf(src)
 			for(var/obj/item/I in LB.contents)
 				LB.remove_from_storage(I, T)
-			user.visible_message("<span class='notice'>[user] empties \the [LB] into \the [src].</span>", \
-								 "<span class='notice'>You empty \the [LB] into \the [src].</span>", \
-								 "<span class='notice'>You hear rustling of clothes.</span>")
+			user.visible_message(SPAN_NOTICE("[user] empties \the [LB] into \the [src]."),
+								 \SPAN_NOTICE("You empty \the [LB] into \the [src]."),
+								 \SPAN_NOTICE("You hear rustling of clothes."))
 			return
 
 		if(istype(W, /obj/item/weapon/screwdriver) && dremovable && cdoor)
-			user.visible_message("<span class='notice'>[user] starts unscrewing [cdoor] from [src].</span>")
+			user.visible_message(SPAN_NOTICE("[user] starts unscrewing [cdoor] from [src]."))
 			user.next_move = world.time + 10
 			if(!do_after(user, 30))
-				return 0
+				return FALSE
 			if(!cdoor)
-				return 0
+				return FALSE
 			if(remove_door())
-				user.visible_message(SPAN("notice", "[user] unscrewed [cdoor] from [src]."))
+				user.visible_message(SPAN_NOTICE("[user] unscrewed [cdoor] from [src]."))
 			return
 
 		if(istype(W, /obj/item/weapon/shield/closet) && dremovable && !cdoor)
 			var/obj/item/weapon/shield/closet/C = W
-			user.visible_message("<span class='notice'>[user] starts connecting [C] to [src].</span>")
+			user.visible_message(SPAN_NOTICE("[user] starts connecting [C] to [src]."))
 			user.next_move = world.time + 10
 			if(!do_after(user, 20))
-				return 0
+				return FALSE
 			if(cdoor)
-				return 0
-			user.visible_message("<span class='notice'>[user] connected [C] to [src].</span>")
+				return FALSE
+			user.visible_message(SPAN_NOTICE("[user] connected [C] to [src]."))
 			user.drop_item()
 			attach_door(C)
 			return
@@ -400,7 +402,7 @@
 			W.pixel_w = 0
 		return
 	else if(istype(W, /obj/item/weapon/melee/energy/blade))
-		if(emag_act(INFINITY, user, "<span class='danger'>The locker has been sliced open by [user] with \an [W]</span>!", "<span class='danger'>You hear metal being sliced and sparks flying.</span>"))
+		if(emag_act(INFINITY, user, SPAN_DANGER("The locker has been sliced open by [user] with \an [W]!"), SPAN_DANGER("You hear metal being sliced and sparks flying.")))
 			var/datum/effect/effect/system/spark_spread/spark_system = new /datum/effect/effect/system/spark_spread()
 			spark_system.set_up(5, 0, src.loc)
 			spark_system.start()
@@ -415,21 +417,19 @@
 			if(!WT.isOn())
 				return
 			else
-				to_chat(user, "<span class='notice'>You need more welding fuel to complete this task.</span>")
+				to_chat(user, SPAN_NOTICE("You need more welding fuel to complete this task."))
 				return
 		src.welded = !src.welded
 		src.update_icon()
-		user.visible_message("<span class='warning'>\The [src] has been [welded?"welded shut":"unwelded"] by \the [user].</span>", blind_message = "You hear welding.", range = 3)
+		user.visible_message(SPAN_WARNING("\The [src] has been [welded?"welded shut":"unwelded"] by \the [user]."), blind_message = "You hear welding.", range = 3)
 	else if(istype(W, /obj/item/device/multitool) && (setup & CLOSET_HAS_LOCK))
 		var/obj/item/device/multitool/multi = W
 		if(multi.in_use)
-			to_chat(user, "<span class='warning'>This multitool is already in use!</span>")
+			to_chat(user, SPAN_WARNING("This multitool is already in use!"))
 			return
 		multi.in_use = 1
 		for(var/i in 1 to rand(4,8))
-			user.visible_message(
-				"<span class='warning'>[user] picks in wires of the [src.name] with a multitool.</span>",
-				"<span class='warning'>I am trying to reset circuitry lock module ([i])...</span>"
+			user.visible_message(SPAN_WARNING("[user] picks in wires of the [src.name] with a multitool."), SPAN_WARNING("I am trying to reset circuitry lock module ([i])...")
 				)
 			if(!do_after(user,200)||!locked)
 				multi.in_use=0
@@ -438,8 +438,7 @@
 		broken = 1
 		src.update_icon()
 		multi.in_use=0
-		user.visible_message("<span class='warning'>[user] [locked?"locks":"unlocks"] [name] with a multitool.</span>",
-			"<span class='warning'>I [locked?"enable":"disable"] the locking modules.</span>")
+		user.visible_message(SPAN_WARNING("[user] [locked?"locks":"unlocks"] [name] with a multitool."), SPAN_WARNING("I [locked?"enable":"disable"] the locking modules."))
 	else if(setup & CLOSET_HAS_LOCK)
 		src.togglelock(user, W)
 	else
@@ -447,15 +446,13 @@
 
 /obj/structure/closet/proc/slice_into_parts(obj/item/weapon/weldingtool/WT, mob/user)
 	if(!WT.remove_fuel(0,user))
-		to_chat(user, "<span class='notice'>You need more welding fuel to complete this task.</span>")
+		to_chat(user, SPAN_NOTICE("You need more welding fuel to complete this task."))
 		return
-	new /obj/item/stack/material/steel(src.loc)
-	user.visible_message("<span class='notice'>\The [src] has been cut apart by [user] with \the [WT].</span>", \
-						 "<span class='notice'>You have cut \the [src] apart with \the [WT].</span>", \
-						 "You hear welding.")
+	new src.material(src.loc)
+	user.visible_message(SPAN_NOTICE("\The [src] has been cut apart by [user] with \the [WT]."), SPAN_NOTICE("You have cut \the [src] apart with \the [WT]."), "You hear welding.")
 	qdel(src)
 
-/obj/structure/closet/MouseDrop_T(atom/movable/O as mob|obj, mob/user as mob)
+/obj/structure/closet/MouseDrop_T(atom/movable/O, mob/user)
 	if(istype(O, /obj/screen))	//fix for HUD elements making their way into the world	-Pete
 		return
 	if(O.loc == user)
@@ -474,7 +471,7 @@
 		return
 	step_towards(O, src.loc)
 	if(user != O)
-		user.show_viewers("<span class='danger'>[user] stuffs [O] into [src]!</span>")
+		user.show_viewers(SPAN_DANGER("[user] stuffs [O] into [src]!"))
 	src.add_fingerprint(user)
 	return
 
@@ -482,18 +479,18 @@
 	if(istype(user, /mob/living/silicon/robot) && Adjacent(user)) // Robots can open/close it, but not the AI.
 		attack_hand(user)
 
-/obj/structure/closet/relaymove(mob/user as mob)
+/obj/structure/closet/relaymove(mob/user)
 	if(user.stat || !isturf(src.loc))
 		return
 
 	if(!src.open())
-		to_chat(user, "<span class='notice'>It won't budge!</span>")
+		to_chat(user, SPAN_NOTICE("It won't budge!"))
 
 /obj/structure/closet/attack_hand(mob/user)
 	add_fingerprint(user)
 	user.setClickCooldown(2)
 	if(in_use)
-		to_chat(user, SPAN("warning", "You can't do this right now."))
+		to_chat(user, SPAN_WARNING("You can't do this right now."))
 		return
 	in_use = TRUE
 	if(open_delay && !do_after(user, open_delay))
@@ -503,10 +500,10 @@
 	in_use = FALSE
 
 // tk grab then use on self
-/obj/structure/closet/attack_self_tk(mob/user as mob)
+/obj/structure/closet/attack_self_tk(mob/user)
 	src.add_fingerprint(user)
 	if(!src.toggle())
-		to_chat(usr, "<span class='notice'>It won't budge!</span>")
+		to_chat(usr, SPAN_NOTICE("It won't budge!"))
 
 /obj/structure/closet/attack_ghost(mob/ghost)
 	if(ghost.client && ghost.client.inquisitive_ghost)
@@ -525,7 +522,7 @@
 	if(ishuman(usr))
 		attack_hand(usr)
 	else
-		to_chat(usr, "<span class='warning'>This mob type can't use this verb.</span>")
+		to_chat(usr, SPAN_WARNING("This mob type can't use this verb."))
 
 /obj/structure/closet/update_icon()//Putting the welded stuff in update_icon() so it's easy to overwrite for special cases (Fridges, cabinets, and whatnot)
 	overlays.Cut()
@@ -567,18 +564,18 @@
 	if(!damage || !wallbreaker)
 		return
 	attack_animation(user)
-	visible_message("<span class='danger'>[user] [attack_message] the [src]!</span>")
+	visible_message(SPAN_DANGER("[user] [attack_message] the [src]!"))
 	dump_contents()
 	spawn(1) qdel(src)
-	return 1
+	return TRUE
 
 /obj/structure/closet/proc/req_breakout()
 	if(opened)
-		return 0 //Door's open... wait, why are you in it's contents then?
+		return FALSE //Door's open... wait, why are you in it's contents then?
 	if((setup & CLOSET_HAS_LOCK) && locked)
-		return 1 // Closed and locked
+		return TRUE // Closed and locked
 	if(welded)
-		return 1 // Welded
+		return TRUE // Welded
 	return (!welded) //closed but not welded...
 
 /obj/structure/closet/proc/mob_breakout(mob/living/escapee)
@@ -594,11 +591,11 @@
 
 	//okay, so the closet is either welded or locked... resist!!!
 	if(istype(src, /obj/structure/closet/body_bag))
-		to_chat(escapee, "<span class='warning'>You're trying to open \the [src] from the inside. (this will take about [breakout_time] minutes)</span>")
+		to_chat(escapee, SPAN_WARNING("You're trying to open \the [src] from the inside. (this will take about [breakout_time] minutes)"))
 	else
-		to_chat(escapee, "<span class='warning'>You lean on the back of \the [src] and start pushing the door open. (this will take about [breakout_time] minutes)</span>")
+		to_chat(escapee, SPAN_WARNING("You lean on the back of \the [src] and start pushing the door open. (this will take about [breakout_time] minutes)"))
 
-	visible_message("<span class='danger'>\The [src] begins to shake violently!</span>")
+	visible_message(SPAN_DANGER("\The [src] begins to shake violently!"))
 
 	breakout = 1 //can't think of a better way to do this right now.
 	for(var/i in 1 to (6*breakout_time * 2)) //minutes * 6 * 5seconds * 2
@@ -615,15 +612,15 @@
 		add_fingerprint(escapee)
 
 	//Well then break it!
-	breakout = 0
-	to_chat(escapee, "<span class='warning'>You successfully break out!</span>")
-	visible_message("<span class='danger'>\The [escapee] successfully broke out of \the [src]!</span>")
+	breakout = FALSE
+	to_chat(escapee, SPAN_WARNING("You successfully break out!"))
+	visible_message(SPAN_DANGER("<span class='danger'>\The [escapee] successfully broke out of \the [src]!"))
 	playsound(src.loc, 'sound/effects/grillehit.ogg', 100, 1)
 	break_open()
 	shake_animation()
 
 /obj/structure/closet/proc/break_open()
-	welded = 0
+	welded = FALSE
 
 	if((setup & CLOSET_HAS_LOCK) && locked)
 		make_broken()
@@ -653,13 +650,13 @@
 	if(!CanPhysicallyInteract(user))
 		return FALSE
 	if(src.opened)
-		to_chat(user, "<span class='notice'>Close \the [src] first.</span>")
+		to_chat(user, SPAN_NOTICE("Close \the [src] first."))
 		return FALSE
 	if(src.broken)
-		to_chat(user, "<span class='warning'>\The [src] appears to be broken.</span>")
+		to_chat(user, SPAN_WARNING("\The [src] appears to be broken."))
 		return FALSE
 	if(user.loc == src)
-		to_chat(user, "<span class='notice'>You can't reach the lock from inside.</span>")
+		to_chat(user, SPAN_NOTICE("You can't reach the lock from inside."))
 		return FALSE
 
 	add_fingerprint(user)
@@ -670,11 +667,11 @@
 
 	if(CanToggleLock(user, id_card))
 		locked = !locked
-		visible_message("<span class='notice'>\The [src] has been [locked ? null : "un"]locked by \the [user].</span>", range = 3)
+		visible_message(SPAN_NOTICE("\The [src] has been [locked ? null : "un"]locked by \the [user]."), range = 3)
 		update_icon()
 		return TRUE
 	else
-		to_chat(user, "<span class='warning'>Access denied!</span>")
+		to_chat(user, SPAN_WARNING("Access denied!"))
 		return FALSE
 
 /obj/structure/closet/proc/CanToggleLock(mob/user, obj/item/weapon/card/id/id_card)
@@ -710,9 +707,9 @@
 		if(visual_feedback)
 			visible_message(visual_feedback, audible_feedback)
 		else if(user && emag_source)
-			visible_message("<span class='warning'>\The [src] has been broken by \the [user] with \an [emag_source]!</span>", "You hear a faint electrical spark.")
+			visible_message(SPAN_WARNING("\The [src] has been broken by \the [user] with \an [emag_source]!"), "You hear a faint electrical spark.")
 		else
-			visible_message("<span class='warning'>\The [src] sparks and breaks open!</span>", "You hear a faint electrical spark.")
+			visible_message(SPAN_WARNING("\The [src] sparks and breaks open!"), "You hear a faint electrical spark.")
 		return 1
 	else
 		. = ..()
@@ -750,7 +747,7 @@
 
 /obj/structure/closet/proc/attach_door(obj/item/weapon/shield/closet/C)
 	if(cdoor)
-		return 0
+		return FALSE
 	broken = FALSE
 	locked = FALSE
 	C.loc = src
@@ -763,7 +760,7 @@
 
 	update_icon()
 
-	return 1
+	return TRUE
 
 /obj/structure/closet/hides_inside_walls() // Let's just don't
 	return FALSE

--- a/code/game/objects/structures/crates_lockers/closets.dm
+++ b/code/game/objects/structures/crates_lockers/closets.dm
@@ -617,7 +617,7 @@
 	//Well then break it!
 	breakout = FALSE
 	to_chat(escapee, SPAN_WARNING("You successfully break out!"))
-	visible_message(SPAN_DANGER("<span class='danger'>\The [escapee] successfully broke out of \the [src]!"))
+	visible_message(SPAN_DANGER("\The [escapee] successfully broke out of \the [src]!"))
 	playsound(src.loc, 'sound/effects/grillehit.ogg', 100, 1)
 	break_open()
 	shake_animation()

--- a/code/game/objects/structures/crates_lockers/crates.dm
+++ b/code/game/objects/structures/crates_lockers/crates.dm
@@ -108,7 +108,7 @@
 
 /obj/structure/closet/crate/handmade
 	name = "Handmade crate"
-	desc = "Another handmade by a young assistant. How cute! It looks like crude steel crate with no plastic in it."
+	desc = "Another handmade by a young assistant. Crude crate, now it`s more steel than plasteel."
 	icon_state = "handmadecrate"
 	icon_opened = "handmadecrateopen"
 	icon_closed = "handmadecrate"

--- a/code/game/objects/structures/crates_lockers/crates.dm
+++ b/code/game/objects/structures/crates_lockers/crates.dm
@@ -98,7 +98,7 @@
 		overlays += greenlight
 
 /obj/structure/closet/crate/plastic
-	name = "plastic crate"
+	name = "Plastic crate"
 	desc = "A rectangular plastic crate."
 	icon_state = "plasticcrate"
 	icon_opened = "plasticcrateopen"
@@ -107,8 +107,8 @@
 	material = /obj/item/stack/material/plastic
 
 /obj/structure/closet/crate/handmade
-	name = "handmade crate"
-	desc = "Another handmade by a young assistant. How cute!"
+	name = "Handmade crate"
+	desc = "Handame crate made of plasteel, looks like it lost plastic properties"
 	icon_state = "handmadecrate"
 	icon_opened = "handmadecrateopen"
 	icon_closed = "handmadecrate"

--- a/code/game/objects/structures/crates_lockers/crates.dm
+++ b/code/game/objects/structures/crates_lockers/crates.dm
@@ -98,7 +98,7 @@
 		overlays += greenlight
 
 /obj/structure/closet/crate/plastic
-	name = "Plastic crate"
+	name = "plastic crate"
 	desc = "A rectangular plastic crate."
 	icon_state = "plasticcrate"
 	icon_opened = "plasticcrateopen"
@@ -107,7 +107,7 @@
 	material = /obj/item/stack/material/plastic
 
 /obj/structure/closet/crate/handmade
-	name = "Handmade crate"
+	name = "handmade crate"
 	desc = "Another handmade by a young assistant. Crude crate, now it`s more steel than plasteel."
 	icon_state = "handmadecrate"
 	icon_opened = "handmadecrateopen"

--- a/code/game/objects/structures/crates_lockers/crates.dm
+++ b/code/game/objects/structures/crates_lockers/crates.dm
@@ -108,7 +108,7 @@
 
 /obj/structure/closet/crate/handmade
 	name = "Handmade crate"
-	desc = "Handame crate made of plasteel, looks like it lost plastic properties"
+	desc = "Handmade crate made of plasteel, looks like it lost plastic properties"
 	icon_state = "handmadecrate"
 	icon_opened = "handmadecrateopen"
 	icon_closed = "handmadecrate"

--- a/code/game/objects/structures/crates_lockers/crates.dm
+++ b/code/game/objects/structures/crates_lockers/crates.dm
@@ -108,7 +108,7 @@
 
 /obj/structure/closet/crate/handmade
 	name = "Handmade crate"
-	desc = "Another handmade by a young assistant. How cute! It looks like crude steel crate with no plastic in it"
+	desc = "Another handmade by a young assistant. How cute! It looks like crude steel crate with no plastic in it."
 	icon_state = "handmadecrate"
 	icon_opened = "handmadecrateopen"
 	icon_closed = "handmadecrate"

--- a/code/game/objects/structures/crates_lockers/crates.dm
+++ b/code/game/objects/structures/crates_lockers/crates.dm
@@ -108,7 +108,7 @@
 
 /obj/structure/closet/crate/handmade
 	name = "Handmade crate"
-	desc = "Handmade crate made of plasteel, looks like it lost plastic properties"
+	desc = "Another handmade by a young assistant. How cute! It looks like crude steel crate with no plastic in it"
 	icon_state = "handmadecrate"
 	icon_opened = "handmadecrateopen"
 	icon_closed = "handmadecrate"

--- a/code/game/objects/structures/crates_lockers/crates.dm
+++ b/code/game/objects/structures/crates_lockers/crates.dm
@@ -24,7 +24,7 @@
 	. = ..()
 	if(.)
 		if(rigged)
-			visible_message("<span class='danger'>There are wires attached to the lid of [src]...</span>")
+			visible_message(SPAN_DANGER("There are wires attached to the lid of [src]..."))
 			for(var/obj/item/device/assembly_holder/H in src)
 				H.process_activation(usr)
 			for(var/obj/item/device/assembly/A in src)
@@ -40,7 +40,7 @@
 			devices += A
 		. += "\nThere are some wires attached to the lid, connected to [english_list(devices)]."
 
-/obj/structure/closet/crate/attackby(obj/item/weapon/W as obj, mob/user as mob)
+/obj/structure/closet/crate/attackby(obj/item/weapon/W, mob/user)
 	if(opened)
 		return ..()
 	else if(istype(W, /obj/item/weapon/packageWrap))
@@ -48,23 +48,23 @@
 	else if(istype(W, /obj/item/stack/cable_coil))
 		var/obj/item/stack/cable_coil/C = W
 		if(rigged)
-			to_chat(user, "<span class='notice'>[src] is already rigged!</span>")
+			to_chat(user, SPAN_NOTICE("[src] is already rigged!"))
 			return
 		if (C.use(1))
-			to_chat(user, "<span class='notice'>You rig [src].</span>")
-			rigged = 1
+			to_chat(user, SPAN_NOTICE("You rig [src]."))
+			rigged = TRUE
 			return
 	else if(istype(W, /obj/item/device/assembly_holder) || istype(W, /obj/item/device/assembly))
 		if(rigged)
-			to_chat(user, "<span class='notice'>You attach [W] to [src].</span>")
+			to_chat(user, SPAN_NOTICE("You attach [W] to [src]."))
 			user.drop_item()
 			W.forceMove(src)
 			return
 	else if(isWirecutter(W))
 		if(rigged)
-			to_chat(user, "<span class='notice'>You cut away the wiring.</span>")
+			to_chat(user, SPAN_NOTICE("You cut away the wiring."))
 			playsound(loc, 'sound/items/Wirecutter.ogg', 100, 1)
-			rigged = 0
+			rigged = FALSE
 			return
 	else
 		return ..()
@@ -104,6 +104,7 @@
 	icon_opened = "plasticcrateopen"
 	icon_closed = "plasticcrate"
 	points_per_crate = 1
+	material = /obj/item/stack/material/plastic
 
 /obj/structure/closet/crate/handmade
 	name = "handmade crate"

--- a/code/modules/materials/material_recipes.dm
+++ b/code/modules/materials/material_recipes.dm
@@ -98,7 +98,7 @@
 /material/plasteel/generate_recipes()
 	..()
 	recipes += new /datum/stack_recipe("AI core", /obj/structure/AIcore, 8, time = 50, one_per_turf = 1)
-	recipes += new /datum/stack_recipe("Metal crate", /obj/structure/closet/crate/handmade, 5, time = 30, one_per_turf = 1)
+	recipes += new /datum/stack_recipe("Handmade crate", /obj/structure/closet/crate/handmade, 5, time = 30, one_per_turf = 1)
 
 /material/stone/generate_recipes()
 	..()


### PR DESCRIPTION
Добавил контейнерам переменную материала, теперь можно настроить во что разбирается каждый тип контейнера. Немного рефакторинга.
Поправил описание самодельного контейнера

close #5624
сlose #5625

<details>
<summary>Чейнджлог</summary>

```yml
🆑
bugfix: Пластиковый ящик при разборе больше не дает стальной лист
bugfix: Поправил описание самодельного контейнера из пластали
/🆑
```

</details>

- [x] Pull Request полностью завершен, мне не нужна помощь чтобы его закончить.
- [x] Я внимательно прочитал все свои изменения и багов в них не нашел.
- [x] Я запускал сервер со своими изменениями локально и все протестировал.
- [x] Я ознакомился c [Guide to Contribute](https://github.com/ChaoticOnyx/OnyxBay/blob/dev/docs/contributing.md).
