### PR TITLE
fix(twohanded): fix display of two-handed weapons on the back

### DIFF
--- a/code/game/objects/items/weapons/material/twohanded.dm
+++ b/code/game/objects/items/weapons/material/twohanded.dm
@@ -69,7 +69,7 @@
 	update_icon()
 
 /obj/item/weapon/material/twohanded/update_icon()
-	var/tmp/new_item_state = "[base_icon][wielded]"
+	var/new_item_state = "[base_icon][wielded]"
 	item_state_slots[slot_l_hand_str] = new_item_state
 	item_state_slots[slot_r_hand_str] = new_item_state
 

--- a/code/game/objects/items/weapons/material/twohanded.dm
+++ b/code/game/objects/items/weapons/material/twohanded.dm
@@ -69,9 +69,9 @@
 	update_icon()
 
 /obj/item/weapon/material/twohanded/update_icon()
-	icon_state = "[base_icon][wielded]"
-	item_state_slots[slot_l_hand_str] = icon_state
-	item_state_slots[slot_r_hand_str] = icon_state
+	var/tmp/new_item_state = "[base_icon][wielded]"
+	item_state_slots[slot_l_hand_str] = new_item_state
+	item_state_slots[slot_r_hand_str] = new_item_state
 
 /*
  * Fireaxe
@@ -151,7 +151,6 @@
 	desc = "HOME RUN!"
 	icon_state = "metalbat0"
 	base_icon = "metalbat"
-	item_state = "metalbat"
 	w_class = ITEM_SIZE_LARGE
 	mod_weight = 1.5
 	mod_reach = 1.0


### PR DESCRIPTION
Исправил отображение копья и биты на спине. Раньше они отображались лишь тогда, когда во время перемещения на спину вторая рука была занята.

fix #5756

<details>
<summary>Чейнджлог</summary>

```yml
🆑Oubi
bugfix: Исправлено отображение копья и биты на спине
/🆑
```

</details>

- [x] Pull Request полностью завершен, мне не нужна помощь чтобы его закончить.
- [x] Я внимательно прочитал все свои изменения и багов в них не нашел.
- [x] Я запускал сервер со своими изменениями локально и все протестировал.
- [x] Я ознакомился c [Guide to Contribute](https://github.com/ChaoticOnyx/OnyxBay/blob/dev/docs/contributing.md).
