### PR TITLE
fix(armblades): fixes description of arm_blade and EMP gib of fake_arm_blade

### DIFF
--- a/code/game/gamemodes/changeling/helpcode.dm
+++ b/code/game/gamemodes/changeling/helpcode.dm
@@ -164,7 +164,6 @@ var/global/list/possible_changeling_IDs = list("Alpha","Beta","Gamma","Delta","E
 	icon_state = "arm_blade"
 	force = 25
 	armor_penetration = 15
-	mod_shield = 2.5
 	sharp = 1
 	edge = 1
 	anchored = 1

--- a/code/game/gamemodes/changeling/helpcode.dm
+++ b/code/game/gamemodes/changeling/helpcode.dm
@@ -164,6 +164,7 @@ var/global/list/possible_changeling_IDs = list("Alpha","Beta","Gamma","Delta","E
 	icon_state = "arm_blade"
 	force = 25
 	armor_penetration = 15
+	mod_shield = 2.5
 	sharp = 1
 	edge = 1
 	anchored = 1

--- a/code/game/gamemodes/changeling/modularchangling.dm
+++ b/code/game/gamemodes/changeling/modularchangling.dm
@@ -210,7 +210,7 @@ var/list/datum/power/changeling/powerinstances = list()
 /datum/power/changeling/arm_blade
 	name = "Arm Blade"
 	desc = "We reform one of our arms into a deadly blade."
-	helptext = "We may retract our armblade by dropping it. Do not deflect projectiles."
+	helptext = "We may retract our armblade by dropping it."
 	enhancedtext = "The blade would have armor peneratration."
 	genomecost = 8
 	verbpath = /mob/proc/changeling_arm_blade

--- a/code/game/gamemodes/changeling/modularchangling.dm
+++ b/code/game/gamemodes/changeling/modularchangling.dm
@@ -210,7 +210,7 @@ var/list/datum/power/changeling/powerinstances = list()
 /datum/power/changeling/arm_blade
 	name = "Arm Blade"
 	desc = "We reform one of our arms into a deadly blade."
-	helptext = "We may retract our armblade by dropping it.  It can deflect projectiles."
+	helptext = "We may retract our armblade by dropping it. Do not deflect projectiles."
 	enhancedtext = "The blade would have armor peneratration."
 	genomecost = 8
 	verbpath = /mob/proc/changeling_arm_blade

--- a/code/game/gamemodes/changeling/powers/fake_armblade.dm
+++ b/code/game/gamemodes/changeling/powers/fake_armblade.dm
@@ -42,4 +42,5 @@
 					failed = TRUE
 		if(!failed)
 			target.visible_message(SPAN("danger", "The flesh is torn around the [target.name]\'s arm!"))
-			new /obj/item/weapon/melee/prosthetic/bio/fake_arm_blade(target, target.organs_by_name[hand])
+			var/obj/item/weapon/W = new /obj/item/weapon/melee/prosthetic/bio/fake_arm_blade
+			target.put_in_hands(W)

--- a/code/modules/augmentation/prosthetic/prosthetic.dm
+++ b/code/modules/augmentation/prosthetic/prosthetic.dm
@@ -65,7 +65,7 @@
 /obj/item/weapon/melee/prosthetic/bio/attach_prosthetic(prosthetic, organ)
 	if(!prosthetic || !organ || !isProsthetic(prosthetic))
 		return FALSE
-	if(istype(prosthetic,/obj/item/weapon/melee/prosthetic))
+	if(istype(prosthetic, /obj/item/weapon/melee/prosthetic))
 		var/obj/item/weapon/melee/prosthetic/P = prosthetic
 		var/obj/item/organ/external/O = organ
 

--- a/code/modules/augmentation/prosthetic/prosthetic.dm
+++ b/code/modules/augmentation/prosthetic/prosthetic.dm
@@ -1,15 +1,15 @@
 /obj/item/weapon/melee/prosthetic/
 	var/prost_type = "prosthetic"
 	var/obj/item/organ/external/parent_hand
-	canremove = 0
-	candrop = 0
+	canremove = FALSE
+	candrop = FALSE
 
 /obj/item/weapon/melee/prosthetic/New(atom/location, obj/item/organ/external/limb)
 	attach_prosthetic(src,limb)
 
 /obj/proc/attach_prosthetic(prosthetic , organ)
 	if (!prosthetic || !organ || !isProsthetic(prosthetic))
-		return 0
+		return FALSE
 	if (istype(prosthetic,/obj/item/weapon/melee/prosthetic))
 		var/obj/item/weapon/melee/prosthetic/P = prosthetic
 		var/obj/item/organ/external/O = organ
@@ -17,47 +17,67 @@
 		switch(O.organ_tag)
 			if(BP_L_HAND)
 				if (O.owner.l_hand)
-					return 0
+					return FALSE
 				O.owner.put_in_l_hand(P)
 			if(BP_R_HAND)
 				if (O.owner.r_hand)
-					return 0
+					return FALSE
 				O.owner.put_in_r_hand(P)
 
 		O.status = ORGAN_ROBOTIC
 		P.parent_hand = organ
-	return 1
+	return TRUE
 
 /obj/proc/remove_prosthetic(prosthetic = src)
 	if (istype(prosthetic,/obj/item/weapon/melee/prosthetic))
 		var/obj/item/weapon/melee/prosthetic/P = prosthetic
 		P.parent_hand = null
-		P.candrop = 1
-		P.canremove = 1
+		P.candrop = TRUE
+		P.canremove = TRUE
 
 /proc/isProsthetic(A)
 	if (A)
 		if (istype(A,/obj/item/weapon/melee/prosthetic))
-			return 1
-	return 0
+			return TRUE
+	return FALSE
 
 /obj/item/weapon/melee/prosthetic/attack_self(mob/user)
 	if (parent_hand)
 		..()
 	else
-		to_chat(user, "<span class='notice'>[capitalize(prost_type)] needs to be surgicaly applied first.</span>")
+		to_chat(user, SPAN("notice", "[capitalize(prost_type)] needs to be surgicaly applied first."))
 
 /obj/item/weapon/melee/prosthetic/attackby(obj/item/I, mob/user)
 	if (parent_hand)
 		..()
 	else
-		to_chat(user, "<span class='notice'>[capitalize(prost_type)] needs to be surgicaly applied first.</span>")
+		to_chat(user, SPAN("notice", "[capitalize(prost_type)] needs to be surgicaly applied first."))
 
 /obj/item/weapon/melee/prosthetic/attack(mob/living/carbon/M as mob, mob/living/carbon/user as mob)
 	if (parent_hand)
 		..()
 	else
-		to_chat(user, "<span class='notice'>[capitalize(prost_type)] needs to be surgicaly applied first.</span>")
+		to_chat(user, SPAN("notice", "[capitalize(prost_type)] needs to be surgicaly applied first."))
 
 /obj/item/weapon/melee/prosthetic/bio/
 	prost_type = "bioprosthetic"
+
+/obj/item/weapon/melee/prosthetic/bio/attach_prosthetic(prosthetic , organ)
+	if (!prosthetic || !organ || !isProsthetic(prosthetic))
+		return FALSE
+	if (istype(prosthetic,/obj/item/weapon/melee/prosthetic))
+		var/obj/item/weapon/melee/prosthetic/P = prosthetic
+		var/obj/item/organ/external/O = organ
+
+		switch(O.organ_tag)
+			if(BP_L_HAND)
+				if (O.owner.l_hand)
+					return FALSE
+				O.owner.put_in_l_hand(P)
+			if(BP_R_HAND)
+				if (O.owner.r_hand)
+					return FALSE
+				O.owner.put_in_r_hand(P)
+
+		P.parent_hand = organ
+	return TRUE

--- a/code/modules/augmentation/prosthetic/prosthetic.dm
+++ b/code/modules/augmentation/prosthetic/prosthetic.dm
@@ -62,7 +62,7 @@
 /obj/item/weapon/melee/prosthetic/bio/
 	prost_type = "bioprosthetic"
 
-/obj/item/weapon/melee/prosthetic/bio/attach_prosthetic(prosthetic , organ)
+/obj/item/weapon/melee/prosthetic/bio/attach_prosthetic(prosthetic, organ)
 	if(!prosthetic || !organ || !isProsthetic(prosthetic))
 		return FALSE
 	if(istype(prosthetic,/obj/item/weapon/melee/prosthetic))

--- a/code/modules/augmentation/prosthetic/prosthetic.dm
+++ b/code/modules/augmentation/prosthetic/prosthetic.dm
@@ -8,19 +8,19 @@
 	attach_prosthetic(src,limb)
 
 /obj/proc/attach_prosthetic(prosthetic , organ)
-	if (!prosthetic || !organ || !isProsthetic(prosthetic))
+	if(!prosthetic || !organ || !isProsthetic(prosthetic))
 		return FALSE
-	if (istype(prosthetic,/obj/item/weapon/melee/prosthetic))
+	if(istype(prosthetic,/obj/item/weapon/melee/prosthetic))
 		var/obj/item/weapon/melee/prosthetic/P = prosthetic
 		var/obj/item/organ/external/O = organ
 
 		switch(O.organ_tag)
 			if(BP_L_HAND)
-				if (O.owner.l_hand)
+				if(O.owner.l_hand)
 					return FALSE
 				O.owner.put_in_l_hand(P)
 			if(BP_R_HAND)
-				if (O.owner.r_hand)
+				if(O.owner.r_hand)
 					return FALSE
 				O.owner.put_in_r_hand(P)
 
@@ -29,32 +29,32 @@
 	return TRUE
 
 /obj/proc/remove_prosthetic(prosthetic = src)
-	if (istype(prosthetic,/obj/item/weapon/melee/prosthetic))
+	if(istype(prosthetic,/obj/item/weapon/melee/prosthetic))
 		var/obj/item/weapon/melee/prosthetic/P = prosthetic
 		P.parent_hand = null
 		P.candrop = TRUE
 		P.canremove = TRUE
 
 /proc/isProsthetic(A)
-	if (A)
-		if (istype(A,/obj/item/weapon/melee/prosthetic))
+	if(A)
+		if(istype(A,/obj/item/weapon/melee/prosthetic))
 			return TRUE
 	return FALSE
 
 /obj/item/weapon/melee/prosthetic/attack_self(mob/user)
-	if (parent_hand)
+	if(parent_hand)
 		..()
 	else
 		to_chat(user, SPAN("notice", "[capitalize(prost_type)] needs to be surgicaly applied first."))
 
 /obj/item/weapon/melee/prosthetic/attackby(obj/item/I, mob/user)
-	if (parent_hand)
+	if(parent_hand)
 		..()
 	else
 		to_chat(user, SPAN("notice", "[capitalize(prost_type)] needs to be surgicaly applied first."))
 
 /obj/item/weapon/melee/prosthetic/attack(mob/living/carbon/M as mob, mob/living/carbon/user as mob)
-	if (parent_hand)
+	if(parent_hand)
 		..()
 	else
 		to_chat(user, SPAN("notice", "[capitalize(prost_type)] needs to be surgicaly applied first."))
@@ -63,19 +63,19 @@
 	prost_type = "bioprosthetic"
 
 /obj/item/weapon/melee/prosthetic/bio/attach_prosthetic(prosthetic , organ)
-	if (!prosthetic || !organ || !isProsthetic(prosthetic))
+	if(!prosthetic || !organ || !isProsthetic(prosthetic))
 		return FALSE
-	if (istype(prosthetic,/obj/item/weapon/melee/prosthetic))
+	if(istype(prosthetic,/obj/item/weapon/melee/prosthetic))
 		var/obj/item/weapon/melee/prosthetic/P = prosthetic
 		var/obj/item/organ/external/O = organ
 
 		switch(O.organ_tag)
 			if(BP_L_HAND)
-				if (O.owner.l_hand)
+				if(O.owner.l_hand)
 					return FALSE
 				O.owner.put_in_l_hand(P)
 			if(BP_R_HAND)
-				if (O.owner.r_hand)
+				if(O.owner.r_hand)
 					return FALSE
 				O.owner.put_in_r_hand(P)
 


### PR DESCRIPTION
Починил гиб фейкового от ЕМП. Проверил баг с его полным отсутствием #5284, но оказалось что он не работает только на апатиков, как это исправить я не знаю.
Обновил описание скилла, убрал информацию про отражение пуль

fixes #5458
fixes #5284

<details>
<summary>Чейнджлог</summary>

```yml
🆑
bugfix: Фейковый армблейд больше не гиббается от ЭМИ.
bugfix: Исправлено описание армблейда, убрана строчка про рефлект пуль.
/🆑
```

</details>


- [x] Pull Request полностью завершен, мне не нужна помощь чтобы его закончить.
- [x] Я внимательно прочитал все свои изменения и багов в них не нашел.
- [x] Я запускал сервер со своими изменениями локально и все протестировал.
- [x] Я ознакомился c [Guide to Contribute](https://github.com/ChaoticOnyx/OnyxBay/blob/dev/docs/contributing.md).
