### PR TITLE
Syndicate toolbox fix

### DIFF
--- a/code/__defines/inventory_sizes.dm
+++ b/code/__defines/inventory_sizes.dm
@@ -18,4 +18,3 @@
 #define DEFAULT_BACKPACK_STORAGE base_storage_capacity(5)
 #define DEFAULT_LARGEBOX_STORAGE base_storage_capacity(4)
 #define DEFAULT_BOX_STORAGE      base_storage_capacity(3)
-#define DEFAULT_SYNDY_BOX_STORAGE      base_storage_capacity(4.29)

--- a/code/__defines/inventory_sizes.dm
+++ b/code/__defines/inventory_sizes.dm
@@ -18,3 +18,4 @@
 #define DEFAULT_BACKPACK_STORAGE base_storage_capacity(5)
 #define DEFAULT_LARGEBOX_STORAGE base_storage_capacity(4)
 #define DEFAULT_BOX_STORAGE      base_storage_capacity(3)
+#define DEFAULT_SYNDY_BOX_STORAGE      base_storage_capacity(4.29)

--- a/code/game/objects/items/weapons/storage/toolbox.dm
+++ b/code/game/objects/items/weapons/storage/toolbox.dm
@@ -78,8 +78,7 @@
 	mod_weight = 1.75
 	mod_reach = 0.75
 	mod_handy = 1.0
-	max_storage_space = DEFAULT_SYNDY_BOX_STORAGE
-
+	max_storage_space = 23
 /obj/item/weapon/storage/toolbox/syndicate/New()
 	..()
 	new /obj/item/clothing/gloves/insulated(src)

--- a/code/game/objects/items/weapons/storage/toolbox.dm
+++ b/code/game/objects/items/weapons/storage/toolbox.dm
@@ -78,6 +78,7 @@
 	mod_weight = 1.75
 	mod_reach = 0.75
 	mod_handy = 1.0
+	max_storage_space = DEFAULT_SYNDY_BOX_STORAGE
 
 /obj/item/weapon/storage/toolbox/syndicate/New()
 	..()

--- a/code/game/objects/items/weapons/storage/toolbox.dm
+++ b/code/game/objects/items/weapons/storage/toolbox.dm
@@ -79,6 +79,7 @@
 	mod_reach = 0.75
 	mod_handy = 1.0
 	max_storage_space = 23
+
 /obj/item/weapon/storage/toolbox/syndicate/New()
 	..()
 	new /obj/item/clothing/gloves/insulated(src)


### PR DESCRIPTION
Исправил вместимость тулбокса синдиката

Добавил значение для вместимости тулбокса синдиката и добавил его самому тулбоксу, теперь он вмещает идеальное количество предметов

<details>
<summary>Чейнджлог</summary>

```yml
🆑
bugfix: Исправлена вместимость тулбокса Синдиката
/🆑
```

</details>

close #5950 

- [x] Pull Request полностью завершен, мне не нужна помощь чтобы его закончить.
- [x] Я внимательно прочитал все свои изменения и багов в них не нашел.
- [x] Я запускал сервер со своими изменениями локально и все протестировал.
- [x] Я ознакомился c [Guide to Contribute](https://github.com/ChaoticOnyx/OnyxBay/blob/dev/docs/contributing.md).
