### PR TITLE
tweak(vampire): Changed memory loss message to alert

### DIFF
--- a/code/game/gamemodes/vampire/vampire_powers.dm
+++ b/code/game/gamemodes/vampire/vampire_powers.dm
@@ -155,7 +155,6 @@
 		if(T.stat != DEAD && vampire.stealth)
 			spawn()			//Spawned in the same manner the brain damage alert is, just so the proc keeps running without stops.
 				alert(T, "You remember NOTHING about the cause of your blackout. Instead, you remember having a pleasant encounter with [src.name].", "Bitten by a vampire")
-			// to_chat(T, SPAN("warning", FONT_LARGE("You remember nothing about the cause of blacked out. Instead, you simply remember having a pleasant encounter with [src.name]")))
 		else if(T.stat != DEAD)
 			spawn()
 				alert(T, "You remember everything that happened. Remember how blood was sucked from your neck. It gave you pleasure, like a pleasant dream. You feel great. How you react to [src.name]'s actions is up to you.", "Bitten by a vampire")

--- a/code/game/gamemodes/vampire/vampire_powers.dm
+++ b/code/game/gamemodes/vampire/vampire_powers.dm
@@ -153,9 +153,13 @@
 	if(target_aware)
 		T.paralysis = 0
 		if(T.stat != DEAD && vampire.stealth)
-			to_chat(T, SPAN("warning", FONT_LARGE("You remember nothing about the cause of blacked out. Instead, you simply remember having a pleasant encounter with [src.name]")))
+			spawn()			//Spawned in the same manner the brain damage alert is, just so the proc keeps running without stops.
+				alert(T, "You remember NOTHING about the cause of your blackout. Instead, you remember having a pleasant encounter with [src.name].", "Bitten by a vampire")
+			// to_chat(T, SPAN("warning", FONT_LARGE("You remember nothing about the cause of blacked out. Instead, you simply remember having a pleasant encounter with [src.name]")))
 		else if(T.stat != DEAD)
-			to_chat(T, SPAN("warning", FONT_LARGE("You remember everything that happened. Remember how blood was sucked from your neck. It gave you pleasure, like a pleasant dream. You feel great. How you react to [src.name]'s actions is up to you.")))
+			spawn()
+				alert(T, "You remember everything that happened. Remember how blood was sucked from your neck. It gave you pleasure, like a pleasant dream. You feel great. How you react to [src.name]'s actions is up to you.", "Bitten by a vampire")
+			// to_chat(T, SPAN("warning", FONT_LARGE("You remember everything that happened. Remember how blood was sucked from your neck. It gave you pleasure, like a pleasant dream. You feel great. How you react to [src.name]'s actions is up to you.")))
 	verbs -= /mob/living/carbon/human/proc/vampire_drain_blood
 	if(blood_drained <= 85)
 

--- a/code/game/gamemodes/vampire/vampire_powers.dm
+++ b/code/game/gamemodes/vampire/vampire_powers.dm
@@ -158,7 +158,6 @@
 		else if(T.stat != DEAD)
 			spawn()
 				alert(T, "You remember everything that happened. Remember how blood was sucked from your neck. It gave you pleasure, like a pleasant dream. You feel great. How you react to [src.name]'s actions is up to you.", "Bitten by a vampire")
-			// to_chat(T, SPAN("warning", FONT_LARGE("You remember everything that happened. Remember how blood was sucked from your neck. It gave you pleasure, like a pleasant dream. You feel great. How you react to [src.name]'s actions is up to you.")))
 	verbs -= /mob/living/carbon/human/proc/vampire_drain_blood
 	if(blood_drained <= 85)
 


### PR DESCRIPTION
В связи с жалобами Типса о том, что игроки слишком легко упускают из виду сообщение о потери памяти после того, как вампир высосал у них кровь, я слегка переиначил процесс: теперь это не сообщение в чате, а отдельное всплывающее окно как у повреждений мозга. Надеюсь, это будет значительно заметнее.

close #6290

<details>
<summary>Чейнджлог</summary>

```yml
🆑
tweak: Сообщение о потере памяти через укус вампира стало заметнее.
/🆑
```

</details>

- [ ] Pull Request полностью завершен, мне не нужна помощь чтобы его закончить.
- [x] Я внимательно прочитал все свои изменения и багов в них не нашел.
- [x] Я запускал сервер со своими изменениями локально и все протестировал.
- [x] Я ознакомился c [Guide to Contribute](https://github.com/ChaoticOnyx/OnyxBay/blob/dev/docs/contributing.md).
