### PR TITLE
fix(wizard): corrected sacrifice in spellbook

### DIFF
--- a/code/modules/spells/spellbook.dm
+++ b/code/modules/spells/spellbook.dm
@@ -265,6 +265,7 @@ var/list/artefact_feedback = list(/obj/structure/closet/wizard/armor = 		"HS",
 		if(uses > spellbook.max_uses)
 			spellbook.max_uses = uses
 		investing_time = 0
+		has_sacrificed = 0
 		STOP_PROCESSING(SSobj, src)
 	return 1
 


### PR DESCRIPTION
Добавил обновление "has_sacrificed" после завершения инвестиции слота заклинания.
Теперь жертвоприношение книге не одноразовое, как и должно быть.
Доказательство:

var/has_sacrificed = 0 //whether we have **already got** our sacrifice bonus **for the current** investment.


<details>
<summary>Чейнджлог</summary>

```yml
🆑
bugfix: Теперь жертвоприношение книге для сокращения времени получения слота заклинаний у мага не одноразовое, как и должно быть.
/🆑
```

</details>

- [x] Pull Request полностью завершен, мне не нужна помощь чтобы его закончить.
- [x] Я внимательно прочитал все свои изменения и багов в них не нашел.
- [x] Я запускал сервер со своими изменениями локально и все протестировал.
- [x] Я ознакомился c [Guide to Contribute](https://github.com/ChaoticOnyx/OnyxBay/blob/dev/docs/contributing.md).
