### PR TITLE
fix(misc): Исправлен спрайт у мачеты в автолате

### DIFF
--- a/code/game/objects/items/weapons/material/misc.dm
+++ b/code/game/objects/items/weapons/material/misc.dm
@@ -46,6 +46,7 @@
 /obj/item/weapon/material/hatchet/machete
 	name = "machete"
 	desc = "A long, sturdy blade with a rugged handle. Leading the way to cursed treasures since before space travel."
+	icon_state = "machete"
 	item_state = "machete"
 	w_class = ITEM_SIZE_NORMAL
 	slot_flags = SLOT_BELT


### PR DESCRIPTION
Вместо спрайта топорика у мачете родной спрайт.

fix #6173

<details>
<summary>Чейнджлог</summary>

```yml
🆑
bugfix: Иконка топорика у мачете в автолате заменена на иконку мачете.
/🆑
```

</details>

- [x] Pull Request полностью завершен, мне не нужна помощь чтобы его закончить.
- [x] Я внимательно прочитал все свои изменения и багов в них не нашел.
- [x] Я запускал сервер со своими изменениями локально и все протестировал.
- [x] Я ознакомился c [Guide to Contribute](https://github.com/ChaoticOnyx/OnyxBay/blob/dev/docs/contributing.md).
