### PR TITLE
fix(antagonist): fix update_antag_mob

### DIFF
--- a/code/game/antagonist/antagonist_update.dm
+++ b/code/game/antagonist/antagonist_update.dm
@@ -6,10 +6,9 @@
 
 	// Get the mob.
 	if((flags & ANTAG_OVERRIDE_MOB) && (!player.current || (mob_path && !istype(player.current, mob_path))))
-		var/mob/holder = player.current
-		player.current = new mob_path(get_turf(player.current))
-		player.transfer_to(player.current)
-		if(holder) qdel(holder)
+		var/mob/previous_mob = player.current
+		player.transfer_to(new mob_path(get_turf(previous_mob)))
+		if(previous_mob) qdel(previous_mob)
 	player.original = player.current
 	if(!preserve_appearance && (flags & ANTAG_SET_APPEARANCE))
 		spawn(3)


### PR DESCRIPTION
Исправил логику update_antag_mob из-за которой антагонисты спавнились с битым майндом (current = null), из-за чего возникали другие баги, в том числе их не телепортировало на спавн.

<details>
<summary>Чейнджлог</summary>

```yml
🆑
bugfix: Исправил спавн воксов-рейдеров на станции вместо их собственной локации.
/🆑
```

</details>

fix #5965

- [x] Pull Request полностью завершен, мне не нужна помощь чтобы его закончить.
- [x] Я внимательно прочитал все свои изменения и багов в них не нашел.
- [x] Я запускал сервер со своими изменениями локально и все протестировал.
- [x] Я ознакомился c [Guide to Contribute](https://github.com/ChaoticOnyx/OnyxBay/blob/dev/docs/contributing.md).
