### PR TITLE
fix(assembly).Removed the ability to remotely activate.

### DIFF
--- a/code/modules/assembly/signaler.dm
+++ b/code/modules/assembly/signaler.dm
@@ -71,6 +71,8 @@
 
 
 /obj/item/device/assembly/signaler/Topic(href, href_list, state = GLOB.physical_state)
+	if(!usr.get_active_hand(src) && !usr.get_inactive_hand(src))
+		return
 	if((. = ..()))
 		close_browser(usr, "window=radio")
 		onclose(usr, "radio")

--- a/code/modules/assembly/timer.dm
+++ b/code/modules/assembly/timer.dm
@@ -82,6 +82,8 @@
 
 
 /obj/item/device/assembly/timer/Topic(href, href_list, state = GLOB.physical_state)
+	if(!usr.get_active_hand(src) && !usr.get_inactive_hand(src))
+		return
 	if((. = ..()))
 		close_browser(usr, "window=timer")
 		onclose(usr, "timer")


### PR DESCRIPTION
close: #6214 

<details>
<summary>Чейнджлог</summary>

```yml
🆑
bugfix: Теперь для использования сигналлера и таймера нужно держать их в руке.
/🆑
```

</details>

- [x] Pull Request полностью завершен, мне не нужна помощь чтобы его закончить.
- [x] Я внимательно прочитал все свои изменения и багов в них не нашел.
- [x] Я запускал сервер со своими изменениями локально и все протестировал.
- [x] Я ознакомился c [Guide to Contribute](https://github.com/ChaoticOnyx/OnyxBay/blob/dev/docs/contributing.md).
