### PR TITLE
tweak(portal) move all objects from portal loc

### DIFF
--- a/code/game/objects/effects/portals.dm
+++ b/code/game/objects/effects/portals.dm
@@ -23,13 +23,15 @@
 /obj/effect/portal/Initialize(mapload, end, delete_after = 300, failure_rate)
 	. = ..()
 	setup_portal(end, delete_after, failure_rate)
-	move_all_objects()
+	addtimer(CALLBACK(src, .proc/move_all_objects), 1.5 SECONDS)
 
 /obj/effect/portal/Destroy()
 	target = null
 	return ..()
 
 /obj/effect/portal/proc/move_all_objects()
+	if(QDELETED(src))
+		return
 	var/turf/T = get_turf(src)
 	for(var/atom/movable/M in T)
 		if(iseffect(M))

--- a/code/game/objects/effects/portals.dm
+++ b/code/game/objects/effects/portals.dm
@@ -43,7 +43,9 @@
 		if (!target)
 			qdel(src)
 			return
-		for(var/cardinal in GLOB.cardinal)
+		if(!ismob(M) && !M.density)
+			continue
+		for(var/cardinal in shuffle(GLOB.cardinal))
 			if(step(M, cardinal))
 				break
 	// if any objcets still in loc, teleport them, e.g. crates abuse

--- a/code/game/objects/effects/portals.dm
+++ b/code/game/objects/effects/portals.dm
@@ -23,10 +23,30 @@
 /obj/effect/portal/Initialize(mapload, end, delete_after = 300, failure_rate)
 	. = ..()
 	setup_portal(end, delete_after, failure_rate)
+	move_all_objects()
 
 /obj/effect/portal/Destroy()
 	target = null
 	return ..()
+
+/obj/effect/portal/proc/move_all_objects()
+	var/turf/T = get_turf(src)
+	for(var/atom/movable/M in T)
+		if(iseffect(M))
+			continue
+		if(M.anchored && !ismech(M))
+			continue
+		if(!ismovable(M))
+			continue
+		if (!target)
+			qdel(src)
+			return
+		for(var/cardinal in GLOB.cardinal)
+			if(step(M, cardinal))
+				break
+	// if any objcets still in loc, teleport them, e.g. crates abuse
+	for(var/atom/movable/M in T)
+		teleport(M)
 
 /obj/effect/portal/proc/setup_portal(end, delete_after, failure_rate)
 	if(failure_rate)


### PR DESCRIPTION
Данный ПР исправляет возможность "абузить" порталы, позволяю получить полное бессмертие от пуль.

<details>
<summary>Чейнджлог</summary>

```yml
🆑
tweak: При активации портала, все объекты на турфе, где находится портал, перемещаются в соседние турфы.
/🆑
```

</details>

- [x] Pull Request полностью завершен, мне не нужна помощь чтобы его закончить.
- [x] Я внимательно прочитал все свои изменения и багов в них не нашел.
- [x] Я запускал сервер со своими изменениями локально и все протестировал.
- [x] Я ознакомился c [Guide to Contribute](https://github.com/ChaoticOnyx/OnyxBay/blob/dev/docs/contributing.md).
