### PR TITLE
свет от сигарет

### DIFF
--- a/code/game/objects/items/weapons/smokables/smokables.dm
+++ b/code/game/objects/items/weapons/smokables/smokables.dm
@@ -112,7 +112,7 @@
 	update_icon()
 	var/turf/T = get_turf(src)
 	T.visible_message(generate_lighting_message(used_tool, holder))
-	set_light(0.6, 0.5, 2, 2, "#e38f46")
+	set_light(0.3, 0.2, 1, 1, "#e38f46")
 	smokeamount = reagents.total_volume / smoketime
 	START_PROCESSING(SSobj, src)
 


### PR DESCRIPTION
Сила света, излучаемого горящей сигаретой была уменьшена вдвое.

close #6112 #6096

<details>
<summary>Чейнджлог</summary>

```yml
🆑Nod404
tweak: Зажжённые сигареты теперь светят не так ярко.
/🆑Nod404
```

</details>

- [x] Pull Request полностью завершен, мне не нужна помощь чтобы его закончить.
- [x] Я внимательно прочитал все свои изменения и багов в них не нашел.
- [x] Я запускал сервер со своими изменениями локально и все протестировал.
- [x] Я ознакомился c [Guide to Contribute](https://github.com/ChaoticOnyx/OnyxBay/blob/dev/docs/contributing.md).
