### PR TITLE
feat(roundstart) add configuration vars to disable ooc at roundstart

### DIFF
--- a/code/controllers/configuration.dm
+++ b/code/controllers/configuration.dm
@@ -285,8 +285,8 @@ var/list/gamemode_cache = list()
 	var/db_uses_cp1251_encoding = FALSE
 
 	// round OOC disable
-	var/disable_ooc_r = FALSE
-	var/disable_looc_r = FALSE
+	var/disable_ooc_roundstart = FALSE
+	var/disable_looc_roundstart = FALSE
 
 /datum/configuration/proc/Initialize()
 	var/list/L = typesof(/datum/game_mode) - /datum/game_mode
@@ -362,10 +362,10 @@ var/list/gamemode_cache = list()
 					config.use_age_restriction_for_antags = 1
 
 				if ("disable_ooc_at_roundstart")
-					disable_ooc_r = TRUE
+					disable_ooc_roundstart = TRUE
 
 				if ("disable_looc_at_roundstart")
-					disable_looc_r = TRUE
+					disable_looc_roundstart = TRUE
 
 				if ("traitor_min_age")
 					config.traitor_min_age = text2num(value)

--- a/code/controllers/configuration.dm
+++ b/code/controllers/configuration.dm
@@ -284,6 +284,10 @@ var/list/gamemode_cache = list()
 
 	var/db_uses_cp1251_encoding = FALSE
 
+	// round OOC disable
+	var/disable_ooc_r = FALSE
+	var/disable_looc_r = FALSE
+
 /datum/configuration/proc/Initialize()
 	var/list/L = typesof(/datum/game_mode) - /datum/game_mode
 	for (var/T in L)
@@ -356,6 +360,12 @@ var/list/gamemode_cache = list()
 
 				if ("use_age_restriction_for_antags")
 					config.use_age_restriction_for_antags = 1
+
+				if ("disable_ooc_at_roundstart")
+					disable_ooc_r = TRUE
+
+				if ("disable_looc_at_roundstart")
+					disable_looc_r = TRUE
 
 				if ("traitor_min_age")
 					config.traitor_min_age = text2num(value)

--- a/code/controllers/subsystems/ticker.dm
+++ b/code/controllers/subsystems/ticker.dm
@@ -105,6 +105,14 @@ SUBSYSTEM_DEF(ticker)
 	if(!length(GLOB.admins))
 		send2adminirc("Round has started with no admins online.")
 
+	if(config.disable_ooc_r)
+		config.ooc_allowed = FALSE
+		to_world("<B>The OOC channel has been globally disabled!</B>")
+
+	if(config.disable_looc_r)
+		config.looc_allowed = FALSE
+		to_world("<B>The LOOC channel has been globally disabled!</B>")
+
 /datum/controller/subsystem/ticker/proc/playing_tick()
 	mode.process()
 	var/mode_finished = mode_finished()
@@ -156,6 +164,15 @@ SUBSYSTEM_DEF(ticker)
 
 			handle_tickets()
 			SSstoryteller.collect_statistics()
+
+			if(config.disable_ooc_r)
+				config.ooc_allowed = TRUE
+				to_world("<B>The OOC channel has been globally enabled!</B>")
+
+			if(config.disable_looc_r)
+				config.looc_allowed = TRUE
+				to_world("<B>The LOOC channel has been globally enabled!</B>")
+
 		if(END_GAME_ENDING)
 			restart_timeout -= (world.time - last_fire)
 			if(restart_timeout <= 0)

--- a/code/controllers/subsystems/ticker.dm
+++ b/code/controllers/subsystems/ticker.dm
@@ -107,11 +107,11 @@ SUBSYSTEM_DEF(ticker)
 
 	if(config.disable_ooc_r)
 		config.ooc_allowed = FALSE
-		to_world("<B>The OOC channel has been globally disabled!</B>")
+		to_world("<b>The OOC channel has been globally disabled!</b>")
 
 	if(config.disable_looc_r)
 		config.looc_allowed = FALSE
-		to_world("<B>The LOOC channel has been globally disabled!</B>")
+		to_world("<b>The LOOC channel has been globally disabled!</b>")
 
 /datum/controller/subsystem/ticker/proc/playing_tick()
 	mode.process()
@@ -167,11 +167,11 @@ SUBSYSTEM_DEF(ticker)
 
 			if(config.disable_ooc_r)
 				config.ooc_allowed = TRUE
-				to_world("<B>The OOC channel has been globally enabled!</B>")
+				to_world("<b>The OOC channel has been globally enabled!</b>")
 
 			if(config.disable_looc_r)
 				config.looc_allowed = TRUE
-				to_world("<B>The LOOC channel has been globally enabled!</B>")
+				to_world("<b>The LOOC channel has been globally enabled!</b>")
 
 		if(END_GAME_ENDING)
 			restart_timeout -= (world.time - last_fire)

--- a/code/controllers/subsystems/ticker.dm
+++ b/code/controllers/subsystems/ticker.dm
@@ -106,10 +106,10 @@ SUBSYSTEM_DEF(ticker)
 		send2adminirc("Round has started with no admins online.")
 
 	if(config.disable_ooc_roundstart)
-		set_ooc(FALSE)
+		disable_ooc()
 
 	if(config.disable_looc_roundstart)
-		set_looc(FALSE)
+		disable_looc()
 
 /datum/controller/subsystem/ticker/proc/playing_tick()
 	mode.process()

--- a/code/controllers/subsystems/ticker.dm
+++ b/code/controllers/subsystems/ticker.dm
@@ -106,10 +106,10 @@ SUBSYSTEM_DEF(ticker)
 		send2adminirc("Round has started with no admins online.")
 
 	if(config.disable_ooc_roundstart)
-		toggle_ooc(FALSE)
+		set_ooc()
 
 	if(config.disable_looc_roundstart)
-		toggle_looc(FALSE)
+		set_looc()
 
 /datum/controller/subsystem/ticker/proc/playing_tick()
 	mode.process()

--- a/code/controllers/subsystems/ticker.dm
+++ b/code/controllers/subsystems/ticker.dm
@@ -106,10 +106,10 @@ SUBSYSTEM_DEF(ticker)
 		send2adminirc("Round has started with no admins online.")
 
 	if(config.disable_ooc_roundstart)
-		set_ooc()
+		set_ooc(FALSE)
 
 	if(config.disable_looc_roundstart)
-		set_looc()
+		set_looc(FALSE)
 
 /datum/controller/subsystem/ticker/proc/playing_tick()
 	mode.process()

--- a/code/controllers/subsystems/ticker.dm
+++ b/code/controllers/subsystems/ticker.dm
@@ -105,13 +105,11 @@ SUBSYSTEM_DEF(ticker)
 	if(!length(GLOB.admins))
 		send2adminirc("Round has started with no admins online.")
 
-	if(config.disable_ooc_r)
-		config.ooc_allowed = FALSE
-		to_world("<b>The OOC channel has been globally disabled!</b>")
+	if(config.disable_ooc_roundstart)
+		toggle_ooc(FALSE)
 
-	if(config.disable_looc_r)
-		config.looc_allowed = FALSE
-		to_world("<b>The LOOC channel has been globally disabled!</b>")
+	if(config.disable_looc_roundstart)
+		toggle_looc(FALSE)
 
 /datum/controller/subsystem/ticker/proc/playing_tick()
 	mode.process()
@@ -164,14 +162,6 @@ SUBSYSTEM_DEF(ticker)
 
 			handle_tickets()
 			SSstoryteller.collect_statistics()
-
-			if(config.disable_ooc_r)
-				config.ooc_allowed = TRUE
-				to_world("<b>The OOC channel has been globally enabled!</b>")
-
-			if(config.disable_looc_r)
-				config.looc_allowed = TRUE
-				to_world("<b>The LOOC channel has been globally enabled!</b>")
 
 		if(END_GAME_ENDING)
 			restart_timeout -= (world.time - last_fire)

--- a/code/game/world.dm
+++ b/code/game/world.dm
@@ -24,34 +24,34 @@ var/server_name = "OnyxBay"
 	return 1
 
 /proc/toggle_ooc()
-    config.ooc_allowed = !config.ooc_allowed
-    if(config.ooc_allowed)
-        to_world("<b>The OOC channel has been globally enabled!</b>")
-    else
-        to_world("<b>The OOC channel has been globally disabled!</b>")
+	config.ooc_allowed = !config.ooc_allowed
+	if(config.ooc_allowed)
+		to_world("<b>The OOC channel has been globally enabled!</b>")
+	else
+		to_world("<b>The OOC channel has been globally disabled!</b>")
 
 /proc/disable_ooc()
-    if(config.ooc_allowed)
-        toggle_ooc()
+	if(config.ooc_allowed)
+		toggle_ooc()
 
 /proc/enable_ooc()
-    if(!config.ooc_allowed)
-        toggle_ooc()
+	if(!config.ooc_allowed)
+		toggle_ooc()
 
 /proc/toggle_looc()
-    config.looc_allowed = !config.looc_allowed
-    if(config.looc_allowed)
-        to_world("<b>The LOOC channel has been globally enabled!</b>")
-    else
-        to_world("<b>The LOOC channel has been globally disabled!</b>")
+	config.looc_allowed = !config.looc_allowed
+	if(config.looc_allowed)
+		to_world("<b>The LOOC channel has been globally enabled!</b>")
+	else
+		to_world("<b>The LOOC channel has been globally disabled!</b>")
 
 /proc/disable_looc()
-    if(config.ooc_allowed)
-        toggle_ooc()
+	if(config.ooc_allowed)
+		toggle_ooc()
 
 /proc/enable_looc()
-    if(!config.looc_allowed)
-        toggle_looc()
+	if(!config.looc_allowed)
+		toggle_looc()
 
 // Find mobs matching a given string
 //

--- a/code/game/world.dm
+++ b/code/game/world.dm
@@ -23,14 +23,14 @@ var/server_name = "OnyxBay"
 		t = round(t / l)
 	return 1
 
-/proc/set_ooc(new_value = FALSE)
+/proc/set_ooc(new_value = TRUE)
 	config.ooc_allowed = new_value
 	if(config.ooc_allowed)
 		to_world("<b>The OOC channel has been globally enabled!</b>")
 	else
 		to_world("<b>The OOC channel has been globally disabled!</b>")
 
-/proc/set_looc(new_value = FALSE)
+/proc/set_looc(new_value = TRUE)
 	config.looc_allowed = new_value
 	if(config.looc_allowed)
 		to_world("<b>The LOOC channel has been globally enabled!</b>")

--- a/code/game/world.dm
+++ b/code/game/world.dm
@@ -23,14 +23,14 @@ var/server_name = "OnyxBay"
 		t = round(t / l)
 	return 1
 
-/proc/toggle_ooc(new_value = !(config.ooc_allowed))
+/proc/set_ooc(new_value = FALSE)
 	config.ooc_allowed = new_value
 	if(config.ooc_allowed)
 		to_world("<b>The OOC channel has been globally enabled!</b>")
 	else
 		to_world("<b>The OOC channel has been globally disabled!</b>")
 
-/proc/toggle_looc(new_value = !(config.looc_allowed))
+/proc/set_looc(new_value = FALSE)
 	config.looc_allowed = new_value
 	if(config.looc_allowed)
 		to_world("<b>The LOOC channel has been globally enabled!</b>")
@@ -414,11 +414,7 @@ var/world_topic_spam_protect_time = world.timeofday
 				return "Bad Key (Throttled)"
 			world_topic_spam_protect_time = world.time
 			return "Bad Key"
-		config.ooc_allowed = !(config.ooc_allowed)
-		if (config.ooc_allowed)
-			to_world("<B>The OOC channel has been globally enabled!</B>")
-		else
-			to_world("<B>The OOC channel has been globally disabled!</B>")
+		set_ooc(!(config.ooc_allowed))
 		log_and_message_admins("discord toggled OOC.")
 		return config.ooc_allowed ? "ON" : "OFF"
 

--- a/code/game/world.dm
+++ b/code/game/world.dm
@@ -23,19 +23,35 @@ var/server_name = "OnyxBay"
 		t = round(t / l)
 	return 1
 
-/proc/set_ooc(new_value = TRUE)
-	config.ooc_allowed = new_value
-	if(config.ooc_allowed)
-		to_world("<b>The OOC channel has been globally enabled!</b>")
-	else
-		to_world("<b>The OOC channel has been globally disabled!</b>")
+/proc/toogle_ooc()
+    config.ooc_allowed = !config.ooc_allowed
+    if(config.ooc_allowed)
+        to_world("<b>The OOC channel has been globally enabled!</b>")
+    else
+        to_world("<b>The OOC channel has been globally disabled!</b>")
 
-/proc/set_looc(new_value = TRUE)
-	config.looc_allowed = new_value
-	if(config.looc_allowed)
-		to_world("<b>The LOOC channel has been globally enabled!</b>")
-	else
-		to_world("<b>The LOOC channel has been globally disabled!</b>")
+/proc/disable_ooc()
+    if(config.ooc_allowed)
+        toogle_ooc()
+
+/proc/enable_ooc()
+    if(!config.ooc_allowed)
+        toogle_ooc()
+
+/proc/toogle_looc()
+    config.looc_allowed = !config.looc_allowed
+    if(config.looc_allowed)
+        to_world("<b>The LOOC channel has been globally enabled!</b>")
+    else
+        to_world("<b>The LOOC channel has been globally disabled!</b>")
+
+/proc/disable_looc()
+    if(config.ooc_allowed)
+        toogle_ooc()
+
+/proc/enable_looc()
+    if(!config.looc_allowed)
+        toogle_looc()
 
 // Find mobs matching a given string
 //
@@ -414,7 +430,7 @@ var/world_topic_spam_protect_time = world.timeofday
 				return "Bad Key (Throttled)"
 			world_topic_spam_protect_time = world.time
 			return "Bad Key"
-		set_ooc(!(config.ooc_allowed))
+		toogle_ooc(!(config.ooc_allowed))
 		log_and_message_admins("discord toggled OOC.")
 		return config.ooc_allowed ? "ON" : "OFF"
 

--- a/code/game/world.dm
+++ b/code/game/world.dm
@@ -23,6 +23,20 @@ var/server_name = "OnyxBay"
 		t = round(t / l)
 	return 1
 
+/proc/toggle_ooc(new_value = !(config.ooc_allowed))
+	config.ooc_allowed = new_value
+	if(config.ooc_allowed)
+		to_world("<b>The OOC channel has been globally enabled!</b>")
+	else
+		to_world("<b>The OOC channel has been globally disabled!</b>")
+
+/proc/toggle_looc(new_value = !(config.looc_allowed))
+	config.looc_allowed = new_value
+	if(config.looc_allowed)
+		to_world("<b>The LOOC channel has been globally enabled!</b>")
+	else
+		to_world("<b>The LOOC channel has been globally disabled!</b>")
+
 // Find mobs matching a given string
 //
 // search_string: the string to search for, in params format; for example, "some_key;mob_name"

--- a/code/game/world.dm
+++ b/code/game/world.dm
@@ -23,7 +23,7 @@ var/server_name = "OnyxBay"
 		t = round(t / l)
 	return 1
 
-/proc/toogle_ooc()
+/proc/toggle_ooc()
     config.ooc_allowed = !config.ooc_allowed
     if(config.ooc_allowed)
         to_world("<b>The OOC channel has been globally enabled!</b>")
@@ -32,11 +32,11 @@ var/server_name = "OnyxBay"
 
 /proc/disable_ooc()
     if(config.ooc_allowed)
-        toogle_ooc()
+        toggle_ooc()
 
 /proc/enable_ooc()
     if(!config.ooc_allowed)
-        toogle_ooc()
+        toggle_ooc()
 
 /proc/toggle_looc()
     config.looc_allowed = !config.looc_allowed
@@ -47,7 +47,7 @@ var/server_name = "OnyxBay"
 
 /proc/disable_looc()
     if(config.ooc_allowed)
-        toogle_ooc()
+        toggle_ooc()
 
 /proc/enable_looc()
     if(!config.looc_allowed)
@@ -430,7 +430,7 @@ var/world_topic_spam_protect_time = world.timeofday
 				return "Bad Key (Throttled)"
 			world_topic_spam_protect_time = world.time
 			return "Bad Key"
-		toogle_ooc()
+		toggle_ooc()
 		log_and_message_admins("discord toggled OOC.")
 		return config.ooc_allowed ? "ON" : "OFF"
 

--- a/code/game/world.dm
+++ b/code/game/world.dm
@@ -38,7 +38,7 @@ var/server_name = "OnyxBay"
     if(!config.ooc_allowed)
         toogle_ooc()
 
-/proc/toogle_looc()
+/proc/toggle_looc()
     config.looc_allowed = !config.looc_allowed
     if(config.looc_allowed)
         to_world("<b>The LOOC channel has been globally enabled!</b>")
@@ -51,7 +51,7 @@ var/server_name = "OnyxBay"
 
 /proc/enable_looc()
     if(!config.looc_allowed)
-        toogle_looc()
+        toggle_looc()
 
 // Find mobs matching a given string
 //

--- a/code/modules/admin/admin.dm
+++ b/code/modules/admin/admin.dm
@@ -756,7 +756,7 @@ var/global/floorIsLava = 0
 	if(!check_rights(R_ADMIN))
 		return
 
-	set_ooc(!(config.ooc_allowed))
+	toogle_ooc(!(config.ooc_allowed))
 	log_and_message_admins("toggled OOC.")
 	feedback_add_details("admin_verb","TOOC") //If you are copy-pasting this, ensure the 2nd parameter is unique to the new proc!
 
@@ -784,7 +784,7 @@ var/global/floorIsLava = 0
 	if(!check_rights(R_ADMIN))
 		return
 
-	set_looc(!(config.looc_allowed))
+	toggle_looc()
 	log_and_message_admins("toggled LOOC.")
 	feedback_add_details("admin_verb","TLOOC") //If you are copy-pasting this, ensure the 2nd parameter is unique to the new proc!
 

--- a/code/modules/admin/admin.dm
+++ b/code/modules/admin/admin.dm
@@ -756,7 +756,7 @@ var/global/floorIsLava = 0
 	if(!check_rights(R_ADMIN))
 		return
 
-	toggle_ooc()
+	set_ooc(!(config.ooc_allowed))
 	log_and_message_admins("toggled OOC.")
 	feedback_add_details("admin_verb","TOOC") //If you are copy-pasting this, ensure the 2nd parameter is unique to the new proc!
 
@@ -784,7 +784,7 @@ var/global/floorIsLava = 0
 	if(!check_rights(R_ADMIN))
 		return
 
-	toggle_looc()
+	set_looc(!(config.looc_allowed))
 	log_and_message_admins("toggled LOOC.")
 	feedback_add_details("admin_verb","TLOOC") //If you are copy-pasting this, ensure the 2nd parameter is unique to the new proc!
 

--- a/code/modules/admin/admin.dm
+++ b/code/modules/admin/admin.dm
@@ -756,11 +756,7 @@ var/global/floorIsLava = 0
 	if(!check_rights(R_ADMIN))
 		return
 
-	config.ooc_allowed = !(config.ooc_allowed)
-	if (config.ooc_allowed)
-		to_world("<B>The OOC channel has been globally enabled!</B>")
-	else
-		to_world("<B>The OOC channel has been globally disabled!</B>")
+	toggle_ooc()
 	log_and_message_admins("toggled OOC.")
 	feedback_add_details("admin_verb","TOOC") //If you are copy-pasting this, ensure the 2nd parameter is unique to the new proc!
 
@@ -788,11 +784,7 @@ var/global/floorIsLava = 0
 	if(!check_rights(R_ADMIN))
 		return
 
-	config.looc_allowed = !(config.looc_allowed)
-	if (config.looc_allowed)
-		to_world("<B>The LOOC channel has been globally enabled!</B>")
-	else
-		to_world("<B>The LOOC channel has been globally disabled!</B>")
+	toggle_looc()
 	log_and_message_admins("toggled LOOC.")
 	feedback_add_details("admin_verb","TLOOC") //If you are copy-pasting this, ensure the 2nd parameter is unique to the new proc!
 

--- a/code/modules/admin/admin.dm
+++ b/code/modules/admin/admin.dm
@@ -756,7 +756,7 @@ var/global/floorIsLava = 0
 	if(!check_rights(R_ADMIN))
 		return
 
-	toogle_ooc()
+	toggle_ooc()
 	log_and_message_admins("toggled OOC.")
 	feedback_add_details("admin_verb","TOOC") //If you are copy-pasting this, ensure the 2nd parameter is unique to the new proc!
 

--- a/config/example/config.txt
+++ b/config/example/config.txt
@@ -333,6 +333,10 @@ JOBS_HAVE_MINIMAL_ACCESS
 # GODCULTIST_MIN_AGE     14
 # LOYALISTS_MIN_AGE      14
 
+# SETTINGS TO DISABLE OOC THINGS AFTER ROUND START.
+# DISABLE_OOC_AT_ROUNDSTART
+# DISABLE_LOOC_AT_ROUNDSTART
+
 ## Unhash this to use recursive explosions, keep it hashed to use circle explosions.
 ## Recursive explosions react to walls, airlocks and blast doors, making them look a lot cooler than the boring old circular explosions.
 ## They require more CPU and are (as of january 2013) experimental.


### PR DESCRIPTION
Добавлены конфигурационные  вары для отключение ООЦ и/или ЛООЦ в начале раунда.

close #6241

<details>
<summary>Чейнджлог</summary>

```yml
🆑
admin: В конфиг добавлена возможность отключить LOOC и OOC раундстартом.
/🆑
```

</details>

- [x] Pull Request полностью завершен, мне не нужна помощь чтобы его закончить.
- [x] Я внимательно прочитал все свои изменения и багов в них не нашел.
- [x] Я запускал сервер со своими изменениями локально и все протестировал.
- [x] Я ознакомился c [Guide to Contribute](https://github.com/ChaoticOnyx/OnyxBay/blob/dev/docs/contributing.md).
