### PR TITLE
tweak(contracts) admin menu now display closed contracts

### DIFF
--- a/code/game/gamemodes/traitor/fixer.dm
+++ b/code/game/gamemodes/traitor/fixer.dm
@@ -92,7 +92,7 @@
 
 	var/out = "<meta charset=\"utf-8\"><b>The Syndicate Operations Menu</b>"
 	out += "<hr><b>Contracts (Operations|Objectives)</b></br>"
-	for(var/datum/antag_contract/contract in GLOB.traitors.fixer.return_contracts())
+	for(var/datum/antag_contract/contract in GLOB.all_contracts)
 		out += "<br><b>Contract [contract.name]:</b> <small>[contract.desc]</small> "
 		if(contract.completed)
 			out += "(<font color='green'>completed</font>)"


### PR DESCRIPTION
Из #5755 перенес фикс.

<details>
<summary>Чейнджлог</summary>

```yml
🆑
admin: Меню контрактов теперь отображает выполненные контракты.
/🆑
```

</details>

close #5601

- [x] Pull Request полностью завершен, мне не нужна помощь чтобы его закончить.
- [x] Я внимательно прочитал все свои изменения и багов в них не нашел.
- [x] Я запускал сервер со своими изменениями локально и все протестировал.
- [x] Я ознакомился c [Guide to Contribute](https://github.com/ChaoticOnyx/OnyxBay/blob/dev/docs/contributing.md).
