### PR TITLE
fix labels on deliveries

### DIFF
--- a/code/modules/paperwork/handlabeler.dm
+++ b/code/modules/paperwork/handlabeler.dm
@@ -19,20 +19,7 @@
 	if(A == loc)	// if placing the labeller into something (e.g. backpack)
 		return		// don't set a label
 
-	// Restricts adding a label not through the hand labeller dialog
-	if(A.icon_state == "deliverycrate")
-		return
-	if(A.icon_state == "deliverycrateSmall")
-		return
-	if(A.icon_state == "deliverycrate5")
-		return
-	if(A.icon_state == "deliverycrate4")
-		return
-	if(A.icon_state == "deliverycrate3")
-		return
-	if(A.icon_state == "deliverycrate2")
-		return
-	if(A.icon_state == "deliverycrate1")
+	if(findtext(A.icon_state,"deliverycrate")!=0 || A.icon_state == "deliverycloset")	// Restricts adding a label not through the hand labeller dialog
 		return
 
 	if(!labels_left)

--- a/code/modules/paperwork/handlabeler.dm
+++ b/code/modules/paperwork/handlabeler.dm
@@ -16,13 +16,24 @@
 		return
 	if(!mode)	//if it's off, give up.
 		return
-
 	if(A == loc)	// if placing the labeller into something (e.g. backpack)
 		return		// don't set a label
 
-	switch(A.icon_state)
-		if("deliverycrate" || "deliverycloset" || "deliverycrateSmall" || "deliverycrate5" || "deliverycrate4" || "deliverycrate3" || "deliverycrate2" || "deliverycrate1")
-			return		// Restricts adding a label not through the hand labeller dialog
+	// Restricts adding a label not through the hand labeller dialog
+	if(A.icon_state == "deliverycrate")
+		return
+	if(A.icon_state == "deliverycrateSmall")
+		return
+	if(A.icon_state == "deliverycrate5")
+		return
+	if(A.icon_state == "deliverycrate4")
+		return
+	if(A.icon_state == "deliverycrate3")
+		return
+	if(A.icon_state == "deliverycrate2")
+		return
+	if(A.icon_state == "deliverycrate1")
+		return
 
 	if(!labels_left)
 		to_chat(user, "<span class='notice'>No labels left.</span>")

--- a/code/modules/paperwork/handlabeler.dm
+++ b/code/modules/paperwork/handlabeler.dm
@@ -23,10 +23,10 @@
 		return
 
 	if(!labels_left)
-		to_chat(user, "<span class='notice'>No labels left.</span>")
+		to_chat(user, SPAN("notice", "No labels left."))
 		return
 	if(!label || !length(label))
-		to_chat(user, "<span class='notice'>No label text set.</span>")
+		to_chat(user, SPAN("notice", "No label text set."))
 		return
 	if(has_extension(A, /datum/extension/labels))
 		var/datum/extension/labels/L = get_extension(A, /datum/extension/labels)
@@ -35,14 +35,14 @@
 	A.attach_label(user, src, label)
 
 /atom/proc/attach_label(user, atom/labeler, label_text)
-	to_chat(user, "<span class='notice'>The label refuses to stick to [name].</span>")
+	to_chat(user, SPAN("notice", "The label refuses to stick to [name]."))
 
 /mob/observer/attach_label(user, atom/labeler, label_text)
-	to_chat(user, "<span class='notice'>\The [labeler] passes through \the [src].</span>")
+	to_chat(user, SPAN("notice", "\The [labeler] passes through \the [src]."))
 
 /obj/machinery/portable_atmospherics/hydroponics/attach_label(user)
 	if(!mechanical)
-		to_chat(user, "<span class='notice'>How are you going to label that?</span>")
+		to_chat(user, SPAN("notice", "How are you going to label that?"))
 		return
 	..()
 	update_icon()
@@ -57,13 +57,13 @@
 	mode = !mode
 	icon_state = "labeler[mode]"
 	if(mode)
-		to_chat(user, "<span class='notice'>You turn on \the [src].</span>")
+		to_chat(user, SPAN("notice", "You turn on \the [src]."))
 		//Now let them chose the text.
 		var/str = sanitizeSafe(input(user,"Label text?","Set label",""), MAX_LNAME_LEN)
 		if(!str || !length(str))
-			to_chat(user, "<span class='notice'>Invalid text.</span>")
+			to_chat(user, SPAN("notice", "Invalid text."))
 			return
 		label = str
-		to_chat(user, "<span class='notice'>You set the text to '[str]'.</span>")
+		to_chat(user, SPAN("notice", "You set the text to '[str]'."))
 	else
-		to_chat(user, "<span class='notice'>You turn off \the [src].</span>")
+		to_chat(user, SPAN("notice", "You turn off \the [src]."))

--- a/code/modules/paperwork/handlabeler.dm
+++ b/code/modules/paperwork/handlabeler.dm
@@ -19,7 +19,7 @@
 	if(A == loc)	// if placing the labeller into something (e.g. backpack)
 		return		// don't set a label
 
-	if(istype(A, /obj/structure/bigDelivery) || istype(A, /obj/structure/smallDelivery))	// Restricts adding a label not through the hand labeller dialog
+	if(istype(A, /obj/structure/bigDelivery) || istype(A, /obj/item/smallDelivery))	// Restricts adding a label not through the hand labeller dialog
 		return
 
 	if(!labels_left)

--- a/code/modules/paperwork/handlabeler.dm
+++ b/code/modules/paperwork/handlabeler.dm
@@ -19,7 +19,7 @@
 	if(A == loc)	// if placing the labeller into something (e.g. backpack)
 		return		// don't set a label
 
-	if(findtext(A.icon_state,"deliverycrate")!=0 || A.icon_state == "deliverycloset")	// Restricts adding a label not through the hand labeller dialog
+	if(istype(A, /obj/structure/bigDelivery) || istype(A, /obj/structure/smallDelivery))	// Restricts adding a label not through the hand labeller dialog
 		return
 
 	if(!labels_left)

--- a/code/modules/paperwork/handlabeler.dm
+++ b/code/modules/paperwork/handlabeler.dm
@@ -16,8 +16,13 @@
 		return
 	if(!mode)	//if it's off, give up.
 		return
+
 	if(A == loc)	// if placing the labeller into something (e.g. backpack)
 		return		// don't set a label
+
+	switch(A.icon_state)
+		if("deliverycrate" || "deliverycloset" || "deliverycrateSmall" || "deliverycrate5" || "deliverycrate4" || "deliverycrate3" || "deliverycrate2" || "deliverycrate1")
+			return		// Restricts adding a label not through the hand labeller dialog
 
 	if(!labels_left)
 		to_chat(user, "<span class='notice'>No labels left.</span>")

--- a/code/modules/recycling/sortingmachinery.dm
+++ b/code/modules/recycling/sortingmachinery.dm
@@ -55,7 +55,7 @@
 					"You hear someone scribbling a note.")
 				else
 					user.visible_message("\The [user] titles \the [src] with \a [W]: \"[str]\"",\
-					"<span class='notice'>You title \the [src]: \"[str]\"</span>",\
+					SPAN("notice", You title \the [src]: \"[str]\"),\
 					"You hear the sound of a small printer.")
 				SetName("[name] ([str])")
 				if(!examtext && !nameset)
@@ -76,11 +76,11 @@
 					examtext = str
 				if(istype(W, /obj/item/weapon/pen))
 					user.visible_message("\The [user] labels \the [src] with \a [W], scribbling down: \"[examtext]\"",\
-					"<span class='notice'>You label \the [src]: \"[examtext]\"</span>",\
+					SPAN("notice", "You label \the [src]: \"[examtext]\""),\
 					"You hear someone scribbling a note.")
 				else
 					user.visible_message("\The [user] labels \the [src] with \a [W]: \"[examtext]\"",\
-					"<span class='notice'>You label \the [src]: \"[examtext]\"</span>",\
+					SPAN("notice", "You label \the [src]: \"[examtext]\""),\
 					"You hear the sound of a small printer.")
 
 /obj/structure/bigDelivery/update_icon()
@@ -192,11 +192,11 @@
 					return
 				if(istype(W, /obj/item/weapon/pen))
 					user.visible_message("\The [user] titles \the [src] with \a [W], marking down: \"[str]\"",\
-					"<span class='notice'>You title \the [src]: \"[str]\"</span>",\
+					SPAN("notice", You title \the [src]: \"[str]\"),\
 					"You hear someone scribbling a note.")
 				else
 					user.visible_message("\The [user] titles \the [src] with \a [W]: \"[str]\"",\
-					"<span class='notice'>You title \the [src]: \"[str]\"</span>",\
+					SPAN("notice", You title \the [src]: \"[str]\"),\
 					"You hear the sound of a small printer.")
 				SetName("[name] ([str])")
 				if(!examtext && !nameset)
@@ -217,11 +217,11 @@
 					examtext = str
 				if(istype(W, /obj/item/weapon/pen))
 					user.visible_message("\The [user] labels \the [src] with \a [W], scribbling down: \"[examtext]\"",\
-					"<span class='notice'>You label \the [src]: \"[examtext]\"</span>",\
+					SPAN("notice", "You label \the [src]: \"[examtext]\""),\
 					"You hear someone scribbling a note.")
 				else
 					user.visible_message("\The [user] labels \the [src] with \a [W]: \"[examtext]\"",\
-					"<span class='notice'>You label \the [src]: \"[examtext]\"</span>",\
+					SPAN("notice", "You label \the [src]: \"[examtext]\""),\
 					"You hear the sound of a small printer.")
 	return
 

--- a/code/modules/recycling/sortingmachinery.dm
+++ b/code/modules/recycling/sortingmachinery.dm
@@ -75,13 +75,13 @@
 				else
 					examtext = str
 				if(istype(W, /obj/item/weapon/pen))
-					user.visible_message("\The [user] labels \the [src] with \a [W], scribbling down: \"[examtext]\"",\
-					SPAN("notice", "You label \the [src]: \"[examtext]\""),\
-					"You hear someone scribbling a note.")
+					user.visible_message("\The [user] labels \the [src] with \a [W], scribbling down: \"[examtext]\"",
+					                     SPAN("notice", "You label \the [src]: \"[examtext]\""),
+					                     "You hear someone scribbling a note.")
 				else
-					user.visible_message("\The [user] labels \the [src] with \a [W]: \"[examtext]\"",\
-					SPAN("notice", "You label \the [src]: \"[examtext]\""),\
-					"You hear the sound of a small printer.")
+					user.visible_message("\The [user] labels \the [src] with \a [W]: \"[examtext]\"",
+					                     SPAN("notice", "You label \the [src]: \"[examtext]\""),
+					                     "You hear the sound of a small printer.")
 
 /obj/structure/bigDelivery/update_icon()
 	overlays = new()
@@ -216,13 +216,13 @@
 				else
 					examtext = str
 				if(istype(W, /obj/item/weapon/pen))
-					user.visible_message("\The [user] labels \the [src] with \a [W], scribbling down: \"[examtext]\"",\
-					SPAN("notice", "You label \the [src]: \"[examtext]\""),\
-					"You hear someone scribbling a note.")
+					user.visible_message("\The [user] labels \the [src] with \a [W], scribbling down: \"[examtext]\"",
+					                     SPAN("notice", "You label \the [src]: \"[examtext]\""),
+					                     "You hear someone scribbling a note.")
 				else
-					user.visible_message("\The [user] labels \the [src] with \a [W]: \"[examtext]\"",\
-					SPAN("notice", "You label \the [src]: \"[examtext]\""),\
-					"You hear the sound of a small printer.")
+					user.visible_message("\The [user] labels \the [src] with \a [W]: \"[examtext]\"",
+					                     SPAN("notice", "You label \the [src]: \"[examtext]\""),
+					                     "You hear the sound of a small printer.")
 	return
 
 /obj/item/smallDelivery/update_icon()

--- a/code/modules/recycling/sortingmachinery.dm
+++ b/code/modules/recycling/sortingmachinery.dm
@@ -42,46 +42,21 @@
 		else
 			to_chat(user, "<span class='warning'>You need to set a destination first!</span>")
 
-	else if(istype(W, /obj/item/weapon/pen))
+	else if(istype(W, /obj/item/weapon/pen) || istype(W, /obj/item/weapon/hand_labeler))
 		switch(alert("What would you like to alter?",,"Title","Description", "Cancel"))
 			if("Title")
 				var/str = sanitizeSafe(input(usr,"Label text?","Set label",""), MAX_NAME_LEN)
 				if(!str || !length(str))
 					to_chat(usr, "<span class='warning'> Invalid text.</span>")
 					return
-				user.visible_message("\The [user] titles \the [src] with \a [W], marking down: \"[str]\"",\
-				"<span class='notice'>You title \the [src]: \"[str]\"</span>",\
-				"You hear someone scribbling a note.")
-				SetName("[name] ([str])")
-				if(!examtext && !nameset)
-					nameset = 1
-					update_icon()
+				if(istype(W, /obj/item/weapon/pen))
+					user.visible_message("\The [user] titles \the [src] with \a [W], marking down: \"[str]\"",\
+					"<span class='notice'>You title \the [src]: \"[str]\"</span>",\
+					"You hear someone scribbling a note.")
 				else
-					nameset = 1
-			if("Description")
-				var/str = sanitize(input(usr,"Label text?","Set label",""))
-				if(!str || !length(str))
-					to_chat(usr, "<span class='warning'>Invalid text.</span>")
-					return
-				if(!examtext && !nameset)
-					examtext = str
-					update_icon()
-				else
-					examtext = str
-				user.visible_message("\The [user] labels \the [src] with \a [W], scribbling down: \"[examtext]\"",\
-				"<span class='notice'>You label \the [src]: \"[examtext]\"</span>",\
-				"You hear someone scribbling a note.")
-
-	else if(istype(W, /obj/item/weapon/hand_labeler))
-		switch(alert("What would you like to alter?",,"Title","Description", "Cancel"))
-			if("Title")
-				var/str = sanitizeSafe(input(usr,"Label text?","Set label",""), MAX_NAME_LEN)
-				if(!str || !length(str))
-					to_chat(usr, "<span class='warning'> Invalid text.</span>")
-					return
-				user.visible_message("\The [user] titles \the [src] with \a [W], marking down: \"[str]\"",\
-				"<span class='notice'>You title \the [src]: \"[str]\"</span>",\
-				"You hear the sound of a small printer.")
+					user.visible_message("\The [user] titles \the [src] with \a [W]: \"[str]\"",\
+					"<span class='notice'>You title \the [src]: \"[str]\"</span>",\
+					"You hear the sound of a small printer.")
 				SetName("[name] ([str])")
 				if(!examtext && !nameset)
 					nameset = 1
@@ -99,10 +74,14 @@
 					update_icon()
 				else
 					examtext = str
-				user.visible_message("\The [user] labels \the [src] with \a [W], scribbling down: \"[examtext]\"",\
-				"<span class='notice'>You label \the [src]: \"[examtext]\"</span>",\
-				"You hear the sound of a small printer.")
-	return
+				if(istype(W, /obj/item/weapon/pen))
+					user.visible_message("\The [user] labels \the [src] with \a [W], scribbling down: \"[examtext]\"",\
+					"<span class='notice'>You label \the [src]: \"[examtext]\"</span>",\
+					"You hear someone scribbling a note.")
+				else
+					user.visible_message("\The [user] labels \the [src] with \a [W]: \"[examtext]\"",\
+					"<span class='notice'>You label \the [src]: \"[examtext]\"</span>",\
+					"You hear the sound of a small printer.")
 
 /obj/structure/bigDelivery/update_icon()
 	overlays = new()
@@ -204,16 +183,21 @@
 		else
 			to_chat(user, "<span class='warning'>You need to set a destination first!</span>")
 
-	else if(istype(W, /obj/item/weapon/pen))
+	else if(istype(W, /obj/item/weapon/pen) || istype(W, /obj/item/weapon/hand_labeler))
 		switch(alert("What would you like to alter?",,"Title","Description", "Cancel"))
 			if("Title")
 				var/str = sanitizeSafe(input(usr,"Label text?","Set label",""), MAX_NAME_LEN)
 				if(!str || !length(str))
 					to_chat(usr, "<span class='warning'> Invalid text.</span>")
 					return
-				user.visible_message("\The [user] titles \the [src] with \a [W], marking down: \"[str]\"",\
-				"<span class='notice'>You title \the [src]: \"[str]\"</span>",\
-				"You hear someone scribbling a note.")
+				if(istype(W, /obj/item/weapon/pen))
+					user.visible_message("\The [user] titles \the [src] with \a [W], marking down: \"[str]\"",\
+					"<span class='notice'>You title \the [src]: \"[str]\"</span>",\
+					"You hear someone scribbling a note.")
+				else
+					user.visible_message("\The [user] titles \the [src] with \a [W]: \"[str]\"",\
+					"<span class='notice'>You title \the [src]: \"[str]\"</span>",\
+					"You hear the sound of a small printer.")
 				SetName("[name] ([str])")
 				if(!examtext && !nameset)
 					nameset = 1
@@ -231,9 +215,14 @@
 					update_icon()
 				else
 					examtext = str
-				user.visible_message("\The [user] labels \the [src] with \a [W], scribbling down: \"[examtext]\"",\
-				"<span class='notice'>You label \the [src]: \"[examtext]\"</span>",\
-				"You hear someone scribbling a note.")
+				if(istype(W, /obj/item/weapon/pen))
+					user.visible_message("\The [user] labels \the [src] with \a [W], scribbling down: \"[examtext]\"",\
+					"<span class='notice'>You label \the [src]: \"[examtext]\"</span>",\
+					"You hear someone scribbling a note.")
+				else
+					user.visible_message("\The [user] labels \the [src] with \a [W]: \"[examtext]\"",\
+					"<span class='notice'>You label \the [src]: \"[examtext]\"</span>",\
+					"You hear the sound of a small printer.")
 	return
 
 /obj/item/smallDelivery/update_icon()

--- a/code/modules/recycling/sortingmachinery.dm
+++ b/code/modules/recycling/sortingmachinery.dm
@@ -30,7 +30,7 @@
 		var/obj/item/device/destTagger/O = W
 		if(O.currTag)
 			if(src.sortTag != O.currTag)
-				to_chat(user, "<span class='notice'>You have labeled the destination as [O.currTag].</span>")
+				to_chat(user, SPAN("notice", "You have labeled the destination as [O.currTag]"))
 				if(!src.sortTag)
 					src.sortTag = O.currTag
 					update_icon()
@@ -38,24 +38,24 @@
 					src.sortTag = O.currTag
 				playsound(src.loc, 'sound/signals/ping1.ogg', 50, 0)
 			else
-				to_chat(user, "<span class='warning'>The package is already labeled for [O.currTag].</span>")
+				to_chat(user, SPAN("warning", "The package is already labeled for [O.currTag]"))
 		else
-			to_chat(user, "<span class='warning'>You need to set a destination first!</span>")
+			to_chat(user, SPAN("warning", "You need to set a destination first!</span>"))
 
 	else if(istype(W, /obj/item/weapon/pen) || istype(W, /obj/item/weapon/hand_labeler))
 		switch(alert("What would you like to alter?",,"Title","Description", "Cancel"))
 			if("Title")
 				var/str = sanitizeSafe(input(usr,"Label text?","Set label",""), MAX_NAME_LEN)
 				if(!str || !length(str))
-					to_chat(usr, "<span class='warning'> Invalid text.</span>")
+					to_chat(usr, SPAN("warning", "Invalid text"))
 					return
 				if(istype(W, /obj/item/weapon/pen))
 					user.visible_message("\The [user] titles \the [src] with \a [W], marking down: \"[str]\"",\
-					"<span class='notice'>You title \the [src]: \"[str]\"</span>",\
+					SPAN("notice", "You title \the [src]: \"[str]\""),\
 					"You hear someone scribbling a note.")
 				else
 					user.visible_message("\The [user] titles \the [src] with \a [W]: \"[str]\"",\
-					SPAN("notice", You title \the [src]: \"[str]\"),\
+					SPAN("notice", "You title \the [src]: \"[str]\""),\
 					"You hear the sound of a small printer.")
 				SetName("[name] ([str])")
 				if(!examtext && !nameset)
@@ -67,7 +67,7 @@
 			if("Description")
 				var/str = sanitize(input(usr,"Label text?","Set label",""))
 				if(!str || !length(str))
-					to_chat(usr, "<span class='warning'>Invalid text.</span>")
+					to_chat(usr, SPAN("warning", "Invalid text"))
 					return
 				if(!examtext && !nameset)
 					examtext = str
@@ -171,7 +171,7 @@
 		var/obj/item/device/destTagger/O = W
 		if(O.currTag)
 			if(src.sortTag != O.currTag)
-				to_chat(user, "<span class='notice'>You have labeled the destination as [O.currTag].</span>")
+				to_chat(user, SPAN("notice", "You have labeled the destination as [O.currTag]"))
 				if(!src.sortTag)
 					src.sortTag = O.currTag
 					update_icon()
@@ -179,24 +179,24 @@
 					src.sortTag = O.currTag
 				playsound(src.loc, 'sound/signals/ping1.ogg', 50, 0)
 			else
-				to_chat(user, "<span class='warning'>The package is already labeled for [O.currTag].</span>")
+				to_chat(user, SPAN("warning", "The package is already labeled for [O.currTag]"))
 		else
-			to_chat(user, "<span class='warning'>You need to set a destination first!</span>")
+			to_chat(user, SPAN("warning", "You need to set a destination first!</span>"))
 
 	else if(istype(W, /obj/item/weapon/pen) || istype(W, /obj/item/weapon/hand_labeler))
 		switch(alert("What would you like to alter?",,"Title","Description", "Cancel"))
 			if("Title")
 				var/str = sanitizeSafe(input(usr,"Label text?","Set label",""), MAX_NAME_LEN)
 				if(!str || !length(str))
-					to_chat(usr, "<span class='warning'> Invalid text.</span>")
+					to_chat(usr, SPAN("warning", "Invalid text"))
 					return
 				if(istype(W, /obj/item/weapon/pen))
 					user.visible_message("\The [user] titles \the [src] with \a [W], marking down: \"[str]\"",\
-					SPAN("notice", You title \the [src]: \"[str]\"),\
+					SPAN("notice", "You title \the [src]: \"[str]\""),\
 					"You hear someone scribbling a note.")
 				else
 					user.visible_message("\The [user] titles \the [src] with \a [W]: \"[str]\"",\
-					SPAN("notice", You title \the [src]: \"[str]\"),\
+					SPAN("notice", "You title \the [src]: \"[str]\""),\
 					"You hear the sound of a small printer.")
 				SetName("[name] ([str])")
 				if(!examtext && !nameset)
@@ -208,7 +208,7 @@
 			if("Description")
 				var/str = sanitize(input(usr,"Label text?","Set label",""))
 				if(!str || !length(str))
-					to_chat(usr, "<span class='warning'>Invalid text.</span>")
+					to_chat(usr, SPAN("warning", "Invalid text"))
 					return
 				if(!examtext && !nameset)
 					examtext = str
@@ -319,7 +319,7 @@
 			src.add_fingerprint(usr)
 			src.amount -= 1
 			user.visible_message("\The [user] wraps \a [target] with \a [src].",\
-			"<span class='notice'>You wrap \the [target], leaving [amount] units of paper on \the [src].</span>",\
+			SPAN("notice", "You wrap \the [target], leaving [amount] units of paper on \the [src]"),\
 			"You hear someone taping paper around a small object.")
 	else if (istype(target, /obj/structure/closet/crate))
 		var/obj/structure/closet/crate/O = target
@@ -330,10 +330,10 @@
 			O.forceMove(P)
 			src.amount -= 3
 			user.visible_message("\The [user] wraps \a [target] with \a [src].",\
-			"<span class='notice'>You wrap \the [target], leaving [amount] units of paper on \the [src].</span>",\
+			SPAN("notice", "You wrap \the [target], leaving [amount] units of paper on \the [src]"),\
 			"You hear someone taping paper around a large object.")
 		else if(src.amount < 3)
-			to_chat(user, "<span class='warning'>You need more paper.</span>")
+			to_chat(user, SPAN("warning", "You need more paper"))
 	else if (istype (target, /obj/structure/closet))
 		var/obj/structure/closet/O = target
 		if (src.amount > 3 && !O.opened)
@@ -343,12 +343,12 @@
 			O.forceMove(P)
 			src.amount -= 3
 			user.visible_message("\The [user] wraps \a [target] with \a [src].",\
-			"<span class='notice'>You wrap \the [target], leaving [amount] units of paper on \the [src].</span>",\
+			SPAN("notice", "You wrap \the [target], leaving [amount] units of paper on \the [src]"),\
 			"You hear someone taping paper around a large object.")
 		else if(src.amount < 3)
-			to_chat(user, "<span class='warning'>You need more paper.</span>")
+			to_chat(user, SPAN("warning", "You need more paper"))
 	else
-		to_chat(user, "<span class='notice'>The object you are trying to wrap is unsuitable for the sorting machinery!</span>")
+		to_chat(user, SPAN("notice", "The object you are trying to wrap is unsuitable for the sorting machinery!"))
 	if (src.amount <= 0)
 		new /obj/item/weapon/c_tube( src.loc )
 		qdel(src)

--- a/code/modules/recycling/sortingmachinery.dm
+++ b/code/modules/recycling/sortingmachinery.dm
@@ -50,11 +50,11 @@
 					to_chat(usr, SPAN("warning", "Invalid text"))
 					return
 				if(istype(W, /obj/item/weapon/pen))
-					user.visible_message("\The [user] titles \the [src] with \a [W]",\
+					user.visible_message("\The [user] titles \the [src] with \a [W].",\
 					SPAN("notice", "You title \the [src]: \"[str]\""),\
 					"You hear someone scribbling a note.")
 				else
-					user.visible_message("\The [user] titles \the [src] with \a [W]",\
+					user.visible_message("\The [user] titles \the [src] with \a [W].",\
 					SPAN("notice", "You title \the [src]: \"[str]\""),\
 					"You hear the sound of a small printer.")
 				SetName("[name] ([str])")
@@ -75,11 +75,11 @@
 				else
 					examtext = str
 				if(istype(W, /obj/item/weapon/pen))
-					user.visible_message("\The [user] labels \the [src] with \a [W], scribbling something down",
+					user.visible_message("\The [user] labels \the [src] with \a [W], scribbling something down.",
 					                     SPAN("notice", "You label \the [src]: \"[examtext]\""),
 					                     "You hear someone scribbling a note.")
 				else
-					user.visible_message("\The [user] labels \the [src] with \a [W]",
+					user.visible_message("\The [user] labels \the [src] with \a [W].",
 					                     SPAN("notice", "You label \the [src]: \"[examtext]\""),
 					                     "You hear the sound of a small printer.")
 
@@ -191,11 +191,11 @@
 					to_chat(usr, SPAN("warning", "Invalid text"))
 					return
 				if(istype(W, /obj/item/weapon/pen))
-					user.visible_message("\The [user] titles \the [src] with \a [W]",\
+					user.visible_message("\The [user] titles \the [src] with \a [W].",\
 					SPAN("notice", "You title \the [src]: \"[str]\""),\
 					"You hear someone scribbling a note.")
 				else
-					user.visible_message("\The [user] titles \the [src] with \a [W]:",\
+					user.visible_message("\The [user] titles \the [src] with \a [W].",\
 					SPAN("notice", "You title \the [src]: \"[str]\""),\
 					"You hear the sound of a small printer.")
 				SetName("[name] ([str])")
@@ -216,11 +216,11 @@
 				else
 					examtext = str
 				if(istype(W, /obj/item/weapon/pen))
-					user.visible_message("\The [user] labels \the [src] with \a [W], scribbling something down",
+					user.visible_message("\The [user] labels \the [src] with \a [W], scribbling something down.",
 					                     SPAN("notice", "You label \the [src]: \"[examtext]\""),
 					                     "You hear someone scribbling a note.")
 				else
-					user.visible_message("\The [user] labels \the [src] with \a [W]",
+					user.visible_message("\The [user] labels \the [src] with \a [W].",
 					                     SPAN("notice", "You label \the [src]: \"[examtext]\""),
 					                     "You hear the sound of a small printer.")
 	return
@@ -319,7 +319,7 @@
 			src.add_fingerprint(usr)
 			src.amount -= 1
 			user.visible_message("\The [user] wraps \a [target] with \a [src].",\
-			SPAN("notice", "You wrap \the [target], leaving [amount] units of paper on \the [src]"),\
+			SPAN("notice", "You wrap \the [target], leaving [amount] units of paper on \the [src]."),\
 			"You hear someone taping paper around a small object.")
 	else if (istype(target, /obj/structure/closet/crate))
 		var/obj/structure/closet/crate/O = target

--- a/code/modules/recycling/sortingmachinery.dm
+++ b/code/modules/recycling/sortingmachinery.dm
@@ -71,6 +71,37 @@
 				user.visible_message("\The [user] labels \the [src] with \a [W], scribbling down: \"[examtext]\"",\
 				"<span class='notice'>You label \the [src]: \"[examtext]\"</span>",\
 				"You hear someone scribbling a note.")
+
+	else if(istype(W, /obj/item/weapon/hand_labeler))
+		switch(alert("What would you like to alter?",,"Title","Description", "Cancel"))
+			if("Title")
+				var/str = sanitizeSafe(input(usr,"Label text?","Set label",""), MAX_NAME_LEN)
+				if(!str || !length(str))
+					to_chat(usr, "<span class='warning'> Invalid text.</span>")
+					return
+				user.visible_message("\The [user] titles \the [src] with \a [W], marking down: \"[str]\"",\
+				"<span class='notice'>You title \the [src]: \"[str]\"</span>",\
+				"You hear the sound of a small printer.")
+				SetName("[name] ([str])")
+				if(!examtext && !nameset)
+					nameset = 1
+					update_icon()
+				else
+					nameset = 1
+
+			if("Description")
+				var/str = sanitize(input(usr,"Label text?","Set label",""))
+				if(!str || !length(str))
+					to_chat(usr, "<span class='warning'>Invalid text.</span>")
+					return
+				if(!examtext && !nameset)
+					examtext = str
+					update_icon()
+				else
+					examtext = str
+				user.visible_message("\The [user] labels \the [src] with \a [W], scribbling down: \"[examtext]\"",\
+				"<span class='notice'>You label \the [src]: \"[examtext]\"</span>",\
+				"You hear the sound of a small printer.")
 	return
 
 /obj/structure/bigDelivery/update_icon()

--- a/code/modules/recycling/sortingmachinery.dm
+++ b/code/modules/recycling/sortingmachinery.dm
@@ -50,11 +50,11 @@
 					to_chat(usr, SPAN("warning", "Invalid text"))
 					return
 				if(istype(W, /obj/item/weapon/pen))
-					user.visible_message("\The [user] titles \the [src] with \a [W], marking down: \"[str]\"",\
+					user.visible_message("\The [user] titles \the [src] with \a [W]",\
 					SPAN("notice", "You title \the [src]: \"[str]\""),\
 					"You hear someone scribbling a note.")
 				else
-					user.visible_message("\The [user] titles \the [src] with \a [W]: \"[str]\"",\
+					user.visible_message("\The [user] titles \the [src] with \a [W]",\
 					SPAN("notice", "You title \the [src]: \"[str]\""),\
 					"You hear the sound of a small printer.")
 				SetName("[name] ([str])")
@@ -75,11 +75,11 @@
 				else
 					examtext = str
 				if(istype(W, /obj/item/weapon/pen))
-					user.visible_message("\The [user] labels \the [src] with \a [W], scribbling down: \"[examtext]\"",
+					user.visible_message("\The [user] labels \the [src] with \a [W], scribbling something down",
 					                     SPAN("notice", "You label \the [src]: \"[examtext]\""),
 					                     "You hear someone scribbling a note.")
 				else
-					user.visible_message("\The [user] labels \the [src] with \a [W]: \"[examtext]\"",
+					user.visible_message("\The [user] labels \the [src] with \a [W]",
 					                     SPAN("notice", "You label \the [src]: \"[examtext]\""),
 					                     "You hear the sound of a small printer.")
 
@@ -191,11 +191,11 @@
 					to_chat(usr, SPAN("warning", "Invalid text"))
 					return
 				if(istype(W, /obj/item/weapon/pen))
-					user.visible_message("\The [user] titles \the [src] with \a [W], marking down: \"[str]\"",\
+					user.visible_message("\The [user] titles \the [src] with \a [W]",\
 					SPAN("notice", "You title \the [src]: \"[str]\""),\
 					"You hear someone scribbling a note.")
 				else
-					user.visible_message("\The [user] titles \the [src] with \a [W]: \"[str]\"",\
+					user.visible_message("\The [user] titles \the [src] with \a [W]:",\
 					SPAN("notice", "You title \the [src]: \"[str]\""),\
 					"You hear the sound of a small printer.")
 				SetName("[name] ([str])")
@@ -216,11 +216,11 @@
 				else
 					examtext = str
 				if(istype(W, /obj/item/weapon/pen))
-					user.visible_message("\The [user] labels \the [src] with \a [W], scribbling down: \"[examtext]\"",
+					user.visible_message("\The [user] labels \the [src] with \a [W], scribbling something down",
 					                     SPAN("notice", "You label \the [src]: \"[examtext]\""),
 					                     "You hear someone scribbling a note.")
 				else
-					user.visible_message("\The [user] labels \the [src] with \a [W]: \"[examtext]\"",
+					user.visible_message("\The [user] labels \the [src] with \a [W]",
 					                     SPAN("notice", "You label \the [src]: \"[examtext]\""),
 					                     "You hear the sound of a small printer.")
 	return


### PR DESCRIPTION
close #5753

<summary>Чейнджлог</summary>

```yml
🆑 Artemonim
bugfix: Теперь при креплении этикетки на посылку появляется спрайт этикетки.
tweak: Для посылок теперь можно сделать этикетку с описанием, а не только строчку названия.
/🆑
```
Есть стойкое ощущение, что логика должна быть только в handlabeler.dm иначе нанесение новых заголовков и описаний дополняет, а не заменяет старые надписи.

- [x] Pull Request полностью завершен, мне не нужна помощь чтобы его закончить.
- [x] Я внимательно прочитал все свои изменения и багов в них не нашел.
- [x] Я запускал сервер со своими изменениями локально и все протестировал.
- [x] Я ознакомился c [Guide to Contribute](https://github.com/ChaoticOnyx/OnyxBay/blob/dev/docs/contributing.md).
