### PR TITLE
fix(suicide): Fixed many bugs with gunshot suicide

### DIFF
--- a/code/modules/projectiles/gun.dm
+++ b/code/modules/projectiles/gun.dm
@@ -409,21 +409,9 @@
 			log_and_message_admins("[key_name(user)] try commited suicide using \a [src]")
 			user.adjustBrainLoss(amount = (result_dmg * rand(3, 4)))
 			if(in_chamber.check_armour == "bullet" || in_chamber.check_armour == "melee")
-<<<<<<< HEAD
 				M.get_organ(BP_HEAD).take_external_damage(brute = result_dmg * rand(2,5), used_weapon = "Point blank shot in the head with \a [in_chamber]")
-||||||| 51542daa0c
-				M.get_organ(BP_HEAD).take_external_damage(brute = result_dmg * rand(2,5), used_weapon = src)
-=======
-				M.get_organ(BP_HEAD).take_external_damage(brute = result_dmg * rand(2, 5), used_weapon = src)
->>>>>>> 823fa32eb1d0b6e16b0a323443f1b4bebb9d6fbe
 			else
-<<<<<<< HEAD
 				M.get_organ(BP_HEAD).take_external_damage(burn = result_dmg * rand(2,5), used_weapon = "Point blank shot in the head with \a [in_chamber]")
-||||||| 51542daa0c
-				M.get_organ(BP_HEAD).take_external_damage(burn = result_dmg * rand(2,5), used_weapon = src)
-=======
-				M.get_organ(BP_HEAD).take_external_damage(burn = result_dmg * rand(2, 5), used_weapon = src)
->>>>>>> 823fa32eb1d0b6e16b0a323443f1b4bebb9d6fbe
 		else
 			to_chat(user, SPAN_NOTICE("Ow..."))
 			user.apply_effect(110,PAIN,0)

--- a/code/modules/projectiles/gun.dm
+++ b/code/modules/projectiles/gun.dm
@@ -408,13 +408,13 @@
 
 		in_chamber.on_hit(M)
 		if (in_chamber.damage_type != PAIN)
-			var/result_dmg = in_chamber.damage * ((100-(M.run_armor_check(BP_HEAD, in_chamber.check_armour, in_chamber.armor_penetration)))/100)
+			var/result_dmg = in_chamber.damage * ((100 - (M.run_armor_check(BP_HEAD, in_chamber.check_armour, in_chamber.armor_penetration))) / 100)
 			log_and_message_admins("[key_name(user)] try commited suicide using \a [src]")
-			user.adjustBrainLoss(amount = (result_dmg * rand(3,4)))
+			user.adjustBrainLoss(amount = (result_dmg * rand(3, 4)))
 			if(in_chamber.check_armour == "bullet" || in_chamber.check_armour == "melee")
-				M.get_organ(BP_HEAD).take_external_damage(brute = result_dmg * rand(2,5), used_weapon = src)
+				M.get_organ(BP_HEAD).take_external_damage(brute = result_dmg * rand(2, 5), used_weapon = src)
 			else
-				M.get_organ(BP_HEAD).take_external_damage(burn = result_dmg * rand(2,5), used_weapon = src)
+				M.get_organ(BP_HEAD).take_external_damage(burn = result_dmg * rand(2, 5), used_weapon = src)
 		else
 			to_chat(user, "<span class = 'notice'>Ow...</span>")
 			user.apply_effect(110,PAIN,0)

--- a/code/modules/projectiles/gun.dm
+++ b/code/modules/projectiles/gun.dm
@@ -123,7 +123,7 @@
 
 	var/mob/living/M = user
 	if(MUTATION_HULK in M.mutations)
-		to_chat(M, "<span class='danger'>Your fingers are much too large for the trigger guard!</span>")
+		to_chat(M, SPAN_DANGER("Your fingers are much too large for the trigger guard!"))
 		return 0
 	if((MUTATION_CLUMSY in M.mutations) && prob(40) && !clumsy_unaffected) //Clumsy handling
 		var/obj/P = consume_next_projectile()
@@ -131,8 +131,8 @@
 			if(process_projectile(P, user, user, pick(BP_L_FOOT, BP_R_FOOT)))
 				handle_post_fire(user, user)
 				user.visible_message(
-					"<span class='danger'>\The [user] shoots \himself in the foot with \the [src]!</span>",
-					"<span class='danger'>You shoot yourself in the foot with \the [src]!</span>"
+					SPAN_DANGER("\The [user] shoots \himself in the foot with \the [src]!"),
+					SPAN_DANGER("You shoot yourself in the foot with \the [src]!")
 					)
 				M.drop_item()
 		else
@@ -177,7 +177,7 @@
 
 	if(world.time < next_fire_time)
 		if (world.time % 3) //to prevent spam
-			to_chat(user, "<span class='warning'>[src] is not ready to fire again!</span>")
+			to_chat(user, SPAN_WARNING("[src] is not ready to fire again!"))
 		return
 
 	var/shoot_time = (burst - 1)* burst_delay
@@ -237,7 +237,7 @@
 //called if there was no projectile to shoot
 /obj/item/weapon/gun/proc/handle_click_empty(mob/user)
 	if (user)
-		user.visible_message("*click click*", "<span class='danger'>*click*</span>")
+		user.visible_message("*click click*", SPAN_DANGER("*click*"))
 	else
 		src.visible_message("*click click*")
 	playsound(src.loc, 'sound/effects/weapons/gun/gun_empty.ogg', 75)
@@ -256,8 +256,8 @@
 			)
 		else
 			user.visible_message(
-				"<span class='danger'>\The [user] fires \the [src][pointblank ? " point blank at \the [target]":""][burstfire == 1 ? " in a burst":""]!</span>",
-				"<span class='warning'>You fire \the [src]!</span>",
+				SPAN_DANGER("\The [user] fires \the [src][pointblank ? " point blank at \the [target]":""][burstfire == 1 ? " in a burst":""]!"),
+				SPAN_WARNING("You fire \the [src]!"),
 				"You hear a [fire_sound_text]!"
 				)
 
@@ -266,24 +266,24 @@
 			switch(one_hand_penalty)
 				if(1)
 					if(prob(50)) //don't need to tell them every single time
-						to_chat(user, "<span class='warning'>Your aim wavers slightly.</span>")
+						to_chat(user, SPAN_WARNING("Your aim wavers slightly."))
 				if(2)
-					to_chat(user, "<span class='warning'>Your aim wavers as you fire \the [src] with just one hand.</span>")
+					to_chat(user, SPAN_WARNING("Your aim wavers as you fire \the [src] with just one hand."))
 				if(3)
-					to_chat(user, "<span class='warning'>You have trouble keeping \the [src] on target with just one hand.</span>")
+					to_chat(user, SPAN_WARNING("You have trouble keeping \the [src] on target with just one hand."))
 				if(4 to INFINITY)
-					to_chat(user, "<span class='warning'>You struggle to keep \the [src] on target with just one hand!</span>")
+					to_chat(user, SPAN_WARNING("You struggle to keep \the [src] on target with just one hand!"))
 		else if(!user.can_wield_item(src))
 			switch(one_hand_penalty)
 				if(1)
 					if(prob(50)) //don't need to tell them every single time
-						to_chat(user, "<span class='warning'>Your aim wavers slightly.</span>")
+						to_chat(user, SPAN_WARNING("Your aim wavers slightly."))
 				if(2)
-					to_chat(user, "<span class='warning'>Your aim wavers as you try to hold \the [src] steady.</span>")
+					to_chat(user, SPAN_WARNING("Your aim wavers as you try to hold \the [src] steady."))
 				if(3)
-					to_chat(user, "<span class='warning'>You have trouble holding \the [src] steady.</span>")
+					to_chat(user, SPAN_WARNING("You have trouble holding \the [src] steady."))
 				if(4 to INFINITY)
-					to_chat(user, "<span class='warning'>You struggle to hold \the [src] steady!</span>")
+					to_chat(user, SPAN_WARNING("You struggle to hold \the [src] steady!"))
 
 	if(screen_shake)
 		spawn()
@@ -381,12 +381,9 @@
 	var/mob/living/carbon/human/M = user
 
 	mouthshoot = 1
-	if(M.check_mouth_coverage())
-		M.visible_message("<span class='danger'>[user] puts a gun to his temple, ready to pull the trigger...</span>")
-	else
-		M.visible_message("<span class='danger'>[user] sticks their gun in their mouth, ready to pull the trigger...</span>")
+	M.visible_message(SPAN_DANGER("[user] [M.check_mouth_coverage() ? "puts a gun to his temple" : "sticks their gun in their mouth"], ready to pull the trigger..."))
 	if(!do_after(user, 40, progress=0))
-		M.visible_message("<span class='notice'>[user] decided life was worth living</span>")
+		M.visible_message(SPAN_NOTICE("[user] decided life was worth living"))
 		mouthshoot = 0
 		return
 	if(istype(src, /obj/item/weapon/gun/flamer))
@@ -399,10 +396,10 @@
 		return
 	var/obj/item/projectile/in_chamber = consume_next_projectile()
 	if (istype(in_chamber) && process_projectile(in_chamber, user, user, BP_MOUTH))
-		user.visible_message("<span class = 'warning'>[user] pulls the trigger.</span>")
+		user.visible_message(SPAN_WARNING("[user] pulls the trigger."))
 		handle_post_fire(user,user)
 		if(istype(in_chamber, /obj/item/projectile/beam/lastertag))
-			user.show_message("<span class = 'warning'>You feel rather silly, trying to commit suicide with a toy.</span>")
+			user.show_message(SPAN_WARNING("You feel rather silly, trying to commit suicide with a toy."))
 			mouthshoot = 0
 			return
 
@@ -412,11 +409,11 @@
 			log_and_message_admins("[key_name(user)] try commited suicide using \a [src]")
 			user.adjustBrainLoss(amount = (result_dmg * rand(3,4)))
 			if(in_chamber.check_armour == "bullet" || in_chamber.check_armour == "melee")
-				M.get_organ(BP_HEAD).take_external_damage(brute = result_dmg * rand(2,5), used_weapon = src)
+				M.get_organ(BP_HEAD).take_external_damage(brute = result_dmg * rand(2,5), used_weapon = "Point blank shot in the head with \a [in_chamber]")
 			else
-				M.get_organ(BP_HEAD).take_external_damage(burn = result_dmg * rand(2,5), used_weapon = src)
+				M.get_organ(BP_HEAD).take_external_damage(burn = result_dmg * rand(2,5), used_weapon = "Point blank shot in the head with \a [in_chamber]")
 		else
-			to_chat(user, "<span class = 'notice'>Ow...</span>")
+			to_chat(user, SPAN_NOTICE("Ow..."))
 			user.apply_effect(110,PAIN,0)
 		qdel(in_chamber)
 		mouthshoot = 0
@@ -534,4 +531,4 @@
 /obj/item/weapon/gun/attack_self(mob/user)
 	var/datum/firemode/new_mode = switch_firemodes(user)
 	if(new_mode)
-		to_chat(user, "<span class='notice'>\The [src] is now set to [new_mode.name].</span>")
+		to_chat(user, SPAN_NOTICE("\The [src] is now set to [new_mode.name]."))

--- a/code/modules/projectiles/gun.dm
+++ b/code/modules/projectiles/gun.dm
@@ -410,7 +410,6 @@
 		in_chamber.on_hit(M)
 		if (in_chamber.damage_type != PAIN)
 			log_and_message_admins("[key_name(user)] tried to commit suicide \a [src]")
-			to_world("inchamber=[ref(in_chamber)] | pm=[in_chamber.penetration_modifier] | pen=[in_chamber.armor_penetration] | dam=[in_chamber.damage]")
 			M.get_organ(BP_HEAD).createwound(PIERCE, in_chamber.damage * 4)
 			user.adjustBrainLoss(amount = (in_chamber.damage * rand(15,20)))
 			Fire(user, user, src, "head")

--- a/code/modules/projectiles/gun.dm
+++ b/code/modules/projectiles/gun.dm
@@ -402,6 +402,7 @@
 	var/obj/item/projectile/in_chamber = consume_next_projectile()
 	if (istype(in_chamber) && process_projectile(in_chamber, user, user, BP_MOUTH))
 		user.visible_message("<span class = 'warning'>[user] pulls the trigger.</span>")
+		handle_post_fire(user,user)
 		if(istype(in_chamber, /obj/item/projectile/beam/lastertag))
 			user.show_message("<span class = 'warning'>You feel rather silly, trying to commit suicide with a toy.</span>")
 			mouthshoot = 0
@@ -409,10 +410,9 @@
 
 		in_chamber.on_hit(M)
 		if (in_chamber.damage_type != PAIN)
-			log_and_message_admins("[key_name(user)] tried to commit suicide \a [src]")
+			log_and_message_admins("[key_name(user)] try commited suicide using \a [src]")
 			M.get_organ(BP_HEAD).createwound(PIERCE, in_chamber.damage * 4)
 			user.adjustBrainLoss(amount = (in_chamber.damage * rand(15,20)))
-			Fire(user, user, src, "head")
 		else
 			to_chat(user, "<span class = 'notice'>Ow...</span>")
 			user.apply_effect(110,PAIN,0)


### PR DESCRIPTION
- Добавлена проверка на открытость рта (до этого можно было заснуть оружие в рот даже в воидсуите).
- Теперь после выстрела, следующий патрон из магазина в патроннике не создается. Эта часть была еще со времен старой стрельбы. Так же вернул дроп гильзы и убрал старые костыли ~~добавив новые~~.
- Вероятность суицида теперь зависит от патрона в стволе. Есть большая вероятность застрелиться даже резиновой пулей (урон по мозгу). damage резиновой пули .45 == 5. Формула > `in_chamber.damage * rand(15,20)`. Урон по мозгу в таком случае будет от 75 до 100, помимо урона который еще идет от самого выстрела. К тому же накладывается рана в виде дыры на голову, которая в большинстве случае заставит её кровоточить, тоже в зависимости от дамага пули.

fix #6130
fix #4846
fix #4632

<details>
<summary>Чейнджлог</summary>

```yml
🆑Oubi
bugfix: Исправлена серия багов суицида с помощью огнестрела, теперь он работает более предсказуемо
/🆑
```

</details>

- [x] Pull Request полностью завершен, мне не нужна помощь чтобы его закончить.
- [x] Я внимательно прочитал все свои изменения и багов в них не нашел.
- [x] Я запускал сервер со своими изменениями локально и все протестировал.
- [x] Я ознакомился c [Guide to Contribute](https://github.com/ChaoticOnyx/OnyxBay/blob/dev/docs/contributing.md).
