### PR TITLE
Changed Happy Christmas to Merry Christmas

### DIFF
--- a/code/game/gamemodes/events/holidays/Holidays.dm
+++ b/code/game/gamemodes/events/holidays/Holidays.dm
@@ -140,7 +140,10 @@ var/global/Holiday = null
 /proc/Holiday_Game_Start()
 	if(Holiday)
 		to_world("<span class='info'>and...</span>")
-		to_world("<h4>Happy [Holiday] Everybody!</h4>")
+		if (Holiday == "Christmas Eve" || Holiday == "Christmas")
+			to_world("<h4>Merry [Holiday] Everybody!</h4>")
+		else
+			to_world("<h4>Happy [Holiday] Everybody!</h4>")
 		switch(Holiday)			//special holidays
 			if("Easter")
 				//do easter stuff

--- a/code/game/gamemodes/events/holidays/Holidays.dm
+++ b/code/game/gamemodes/events/holidays/Holidays.dm
@@ -140,7 +140,7 @@ var/global/Holiday = null
 /proc/Holiday_Game_Start()
 	if(Holiday)
 		to_world("<span class='info'>and...</span>")
-		if (Holiday == "Christmas Eve" || Holiday == "Christmas")
+		if(Holiday == "Christmas Eve" || Holiday == "Christmas")
 			to_world("<h4>Merry [Holiday] Everybody!</h4>")
 		else
 			to_world("<h4>Happy [Holiday] Everybody!</h4>")


### PR DESCRIPTION
Измен текст который появляется на рождество в начале раунда с Happy Christmas на Merry Christmas

close [#4095](https://github.com/ChaoticOnyx/OnyxBay/issues/4095)

<details>
<summary>Чейнджлог</summary>

```yml
🆑SerJo
bugfix: Happy Christmas изменен на Merry Christmas
/🆑
```

</details>


- [x] Pull Request полностью завершен, мне не нужна помощь чтобы его закончить.
- [x] Я внимательно прочитал все свои изменения и багов в них не нашел.
- [x] Я запускал сервер со своими изменениями локально и все протестировал.
- [x] Я ознакомился c [Guide to Contribute](https://github.com/ChaoticOnyx/OnyxBay/blob/dev/docs/contributing.md).
