### PR TITLE
Removes inability to repair hacked lockers

### DIFF
--- a/code/game/objects/structures/crates_lockers/closets.dm
+++ b/code/game/objects/structures/crates_lockers/closets.dm
@@ -13,7 +13,7 @@
 	var/icon_opened = "open"
 
 	var/icon_locked
-	var/icon_broken = "spark"
+	var/icon_broken = "sparks"
 	var/icon_off
 
 	var/welded = FALSE
@@ -425,20 +425,22 @@
 	else if(istype(W, /obj/item/device/multitool) && (setup & CLOSET_HAS_LOCK))
 		var/obj/item/device/multitool/multi = W
 		if(multi.in_use)
-			to_chat(user, SPAN_WARNING("This multitool is already in use!"))
+			to_chat(user, SPAN("warning", "This multitool is already in use!"))
 			return
 		multi.in_use = 1
-		for(var/i in 1 to rand(4,8))
-			user.visible_message(SPAN_WARNING("[user] picks in wires of the [src.name] with a multitool."), SPAN_WARNING("I am trying to reset circuitry lock module ([i])...")
-				)
-			if(!do_after(user,200)||!locked)
-				multi.in_use=0
+		var/prev_locked = locked
+		for(var/i in 1 to rand(4, 8))
+			user.visible_message(SPAN("warning", "[user] picks in wires of \the [name] with a multitool."),
+								 SPAN("warning", "I am trying to reset circuitry lock module ([i])..."))
+			if(!do_after(user, 200)|| locked != prev_locked || opened || !cdoor)
+				multi.in_use = 0
 				return
-		locked = 0
-		broken = 1
-		src.update_icon()
-		multi.in_use=0
-		user.visible_message(SPAN_WARNING("[user] [locked ? "locks" : "unlocks"] [name] with a multitool."), SPAN_WARNING("I [locked ? "enable" : "disable"] the locking modules."))
+		locked = !locked
+		broken = !locked
+		update_icon()
+		multi.in_use = 0
+		user.visible_message(SPAN("warning", "[user] [locked ? "locks" : "unlocks"] \the [name] with a multitool."),
+							 SPAN("warning", "I [locked ? "enable" : "disable"] the locking modules."))
 	else if(setup & CLOSET_HAS_LOCK)
 		src.togglelock(user, W)
 	else


### PR DESCRIPTION
Судя по сообщениям, возможность развзламывать ящики обратно изначально таки была задумана. Но код оказался говном.
А искры Игорь поломал. За что, Игорь?

```yml
🆑
bugfix: Теперь взломанные мультитулом ящики нормально чинятся мультитулом же.
bugfix: Исправлено отсутствие сыплющихся из взломанных ящиков искр.
/🆑
```

- [x] Pull Request полностью завершен, мне не нужна помощь чтобы его закончить.
- [x] Я внимательно прочитал все свои изменения и багов в них не нашел.
- [x] Я запускал сервер со своими изменениями локально и все протестировал.
- [x] Я ознакомился c [Guide to Contribute](https://github.com/ChaoticOnyx/OnyxBay/blob/dev/docs/contributing.md).
