### PR TITLE
Vamp skill rebalance and some tweaks

### DIFF
--- a/code/game/gamemodes/vampire/modular_vampire.dm
+++ b/code/game/gamemodes/vampire/modular_vampire.dm
@@ -91,4 +91,5 @@ var/list/datum/power/vampire/vampirepowers = list()
 	blood_cost = 500
 	verbpath = /mob/living/carbon/human/proc/vampire_embrace
 
-
+/datum/power/vampire/night_vision
+	verbpath = /mob/living/carbon/human/proc/night_vision

--- a/code/game/gamemodes/vampire/vampire_powers.dm
+++ b/code/game/gamemodes/vampire/vampire_powers.dm
@@ -1013,3 +1013,17 @@
 
 	verbs -= /mob/living/carbon/human/proc/grapple
 	ADD_VERB_IN_IF(src, 800, /mob/living/carbon/human/proc/grapple, CALLBACK(src, .proc/finish_vamp_timeout, VAMP_FRENZIED))
+
+/mob/living/carbon/human/proc/night_vision()
+	set category = "Vampire"
+	set name = "Toggle Darkvision"
+	set desc = "You're are able to see in the dark."
+
+
+	var/mob/living/carbon/C = src
+	C.seeDarkness = !C.seeDarkness
+	if(C.seeDarkness)
+		to_chat(C, SPAN("notice", "You're no longer need light to see."))
+	else
+		to_chat(C, SPAN("notice", "You're allow the shadows to return."))
+	return TRUE

--- a/code/game/gamemodes/vampire/vampire_powers.dm
+++ b/code/game/gamemodes/vampire/vampire_powers.dm
@@ -838,10 +838,10 @@
 
 /mob/living/carbon/human/proc/vampire_touch_of_life()
 	set category = "Vampire"
-	set name = "Touch of Life (50)"
+	set name = "Touch of Life (30)"
 	set desc = "You lay your hands on the target, transferring healing chemicals to them."
 
-	var/datum/vampire/vampire = vampire_power(50, 0)
+	var/datum/vampire/vampire = vampire_power(30, 0)
 	if (!vampire)
 		return
 
@@ -857,7 +857,7 @@
 
 	visible_message("<b>[src]</b> gently touches [T].")
 	to_chat(T, SPAN_NOTICE("You feel pure bliss as [src] touches you."))
-	vampire.use_blood(50)
+	vampire.use_blood(30)
 
 	T.reagents.add_reagent(/datum/reagent/rezadone, 3)
 	T.reagents.add_reagent(/datum/reagent/tramadol/oxycodone, 0.15) //enough to get back onto their feet

--- a/code/game/gamemodes/vampire/vampire_powers.dm
+++ b/code/game/gamemodes/vampire/vampire_powers.dm
@@ -340,10 +340,10 @@
 // Chiropteran Screech
 /mob/living/carbon/human/proc/vampire_screech()
 	set category = "Vampire"
-	set name = "Chiropteran Screech (90)"
+	set name = "Chiropteran Screech (70)"
 	set desc = "Emit a powerful screech which shatters glass within a seven-tile radius, and stuns hearers in a four-tile radius."
 
-	var/datum/vampire/vampire = vampire_power(90, 0)
+	var/datum/vampire/vampire = vampire_power(70, 0)
 	if (!vampire)
 		return
 
@@ -374,7 +374,7 @@
 		L.broken()
 
 	playsound(src.loc, 'sound/effects/creepyshriek.ogg', 100, 1)
-	vampire.use_blood(90)
+	vampire.use_blood(70)
 
 	if (victims.len)
 		admin_attacker_log_many_victims(src, victims, "used chriopteran screech to stun", "was stunned by [key_name(src)] using chriopteran screech", "used chiropteran screech to stun")
@@ -721,7 +721,7 @@
 // Enthralls a person, giving the vampire a mortal slave.
 /mob/living/carbon/human/proc/vampire_enthrall()
 	set category = "Vampire"
-	set name = "Enthrall (150)"
+	set name = "Enthrall (120)"
 	set desc = "Bind a mortal soul with a bloodbond to obey your every command."
 
 	var/datum/vampire/vampire = vampire_power(120, 0)
@@ -768,7 +768,7 @@
 	to_chat(src, SPAN_NOTICE("You have completed the thralling process. They are now your slave and will obey your commands."))
 	admin_attack_log(src, T, "enthralled [key_name(T)]", "was enthralled by [key_name(src)]", "successfully enthralled")
 
-	vampire.use_blood(150)
+	vampire.use_blood(120)
 	verbs -= /mob/living/carbon/human/proc/vampire_enthrall
 	ADD_VERB_IN_IF(src, 2800, /mob/living/carbon/human/proc/vampire_enthrall, CALLBACK(src, .proc/finish_vamp_timeout))
 
@@ -786,8 +786,8 @@
 		vampire.status &= ~VAMP_PRESENCE
 		to_chat(src, SPAN_WARNING("You are no longer influencing those weak of mind."))
 		return
-	else if (vampire.blood_usable < 15)
-		to_chat(src, SPAN_WARNING("You do not have enough usable blood. 15 needed."))
+	else if (vampire.blood_usable < 10)
+		to_chat(src, SPAN_WARNING("You do not have enough usable blood. 10 needed."))
 		return
 
 	to_chat(src, SPAN_NOTICE("You begin passively influencing the weak minded."))
@@ -800,7 +800,7 @@
 							"[src] has your best interests at heart, you can feel it.",
 							"A quiet voice tells you that [src] should be considered a friend.")
 
-	vampire.use_blood(10)
+	vampire.use_blood(5)
 
 	log_and_message_admins("activated presence.")
 
@@ -1018,7 +1018,9 @@
 	set category = "Vampire"
 	set name = "Toggle Darkvision"
 	set desc = "You're are able to see in the dark."
-
+	var/datum/vampire/vampire = vampire_power(0, 0)
+	if (!vampire)
+		return
 
 	var/mob/living/carbon/C = src
 	C.seeDarkness = !C.seeDarkness

--- a/code/game/gamemodes/vampire/vampire_powers.dm
+++ b/code/game/gamemodes/vampire/vampire_powers.dm
@@ -9,8 +9,8 @@
 	set category = "Vampire"
 	set name = "Victim Alertness"
 	set desc = "Toggle whether you wish for your victims to get paralyzed and forget your deeds."
-
-	var/datum/vampire/vampire = vampire_power(0, 0)
+	var/power_use_cost = 0
+	var/datum/vampire/vampire = vampire_power(power_use_cost, 0)
 	vampire.stealth = !vampire.stealth
 	if(vampire.stealth)
 		to_chat(src, SPAN_NOTICE("Your victims will now forget your interactions, and get paralyzed when you do them."))
@@ -22,8 +22,8 @@
 	set category = "Vampire"
 	set name = "Drain Blood"
 	set desc = "Drain the blood of a humanoid creature."
-
-	var/datum/vampire/vampire = vampire_power(0, 0)
+	var/power_use_cost = 0
+	var/datum/vampire/vampire = vampire_power(power_use_cost, 0)
 	if (!vampire)
 		return
 
@@ -74,7 +74,7 @@
 		remembrance = "remembered"
 	admin_attack_log(src, T, "drained blood from [key_name(T)], who [remembrance] the encounter.", "had their blood drained by [key_name(src)] and [remembrance] the encounter.", "is draining blood from")
 
-	to_chat(T, SPAN("warning",FONT_LARGE("You feel yourself falling into a pleasant dream, from which even a smile appeared on your face.")))
+	to_chat(T, SPAN("warning", FONT_LARGE("You feel yourself falling into a pleasant dream, from which even a smile appeared on your face.")))
 	T.paralysis = 3400
 
 	playsound(src.loc, 'sound/effects/drain_blood.ogg', 50, 1)
@@ -153,9 +153,9 @@
 	if(target_aware)
 		T.paralysis = 0
 		if(T.stat != DEAD && vampire.stealth)
-			to_chat(T, SPAN("warning",FONT_LARGE("You remember nothing about the cause of blacked out. Instead, you simply remember having a pleasant encounter with [src.name]")))
+			to_chat(T, SPAN("warning", FONT_LARGE("You remember nothing about the cause of blacked out. Instead, you simply remember having a pleasant encounter with [src.name]")))
 		else if(T.stat != DEAD)
-			to_chat(T, SPAN("warning",FONT_LARGE("You remember everything that happened. Remember how blood was sucked from your neck. It gave you pleasure, like a pleasant dream. You feel great. How you react to [src.name]'s actions is up to you.")))
+			to_chat(T, SPAN("warning", FONT_LARGE("You remember everything that happened. Remember how blood was sucked from your neck. It gave you pleasure, like a pleasant dream. You feel great. How you react to [src.name]'s actions is up to you.")))
 	verbs -= /mob/living/carbon/human/proc/vampire_drain_blood
 	if(blood_drained <= 85)
 
@@ -173,8 +173,9 @@
 	set category = "Vampire"
 	set name = "Glare"
 	set desc = "Your eyes flash a bright light, stunning any who are watching."
+	var/power_use_cost = 0
 
-	if (!vampire_power(0, 1))
+	if (!vampire_power(power_use_cost, 1))
 		return
 	if (eyecheck() > FLASH_PROTECTION_NONE)
 		to_chat(src, SPAN_WARNING("You can't do that, because no one will see the light of your eyes!"))
@@ -207,8 +208,9 @@
 	set category = "Vampire"
 	set name = "Hypnotise (10)"
 	set desc = "Through blood magic, you dominate the victim's mind and force them into a hypnotic transe."
+	var/power_use_cost = 10
 
-	var/datum/vampire/vampire = vampire_power(10, 1)
+	var/datum/vampire/vampire = vampire_power(power_use_cost, 1)
 	if (!vampire)
 		return
 
@@ -241,7 +243,7 @@
 		T.Stun(25)
 		T.silent += 30
 
-		vampire.use_blood(10)
+		vampire.use_blood(power_use_cost)
 		admin_attack_log(src, T, "used hypnotise to stun [key_name(T)]", "was stunned by [key_name(src)] using hypnotise", "used hypnotise on")
 
 		verbs -= /mob/living/carbon/human/proc/vampire_hypnotise
@@ -254,12 +256,13 @@
 	set category = null
 	set name = "Veil Step (20)"
 	set desc = "For a moment, move through the Veil and emerge at a shadow of your choice."
+	var/power_use_cost = 20
 
 	if (!T || T.density || T.contains_dense_objects())
 		to_chat(src, SPAN_WARNING("You cannot do that."))
 		return
 
-	var/datum/vampire/vampire = vampire_power(20, 1)
+	var/datum/vampire/vampire = vampire_power(power_use_cost, 1)
 	if (!vampire)
 		return
 	if (!istype(loc, /turf))
@@ -287,7 +290,7 @@
 
 	log_and_message_admins("activated veil step.")
 
-	vampire.use_blood(20)
+	vampire.use_blood(power_use_cost)
 	verbs -= /mob/living/carbon/human/proc/vampire_veilstep
 	ADD_VERB_IN_IF(src, 300, /mob/living/carbon/human/proc/vampire_veilstep, CALLBACK(src, .proc/finish_vamp_timeout))
 
@@ -296,8 +299,9 @@
 	set category = "Vampire"
 	set name = "Summon Bats (60)"
 	set desc = "You tear open the Veil for just a moment, in order to summon a pair of bats to assist you in combat."
+	var/power_use_cost = 60
 
-	var/datum/vampire/vampire = vampire_power(60, 0)
+	var/datum/vampire/vampire = vampire_power(power_use_cost, 0)
 	if (!vampire)
 		return
 
@@ -333,7 +337,7 @@
 
 	log_and_message_admins("summoned bats.")
 
-	vampire.use_blood(60)
+	vampire.use_blood(power_use_cost)
 	verbs -= /mob/living/carbon/human/proc/vampire_bats
 	ADD_VERB_IN_IF(src, 1200, /mob/living/carbon/human/proc/vampire_bats, CALLBACK(src, .proc/finish_vamp_timeout))
 
@@ -342,8 +346,9 @@
 	set category = "Vampire"
 	set name = "Chiropteran Screech (70)"
 	set desc = "Emit a powerful screech which shatters glass within a seven-tile radius, and stuns hearers in a four-tile radius."
+	var/power_use_cost = 70
 
-	var/datum/vampire/vampire = vampire_power(70, 0)
+	var/datum/vampire/vampire = vampire_power(power_use_cost, 0)
 	if (!vampire)
 		return
 
@@ -374,7 +379,7 @@
 		L.broken()
 
 	playsound(src.loc, 'sound/effects/creepyshriek.ogg', 100, 1)
-	vampire.use_blood(70)
+	vampire.use_blood(power_use_cost)
 
 	if (victims.len)
 		admin_attacker_log_many_victims(src, victims, "used chriopteran screech to stun", "was stunned by [key_name(src)] using chriopteran screech", "used chiropteran screech to stun")
@@ -389,6 +394,7 @@
 	set category = "Vampire"
 	set name = "Toggle Veil Walking (80)"
 	set desc = "You enter the veil, leaving only an incorporeal manifestation of you visible to the others."
+	var/power_use_cost = 80
 
 	var/datum/vampire/vampire = vampire_power(0, 0, 1)
 	if (!vampire)
@@ -397,7 +403,7 @@
 	if (vampire.holder)
 		vampire.holder.deactivate()
 	else
-		vampire = vampire_power(80, 0, 1)
+		vampire = vampire_power(power_use_cost, 0, 1)
 		if (!vampire)
 			return
 
@@ -406,7 +412,7 @@
 
 		log_and_message_admins("activated veil walk.")
 
-		vampire.use_blood(80)
+		vampire.use_blood(power_use_cost)
 
 // Veilwalk's dummy holder
 /obj/effect/dummy/veil_walk
@@ -415,6 +421,7 @@
 	icon = 'icons/mob/mob.dmi'
 	icon_state = "blank"
 	density = FALSE
+	var/power_use_cost = 5
 
 	var/last_valid_turf = null
 	var/can_move = TRUE
@@ -463,7 +470,7 @@
 			return
 
 	if (owner_vampire.blood_usable >= 5)
-		owner_vampire.use_blood(5)
+		owner_vampire.use_blood(power_use_cost)
 
 		switch (warning_level)
 			if (0)
@@ -667,8 +674,9 @@
 	set category = "Vampire"
 	set name = "Dominate (50)"
 	set desc = "Dominate the mind of a victim, make them obey your will."
+	var/power_use_cost = 50
 
-	var/datum/vampire/vampire = vampire_power(25, 0)
+	var/datum/vampire/vampire = vampire_power(power_use_cost, 0)
 	if (!vampire)
 		return
 
@@ -714,7 +722,7 @@
 	to_chat(src, SPAN_NOTICE("You command [T], and they will obey."))
 	emote("me", 1, "whispers.")
 
-	vampire.use_blood(50)
+	vampire.use_blood(power_use_cost)
 	verbs -= /mob/living/carbon/human/proc/vampire_dominate
 	ADD_VERB_IN_IF(src, 1800, /mob/living/carbon/human/proc/vampire_dominate, CALLBACK(src, .proc/finish_vamp_timeout))
 
@@ -723,8 +731,9 @@
 	set category = "Vampire"
 	set name = "Enthrall (120)"
 	set desc = "Bind a mortal soul with a bloodbond to obey your every command."
+	var/power_use_cost = 120
 
-	var/datum/vampire/vampire = vampire_power(120, 0)
+	var/datum/vampire/vampire = vampire_power(power_use_cost, 0)
 	if (!vampire)
 		return
 
@@ -768,7 +777,7 @@
 	to_chat(src, SPAN_NOTICE("You have completed the thralling process. They are now your slave and will obey your commands."))
 	admin_attack_log(src, T, "enthralled [key_name(T)]", "was enthralled by [key_name(src)]", "successfully enthralled")
 
-	vampire.use_blood(120)
+	vampire.use_blood(power_use_cost)
 	verbs -= /mob/living/carbon/human/proc/vampire_enthrall
 	ADD_VERB_IN_IF(src, 2800, /mob/living/carbon/human/proc/vampire_enthrall, CALLBACK(src, .proc/finish_vamp_timeout))
 
@@ -777,8 +786,9 @@
 	set category = "Vampire"
 	set name = "Presence (5)"
 	set desc = "Influences those weak of mind to look at you in a friendlier light."
+	var/power_use_cost = 5
 
-	var/datum/vampire/vampire = vampire_power(0, 0)
+	var/datum/vampire/vampire = vampire_power(power_use_cost, 0)
 	if (!vampire)
 		return
 
@@ -800,7 +810,7 @@
 							"[src] has your best interests at heart, you can feel it.",
 							"A quiet voice tells you that [src] should be considered a friend.")
 
-	vampire.use_blood(5)
+	vampire.use_blood(power_use_cost)
 
 	log_and_message_admins("activated presence.")
 
@@ -829,7 +839,7 @@
 			if (prob(probability))
 				to_chat(T, "<font color='green'><i>[pick(emotes)]</i></font>")
 
-		vampire.use_blood(5)
+		vampire.use_blood(power_use_cost)
 
 		if (vampire.blood_usable < 5)
 			vampire.status &= ~VAMP_PRESENCE
@@ -840,8 +850,9 @@
 	set category = "Vampire"
 	set name = "Touch of Life (30)"
 	set desc = "You lay your hands on the target, transferring healing chemicals to them."
+	var/power_use_cost = 30
 
-	var/datum/vampire/vampire = vampire_power(30, 0)
+	var/datum/vampire/vampire = vampire_power(power_use_cost, 0)
 	if (!vampire)
 		return
 
@@ -857,7 +868,7 @@
 
 	visible_message("<b>[src]</b> gently touches [T].")
 	to_chat(T, SPAN_NOTICE("You feel pure bliss as [src] touches you."))
-	vampire.use_blood(30)
+	vampire.use_blood(power_use_cost)
 
 	T.reagents.add_reagent(/datum/reagent/rezadone, 3)
 	T.reagents.add_reagent(/datum/reagent/tramadol/oxycodone, 0.15) //enough to get back onto their feet
@@ -867,8 +878,9 @@
 	set category = "Vampire"
 	set name = "The Embrace"
 	set desc = "Spread your corruption to an innocent soul, turning them into a spawn of the Veil, much akin to yourself."
+	var/power_use_cost = 0
 
-	var/datum/vampire/vampire = vampire_power(0, 0)
+	var/datum/vampire/vampire = vampire_power(power_use_cost, 0)
 	if (!vampire)
 		return
 
@@ -1018,7 +1030,9 @@
 	set category = "Vampire"
 	set name = "Toggle Darkvision"
 	set desc = "You're are able to see in the dark."
-	var/datum/vampire/vampire = vampire_power(0, 0)
+	var/power_use_cost = 0
+
+	var/datum/vampire/vampire = vampire_power(power_use_cost, 0)
 	if (!vampire)
 		return
 

--- a/code/game/gamemodes/vampire/vampire_powers.dm
+++ b/code/game/gamemodes/vampire/vampire_powers.dm
@@ -74,7 +74,7 @@
 		remembrance = "remembered"
 	admin_attack_log(src, T, "drained blood from [key_name(T)], who [remembrance] the encounter.", "had their blood drained by [key_name(src)] and [remembrance] the encounter.", "is draining blood from")
 
-	to_chat(T, SPAN_WARNING("You feel yourself falling into a pleasant dream, from which even a smile appeared on your face."))
+	to_chat(T, SPAN("warning",FONT_LARGE("You feel yourself falling into a pleasant dream, from which even a smile appeared on your face.")))
 	T.paralysis = 3400
 
 	playsound(src.loc, 'sound/effects/drain_blood.ogg', 50, 1)
@@ -153,9 +153,9 @@
 	if(target_aware)
 		T.paralysis = 0
 		if(T.stat != DEAD && vampire.stealth)
-			to_chat(T, SPAN_WARNING("You remember nothing about the cause of blacked out. Instead, you simply remember having a pleasant encounter with [src.name]"))
+			to_chat(T, SPAN("warning",FONT_LARGE("You remember nothing about the cause of blacked out. Instead, you simply remember having a pleasant encounter with [src.name]")))
 		else if(T.stat != DEAD)
-			to_chat(T, SPAN_WARNING("You remember everything that happened. Remember how blood was sucked from your neck. It gave you pleasure, like a pleasant dream. You feel great. How you react to [src.name]'s actions is up to you."))
+			to_chat(T, SPAN("warning",FONT_LARGE("You remember everything that happened. Remember how blood was sucked from your neck. It gave you pleasure, like a pleasant dream. You feel great. How you react to [src.name]'s actions is up to you.")))
 	verbs -= /mob/living/carbon/human/proc/vampire_drain_blood
 	if(blood_drained <= 85)
 
@@ -724,7 +724,7 @@
 	set name = "Enthrall (150)"
 	set desc = "Bind a mortal soul with a bloodbond to obey your every command."
 
-	var/datum/vampire/vampire = vampire_power(150, 0)
+	var/datum/vampire/vampire = vampire_power(120, 0)
 	if (!vampire)
 		return
 
@@ -775,7 +775,7 @@
 // Makes the vampire appear 'friendlier' to others.
 /mob/living/carbon/human/proc/vampire_presence()
 	set category = "Vampire"
-	set name = "Presence (10)"
+	set name = "Presence (5)"
 	set desc = "Influences those weak of mind to look at you in a friendlier light."
 
 	var/datum/vampire/vampire = vampire_power(0, 0)


### PR DESCRIPTION
- "Blood Heal" - **ничего не трогал** в связи с ребалансом боёвки и огнестрела, властелин ночи теперь сосёт бибу если увеличить задержку даже на пол секунды
- "Hypnotise" - не работает на генках и вампирах.**Так и надо было**
- "Presence" - Снизил расход крови с **_10_** до **_5_**
- "Touch of Life" - Снизил цену с **_50_** до **_30_**
- "Summon Bats" - Ничего не делал, **по хорошему вырезать говнину требую геймдизайн**
- "Chiropteran Screech" - Снизил цену с **_90_** до **_70_**
- "Veil Walking" - **Ничего не делал.**
- "Enthrall" - Снизил цену с **_150_** до **_120_**
- "Toggle Darkvision" - Добавил вампирчику скилл для возможности просмотра порнушки без фонарика
- **Текст о том что тебя укусили и о том что ты ничего не помнишь/что-то помнишь теперь выводится большими буквами**

<details>
<summary>Чейнджлог</summary>

```yml
🆑
balance: Ребаланс цен на некоторые скиллы для вампира
rscadd: Добавлен скилл на ночное зрение
tweak: Текст о укусе и возможных проблемах стал побольше
/🆑
```

</details>

close #4222 
close #4184 
close #5995 

- [X] Pull Request полностью завершен, мне не нужна помощь чтобы его закончить.
- [X] Я внимательно прочитал все свои изменения и багов в них не нашел.
- [X] Я запускал сервер со своими изменениями локально и все протестировал.
- [X] Я ознакомился c [Guide to Contribute](https://github.com/ChaoticOnyx/OnyxBay/blob/dev/docs/contributing.md).
