### PR TITLE
Удаление лишних слов при альтклике на пда в рюкзаке

### DIFF
--- a/code/game/objects/items/devices/PDA/PDA.dm
+++ b/code/game/objects/items/devices/PDA/PDA.dm
@@ -1112,7 +1112,7 @@ var/global/list/obj/item/device/pda/PDAs = list()
 		SSnano.update_uis(src)
 		to_chat(usr, "<span class='notice'>You press the reset button on \the [src].</span>")
 	else
-		to_chat(usr, "<span class='notice'>You cannot do this while restrained.</span>")
+		to_chat(usr, "<span class='notice'>You cannot do this.</span>")
 
 /obj/item/device/pda/verb/verb_remove_id()
 	set category = "Object"
@@ -1128,7 +1128,7 @@ var/global/list/obj/item/device/pda/PDAs = list()
 		else
 			to_chat(usr, "<span class='notice'>\The [src] does not have an ID in it.</span>")
 	else
-		to_chat(usr, "<span class='notice'>You cannot do this while restrained.</span>")
+		to_chat(usr, "<span class='notice'>You cannot do this.</span>")
 
 
 /obj/item/device/pda/verb/verb_remove_pen()
@@ -1152,7 +1152,7 @@ var/global/list/obj/item/device/pda/PDAs = list()
 		else
 			to_chat(usr, "<span class='notice'>\The [src] does not have a pen in it.</span>")
 	else
-		to_chat(usr, "<span class='notice'>You cannot do this while restrained.</span>")
+		to_chat(usr, "<span class='notice'>You cannot do this.</span>")
 
 /obj/item/device/pda/verb/verb_remove_cartridge()
 	set category = "Object"
@@ -1181,7 +1181,7 @@ var/global/list/obj/item/device/pda/PDAs = list()
 		to_chat(usr, "<span class='notice'>You remove \the [cartridge] from the [name].</span>")
 		cartridge = null
 	else
-		to_chat(usr, "<span class='notice'>You cannot do this while restrained.</span>")
+		to_chat(usr, "<span class='notice'>You cannot do this.</span>")
 
 /obj/item/device/pda/proc/id_check(mob/user as mob, choice as num)//To check for IDs; 1 for in-pda use, 2 for out of pda use.
 	if(choice == 1)


### PR DESCRIPTION
Удалил лишние слова при альтклике на пда в рюкзаке

Теперь, когда ты нажимаешь Альт-Кликом по ПДА в рюкзаке, то тебе выдаётся "You cannot do this", вместо "You cannot do this when restrained".
(просто нельзя взаимодействовать нормально с объектами в контейнерах)

<details>
<summary>Чейнджлог</summary>

```yml
🆑
tweak: Удалены лишние слова при альтклике по ПДА в рюкзаке
/🆑
```

</details>

close #4463

- [x] Pull Request полностью завершен, мне не нужна помощь чтобы его закончить.
- [x] Я внимательно прочитал все свои изменения и багов в них не нашел.
- [x] Я запускал сервер со своими изменениями локально и все протестировал.
- [x] Я ознакомился c [Guide to Contribute](https://github.com/ChaoticOnyx/OnyxBay/blob/dev/docs/contributing.md).
