### PR TITLE
Pedalgen type check

### DIFF
--- a/code/modules/power/pedal_gen.dm
+++ b/code/modules/power/pedal_gen.dm
@@ -101,7 +101,7 @@
 	if(!ishuman(user))
 		unbuckle_mob()
 	var/mob/living/carbon/human/pedaler = user
-	if(!pedaler.handcuffed)
+	if(istype(pedaler) && !pedaler.handcuffed)
 		unbuckle_mob()
 	else
 		if(!pedaled)


### PR DESCRIPTION
Исправляет рантайм
`Runtime in pedal_gen.dm,104: undefined variable /mob/living/silicon/robot/drone/var/handcuffed`

- [x] Pull Request полностью завершен, мне не нужна помощь чтобы его закончить.
- [x] Я внимательно прочитал все свои изменения и багов в них не нашел.
- [ ] Я запускал сервер со своими изменениями локально и все протестировал.
- [x] Я ознакомился c [Guide to Contribute](https://github.com/ChaoticOnyx/OnyxBay/blob/dev/docs/contributing.md).
