### PR TITLE
Убираем бессмертных мимиков

### DIFF
--- a/code/modules/mob/living/simple_animal/hostile/mimic.dm
+++ b/code/modules/mob/living/simple_animal/hostile/mimic.dm
@@ -32,7 +32,7 @@ var/global/list/protected_objects = list(/obj/structure/table, /obj/structure/ca
 	faction = "mimic"
 	move_to_delay = 8
 
-	var/weakref/copy_of = /obj/structure/closet/crate
+	var/weakref/copy_of
 	var/weakref/creator // the creator
 	var/destroy_objects = FALSE
 	var/knockdown_people = FALSE

--- a/code/modules/mob/living/simple_animal/hostile/mimic.dm
+++ b/code/modules/mob/living/simple_animal/hostile/mimic.dm
@@ -39,8 +39,7 @@ var/global/list/protected_objects = list(/obj/structure/table, /obj/structure/ca
 
 /mob/living/simple_animal/hostile/mimic/New(newloc, obj/o, mob/living/creator)
 	..()
-	if(o == null)
-		o = /obj/structure/closet/crate
+	o = o || /obj/structure/closet/crate
 	if(o)
 		if(ispath(o))
 			o = new o(newloc)
@@ -66,7 +65,7 @@ var/global/list/protected_objects = list(/obj/structure/table, /obj/structure/ca
 		icon_living = icon_state
 
 		if(istype(O, /obj/structure))
-			health = (anchored * 50) + 50
+			health = anchored * 50 + 50
 			destroy_objects = TRUE
 			if(O.density && O.anchored)
 				knockdown_people = TRUE
@@ -83,8 +82,6 @@ var/global/list/protected_objects = list(/obj/structure/table, /obj/structure/ca
 		if(creator)
 			creator = weakref(creator)
 			faction = "\ref[creator]" // very unique
-		return TRUE
-	return
 
 /mob/living/simple_animal/hostile/mimic/death()
 	if(!copy_of)

--- a/code/modules/mob/living/simple_animal/hostile/mimic.dm
+++ b/code/modules/mob/living/simple_animal/hostile/mimic.dm
@@ -40,7 +40,6 @@ var/global/list/protected_objects = list(/obj/structure/table, /obj/structure/ca
 /mob/living/simple_animal/hostile/mimic/New(newloc, obj/o, mob/living/creator)
 	..()
 	o = o || /obj/structure/closet/crate
-	if(o)
 		if(ispath(o))
 			o = new o(newloc)
 		CopyObject(o,creator)

--- a/code/modules/mob/living/simple_animal/hostile/mimic.dm
+++ b/code/modules/mob/living/simple_animal/hostile/mimic.dm
@@ -40,9 +40,9 @@ var/global/list/protected_objects = list(/obj/structure/table, /obj/structure/ca
 /mob/living/simple_animal/hostile/mimic/New(newloc, obj/o, mob/living/creator)
 	..()
 	o = o || /obj/structure/closet/crate
-		if(ispath(o))
-			o = new o(newloc)
-		CopyObject(o,creator)
+	if(ispath(o))
+		o = new o(newloc)
+	CopyObject(o,creator)
 
 /mob/living/simple_animal/hostile/mimic/FindTarget()
 	. = ..()

--- a/code/modules/mob/living/simple_animal/hostile/mimic.dm
+++ b/code/modules/mob/living/simple_animal/hostile/mimic.dm
@@ -32,13 +32,15 @@ var/global/list/protected_objects = list(/obj/structure/table, /obj/structure/ca
 	faction = "mimic"
 	move_to_delay = 8
 
-	var/weakref/copy_of
+	var/weakref/copy_of = /obj/structure/closet/crate
 	var/weakref/creator // the creator
-	var/destroy_objects = 0
-	var/knockdown_people = 0
+	var/destroy_objects = FALSE
+	var/knockdown_people = FALSE
 
 /mob/living/simple_animal/hostile/mimic/New(newloc, obj/o, mob/living/creator)
 	..()
+	if(o == null)
+		o = /obj/structure/closet/crate
 	if(o)
 		if(ispath(o))
 			o = new o(newloc)
@@ -65,9 +67,9 @@ var/global/list/protected_objects = list(/obj/structure/table, /obj/structure/ca
 
 		if(istype(O, /obj/structure))
 			health = (anchored * 50) + 50
-			destroy_objects = 1
+			destroy_objects = TRUE
 			if(O.density && O.anchored)
-				knockdown_people = 1
+				knockdown_people = TRUE
 				melee_damage_lower *= 2
 				melee_damage_upper *= 2
 		else if(istype(O, /obj/item))
@@ -79,9 +81,9 @@ var/global/list/protected_objects = list(/obj/structure/table, /obj/structure/ca
 
 		maxHealth = health
 		if(creator)
-			src.creator = weakref(creator)
+			creator = weakref(creator)
 			faction = "\ref[creator]" // very unique
-		return 1
+		return TRUE
 	return
 
 /mob/living/simple_animal/hostile/mimic/death()
@@ -120,7 +122,7 @@ var/global/list/protected_objects = list(/obj/structure/table, /obj/structure/ca
 		if(istype(L))
 			if(prob(15))
 				L.Weaken(1)
-				L.visible_message("<span class='danger'>\The [src] knocks down \the [L]!</span>")
+				L.visible_message(SPAN_DANGER("\The [src] knocks down \the [L]!"))
 
 /mob/living/simple_animal/hostile/mimic/Destroy()
 	copy_of = null
@@ -129,10 +131,10 @@ var/global/list/protected_objects = list(/obj/structure/table, /obj/structure/ca
 	return ..()
 
 /mob/living/simple_animal/hostile/mimic/sleeping
-	wander = 0
-	stop_automated_movement = 1
+	wander = FALSE
+	stop_automated_movement = TRUE
 
-	var/awake = 0
+	var/awake = FALSE
 
 /mob/living/simple_animal/hostile/mimic/sleeping/ListTargets()
 	if(!awake)
@@ -141,8 +143,8 @@ var/global/list/protected_objects = list(/obj/structure/table, /obj/structure/ca
 
 /mob/living/simple_animal/hostile/mimic/sleeping/proc/trigger()
 	if(!awake)
-		src.visible_message("<b>\The [src]</b> starts to move!")
-		awake = 1
+		visible_message("<b>\The [src]</b> starts to move!")
+		awake = TRUE
 
 /mob/living/simple_animal/hostile/mimic/sleeping/adjustBruteLoss(damage)
 	trigger()


### PR DESCRIPTION
При педальном спавне или спавне из экстракта мимик был бессмертен из-за того, что он обязан быть копией чего-то. Теперь в случаях таких спавнов при смерте он станет обычным контейнером.

fixes #5626

<details>
<summary>Чейнджлог</summary>

```yml
🆑
bugfix: Мимики больше не бессмертные
/🆑
```

</details>

- [x] Pull Request полностью завершен, мне не нужна помощь чтобы его закончить.
- [x] Я внимательно прочитал все свои изменения и багов в них не нашел.
- [x] Я запускал сервер со своими изменениями локально и все протестировал.
- [x] Я ознакомился c [Guide to Contribute](https://github.com/ChaoticOnyx/OnyxBay/blob/dev/docs/contributing.md).
