### PR TITLE
Чиним нерабочие заклинания мага.

### DIFF
--- a/code/_macros.dm
+++ b/code/_macros.dm
@@ -211,8 +211,6 @@
 
 #define SPAN_DEADSAY(X)  SPAN("deadsay", X)
 
-#define SPAN_INFO(X)     SPAN("info", X)
-
 #define FONT_SMALL(X)    SPAN("small", X)
 
 #define FONT_NORMAL(X)   SPAN("normal", X)
@@ -222,4 +220,3 @@
 #define FONT_HUGE(X)     SPAN("huge", X)
 
 #define FONT_GIANT(X)    SPAN("giant", X)
-

--- a/code/_macros.dm
+++ b/code/_macros.dm
@@ -211,6 +211,8 @@
 
 #define SPAN_DEADSAY(X)  SPAN("deadsay", X)
 
+#define SPAN_INFO(X)     SPAN("info", X)
+
 #define FONT_SMALL(X)    SPAN("small", X)
 
 #define FONT_NORMAL(X)   SPAN("normal", X)

--- a/code/_macros.dm
+++ b/code/_macros.dm
@@ -220,3 +220,4 @@
 #define FONT_HUGE(X)     SPAN("huge", X)
 
 #define FONT_GIANT(X)    SPAN("giant", X)
+

--- a/code/modules/spells/aoe_turf/knock.dm
+++ b/code/modules/spells/aoe_turf/knock.dm
@@ -19,14 +19,14 @@
 			spawn(1)
 				if(istype(door,/obj/machinery/door/airlock))
 					var/obj/machinery/door/airlock/AL = door //casting is important
-					AL.locked = 0
-				door.open()
+					AL.locked = FALSE
+				door.open(TRUE)
 	return
 
 
 /spell/aoe_turf/knock/empower_spell()
 	if(!..())
-		return 0
+		return FALSE
 	range *= 2
 
 	return "You've doubled the range of [src]."

--- a/code/modules/spells/contracts.dm
+++ b/code/modules/spells/contracts.dm
@@ -9,7 +9,7 @@
 
 /obj/item/weapon/contract/attack_self(mob/user as mob)
 	if(contract_master == null)
-		to_chat(user, "<span class='notice'>You bind the contract to your soul, making you the recipient of whatever poor fool's soul that decides to contract with you.</span>")
+		to_chat(user, SPAN_NOTICE("You bind the contract to your soul, making you the recipient of whatever poor fool's soul that decides to contract with you."))
 		contract_master = user
 		return
 
@@ -34,7 +34,7 @@
 		qdel(src)
 
 /obj/item/weapon/contract/proc/contract_effect(mob/user as mob)
-	to_chat(user, "<span class='warning'>You've signed your soul over to \the [contract_master] and with that your unbreakable vow of servitude begins.</span>")
+	to_chat(user, SPAN_WARNING("You've signed your soul over to \the [contract_master] and with that your unbreakable vow of servitude begins."))
 	return 1
 
 /obj/item/weapon/contract/apprentice
@@ -44,10 +44,10 @@
 
 /obj/item/weapon/contract/apprentice/contract_effect(mob/user as mob)
 	if(user.mind.special_role == "apprentice")
-		to_chat(user, "<span class='warning'>You are already a wizarding apprentice!</span>")
+		to_chat(user, SPAN_WARNING("You are already a wizarding apprentice!"))
 		return 0
 	if(GLOB.wizards.add_antagonist_mind(user.mind,1,"apprentice","<b>You are an apprentice! Your job is to learn the wizarding arts!</b>"))
-		to_chat(user, "<span class='notice'>With the signing of this paper you agree to become \the [contract_master]'s apprentice in the art of wizardry.</span>")
+		to_chat(user, SPAN_NOTICE("With the signing of this paper you agree to become \the [contract_master]'s apprentice in the art of wizardry."))
 		return 1
 	return 0
 
@@ -67,7 +67,7 @@
 		user.set_sight(user.sight|SEE_MOBS|SEE_OBJS|SEE_TURFS)
 		user.set_see_in_dark(8)
 		user.set_see_invisible(SEE_INVISIBLE_LEVEL_TWO)
-		to_chat(user, "<span class='notice'>The walls suddenly disappear.</span>")
+		to_chat(user, SPAN_NOTICE("The walls suddenly disappear."))
 		return 1
 	return 0
 
@@ -82,7 +82,7 @@
 		user.mutations.Add(mRemotetalk)
 		user.dna.SetSEState(GLOB.REMOTETALKBLOCK,1)
 		domutcheck(user, null, MUTCHK_FORCED)
-		to_chat(user, "<span class='notice'>You expand your mind outwards.</span>")
+		to_chat(user, SPAN_NOTICE("You expand your mind outwards."))
 		return 1
 	return 0
 
@@ -95,7 +95,7 @@
 	..()
 	if(!(MUTATION_TK in user.mutations))
 		user.mutations.Add(MUTATION_TK)
-		to_chat(user, "<span class='notice'>You feel your mind expanding!</span>")
+		to_chat(user, SPAN_NOTICE("You feel your mind expanding!"))
 		return 1
 	return 0
 

--- a/code/modules/spells/general/contract_spells.dm
+++ b/code/modules/spells/general/contract_spells.dm
@@ -43,7 +43,7 @@
 	if(!target)
 		return
 
-	to_chat(target, SPAN_INFO("You feel great!"))
+	to_chat(target, SPAN("info", "You feel great!"))
 	target.ExtinguishMob()
 
 /spell/contract/punish

--- a/code/modules/spells/general/contract_spells.dm
+++ b/code/modules/spells/general/contract_spells.dm
@@ -10,7 +10,6 @@
 	invocation = "none"
 	invocation_type = SpI_NONE
 
-
 	var/mob/subject
 
 /spell/contract/New(mob/M)
@@ -21,7 +20,7 @@
 /spell/contract/choose_targets()
 	return list(subject)
 
-/spell/contract/cast(mob/target,mob/user)
+/spell/contract/cast(mob/target, mob/user)
 	if(!subject)
 		to_chat(usr, "This spell was not properly given a target. Contact a coder.")
 		return null
@@ -34,34 +33,32 @@
 /spell/contract/reward
 	name = "Reward Contractee"
 	desc = "A spell that makes your contracted victim feel better."
-
+	need_target = FALSE
 	charge_max = 300
 	cooldown_min = 100
-
 	hud_state = "wiz_jaunt_old"
 
-/spell/contract/reward/cast(mob/living/target,mob/user)
+/spell/contract/reward/cast(mob/living/target, mob/user)
 	target = ..(target,user)
 	if(!target)
 		return
 
-	to_chat(target, "<span class='info'>You feel great!</span>")
+	to_chat(target, SPAN_INFO("You feel great!"))
 	target.ExtinguishMob()
 
 /spell/contract/punish
 	name = "Punish Contractee"
 	desc = "A spell that sets your contracted victim ablaze."
-
+	need_target = FALSE
 	charge_max = 300
 	cooldown_min = 100
-
 	hud_state = "gen_immolate"
 
-/spell/contract/punish/cast(mob/living/target,mob/user)
+/spell/contract/punish/cast(mob/living/target, mob/user)
 	target = ..(target,user)
 	if(!target)
 		return
 
-	to_chat(target, "<span class='danger'>You feel punished!</span>")
+	to_chat(target, SPAN_DANGER("You feel punished!"))
 	target.fire_stacks += 15
 	target.IgniteMob()

--- a/code/modules/spells/general/return_master.dm
+++ b/code/modules/spells/general/return_master.dm
@@ -8,16 +8,17 @@
 	invocation = "none"
 	invocation_type = SpI_NONE
 	cooldown_min = 200
-
 	smoke_spread = 1
 	smoke_amt = 5
-
+	need_target = FALSE
 	hud_state = "wiz_tele"
 
 
-/spell/contract/return_master/cast(mob/target,mob/user)
-	target = ..(target,user)
+/spell/contract/return_master/cast(mob/target, mob/user)
+	target = ..(target, user)
 	if(!target)
 		return
-
-	user.forceMove(get_turf(target))
+	if(istype(target.loc, /obj/machinery/atmospherics/unary/cryo_cell))
+		var/obj/machinery/atmospherics/unary/cryo_cell/cell = target.loc
+		cell.go_out()
+	target.forceMove(get_turf(user))


### PR DESCRIPTION
Одной строчкой поправил действие Knock указав что шлюз открывается насильно, как монтировкой.
Парой строк поправил действия скиллов которые влияют на ученика мага. Теперь ученик телепортируется К МАГУ, а не наоборот. Область действия скиллов больше не ограниченна областью видимости. 

close #5693
close #5656

<details>
<summary>Чейнджлог</summary>

```yml
🆑
bugfix: Заклинание "Knock" открывает обесточенные шлюзы.
bugfix: Исправлены заклинания взаимодействия мага с учениками.
tweak: Заклинание "Return to Master" телепортирует ученика к магу, а не наоборот.
/🆑
```

</details>

- [x] Pull Request полностью завершен, мне не нужна помощь чтобы его закончить.
- [x] Я внимательно прочитал все свои изменения и багов в них не нашел.
- [x] Я запускал сервер со своими изменениями локально и все протестировал.
- [x] Я ознакомился c [Guide to Contribute](https://github.com/ChaoticOnyx/OnyxBay/blob/dev/docs/contributing.md).
