### PR TITLE
Исправление дюпа пирогов

### DIFF
--- a/code/game/machinery/kitchen/cooking_machines/_cooker.dm
+++ b/code/game/machinery/kitchen/cooking_machines/_cooker.dm
@@ -79,6 +79,9 @@
 	if(istype(I, /obj/item/weapon/reagent_containers/food/snacks/badrecipe))
 		to_chat(user, SPAN_WARNING("Making [I] [cook_type] shouldn't help."))
 		return 0
+	if(istype(I, /obj/item/weapon/reagent_containers/food/snacks/slice))
+		to_chat(user, SPAN_WARNING("Making [I] [cook_type] shouldn't help."))
+		return 0
 	else if(istype(I, /obj/item/weapon/reagent_containers/food/snacks))
 		var/obj/item/weapon/reagent_containers/food/snacks/check = I
 		if(cook_type in check.cooked_types)


### PR DESCRIPTION
Исправил дюп пирогов в печке

Теперь когда ты суёшь кусок (slice) чего-либо, то печка (oven) не принимает его, тем самым не давая возможность заново создать полноценный пирог

<details>
<summary>Чейнджлог</summary>

```yml
🆑
bugfix: Исправлен дюп пирогов через печку (oven)
/🆑
```

</details>
close #5545 

- [x] Pull Request полностью завершен, мне не нужна помощь чтобы его закончить.
- [x] Я внимательно прочитал все свои изменения и багов в них не нашел.
- [x] Я запускал сервер со своими изменениями локально и все протестировал.
- [x] Я ознакомился c [Guide to Contribute](https://github.com/ChaoticOnyx/OnyxBay/blob/dev/docs/contributing.md).
