### PR TITLE
tweak(matches), matches now glow a bit when lighted

### DIFF
--- a/code/game/objects/items/weapons/lighters.dm
+++ b/code/game/objects/items/weapons/lighters.dm
@@ -61,6 +61,7 @@ CIGARETTES AND STUFF ARE IN 'SMOKABLES' FOLDER
 	item_state = "cigoff"
 	name = "burnt match"
 	desc = "A match. This one has seen better days."
+	set_light(0) // cont. - After experimenting with two IRL, I came to conclusion both are shit at lighting.
 	STOP_PROCESSING(SSobj, src)
 
 /////////

--- a/code/game/objects/items/weapons/storage/boxes.dm
+++ b/code/game/objects/items/weapons/storage/boxes.dm
@@ -404,6 +404,7 @@
 			W.lit = 1
 			W.damtype = "burn"
 			W.icon_state = "match_lit"
+			W.set_light(0.2, 0.5, 2, 3.5, "#e38f46") //Added light proc of a shitty ver of lighter
 			START_PROCESSING(SSobj, W)
 			playsound(src.loc, 'sound/items/match.ogg', 60, 1, -4)
 			user.visible_message("<span class='notice'>[user] strikes the match on the matchbox.</span>")

--- a/code/modules/reagents/reagent_containers/food/snacks.dm
+++ b/code/modules/reagents/reagent_containers/food/snacks.dm
@@ -44,7 +44,17 @@
 /obj/item/weapon/reagent_containers/food/snacks/attack(mob/M as mob, mob/user as mob, def_zone)
 	if(!reagents.total_volume)
 		to_chat(user, "<span class='danger'>None of [src] left!</span>")
-		user.drop_from_inventory(src)
+		//Gordo spijxjxeno iz strocxek vysxe. Top notch monkey coding.
+		M.drop_item()
+		if(trash)
+			if(ispath(trash,/obj/item))
+				var/obj/item/TrashItem = new trash(get_turf(M))
+				M.put_in_hands(TrashItem)
+			else if(istype(trash,/obj/item))
+				M.put_in_hands(trash)
+		if(istype(loc, /obj/item/organ))
+			var/obj/item/organ/O = loc
+			O.organ_eaten(M)
 		qdel(src)
 		return 0
 


### PR DESCRIPTION
Как гласил иссуй #6258, спички не горели. Не столько баг, сколько просто недочёт, но да ладно. Зато теперь горят. Без понятия, как с их помощью ориентироваться в пространстве - зажигалка хоть продолжительно горит, в отличие от спичек.

close #6258

<details>
<summary>Чейнджлог</summary>

```yml
🆑
tweak: Зажжёные спички теперь слабо светятся.
/🆑
```

</details>

- [x] Pull Request полностью завершен, мне не нужна помощь чтобы его закончить.
- [x] Я внимательно прочитал все свои изменения и багов в них не нашел.
- [x] Я запускал сервер со своими изменениями локально и все протестировал.
- [x] Я ознакомился c [Guide to Contribute](https://github.com/ChaoticOnyx/OnyxBay/blob/dev/docs/contributing.md).
