### PR TITLE
fix(syringe-snack), food now leaves trash even with no reagents.

### DIFF
--- a/code/modules/reagents/reagent_containers/food/snacks.dm
+++ b/code/modules/reagents/reagent_containers/food/snacks.dm
@@ -44,7 +44,17 @@
 /obj/item/weapon/reagent_containers/food/snacks/attack(mob/M as mob, mob/user as mob, def_zone)
 	if(!reagents.total_volume)
 		to_chat(user, "<span class='danger'>None of [src] left!</span>")
-		user.drop_from_inventory(src)
+		//Gordo spijxjxeno iz strocxek vysxe. Top notch monkey coding.
+		M.drop_item()
+		if(trash)
+			if(ispath(trash,/obj/item))
+				var/obj/item/TrashItem = new trash(get_turf(M))
+				M.put_in_hands(TrashItem)
+			else if(istype(trash,/obj/item))
+				M.put_in_hands(trash)
+		if(istype(loc, /obj/item/organ))
+			var/obj/item/organ/O = loc
+			O.organ_eaten(M)
 		qdel(src)
 		return 0
 


### PR DESCRIPTION
Как гласил иссуй №5957, еда, из которой шприцом вынули всё содержимое, при попытке съесть её исчезала, не оставляя связанного с ней мусора. Теперь проблема решена; спи спокойно, /null.#2985!

`fix #5957`

<details>
<summary>Чейнджлог</summary>

```yml
🆑
fix: Доеденная еда теперь всегда оставляет связанный с ней мусор.
/🆑
```

</details>

- [x] Pull Request полностью завершен, мне не нужна помощь чтобы его закончить.
- [x] Я внимательно прочитал все свои изменения и багов в них не нашел.
- [x] Я запускал сервер со своими изменениями локально и все протестировал.
- [x] Я ознакомился c [Guide to Contribute](https://github.com/ChaoticOnyx/OnyxBay/blob/dev/docs/contributing.md).
