### PR TITLE
Allow Tajar to overheating with no damage

### DIFF
--- a/code/modules/mob/living/carbon/human/species/station/station.dm
+++ b/code/modules/mob/living/carbon/human/species/station/station.dm
@@ -97,7 +97,7 @@
 	name_language = LANGUAGE_SIIK_MAAS
 	health_hud_intensity = 1.75
 
-	passive_temp_gain = 3 // Allow Tajar stabilize at 38-40C at 20C environment, and 47-49 in a spacesuit.
+	passive_temp_gain = 1 // Allow Tajar stabilize at 38-40C at 20C environment, and 47-49 in a spacesuit.
 
 	min_age = 18
 	max_age = 140


### PR DESCRIPTION
Температура Таяр будет в пределах, которые не вызовут урон, но будет отображатся иконка о перегреве.

fix #5776 
<details>
<summary>Чейнджлог</summary>

```yml
🆑
bugfix: Теперь таяры не получают урон от перегрева.
/🆑
```

</details>

- [x] Pull Request полностью завершен, мне не нужна помощь чтобы его закончить.
- [x] Я внимательно прочитал все свои изменения и багов в них не нашел.
- [x] Я запускал сервер со своими изменениями локально и все протестировал.
- [x] Я ознакомился c [Guide to Contribute](https://github.com/ChaoticOnyx/OnyxBay/blob/dev/docs/contributing.md).
