### PR TITLE
Removes borers' inheritance from xenomorphs, fixes xenomorphs spawn

### DIFF
--- a/code/game/antagonist/alien/borer.dm
+++ b/code/game/antagonist/alien/borer.dm
@@ -1,9 +1,10 @@
-GLOBAL_DATUM_INIT(borers, /datum/antagonist/xenos/borer, new)
+GLOBAL_DATUM_INIT(borers, /datum/antagonist/borer, new)
 
-/datum/antagonist/xenos/borer
+/datum/antagonist/borer
 	id = MODE_BORER
 	role_text = "Cortical Borer"
 	role_text_plural = "Cortical Borers"
+	flags = ANTAG_RANDSPAWN | ANTAG_OVERRIDE_JOB | ANTAG_OVERRIDE_MOB
 	mob_path = /mob/living/simple_animal/borer/initial
 	welcome_text = "Use your Infest power to crawl into the ear of a host and fuse with their brain. You can only take control temporarily, and at risk of hurting your host, so be clever and careful; your host is encouraged to help you however they can. Talk to your fellow borers with :x."
 	antag_indicator = "hudborer"
@@ -14,25 +15,57 @@ GLOBAL_DATUM_INIT(borers, /datum/antagonist/xenos/borer, new)
 	faction_welcome = "You are now a thrall to a cortical borer. Please listen to what they have to say; they're in your head."
 	faction = "borer"
 
+	hard_cap = 5
+	hard_cap_round = 8
 	initial_spawn_req = 3
 	initial_spawn_target = 5
 
+	spawn_announcement_title = "Lifesign Alert"
+	spawn_announcement_delay = 5000
+
 	station_crew_involved = FALSE
 
-/datum/antagonist/xenos/borer/Initialize()
+/datum/antagonist/borer/Initialize()
+	spawn_announcement = replacetext(GLOB.using_map.unidentified_lifesigns_message, "%STATION_NAME%", station_name())
+	spawn_announcement_sound = GLOB.using_map.xenomorph_spawn_sound
 	. = ..()
 	if(config.borer_min_age)
 		min_player_age = config.borer_min_age
 
-/datum/antagonist/xenos/borer/get_extra_panel_options(datum/mind/player)
+/datum/antagonist/borer/get_extra_panel_options(datum/mind/player)
 	return "<a href='?src=\ref[src];move_to_spawn=\ref[player.current]'>\[put in host\]</a>"
 
-/datum/antagonist/xenos/borer/create_objectives(datum/mind/player)
-	player.objectives += new /datum/objective/borer_survive()
-	player.objectives += new /datum/objective/borer_reproduce()
-	player.objectives += new /datum/objective/escape()
+/datum/antagonist/xenos/antags_are_dead()
+	for(var/datum/mind/antag in current_antagonists)
+		if(antag.current.stat != DEAD)
+			return FALSE
+	return TRUE
 
-/datum/antagonist/xenos/borer/place_mob(mob/living/mob)
+/datum/antagonist/borer/create_objectives(datum/mind/player)
+	if(!..())
+		return
+
+	var/datum/objective/borer_survive/survive_objective = new
+	survive_objective.owner = player
+	player.objectives += survive_objective
+
+	var/datum/objective/borer_reproduce/reproduce_objective = new
+	reproduce_objective.owner = player
+	player.objectives += reproduce_objective
+
+	var/datum/objective/escape/escape_objective = new
+	escape_objective.owner = player
+	player.objectives += escape_objective
+
+/datum/antagonist/borer/proc/get_vents()
+	var/list/vents = list()
+	for(var/obj/machinery/atmospherics/unary/vent_pump/temp_vent in SSmachines.machinery)
+		if(!temp_vent.welded && temp_vent.network && (temp_vent.loc.z in GLOB.using_map.station_levels))
+			if(temp_vent.network.normal_members.len > 50)
+				vents += temp_vent
+	return vents
+
+/datum/antagonist/borer/place_mob(mob/living/mob)
 	var/mob/living/simple_animal/borer/borer = mob
 	if(istype(borer))
 		var/mob/living/carbon/human/host
@@ -53,4 +86,4 @@ GLOBAL_DATUM_INIT(borers, /datum/antagonist/xenos/borer, new)
 				borer.host_brain.SetName(host.name)
 				borer.host_brain.real_name = host.real_name
 				return
-	..() // Place them at a vent if they can't get a host.
+	mob.forceMove(get_turf(pick(get_vents()))) // Place them at a vent if they can't get a host.

--- a/code/game/antagonist/alien/borer.dm
+++ b/code/game/antagonist/alien/borer.dm
@@ -35,7 +35,7 @@ GLOBAL_DATUM_INIT(borers, /datum/antagonist/borer, new)
 /datum/antagonist/borer/get_extra_panel_options(datum/mind/player)
 	return "<a href='?src=\ref[src];move_to_spawn=\ref[player.current]'>\[put in host\]</a>"
 
-/datum/antagonist/xenos/antags_are_dead()
+/datum/antagonist/borer/antags_are_dead()
 	for(var/datum/mind/antag in current_antagonists)
 		if(antag.current.stat != DEAD)
 			return FALSE

--- a/code/game/antagonist/alien/xenomorph.dm
+++ b/code/game/antagonist/alien/xenomorph.dm
@@ -81,10 +81,9 @@ GLOBAL_DATUM_INIT(xenomorphs, /datum/antagonist/xenos, new)
 
 /datum/antagonist/xenos/update_antag_mob(datum/mind/player, preserve_appearance)
 	if(!player.current || (!ishuman(player.current) && !istype(player.current, mob_path))) // Humans keep their humanity, others become larvae
-		var/mob/holder = player.current
-		player.current = new mob_path(get_turf(player.current))
-		player.transfer_to(player.current)
-		if(holder)
-			qdel(holder)
+		var/mob/previous_mob = player.current
+		player.transfer_to(new mob_path(get_turf(previous_mob)))
+		if(previous_mob)
+			qdel(previous_mob)
 	player.original = player.current
 	return player.current

--- a/code/game/antagonist/alien/xenomorph.dm
+++ b/code/game/antagonist/alien/xenomorph.dm
@@ -5,9 +5,11 @@ GLOBAL_DATUM_INIT(xenomorphs, /datum/antagonist/xenos, new)
 	role_text = "Xenomorph"
 	role_text_plural = "Xenomorphs"
 	flags = ANTAG_RANDSPAWN | ANTAG_OVERRIDE_JOB
+	mob_path = /mob/living/carbon/alien/larva
 	welcome_text = "Hiss! You are a larval alien. Hide and bide your time until you are ready to evolve."
-	antaghud_indicator = "hudalien"
 	antag_indicator = "hudalien"
+	antaghud_indicator = "hudalien"
+
 	faction_role_text = "Xenomorph Thrall"
 	faction_descriptor = "Hive"
 	faction_welcome = "Your will is ripped away as your humanity merges with the xenomorph overmind. You are now \
@@ -28,7 +30,7 @@ GLOBAL_DATUM_INIT(xenomorphs, /datum/antagonist/xenos, new)
 /datum/antagonist/xenos/Initialize()
 	spawn_announcement = replacetext(GLOB.using_map.unidentified_lifesigns_message, "%STATION_NAME%", station_name())
 	spawn_announcement_sound = GLOB.using_map.xenomorph_spawn_sound
-	..()
+	. = ..()
 	if(config.xeno_min_age)
 		min_player_age = config.xeno_min_age
 
@@ -45,7 +47,8 @@ GLOBAL_DATUM_INIT(xenomorphs, /datum/antagonist/xenos, new)
 	return TRUE
 
 /datum/antagonist/xenos/attempt_random_spawn()
-	if(config.aliens_allowed) ..()
+	if(config.aliens_allowed)
+		..()
 
 /datum/antagonist/xenos/antags_are_dead()
 	for(var/datum/mind/antag in current_antagonists)
@@ -75,3 +78,13 @@ GLOBAL_DATUM_INIT(xenomorphs, /datum/antagonist/xenos, new)
 
 /datum/antagonist/xenos/place_mob(mob/living/player)
 	player.forceMove(get_turf(pick(get_vents())))
+
+/datum/antagonist/xenos/update_antag_mob(datum/mind/player, preserve_appearance)
+	if(!player.current || (!ishuman(player.current) && !istype(player.current, mob_path))) // Humans keep their humanity, others become larvae
+		var/mob/holder = player.current
+		player.current = new mob_path(get_turf(player.current))
+		player.transfer_to(player.current)
+		if(holder)
+			qdel(holder)
+	player.original = player.current
+	return player.current

--- a/code/modules/mob/living/carbon/alien/larva/larva.dm
+++ b/code/modules/mob/living/carbon/alien/larva/larva.dm
@@ -50,10 +50,18 @@
 		return
 
 	ckey = user.ckey
-	GLOB.xenomorphs.add_antagonist(mind, 1)
+
+	if(mind && !GLOB.xenomorphs.is_antagonist(mind))
+		GLOB.xenomorphs.add_antagonist(mind, 1)
+
 	spawn(-1)
 		if(user)
 			qdel(user) // Remove the keyless ghost if it exists.
+
+/mob/living/carbon/alien/larva/Login()
+	. = ..()
+	if(mind && !GLOB.xenomorphs.is_antagonist(mind))
+		GLOB.xenomorphs.add_antagonist(mind, 1)
 
 /mob/living/carbon/alien/larva/proc/larva_announce_to_ghosts()
 	for(var/mob/observer/ghost/O in GLOB.ghost_mob_list)

--- a/code/modules/mob/living/carbon/human/species/xenomorphs/alien_species.dm
+++ b/code/modules/mob/living/carbon/human/species/xenomorphs/alien_species.dm
@@ -97,14 +97,12 @@
 					"<span class='notice'>I caress [target] with my scythe-like arm.</span>")
 
 /datum/species/xenos/handle_post_spawn(mob/living/carbon/human/H)
-	if(H.mind)
-		GLOB.xenomorphs.add_antagonist(H.mind, 1)
-
 	alien_number++ //Keep track of how many aliens we've had so far.
 	H.real_name = get_random_name()
 	H.SetName(H.real_name)
-
 	..()
+	if(H.mind && !GLOB.xenomorphs.is_antagonist(H.mind))
+		GLOB.xenomorphs.add_antagonist(H.mind, 1)
 
 /datum/species/xenos/get_random_name()
 	return "alien [caste_name] ([rand(100,999)])"


### PR DESCRIPTION
- Исправлены возможные ошибки при спавне ксеноморфов. Теперь они должны адекватно спавниться при каламити (если каламити можно вообще считать чем-то адекватным) и не ломаться при педальном запихивании игроков в грудоломов. Удаление/вживление хайвманд-нода теперь тоже должно работать надёжнее.
- Бореры больше не наследуются от ксеноморфов. Какого хрена они вообще наследовались - загадка.

```yml
🆑
bugfix: Исправлены возможные ошибки при спавне ксеноморфов.
/🆑
```

- [x] Pull Request полностью завершен, мне не нужна помощь чтобы его закончить.
- [x] Я внимательно прочитал все свои изменения и багов в них не нашел.
- [x] Я запускал сервер со своими изменениями локально и все протестировал.
- [x] Я ознакомился c [Guide to Contribute](https://github.com/ChaoticOnyx/OnyxBay/blob/dev/docs/contributing.md).
