### PR TITLE
fix(mech): Fixed falling of non-existent objects when leaving the mech

### DIFF
--- a/code/game/mecha/mecha.dm
+++ b/code/game/mecha/mecha.dm
@@ -1120,7 +1120,8 @@
 		return
 	for(var/item in dropped_items)
 		var/atom/movable/I = item
-		I.forceMove(loc)
+		if(I in contents)
+			I.forceMove(loc)
 	dropped_items.Cut()
 	if(mob_container.forceMove(src.loc))//ejecting mob container
 	/*


### PR DESCRIPTION
Многое говно с сборке реализовано через дроп с последующим удалением, например "Detach limb" из-за чего и возникал такой баг. Теперь идет проверка в content, что бы убедиться что этот объект действительно существует.

fix #6300

- [x] Pull Request полностью завершен, мне не нужна помощь чтобы его закончить.
- [x] Я внимательно прочитал все свои изменения и багов в них не нашел.
- [x] Я запускал сервер со своими изменениями локально и все протестировал.
- [x] Я ознакомился c [Guide to Contribute](https://github.com/ChaoticOnyx/OnyxBay/blob/dev/docs/contributing.md).
