### PR TITLE
fix(orion): Now updates properly.

### DIFF
--- a/code/game/machinery/computer/arcade_orion.dm
+++ b/code/game/machinery/computer/arcade_orion.dm
@@ -184,13 +184,14 @@
 			if(event == ORION_TRAIL_GAMEOVER)
 				event = null
 				attack_hand(user)
-				return TOPIC_REFRESH
+				. = TOPIC_REFRESH
+				//This used to be "return TOPIC_REFRESH". It wouldn't leave time for operations with the dot variable.
 			if(!settlers.len)
 				event_desc = "You and your crew were killed on the way to Orion, your ship left abandoned for scavengers to find."
 				next_event = ORION_TRAIL_GAMEOVER
 			if(port == 9)
 				win()
-				return TOPIC_REFRESH
+				. = TOPIC_REFRESH
 			var/travel = min(rand(1000,10000),distance)
 			if(href_list["fix"])
 				var/item = href_list["fix"]
@@ -231,34 +232,34 @@
 				generate_event(next_event)
 		else
 			view = ORION_VIEW_MAIN
-		return TOPIC_REFRESH
+		. = TOPIC_REFRESH
 
 	else if(href_list["supplies"])
 		view = ORION_VIEW_SUPPLIES
-		return TOPIC_REFRESH
+		. = TOPIC_REFRESH
 
 	else if(href_list["crew"])
 		view = ORION_VIEW_CREW
-		return TOPIC_REFRESH
+		. = TOPIC_REFRESH
 
 	else if(href_list["buy"])
 		var/item = href_list["buy"]
 		if(supply_cost["[item]"] <= supplies["6"])
 			supplies["[item]"] += (text2num(item) > 3 ? 10 : 1)
 			supplies["6"] -= supply_cost["[item]"]
-		return TOPIC_REFRESH
+		. = TOPIC_REFRESH
 
 	else if(href_list["sell"])
 		var/item = href_list["sell"]
 		if(supplies["[item]"] >= (text2num(item) > 3 ? 10 : 1))
 			supplies["6"] += supply_cost["[item]"]
 			supplies["[item]"] -= (text2num(item) > 3 ? 10 : 1)
-		return TOPIC_REFRESH
+		. = TOPIC_REFRESH
 
 	else if(href_list["kill"])
 		var/item = text2num(href_list["kill"])
 		remove_settler(item)
-		return TOPIC_REFRESH
+		. = TOPIC_REFRESH
 
 	else if(href_list["attack"])
 		supply_cost = list()
@@ -276,7 +277,7 @@
 				if(prob(10))
 					remove_settler(null, "died while you were escaping!")
 		event = ORION_TRAIL_SPACEPORT_RAIDED
-		return TOPIC_REFRESH
+		. = TOPIC_REFRESH
 
 	if(. == TOPIC_REFRESH)
 		attack_hand(user)


### PR DESCRIPTION
Какой-то умник решил, что return-ы не будут прерывать ход программы. Из-за такого финта ушами игнорировалась часть OnTopic(), которая обновляла окно игры после какого-либо действия игрока. Я просто заменил эти возвраты значения на изменение переменной для возврата - по идее теперь и функция возвращает что-то, и окно обновляется.

close #4256

<details>
<summary>Чейнджлог</summary>

```yml
🆑
tweak: Orion Trail теперь обновляется при каждом действий.
/🆑
```

</details>

- [x] Pull Request полностью завершен, мне не нужна помощь чтобы его закончить.
- [x] Я внимательно прочитал все свои изменения и багов в них не нашел.
- [x] Я запускал сервер со своими изменениями локально и все протестировал.
- [x] Я ознакомился c [Guide to Contribute](https://github.com/ChaoticOnyx/OnyxBay/blob/dev/docs/contributing.md).
