### PR TITLE
General Grievous

### DIFF
--- a/code/game/objects/items/weapons/melee/energy.dm
+++ b/code/game/objects/items/weapons/melee/energy.dm
@@ -13,6 +13,7 @@
 	var/active_max_bright = 0.3
 	var/active_outer_range = 1.6
 	var/brightness_color
+	var/needs_blocking = TRUE
 
 /obj/item/weapon/melee/energy/proc/activate(mob/living/user)
 	if(active)
@@ -80,7 +81,7 @@
 /obj/item/weapon/melee/energy/handle_shield(mob/user, damage, atom/damage_source = null, mob/attacker = null, def_zone = null, attack_text = "the attack")
 	if(!active)
 		return 0
-	if(!user.blocking)
+	if(!user.blocking && needs_blocking)
 		return 0
 	if(user.incapacitated(INCAPACITATION_DISABLED))
 		return 0
@@ -363,3 +364,9 @@
 			host.embedded -= src
 			host.drop_from_inventory(src)
 		QDEL_IN(src, 0)
+
+/obj/item/weapon/melee/energy/sword/robot
+	icon_state = "sword0"
+	blade_color = "red"
+	brightness_color = "#ff5959"
+	needs_blocking = FALSE

--- a/code/modules/mob/living/silicon/robot/robot.dm
+++ b/code/modules/mob/living/silicon/robot/robot.dm
@@ -493,6 +493,11 @@
 	return 0
 
 /mob/living/silicon/robot/bullet_act(obj/item/projectile/Proj)
+	var/obj/item/weapon/melee/energy/sword/robot/E = locate() in list(module_state_1, module_state_2, module_state_3)
+	var/shield_handled = E?.handle_shield(src, Proj.damage, Proj)
+	if(shield_handled)
+		return shield_handled
+
 	..(Proj)
 	if(prob(75) && Proj.damage > 0) spark_system.start()
 	return 2

--- a/code/modules/mob/living/silicon/robot/robot_modules.dm
+++ b/code/modules/mob/living/silicon/robot/robot_modules.dm
@@ -200,7 +200,7 @@ var/global/list/robot_modules = list(
 	src.modules += new /obj/item/device/lightreplacer(src)
 	src.modules += new /obj/item/weapon/soap/nanotrasen(src)
 	src.modules += new /obj/item/weapon/matter_decompiler(src)
-	src.emag = new /obj/item/weapon/melee/energy/sword/one_hand(src)
+	src.emag = new /obj/item/weapon/melee/energy/sword/robot(src)
 
 	var/datum/matter_synth/medicine = new /datum/matter_synth/medicine(5000)
 	synths += medicine
@@ -903,7 +903,7 @@ var/global/list/robot_modules = list(
 	src.modules += new /obj/item/device/flash(src)
 	src.modules += new /obj/item/weapon/crowbar(src)
 	src.modules += new /obj/item/weapon/extinguisher/mini(src)
-	src.modules += new /obj/item/weapon/melee/energy/sword/one_hand(src)
+	src.modules += new /obj/item/weapon/melee/energy/sword/robot(src)
 	src.modules += new /obj/item/weapon/gun/energy/pulse_rifle/destroyer(src)
 	src.modules += new /obj/item/weapon/card/emag(src)
 	var/jetpack = new /obj/item/weapon/tank/jetpack/carbondioxide(src)


### PR DESCRIPTION
Железные зады теперь умеют в отражение снарядов при использовании лазерных мечей. 

В настоящее время это оружие присутствует только у взломанного стандартного киборга, а также у синдикатовского.
Мне кажется это вполне заслуженный апгрейд, учитывая тот скудный арсенал, что присутствует у стандартной модели. Да и само по себе оно не шибко помогает киборгу выжить, поскольку тот всё ещё может улететь к праотцам после одной православной флешки, или же от ионного выстрела, снаряд которого нельзя отразить и очень трудно избежать.

<details>
<summary>Чейнджлог</summary>

```yml
🆑
rscadd: Киборг с активированным лазерным мечом теперь способен отражать снаряды. Механика идентична обычным лазерным мечам.
/🆑
```

</details>

- [x] Pull Request полностью завершен, мне не нужна помощь чтобы его закончить.
- [x] Я внимательно прочитал все свои изменения и багов в них не нашел.
- [x] Я запускал сервер со своими изменениями локально и все протестировал.
- [x] Я ознакомился c [Guide to Contribute](https://github.com/ChaoticOnyx/OnyxBay/blob/dev/docs/contributing.md).
