### PR TITLE
fix(water_ballon): w_size approximation & fulfillment from dispensers

### DIFF
--- a/code/game/objects/items/toys.dm
+++ b/code/game/objects/items/toys.dm
@@ -49,6 +49,7 @@
 	icon = 'icons/obj/toy.dmi'
 	icon_state = "waterballoon-e"
 	item_state = "balloon-empty"
+	w_class = ITEM_SIZE_TINY
 
 /obj/item/toy/water_balloon/New()
 	create_reagents(10)
@@ -59,11 +60,12 @@
 
 /obj/item/toy/water_balloon/afterattack(atom/A, mob/user, proximity)
 	if(!proximity) return
-	if (istype(A, /obj/structure/reagent_dispensers/watertank) && get_dist(src,A) <= 1)
+	if (istype(A, /obj/structure/reagent_dispensers) && get_dist(src,A) <= 1)
 		A.reagents.trans_to_obj(src, 10)
 		to_chat(user, "<span class='notice'>You fill the balloon with the contents of [A].</span>")
 		src.desc = "A translucent balloon with some form of liquid sloshing around in it."
 		src.update_icon()
+		w_class = ITEM_SIZE_SMALL
 	return
 
 /obj/item/toy/water_balloon/attackby(obj/O, mob/user)
@@ -80,6 +82,7 @@
 					src.desc = "A translucent balloon with some form of liquid sloshing around in it."
 					to_chat(user, "<span class='notice'>You fill the balloon with the contents of [O].</span>")
 					O.reagents.trans_to_obj(src, 10)
+					w_class = ITEM_SIZE_SMALL
 	src.update_icon()
 	return
 

--- a/code/game/objects/items/toys.dm
+++ b/code/game/objects/items/toys.dm
@@ -60,7 +60,7 @@
 
 /obj/item/toy/water_balloon/afterattack(atom/A, mob/user, proximity)
 	if(!proximity) return
-	if (istype(A, /obj/structure/reagent_dispensers) && get_dist(src,A) <= 1)
+	if(istype(A, /obj/structure/reagent_dispensers) && Adjacent(A))
 		A.reagents.trans_to_obj(src, 10)
 		to_chat(user, "<span class='notice'>You fill the balloon with the contents of [A].</span>")
 		src.desc = "A translucent balloon with some form of liquid sloshing around in it."


### PR DESCRIPTION
close #5679
ура фикс размеров шариков
алсо теперь можно наполнять не только из ватертанков

<details>
<summary>cheenglox</summary>

```yml
🆑
bugfix: Водяные шарики теперь приобрели ожидаемый малый размер и научились менять его при наполнении.
bugfix: Водяные шарики теперь можно наполнять не только из водяных баков.
/🆑
```
</details>

- [x] Pull Request полностью завершен, мне не нужна помощь чтобы его закончить.
- [x] Я внимательно прочитал все свои изменения и багов в них не нашел.
- [x] Я запускал сервер со своими изменениями локально и все протестировал.
- [ ] Я ознакомился c [Guide to Contribute](https://github.com/ChaoticOnyx/OnyxBay/blob/dev/docs/contributing.md).

да я знаю что из раковины хрен наполнишь но мне влом пихать костыли