### PR TITLE
Рантаймовое

### DIFF
--- a/code/_helpers/icons.dm
+++ b/code/_helpers/icons.dm
@@ -603,7 +603,10 @@
 		flat.Blend(add, iconmode, I:pixel_x + 2 - flatX1, I:pixel_y + 2 - flatY1)
 
 	if(A.color)
-		flat.Blend(A.color, ICON_MULTIPLY)
+		if(islist(A.color))
+			flat.MapColors(arglist(A.color))
+		else
+			flat.Blend(A.color, ICON_MULTIPLY)
 	if(A.alpha < 255)
 		flat.Blend(rgb(255, 255, 255, A.alpha), ICON_MULTIPLY)
 

--- a/code/_helpers/roundend.dm
+++ b/code/_helpers/roundend.dm
@@ -216,6 +216,9 @@ GLOBAL_LIST_EMPTY(common_report)
 	log_roundend(GLOB.common_report)
 
 /datum/controller/subsystem/ticker/proc/give_show_report_button(client/C)
+	if(!istype(C.mob, /mob/living))
+		return
+
 	var/datum/action/report/R = new
 	R.Grant(C.mob)
 	to_chat(C,"<a href='?src=\ref[R];report=1'>Show roundend report again</a>")

--- a/code/game/objects/effects/proximity.dm
+++ b/code/game/objects/effects/proximity.dm
@@ -120,4 +120,4 @@
 /obj/effect/abstract/proximity_checker/Crossed(atom/movable/AM)
 	set waitfor = FALSE
 	if(monitor)
-		monitor.hasprox_receiver.HasProximity(AM)
+		monitor.hasprox_receiver?.HasProximity(AM)

--- a/code/game/verbs/ignore.dm
+++ b/code/game/verbs/ignore.dm
@@ -36,9 +36,12 @@
 	return 0
 
 /client/proc/is_key_ignored(key_to_check)
+	if(!prefs)
+		return FALSE
+
 	key_to_check = ckey(key_to_check)
 	if(key_to_check in prefs.ignored_players)
-		if(check_rights(R_MENTOR|R_MOD|R_ADMIN, 0)) // Admins, mentors and moderators are not ignorable
+		if(check_rights(R_MENTOR | R_MOD | R_ADMIN, 0)) // Admins, mentors and moderators are not ignorable
 			return 0
 		return 1
 	return 0

--- a/code/game/verbs/who.dm
+++ b/code/game/verbs/who.dm
@@ -15,7 +15,7 @@
 	var/living_antags = 0 //Are antagonists, and currently alive
 	var/dead_antags = 0 //Are antagonists, and have finally met their match
 	var/rights = check_rights(R_INVESTIGATE, FALSE)
-	var/preference = get_preference_value("ADVANCED_WHO") == GLOB.PREF_YES
+	var/preference = try_get_preference_value("ADVANCED_WHO") == GLOB.PREF_YES
 
 	if(rights && preference)
 		for(var/client/C in GLOB.clients)

--- a/code/modules/admin/verbs/randomverbs.dm
+++ b/code/modules/admin/verbs/randomverbs.dm
@@ -401,10 +401,10 @@ Ccomp's first proc.
 	message_admins("Admin [key_name_admin(usr)] has [action] on joining the round if they use AntagHUD", 1)
 
 /*
-If a guy was gibbed and you want to revive him, this is a good way to do so.
-Works kind of like entering the game with a new character. Character receives a new mind if they didn't have one.
-Traitors and the like can also be revived with the previous role mostly intact.
-/N */
+	If a guy was gibbed and you want to revive him, this is a good way to do so.
+	Works kind of like entering the game with a new character. Character receives a new mind if they didn't have one.
+	Traitors and the like can also be revived with the previous role mostly intact.
+ */
 /client/proc/respawn_character()
 	set category = "Special Verbs"
 	set name = "Respawn Character"
@@ -434,12 +434,12 @@ Traitors and the like can also be revived with the previous role mostly intact.
 
 	if(record_found)//If they have a record we can determine a few things.
 		new_character.real_name = record_found.get_name()
-		new_character.gender = record_found.get_sex()
+		new_character.gender = lowertext(record_found.get_sex())
 		new_character.age = record_found.get_age()
 		new_character.b_type = record_found.get_bloodtype()
 	else
 		new_character.gender = pick(MALE,FEMALE)
-		var/datum/preferences/A = new()
+		var/datum/preferences/A = new(G_found.client)
 		A.randomize_appearance_and_body_for(new_character)
 		new_character.real_name = G_found.real_name
 

--- a/code/modules/client/preference_setup/global/05_settings.dm
+++ b/code/modules/client/preference_setup/global/05_settings.dm
@@ -81,10 +81,21 @@
 
 	return ..()
 
+/// Returns a default value of the preference if it can't be loaded.
+/client/proc/try_get_preference_value(preference)
+	var/value = null
+	
+	try
+		value = get_preference_value(preference)
+	catch
+		value = get_client_preference(preference).default_value
+	
+	return value
+
 /client/proc/get_preference_value(preference)
 	if(!SScharacter_setup.initialized)
 		// Too early to use any preferences
-		CRASH("Trying to get [ckey]'s preferences before the subsystem's initialization.")
+		throw EXCEPTION("Trying to get [ckey]'s preferences before the subsystem's initialization.")
 
 	if(!prefs)
 		log_error("[ckey]'s preferences are broken. Creating new one.")

--- a/code/modules/client/preference_setup/loadout/loadout.dm
+++ b/code/modules/client/preference_setup/loadout/loadout.dm
@@ -270,7 +270,11 @@ var/list/gear_datums = list()
 			gt.tweak_item(gear_virtual_item, selected_tweaks["[gt]"])
 		var/icon/I = icon(gear_virtual_item.icon, gear_virtual_item.icon_state)
 		if(gear_virtual_item.color)
-			I.Blend(gear_virtual_item.color, ICON_MULTIPLY)
+			if(islist(gear_virtual_item.color))
+				I.MapColors(arglist(gear_virtual_item.color))
+			else
+				I.Blend(gear_virtual_item.color, ICON_MULTIPLY)
+
 		I.Scale(I.Width() * 2, I.Height() * 2)
 
 		. += "<td style='width: 80%;' class='block'>"

--- a/code/modules/mob/mob_helpers.dm
+++ b/code/modules/mob/mob_helpers.dm
@@ -316,6 +316,9 @@ It's fairly easy to fix if dealing with single letters but not so much with comp
 
 		var/x
 		for(x=0; x<duration, x++)
+			if(!M.client)
+				return
+
 			if(aiEyeFlag)
 				M.client.eye = locate(dd_range(1,oldeye.loc.x+rand(-strength,strength),world.maxx),dd_range(1,oldeye.loc.y+rand(-strength,strength),world.maxy),oldeye.loc.z)
 			else

--- a/code/modules/modular_computers/file_system/programs/command/comm.dm
+++ b/code/modules/modular_computers/file_system/programs/command/comm.dm
@@ -176,9 +176,6 @@
 					var/input = sanitize(input("Please choose a message to transmit to [GLOB.using_map.boss_short] via quantum entanglement.  Please be aware that this process is very expensive, and abuse will lead to... termination.  Transmission does not guarantee a response. There is a 30 second delay before you may send another message, be clear, full and concise.", "To abort, send an empty message.", "") as message|null)
 					if(!input || !can_still_topic())
 						return 1
-					// TOOD: spellcheck
-					// if(usr.client?.get_preference_value(/datum/client_preference/spell_checking) == GLOB.PREF_YES && usr.client.chatOutput)
-					//	usr.client.chatOutput.spell_check(input)
 					Centcomm_announce(input, usr)
 					to_chat(usr, SPAN("notice", "Message transmitted."))
 					log_say("[key_name(usr)] has made an IA [GLOB.using_map.boss_short] announcement: [input]")

--- a/code/modules/virus2/disease2.dm
+++ b/code/modules/virus2/disease2.dm
@@ -15,9 +15,6 @@ LEGACY_RECORD_STRUCTURE(virus_records, virus_record)
 	var/list/affected_species = list(SPECIES_HUMAN, SPECIES_UNATHI, SPECIES_SKRELL, SPECIES_TAJARA)
 
 /datum/disease2/disease/New(random_severity = 0)
-	if(GAME_STATE <= RUNLEVEL_SETUP) // fix server start runtime
-		qdel(src)
-		return
 	uniqueID = rand(0, 10000)
 	if(random_severity)
 		makerandom(random_severity)


### PR DESCRIPTION
- Добавлена try-get обёртка для безопасного получения значения префа (возвращается дефолтное значение если они не загружены), пока добавил только к вербу вху.
- Добавил проверку на префы в проке `is_key_ignored`, если префы не прогружены - по дефолту возвращается фолз.
- Убрал кринж из конструктора вируса, рантайма который он фиксит не заметил. Так или иначе таких фиксов не надо.
- Добавил ещё одну проверку на клиент у моба в проке шатания камеры, ибо после коварного слипа клиент может (что и происходит) дать съебалды.
- Добавил проверку на тип моба перед выдачей кнопочки показать раунд энд репорт.
- Пофиксил легендарный рантайм с бэд икон оперейшн. Кое-кто забыл что цвет может быть не только в виде "#eeeeee" но и в виде матрицы.
- Пофиксил respawn_character.

fixes #6014 
fixes #5850
fixes #6109, closes #3644
fixes #2456 
closes #3393

🆑
admin: Пофикшен верб Respawn Character.
/🆑

- [x] Pull Request полностью завершен, мне не нужна помощь чтобы его закончить.
- [x] Я внимательно прочитал все свои изменения и багов в них не нашел.
- [x] Я запускал сервер со своими изменениями локально и все протестировал.
- [x] Я ознакомился c [Guide to Contribute](https://github.com/ChaoticOnyx/OnyxBay/blob/dev/docs/contributing.md).
