### PR TITLE
Removes lack of <i>s in proc/hear_sleep()

### DIFF
--- a/code/modules/mob/hear_say.dm
+++ b/code/modules/mob/hear_say.dm
@@ -319,7 +319,7 @@
 			heardword = copytext(heardword, 2)
 		if(copytext(heardword, -1) in punctuation)
 			heardword = copytext(heardword, 1, length(heardword))
-		heard = "<span class = 'game_say'>...<i>You hear something about</i>... <i>[heardword]</b>...</span>"
+		heard = SPAN("game_say", "...<i>You hear something about</i>... <i>[heardword]</i>...")
 
 	else
 		heard = "<span class = 'game_say'>...<i>You almost hear someone talking</i>...</span>"

--- a/code/modules/mob/hear_say.dm
+++ b/code/modules/mob/hear_say.dm
@@ -315,11 +315,11 @@
 		var/list/messages = splittext(message, " ")
 		var/R = rand(1, messages.len)
 		var/heardword = messages[R]
-		if(copytext(heardword,1, 1) in punctuation)
-			heardword = copytext(heardword,2)
-		if(copytext(heardword,-1) in punctuation)
-			heardword = copytext(heardword,1,length(heardword))
-		heard = "<span class = 'game_say'>...You hear something about...[heardword]</span>"
+		if(copytext(heardword, 1, 1) in punctuation)
+			heardword = copytext(heardword, 2)
+		if(copytext(heardword, -1) in punctuation)
+			heardword = copytext(heardword, 1, length(heardword))
+		heard = "<span class = 'game_say'>...<i>You hear something about</i>... <i>[heardword]</b>...</span>"
 
 	else
 		heard = "<span class = 'game_say'>...<i>You almost hear someone talking</i>...</span>"


### PR DESCRIPTION
Добавлен курсив, пробел после многоточия и многоточие после фразы в сообщениях, слышимых в отключке.
До:
![image](https://user-images.githubusercontent.com/45202681/126904407-699ec5ec-5934-45a9-a85a-d3948da93096.png)
После:
![image](https://user-images.githubusercontent.com/45202681/126904412-d0c8a1ab-ea24-47f9-b4a9-5d071c947a59.png)

```yml
🆑
bugfix: Исправлено форматирование в сообщениях типа "...You hear something about...".
/🆑
```

- [x] Pull Request полностью завершен, мне не нужна помощь чтобы его закончить.
- [x] Я внимательно прочитал все свои изменения и багов в них не нашел.
- [x] Я запускал сервер со своими изменениями локально и все протестировал.
- [x] Я ознакомился c [Guide to Contribute](https://github.com/ChaoticOnyx/OnyxBay/blob/dev/docs/contributing.md).
