### PR TITLE
fix(nullrod): fixes nullrod inability to decultify properly

### DIFF
--- a/baystation12.dme
+++ b/baystation12.dme
@@ -548,7 +548,6 @@
 #include "code\game\gamemodes\cult\ritual.dm"
 #include "code\game\gamemodes\cult\runes.dm"
 #include "code\game\gamemodes\cult\talisman.dm"
-#include "code\game\gamemodes\cult\cultify\de-cultify.dm"
 #include "code\game\gamemodes\cult\cultify\mob.dm"
 #include "code\game\gamemodes\cult\cultify\turf.dm"
 #include "code\game\gamemodes\endgame\endgame.dm"

--- a/code/game/gamemodes/cult/cultify/de-cultify.dm
+++ b/code/game/gamemodes/cult/cultify/de-cultify.dm
@@ -1,6 +1,0 @@
-/turf/unsimulated/wall/cult/attackby(obj/item/I, mob/user)
-	if(istype(I, /obj/item/weapon/nullrod))
-		user.visible_message("<span class='notice'>\The [user] touches \the [src] with \the [I], and it shifts.</span>", "<span class='notice'>You touch \the [src] with \the [I], and it shifts.</span>")
-		ChangeTurf(/turf/unsimulated/wall)
-		return
-	..()

--- a/code/game/gamemodes/cult/cultify/turf.dm
+++ b/code/game/gamemodes/cult/cultify/turf.dm
@@ -2,7 +2,6 @@
 	return
 
 /turf/simulated/floor/cultify()
-	//todo: flooring datum cultify check
 	cultify_floor()
 
 /turf/simulated/shuttle/wall/cultify()
@@ -11,29 +10,35 @@
 /turf/simulated/wall/cultify()
 	cultify_wall()
 
-/turf/simulated/wall/cult/cultify()
-	return
-
-/turf/unsimulated/wall/cult/cultify()
-	return
-
-/turf/unsimulated/beach/cultify()
-	return
-
 /turf/unsimulated/wall/cultify()
 	cultify_wall()
 
 /turf/simulated/floor/proc/cultify_floor()
-	set_flooring(get_flooring_data(/decl/flooring/reinforced/cult))
+	var/turf/simulated/floor/floor = src
+	var/old_type = floor.type
+	var/turf/simulated/floor/misc/cult/cult_floor= src
+	ChangeTurf(/turf/simulated/floor/misc/cult)
+	cult_floor.previous_type = old_type
 	GLOB.cult.add_cultiness(CULTINESS_PER_TURF)
 
+/turf/simulated/floor/misc/cult/proc/decultify_floor()
+	ChangeTurf(previous_type)
+	GLOB.cult.remove_cultiness(CULTINESS_PER_TURF)
 
 /turf/proc/cultify_wall()
 	var/turf/simulated/wall/wall = src
+	var/old_type = wall.type
+	var/turf/simulated/wall/cult/cult_wall= src
 	if(!istype(wall))
 		return
 	if(wall.reinf_material)
 		ChangeTurf(/turf/simulated/wall/cult/reinf)
+		cult_wall.previous_type = old_type
 	else
 		ChangeTurf(/turf/simulated/wall/cult)
+		cult_wall.previous_type = old_type
 	GLOB.cult.add_cultiness(CULTINESS_PER_TURF)
+
+/turf/simulated/wall/cult/proc/decultify_wall()
+	ChangeTurf(previous_type)
+	GLOB.cult.remove_cultiness(CULTINESS_PER_TURF)

--- a/code/game/gamemodes/cult/cultify/turf.dm
+++ b/code/game/gamemodes/cult/cultify/turf.dm
@@ -28,7 +28,7 @@
 /turf/proc/cultify_wall()
 	var/turf/simulated/wall/wall = src
 	var/old_type = wall.type
-	var/turf/simulated/wall/cult/cult_wall= src
+	var/turf/simulated/wall/cult/cult_wall = src
 	if(!istype(wall))
 		return
 	if(wall.reinf_material)

--- a/code/game/gamemodes/cult/cultify/turf.dm
+++ b/code/game/gamemodes/cult/cultify/turf.dm
@@ -13,6 +13,9 @@
 /turf/unsimulated/wall/cultify()
 	cultify_wall()
 
+turf/simulated/floor/misc/cult/cultify()
+	return()
+
 /turf/simulated/floor/proc/cultify_floor()
 	var/turf/simulated/floor/floor = src
 	var/old_type = floor.type

--- a/code/game/gamemodes/cult/cultify/turf.dm
+++ b/code/game/gamemodes/cult/cultify/turf.dm
@@ -14,7 +14,7 @@
 	cultify_wall()
 
 turf/simulated/floor/misc/cult/cultify()
-	return()
+	return
 
 /turf/simulated/floor/proc/cultify_floor()
 	var/turf/simulated/floor/floor = src

--- a/code/game/gamemodes/cult/cultify/turf.dm
+++ b/code/game/gamemodes/cult/cultify/turf.dm
@@ -16,7 +16,7 @@
 /turf/simulated/floor/proc/cultify_floor()
 	var/turf/simulated/floor/floor = src
 	var/old_type = floor.type
-	var/turf/simulated/floor/misc/cult/cult_floor= src
+	var/turf/simulated/floor/misc/cult/cult_floor = src
 	ChangeTurf(/turf/simulated/floor/misc/cult)
 	cult_floor.previous_type = old_type
 	GLOB.cult.add_cultiness(CULTINESS_PER_TURF)

--- a/code/game/objects/items/weapons/weaponry.dm
+++ b/code/game/objects/items/weapons/weaponry.dm
@@ -19,7 +19,7 @@
 	user.setClickCooldown(DEFAULT_ATTACK_COOLDOWN)
 	user.do_attack_animation(M)
 	if(M.mind && LAZYLEN(M.mind.learned_spells))
-		M.silence_spells(300)
+		M.silence_spells(30 SECONDS)
 		to_chat(M, SPAN_DANGER("You've been silenced!"))
 		return
 

--- a/code/game/objects/items/weapons/weaponry.dm
+++ b/code/game/objects/items/weapons/weaponry.dm
@@ -13,14 +13,13 @@
 	mod_reach = 0.75
 	mod_handy = 1.0
 
-/obj/item/weapon/nullrod/attack(mob/M as mob, mob/living/user as mob) //Paste from old-code to decult with a null rod.
+/obj/item/weapon/nullrod/attack(mob/M, mob/living/user)
 	admin_attack_log(user, M, "Attacked using \a [src]", "Was attacked with \a [src]", "used \a [src] to attack")
 
 	user.setClickCooldown(DEFAULT_ATTACK_COOLDOWN)
 	user.do_attack_animation(M)
-	//if(user != M)
 	if(M.mind && LAZYLEN(M.mind.learned_spells))
-		M.silence_spells(300) //30 seconds
+		M.silence_spells(300)
 		to_chat(M, SPAN_DANGER("You've been silenced!"))
 		return
 
@@ -47,13 +46,16 @@
 
 	if(istype(A, /turf/simulated/wall/cult))
 		var/turf/simulated/wall/cult/W = A
-		user.visible_message("<span class='notice'>\The [user] touches \the [A] with \the [src], and the enchantment affecting it fizzles away.</span>", "<span class='notice'>You touch \the [A] with \the [src], and the enchantment affecting it fizzles away.</span>")
-		W.ChangeTurf(/turf/simulated/wall)
+		user.visible_message(SPAN("notice", "\The [user] touches \the [A] with \the [src], and the enchantment affecting it fizzles away."))
+		W.decultify_wall()
 
 	if(istype(A, /turf/simulated/floor/misc/cult))
 		var/turf/simulated/floor/misc/cult/F = A
-		user.visible_message("<span class='notice'>\The [user] touches \the [A] with \the [src], and the enchantment affecting it fizzles away.</span>", "<span class='notice'>You touch \the [A] with \the [src], and the enchantment affecting it fizzles away.</span>")
-		F.ChangeTurf(/turf/simulated/floor)
+		user.visible_message(SPAN("notice", "\The [user] touches \the [A] with \the [src], and the enchantment affecting it fizzles away."))
+		F.decultify_floor()
+		playsound(F, 'sound/effects/fighting/Genhit.ogg', 25, 1)
+
+
 
 
 /obj/item/weapon/energy_net

--- a/code/game/turfs/flooring/flooring.dm
+++ b/code/game/turfs/flooring/flooring.dm
@@ -260,7 +260,7 @@ var/list/flooring_types
 	icon_base = "cult"
 	build_type = null
 	has_damage_range = 6
-	flags = TURF_ACID_IMMUNE | TURF_CAN_BREAK | TURF_REMOVE_WRENCH
+	flags = TURF_ACID_IMMUNE | TURF_CAN_BREAK
 	can_paint = null
 
 /decl/flooring/reinforced/cult/on_remove()

--- a/code/game/turfs/flooring/flooring_premade.dm
+++ b/code/game/turfs/flooring/flooring_premade.dm
@@ -405,6 +405,7 @@
 	icon = 'icons/turf/flooring/cult.dmi'
 	icon_state = "cult"
 	initial_flooring = /decl/flooring/reinforced/cult
+	var/previous_type = /turf/simulated/floor
 
 /turf/simulated/floor/misc/cult/cultify()
 	return

--- a/code/game/turfs/simulated/wall_types.dm
+++ b/code/game/turfs/simulated/wall_types.dm
@@ -10,6 +10,7 @@
 
 /turf/simulated/wall/cult
 	icon_state = "cult"
+	var/previous_type = /turf/simulated/wall
 
 /turf/simulated/wall/cult/New(newloc, reinforce = 0)
 	..(newloc, MATERIAL_CULT, reinforce ? MATERIAL_REINFORCED_CULT : null)


### PR DESCRIPTION
Починил работу нуллрода, теперь при декультификации будет возвращена оригинальная стена, которую культифицировали, культо стены хранят в себе тип старой стены. Если стену заспавнили педально, то она декультифицируется в обычную стену, все это также относиться к полу.

Убрал возможность открутить культо-пол так как нуллрод теперь нормально работает, слишком просто космонавтики могут избавиться от проклятого пола.

-  fixes  #4978

<details>
<summary>Чейнджлог</summary>

```yml
🆑
bugfix: Нулл род возвращает стены и пол после культификации в оригинальный вид.
tweak: Культо-пол больше нельзя снять гаечным ключом.

/🆑
```

</details>

- [x] Pull Request полностью завершен, мне не нужна помощь чтобы его закончить.
- [x] Я внимательно прочитал все свои изменения и багов в них не нашел.
- [x] Я запускал сервер со своими изменениями локально и все протестировал.
- [x] Я ознакомился c [Guide to Contribute](https://github.com/ChaoticOnyx/OnyxBay/blob/dev/docs/contributing.md).
