### PR TITLE
fix(rig healthanalyzer): fix health analyzer display output

### DIFF
--- a/code/game/objects/items/devices/scanners.dm
+++ b/code/game/objects/items/devices/scanners.dm
@@ -46,7 +46,7 @@ REAGENT SCANNER
 	playsound(src.loc, 'sound/signals/processing21.ogg', 50)
 	ui_interact(user,target = C)
 
-/obj/item/device/healthanalyzer/ui_interact(mob/user, ui_key = "main", datum/nanoui/ui = null, force_open = 1,mob/living/carbon/human/target)
+/obj/item/device/healthanalyzer/ui_interact(mob/user, ui_key = "main", datum/nanoui/ui = null, force_open = 1,mob/living/carbon/human/target, master_ui = null, datum/topic_state/state = GLOB.default_state)
 
 	var/data[0]
 
@@ -72,10 +72,16 @@ REAGENT SCANNER
 
 	ui = SSnano.try_update_ui(user, src, ui_key, ui, data, force_open)
 	if (!ui)
-		ui = new(user, src, ui_key, "healthanalyzer.tmpl", " ", 640, 370)
+		ui = new(user, src, ui_key, "healthanalyzer.tmpl", " ", 640, 370, master_ui = master_ui, state = state)
 		ui.set_initial_data(data)
 		ui.set_window_options("focus=0;can_close=1;can_minimize=1;can_maximize=0;can_resize=0;titlebar=1;")
 		ui.open()
+
+/obj/item/device/healthanalyzer/CanUseTopic(mob/user, datum/topic_state/state)
+	. = ..()
+	var/datum/src_object = nano_host()
+	if(src_object in get_rig()?.selected_module)
+		return STATUS_INTERACTIVE
 
 /proc/medical_scan_results(mob/living/carbon/human/H, verbose, separate_result)
 	. = list()

--- a/code/game/objects/items/devices/scanners.dm
+++ b/code/game/objects/items/devices/scanners.dm
@@ -79,7 +79,7 @@ REAGENT SCANNER
 
 /obj/item/device/healthanalyzer/CanUseTopic(mob/user, datum/topic_state/state)
 	. = ..()
-	var/datum/src_object = nano_host()
+	var/atom/src_object = nano_host()
 	if(src_object in get_rig()?.selected_module)
 		return STATUS_INTERACTIVE
 


### PR DESCRIPTION
Модуль РИГ-а, позволяющий использовать health analyzer теперь не бесполезная штука. 
~Этот баг висел с 1-го июля 19-го года, вы серьезно?~ ._.

fix #591
fix #1989

<details>
<summary>Чейнджлог</summary>

```yml
🆑Oubi
bugfix: Исправлен модуль медицинского сканера для рига, теперь сканер работает.
/🆑
```

</details>

- [x] Pull Request полностью завершен, мне не нужна помощь чтобы его закончить.
- [x] Я внимательно прочитал все свои изменения и багов в них не нашел.
- [x] Я запускал сервер со своими изменениями локально и все протестировал.
- [x] Я ознакомился c [Guide to Contribute](https://github.com/ChaoticOnyx/OnyxBay/blob/dev/docs/contributing.md).
