### PR TITLE
поправил описания контракта на кражу исследований у триторов

### DIFF
--- a/code/game/gamemodes/traitor/contracts.dm
+++ b/code/game/gamemodes/traitor/contracts.dm
@@ -534,7 +534,7 @@ GLOBAL_LIST_INIT(syndicate_factions, list(
 			if(R?.build_path)
 				targets.Add(R)
 				targets_name.Add(R.name)
-	create_explain_text("send a <b>fabricator data disk</b> with one of the following designs via STD (found in <b>Devices and Tools</b>):<br><i>[english_list(targets_name, and_text = " or ")]</i>.")
+	create_explain_text("send a <b>component design disk</b> with one of the following designs via STD (found in <b>Devices and Tools</b>):<br><i>[english_list(targets_name, and_text = " or ")]</i>.")
 
 /datum/antag_contract/item/research/can_place()
 	return ..() && targets.len && counter < 3


### PR DESCRIPTION
Изменил описание контракта для триторов на кражу исследований.

close #6237

<details>
<summary>Чейнджлог</summary>

```yml
🆑
tweak: Изменил описание контракта на кражу исследований, а именно название нужного диска для выполнения контракта.
/🆑
```

</details>

- [x] Pull Request полностью завершен, мне не нужна помощь чтобы его закончить.
- [x] Я внимательно прочитал все свои изменения и багов в них не нашел.
- [ ] Я запускал сервер со своими изменениями локально и все протестировал.
- [x] Я ознакомился c [Guide to Contribute](https://github.com/ChaoticOnyx/OnyxBay/blob/dev/docs/contributing.md).
