### PR TITLE
Чейнджлоги в окне браузера

### DIFF
--- a/code/controllers/configuration.dm
+++ b/code/controllers/configuration.dm
@@ -112,6 +112,7 @@ var/list/gamemode_cache = list()
 	var/discordurl
 	var/githuburl
 	var/patreonurl
+	var/changelogurl
 
 	var/minutetopiclimit
 	var/secondtopiclimit
@@ -568,6 +569,9 @@ var/list/gamemode_cache = list()
 
 				if ("patreonurl")
 					config.patreonurl = value
+
+				if ("changelogurl")
+					config.changelogurl = value
 
 				if ("ghosts_can_possess_animals")
 					config.ghosts_can_possess_animals = value

--- a/code/game/world.dm
+++ b/code/game/world.dm
@@ -71,7 +71,8 @@ var/server_name = "OnyxBay"
 /world/New()
 	SetupLogs()
 
-	changelog_hash = md5('html/changelog.html')					//used for telling if the changelog has changed recently
+	// Used for telling if the changelog has changed recently
+	changelog_hash = md5('html/changelogs/.all_changelog.json')
 
 	if(byond_version < RECOMMENDED_VERSION)
 		to_world_log("Your server's byond version does not meet the recommended requirements for this server. Please update BYOND")

--- a/code/modules/mob/mob.dm
+++ b/code/modules/mob/mob.dm
@@ -406,19 +406,6 @@
 	return
 */
 
-/client/verb/changes()
-	set name = "Changelog"
-	set category = "OOC"
-	getFiles(
-		'html/pie.htc',
-		'html/changelog.css',
-		'html/changelog.html'
-		)
-	show_browser(src, 'html/changelog.html', "window=changes;size=675x800")
-	if(prefs.lastchangelog != changelog_hash)
-		prefs.lastchangelog = changelog_hash
-		SScharacter_setup.queue_preferences_save(prefs)
-
 /mob/new_player/verb/observe()
 	set name = "Observe"
 	set category = "OOC"

--- a/code/modules/mob/new_player/login.dm
+++ b/code/modules/mob/new_player/login.dm
@@ -77,4 +77,4 @@
 	if(client.prefs.lastchangelog != changelog_hash)
 		to_chat(client, SPAN("info", "You have unread updates in the changelog."))
 		if(config.aggressive_changelog)
-			client.changes()
+			client.changelog()

--- a/config/example/config.txt
+++ b/config/example/config.txt
@@ -622,6 +622,9 @@ DEFAULT_NO_VOTE
 ## Patreon URL
 # PATREONURL http://example.com
 
+## Changelog URL
+# CHANGELOGURL http://example.com
+
 # # # # # # # # # # # # # # # # # # # # # #
 #     EXTERNAL CONNECTIONS / DATABASE     #
 # # # # # # # # # # # # # # # # # # # # # #

--- a/html/changelog.html
+++ b/html/changelog.html
@@ -5,7 +5,7 @@
     <meta http-equiv="X-UA-Compatible" content="IE=edge">
     <meta charset="utf-8">
     <title>Список изменений сервера Chaotic Onyx</title>
-    <link rel="stylesheet" type="text/css" href="font-awesome.css">
+    <link rel="stylesheet" href="https://pro.fontawesome.com/releases/v5.10.0/css/all.css" integrity="sha384-AYmEC3Yw5cVb3ZcuHtOA93w35dYTsvhLPVnYs9eStHfGJvOvKxVfELGroGkvsg+p" crossorigin="anonymous"/>
     <link rel="stylesheet" type="text/css" href="changelog.css">
     <base target="_blank" />
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8">

--- a/html/templates/changelog.tmpl
+++ b/html/templates/changelog.tmpl
@@ -5,7 +5,7 @@
     <meta http-equiv="X-UA-Compatible" content="IE=edge">
     <meta charset="utf-8">
     <title>Список изменений сервера Chaotic Onyx</title>
-    <link rel="stylesheet" type="text/css" href="font-awesome.css">
+    <link rel="stylesheet" href="https://pro.fontawesome.com/releases/v5.10.0/css/all.css" integrity="sha384-AYmEC3Yw5cVb3ZcuHtOA93w35dYTsvhLPVnYs9eStHfGJvOvKxVfELGroGkvsg+p" crossorigin="anonymous"/>
     <link rel="stylesheet" type="text/css" href="changelog.css">
     <base target="_blank" />
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8">

--- a/interface/interface.dm
+++ b/interface/interface.dm
@@ -3,61 +3,71 @@
 	set name = "Wiki"
 	set desc = "Visit the wiki."
 	set hidden = 1
-	if( config.wikiurl )
+	if(config.wikiurl)
 		send_link(src, config.wikiurl)
 	else
-		to_chat(src, "<span class='warning'>The wiki URL is not set in the server configuration.</span>")
+		to_chat(src, SPAN("warning", "The wiki URL is not set in the server configuration."))
 	return
 
 /client/verb/rules()
 	set name = "Rules"
 	set desc = "Show Server Rules."
 	set hidden = 1
-	if( config.rulesurl )
+	if(config.rulesurl)
 		send_link(src, config.rulesurl)
 	else
-		to_chat(src, "<span class='warning'>The rules URL is not set in the server configuration.</span>")
+		to_chat(src, SPAN("warning", "The rules URL is not set in the server configuration."))
 	return
 
 /client/verb/backstory()
 	set name = "Backstory"
 	set desc = "Show server Backstory."
 	set hidden = 1
-	if( config.backstoryurl )
+	if(config.backstoryurl)
 		send_link(src, config.backstoryurl)
 	else
-		to_chat(src, "<span class='warning'>The backstory URL is not set in the server configuration.</span>")
+		to_chat(src, SPAN("warning", "The backstory URL is not set in the server configuration."))
 	return
 
 /client/verb/forum()
 	set name = "Forum"
 	set desc = "Visit the forum."
 	set hidden = 1
-	if( config.forumurl )
+	if(config.forumurl)
 		send_link(src, config.forumurl)
 	else
-		to_chat(src, "<span class='warning'>The forum URL is not set in the server configuration.</span>")
+		to_chat(src, SPAN("warning", "The forum URL is not set in the server configuration."))
 	return
 
 /client/verb/discord()
 	set name = "Discord"
 	set desc = "Visit the community Discord."
 	set hidden = 1
-	if( config.discordurl )
+	if(config.discordurl)
 		send_link(src, config.discordurl)
 	else
-		to_chat(src, "<span class='warning'>The Discord URL is not set in the server configuration.</span>")
+		to_chat(src, SPAN("warning", "The Discord URL is not set in the server configuration."))
 	return
 
 /client/verb/bugreport()
 	set name = "Bug Report"
 	set desc = "Create bug report to developers."
 	set hidden = 1
-	if( config.githuburl )
+	if(config.githuburl)
 		send_link(src, "[config.githuburl]/issues")
 	else
-		to_chat(src, "<span class='warning'>The Github URL is not set in the server configuration.</span>")
+		to_chat(src, SPAN("warning", "The Github URL is not set in the server configuration."))
 	return
+
+/client/verb/changelog()
+	set name = "Changelog"
+	set category = "OOC"
+	
+
+	if(config.changelogurl)
+		send_link(src, "[config.changelogurl]")
+	else
+		to_chat(src, SPAN("warning", "The Github URL is not set in the server configuration."))
 
 /client/verb/hotkeys_help()
 	set name = "Hotkeys Help"


### PR DESCRIPTION
Добавлена опция в конфиге для указания ссылки на чейнджлог.

<details>
<summary>Чейнджлог</summary>

```yml
🆑
experiment: Чейнджлог теперь открывается в браузере.
/🆑
```

</details>

- [x] Pull Request полностью завершен, мне не нужна помощь чтобы его закончить.
- [x] Я внимательно прочитал все свои изменения и багов в них не нашел.
- [x] Я запускал сервер со своими изменениями локально и все протестировал.
- [x] Я ознакомился c [Guide to Contribute](https://github.com/ChaoticOnyx/OnyxBay/blob/dev/docs/contributing.md).
