### PR TITLE
Removes broken stungloves initialize()

### DIFF
--- a/code/modules/clothing/chameleon.dm
+++ b/code/modules/clothing/chameleon.dm
@@ -261,6 +261,9 @@
 //**Chameleon Gloves**
 //********************
 /obj/item/clothing/gloves/chameleon/attackby(obj/item/weapon/card/id/W, mob/user)
+	if(isWirecutter(W) || istype(W, /obj/item/weapon/scalpel) || isCoil(W))
+		to_chat(user, SPAN("notice", "That won't work.")) // Making it obvious
+		return
 	if(!istype(W, /obj/item/weapon/card/id))
 		return
 	check_job(W, user, slot_gloves_str)

--- a/code/modules/clothing/clothing.dm
+++ b/code/modules/clothing/clothing.dm
@@ -296,7 +296,7 @@ BLIND     // can't see anything
 	if(istype(W, /obj/item/weapon/tape_roll) && wired)
 		user.visible_message(SPAN("warning", "\The [user] secures the wires on \the [src] with \the [W]."), SPAN("notice", "You secure the wires on \the [src] with \the [W]."))
 		user.drop_from_inventory(src)
-		new /obj/item/clothing/gloves/stun(src.loc, src)
+		new /obj/item/clothing/gloves/stun(loc, src)
 		return
 
 // Applies "clipped" and removes relevant restricted species from the list,

--- a/code/modules/clothing/gloves/stun.dm
+++ b/code/modules/clothing/gloves/stun.dm
@@ -10,10 +10,12 @@
 	var/attack_cost = 50
 	var/obj/item/weapon/cell/device/bcell
 
-/obj/item/clothing/gloves/stun/Initialize(loc, obj/item/clothing/gloves/G)
-	. = ..()
+/obj/item/clothing/gloves/stun/Initialize(mapload, obj/item/clothing/gloves/G)
+	. = ..(mapload)
 	if(!istype(G))
-		return
+		G = new /obj/item/clothing/gloves/thick // So we won't end up with a broken pair of shites when adminspawning these
+		G.wired = TRUE
+		G.update_icon(TRUE)
 	base_gloves = G
 	appearance = base_gloves.appearance
 	name = "stun gloves"
@@ -30,7 +32,7 @@
 	QDEL_NULL(base_gloves)
 	return ..()
 
-/obj/item/clothing/gloves/stun/update_icon(needs_updating=FALSE)
+/obj/item/clothing/gloves/stun/update_icon(needs_updating = FALSE)
 	..()
 	if(bcell)
 		overlays += image(icon, "gloves_cell")
@@ -99,7 +101,7 @@
 	check_zone(zone)
 	if(zone in restricted_bps)
 		zone = BP_GROIN // To avoid stunning people with one stun attack
-		to_chat(src.loc, SPAN("notice", "The target will dodge your attack on the legs, so you go for their lower body instead!"))
+		to_chat(loc, SPAN("notice", "The target will dodge your attack on the legs, so you go for their lower body instead!"))
 	return zone
 
 /obj/item/clothing/gloves/stun/proc/stun_attack(mob/living/carbon/human/user, mob/living/carbon/human/victim)


### PR DESCRIPTION
- Стан-перчатки инициализировались через жопу.
- Заспавненные/намаппленные стан-перчатки теперь по умолчанию выбирают базой рабочие перчатки. До этого - получалось поломанное нечто.
- Попытка обрезать/обмотать проводами перчатки-хамелеоны теперь выдаёт очевидное сообщение, как у боксёрских перчаток.

- [x] Pull Request полностью завершен, мне не нужна помощь чтобы его закончить.
- [x] Я внимательно прочитал все свои изменения и багов в них не нашел.
- [x] Я запускал сервер со своими изменениями локально и все протестировал.
- [x] Я ознакомился c [Guide to Contribute](https://github.com/ChaoticOnyx/OnyxBay/blob/dev/docs/contributing.md).
