### PR TITLE
tweak(convert): adds restrictions on convert to cult

### DIFF
--- a/code/game/antagonist/alien/xenomorph.dm
+++ b/code/game/antagonist/alien/xenomorph.dm
@@ -1,5 +1,11 @@
 GLOBAL_DATUM_INIT(xenomorphs, /datum/antagonist/xenos, new)
 
+/proc/isXenomorph(mob/player)
+	if(!GLOB.xenomorphs || !player.mind)
+		return FALSE
+	if(player.mind in GLOB.xenomorphs.current_antagonists)
+		return TRUE
+
 /datum/antagonist/xenos
 	id = MODE_XENOMORPH
 	role_text = "Xenomorph"

--- a/code/game/antagonist/alien/xenomorph.dm
+++ b/code/game/antagonist/alien/xenomorph.dm
@@ -1,11 +1,5 @@
 GLOBAL_DATUM_INIT(xenomorphs, /datum/antagonist/xenos, new)
 
-/proc/isXenomorph(mob/player)
-	if(!GLOB.xenomorphs || !player.mind)
-		return FALSE
-	if(player.mind in GLOB.xenomorphs.current_antagonists)
-		return TRUE
-
 /datum/antagonist/xenos
 	id = MODE_XENOMORPH
 	role_text = "Xenomorph"

--- a/code/game/antagonist/outsider/wizard.dm
+++ b/code/game/antagonist/outsider/wizard.dm
@@ -1,11 +1,5 @@
 GLOBAL_DATUM_INIT(wizards, /datum/antagonist/wizard, new)
 
-/proc/isWizard(mob/player)
-	if(!GLOB.wizards || !player.mind)
-		return FALSE
-	if(player.mind in GLOB.wizards.current_antagonists)
-		return TRUE
-
 /datum/antagonist/wizard
 	id = MODE_WIZARD
 	role_text = "Space Wizard"
@@ -79,8 +73,6 @@ GLOBAL_DATUM_INIT(wizards, /datum/antagonist/wizard, new)
 	wizard.current.SetName(wizard.current.real_name)
 	wizard.current.mutations.Add(MUTATION_CLUMSY)
 	wizard.wizard = new()
-	wizard.current.add_language(LANGUAGE_CULT)
-
 
 /datum/antagonist/wizard/equip(mob/living/carbon/human/wizard_mob)
 

--- a/code/game/antagonist/outsider/wizard.dm
+++ b/code/game/antagonist/outsider/wizard.dm
@@ -1,5 +1,12 @@
 GLOBAL_DATUM_INIT(wizards, /datum/antagonist/wizard, new)
 
+/proc/isWizard(mob/player)
+	if(!GLOB.wizards || !player.mind)
+		return FALSE
+	if(player.mind in GLOB.wizards.current_antagonists)
+		return TRUE
+
+
 /datum/antagonist/wizard
 	id = MODE_WIZARD
 	role_text = "Space Wizard"
@@ -72,6 +79,7 @@ GLOBAL_DATUM_INIT(wizards, /datum/antagonist/wizard, new)
 	wizard.current.real_name = "[pick(GLOB.wizard_first)] [pick(GLOB.wizard_second)]"
 	wizard.current.SetName(wizard.current.real_name)
 	wizard.current.mutations.Add(MUTATION_CLUMSY)
+	wizard.current.add_language(LANGUAGE_CULT)
 	wizard.wizard = new()
 
 /datum/antagonist/wizard/equip(mob/living/carbon/human/wizard_mob)

--- a/code/game/antagonist/outsider/wizard.dm
+++ b/code/game/antagonist/outsider/wizard.dm
@@ -1,5 +1,11 @@
 GLOBAL_DATUM_INIT(wizards, /datum/antagonist/wizard, new)
 
+/proc/isWizard(mob/player)
+	if(!GLOB.wizards || !player.mind)
+		return FALSE
+	if(player.mind in GLOB.wizards.current_antagonists)
+		return TRUE
+
 /datum/antagonist/wizard
 	id = MODE_WIZARD
 	role_text = "Space Wizard"

--- a/code/game/antagonist/outsider/wizard.dm
+++ b/code/game/antagonist/outsider/wizard.dm
@@ -78,6 +78,7 @@ GLOBAL_DATUM_INIT(wizards, /datum/antagonist/wizard, new)
 	wizard.current.real_name = "[pick(GLOB.wizard_first)] [pick(GLOB.wizard_second)]"
 	wizard.current.SetName(wizard.current.real_name)
 	wizard.current.mutations.Add(MUTATION_CLUMSY)
+	wizard.current.add_language(LANGUAGE_CULT)
 
 /datum/antagonist/wizard/equip(mob/living/carbon/human/wizard_mob)
 

--- a/code/game/antagonist/station/changeling.dm
+++ b/code/game/antagonist/station/changeling.dm
@@ -1,5 +1,12 @@
 GLOBAL_DATUM_INIT(changelings, /datum/antagonist/changeling, new)
 
+/proc/isChangeling(mob/player)
+	if(!GLOB.changelings || !player.mind)
+		return FALSE
+	if(player.mind in GLOB.changelings.current_antagonists)
+		return TRUE
+
+
 /datum/antagonist/changeling
 	id = MODE_CHANGELING
 	role_text = "Changeling"

--- a/code/game/antagonist/station/changeling.dm
+++ b/code/game/antagonist/station/changeling.dm
@@ -1,12 +1,5 @@
 GLOBAL_DATUM_INIT(changelings, /datum/antagonist/changeling, new)
 
-/proc/isChangeling(mob/player)
-	if(!GLOB.changelings || !player.mind)
-		return FALSE
-	if(player.mind in GLOB.changelings.current_antagonists)
-		return TRUE
-
-
 /datum/antagonist/changeling
 	id = MODE_CHANGELING
 	role_text = "Changeling"

--- a/code/game/antagonist/station/changeling.dm
+++ b/code/game/antagonist/station/changeling.dm
@@ -1,5 +1,11 @@
 GLOBAL_DATUM_INIT(changelings, /datum/antagonist/changeling, new)
 
+/proc/isChangeling(mob/player)
+	if(!GLOB.changelings || !player.mind)
+		return FALSE
+	if(player.mind in GLOB.changelings.current_antagonists)
+		return TRUE
+
 /datum/antagonist/changeling
 	id = MODE_CHANGELING
 	role_text = "Changeling"

--- a/code/game/gamemodes/cult/runes.dm
+++ b/code/game/gamemodes/cult/runes.dm
@@ -242,7 +242,7 @@
 	else if(isChangeling(target))
 		to_chat(target, SPAN("changeling", "Powers of these filthy creatures does not have effect on us"))
 		return
-	else if(isXenomorph(usr))
+	else if(isXenomorph(target))
 		to_chat(target, SPAN_DANGER("Hive mind rejects offer of these creatures"))
 		return
 	else if(istype(target, /mob/living/carbon/alien/diona))

--- a/code/game/gamemodes/cult/runes.dm
+++ b/code/game/gamemodes/cult/runes.dm
@@ -238,7 +238,7 @@
 		GLOB.wizards.remove_antagonist(target.mind, TRUE)
 		GLOB.cult.add_antagonist(target.mind, ignore_role = TRUE, do_not_equip = TRUE)
 		for(var/mob/living/M in cultists)
-			to_chat(M, SPAN_DANGER("This person cant be converted. IT WAS A DEADLY MISTAKE"))
+			to_chat(M, SPAN_DANGER("This person cannot be converted. THIS WAS A DEADLY MISTAKE"))
 			M.gib()
 			return
 	else if(isChangeling(target))

--- a/code/game/gamemodes/cult/runes.dm
+++ b/code/game/gamemodes/cult/runes.dm
@@ -239,7 +239,7 @@
 			to_chat(M, SPAN_DANGER("You have tried to mess with the power beyond your level. IT WAS A DEADLY MISTAKE"))
 			M.gib()
 			return
-	else if(isChangeling(usr))
+	else if(isChangeling(target))
 		to_chat(target, SPAN("changeling", "Powers of these filthy creatures does not have effect on us"))
 		return
 	else if(isXenomorph(usr))

--- a/code/game/gamemodes/cult/runes.dm
+++ b/code/game/gamemodes/cult/runes.dm
@@ -233,8 +233,9 @@
 
 /obj/effect/rune/convert/proc/on_convert_success(list/mob/living/cultists, mob/living/carbon/target)
 	if(isWizard(target))
-		to_chat(target, SPAN_DANGER("Followers of the Blood God have tried to corrupt you. DEATH IS COMMING FOR THOSE FOOLS AND YOU"))
-		target.gib()
+		to_chat(target, SPAN_DANGER("Followers of the Blood God have tried to corrupt you. DEATH IS COMMING FOR THOSE FOOLS"))
+		GLOB.wizards.remove_antagonist(target.mind, TRUE)
+		GLOB.cult.add_antagonist(target.mind, ignore_role = TRUE, do_not_equip = TRUE)
 		for(var/mob/living/M in cultists)
 			to_chat(M, SPAN_DANGER("This person cant be converted. IT WAS A DEADLY MISTAKE"))
 			M.gib()

--- a/code/game/gamemodes/cult/runes.dm
+++ b/code/game/gamemodes/cult/runes.dm
@@ -205,28 +205,53 @@
 	spawn(30)
 		spamcheck = 0
 		if(!iscultist(target) && target.loc == get_turf(src) && GLOB.cult.can_become_antag(target.mind, 1) && cultists.len >= 2)
-			GLOB.cult.add_antagonist(target.mind, ignore_role = 1, do_not_equip = 1)
-		else // They hesitated, resisted, or can't join, and they are still on the rune - damage them
-			if(target.stat == CONSCIOUS)
-				target.take_overall_damage(10, 0)
-				switch(target.getFireLoss())
-					if(0 to 25)
-						to_chat(target, SPAN_DANGER("Your blood boils as you force yourself to resist the corruption invading every corner of your mind."))
-					if(25 to 45)
-						to_chat(target, SPAN_DANGER("Your blood boils and your body burns as the corruption further forces itself into your body and mind."))
-						target.take_overall_damage(3, 5)
-					if(45 to 75)
-						to_chat(target, SPAN_DANGER("You begin to hallucinate images of a dark and incomprehensible being and your entire body feels like its engulfed in flame as your mental defenses crumble."))
-						target.take_overall_damage(5, 10)
-					if(75 to 100)
-						to_chat(target, SPAN_OCCULT("Your mind turns to ash as the burning flames engulf your very soul and images of an unspeakable horror begin to bombard the last remnants of mental resistance."))
-						target.take_overall_damage(10, 20)
+			on_convert_success(cultists, target)
+		else
+			convert_penalty(target)
+
 
 /obj/effect/rune/convert/Topic(href, href_list)
 	var/list/mob/living/cultists = get_cultists()
 	if(href_list["join"] && cultists.len)
 		if(usr.loc == loc && !iscultist(usr))
-			GLOB.cult.add_antagonist(usr.mind, ignore_role = 1, do_not_equip = 1)
+			on_convert_success(cultists, usr)
+
+/obj/effect/rune/convert/proc/convert_penalty(mob/living/carbon/target)
+	if(target.stat == CONSCIOUS)
+		target.take_overall_damage(10, 0)
+		switch(target.getFireLoss())
+			if(0 to 25)
+				to_chat(target, SPAN_DANGER("Your blood boils as you force yourself to resist the corruption invading every corner of your mind."))
+			if(25 to 45)
+				to_chat(target, SPAN_DANGER("Your blood boils and your body burns as the corruption further forces itself into your body and mind."))
+				target.take_overall_damage(3, 5)
+			if(45 to 75)
+				to_chat(target, SPAN_DANGER("You begin to hallucinate images of a dark and incomprehensible being and your entire body feels like its engulfed in flame as your mental defenses crumble."))
+				target.take_overall_damage(5, 10)
+			if(75 to 100)
+				to_chat(target, SPAN_OCCULT("Your mind turns to ash as the burning flames engulf your very soul and images of an unspeakable horror begin to bombard the last remnants of mental resistance."))
+				target.take_overall_damage(10, 20)
+
+/obj/effect/rune/convert/proc/on_convert_success(list/mob/living/cultists, mob/living/carbon/target)
+	if(isWizard(target))
+		to_chat(target, SPAN_DANGER("Followers of the Blood God have tried to corrupt you. DEATH IS COMMING FOR THOSE FOOLS"))
+		GLOB.wizards.remove_antagonist(target.mind, TRUE)
+		GLOB.cult.add_antagonist(target.mind, ignore_role = TRUE, do_not_equip = TRUE)
+		for(var/mob/living/M in cultists)
+			to_chat(M, SPAN_DANGER("This person cant be converted. IT WAS A DEADLY MISTAKE"))
+			M.gib()
+			return
+	else if(isChangeling(target))
+		to_chat(target, SPAN("changeling", "We reject offer of these creatures"))
+		return
+	else if(isXenomorph(target))
+		to_chat(target, SPAN_DANGER("Hive mind rejects offer of those creatures"))
+		return
+	else if(istype(target, /mob/living/carbon/alien/diona))
+		to_chat(target, SPAN_DANGER("Hive mind rejects offer of those creatures"))
+		return
+	else
+		GLOB.cult.add_antagonist(target.mind, ignore_role = TRUE, do_not_equip = TRUE)
 
 /obj/effect/rune/teleport
 	cultname = "teleport"

--- a/code/game/gamemodes/cult/runes.dm
+++ b/code/game/gamemodes/cult/runes.dm
@@ -205,7 +205,21 @@
 	spawn(30)
 		spamcheck = 0
 		if(!iscultist(target) && target.loc == get_turf(src) && GLOB.cult.can_become_antag(target.mind, 1) && cultists.len >= 2)
-			GLOB.cult.add_antagonist(target.mind, ignore_role = 1, do_not_equip = 1)
+			if(isWizard(target))
+				to_chat(target, SPAN_DANGER("Your magick powers resists being corupted. DEATH IS COMMING FOR THESE FOOLS AND YOU"))
+				target.gib()
+				for(var/mob/living/M in cultists)
+					to_chat(M, SPAN_DANGER("You have tried to mess with the power beyond your level. IT WAS A DEADLY MISTAKE"))
+					M.gib()
+				return
+			else if(isChangeling(target))
+				to_chat(target, SPAN("changeling", "Powers of these filthy creatures does not have effect on us"))
+				return
+			else if(istype(target, /mob/living/carbon/alien/diona))
+				to_chat(target, SPAN_DANGER("Hive mind rejects offer off these creatures"))
+				return
+			else
+				GLOB.cult.add_antagonist(target.mind, ignore_role = 1, do_not_equip = 1)
 		else // They hesitated, resisted, or can't join, and they are still on the rune - damage them
 			if(target.stat == CONSCIOUS)
 				target.take_overall_damage(10, 0)
@@ -226,7 +240,20 @@
 	var/list/mob/living/cultists = get_cultists()
 	if(href_list["join"] && cultists.len)
 		if(usr.loc == loc && !iscultist(usr))
-			GLOB.cult.add_antagonist(usr.mind, ignore_role = 1, do_not_equip = 1)
+			if(isWizard(usr))
+				to_chat(usr, SPAN_DANGER("Your magick powers resists being corupted. DEATH IS COMMING FOR THESE FOOLS AND YOU"))
+				usr.gib()
+				for(var/mob/living/M in cultists)
+					to_chat(M, SPAN_DANGER("You have tried to mess with the power beyond your level. IT WAS A DEADLY MISTAKE"))
+					M.gib()
+			else if(isChangeling(usr))
+				to_chat(usr, SPAN("changeling", "Powers of these filthy creatures does not have effect on us"))
+				return
+			else if(istype(usr, /mob/living/carbon/alien/diona))
+				to_chat(usr, SPAN_DANGER("Hive mind rejects offer off these creatures"))
+				return
+			else
+				GLOB.cult.add_antagonist(usr.mind, ignore_role = 1, do_not_equip = 1)
 
 /obj/effect/rune/teleport
 	cultname = "teleport"

--- a/code/game/gamemodes/cult/runes.dm
+++ b/code/game/gamemodes/cult/runes.dm
@@ -233,20 +233,20 @@
 
 /obj/effect/rune/convert/proc/on_convert_success(list/mob/living/cultists, mob/living/carbon/target)
 	if(isWizard(target))
-		to_chat(target, SPAN_DANGER("Your magick powers resists being corupted. DEATH IS COMMING FOR THESE FOOLS AND YOU"))
+		to_chat(target, SPAN_DANGER("Followers of the Blood God have tried to corrupt you. DEATH IS COMMING FOR THOSE FOOLS AND YOU"))
 		target.gib()
 		for(var/mob/living/M in cultists)
-			to_chat(M, SPAN_DANGER("You have tried to mess with the power beyond your level. IT WAS A DEADLY MISTAKE"))
+			to_chat(M, SPAN_DANGER("This person cant be converted. IT WAS A DEADLY MISTAKE"))
 			M.gib()
 			return
 	else if(isChangeling(target))
-		to_chat(target, SPAN("changeling", "Powers of these filthy creatures does not have effect on us"))
+		to_chat(target, SPAN("changeling", "We reject offer of these creatures"))
 		return
 	else if(isXenomorph(target))
-		to_chat(target, SPAN_DANGER("Hive mind rejects offer of these creatures"))
+		to_chat(target, SPAN_DANGER("Hive mind rejects offer of those creatures"))
 		return
 	else if(istype(target, /mob/living/carbon/alien/diona))
-		to_chat(target, SPAN_DANGER("Hive mind rejects offer of these creatures"))
+		to_chat(target, SPAN_DANGER("Hive mind rejects offer of those creatures"))
 		return
 	else
 		GLOB.cult.add_antagonist(target.mind, ignore_role = TRUE, do_not_equip = TRUE)

--- a/code/game/gamemodes/cult/runes.dm
+++ b/code/game/gamemodes/cult/runes.dm
@@ -205,52 +205,28 @@
 	spawn(30)
 		spamcheck = 0
 		if(!iscultist(target) && target.loc == get_turf(src) && GLOB.cult.can_become_antag(target.mind, 1) && cultists.len >= 2)
-			on_convert_success(cultists, target)
-		else
-			convert_penalty(target)
+			GLOB.cult.add_antagonist(target.mind, ignore_role = 1, do_not_equip = 1)
+		else // They hesitated, resisted, or can't join, and they are still on the rune - damage them
+			if(target.stat == CONSCIOUS)
+				target.take_overall_damage(10, 0)
+				switch(target.getFireLoss())
+					if(0 to 25)
+						to_chat(target, SPAN_DANGER("Your blood boils as you force yourself to resist the corruption invading every corner of your mind."))
+					if(25 to 45)
+						to_chat(target, SPAN_DANGER("Your blood boils and your body burns as the corruption further forces itself into your body and mind."))
+						target.take_overall_damage(3, 5)
+					if(45 to 75)
+						to_chat(target, SPAN_DANGER("You begin to hallucinate images of a dark and incomprehensible being and your entire body feels like its engulfed in flame as your mental defenses crumble."))
+						target.take_overall_damage(5, 10)
+					if(75 to 100)
+						to_chat(target, SPAN_OCCULT("Your mind turns to ash as the burning flames engulf your very soul and images of an unspeakable horror begin to bombard the last remnants of mental resistance."))
+						target.take_overall_damage(10, 20)
 
 /obj/effect/rune/convert/Topic(href, href_list)
 	var/list/mob/living/cultists = get_cultists()
 	if(href_list["join"] && cultists.len)
 		if(usr.loc == loc && !iscultist(usr))
-			on_convert_success(cultists, usr)
-
-/obj/effect/rune/convert/proc/convert_penalty(mob/living/carbon/target)
-	if(target.stat == CONSCIOUS)
-		target.take_overall_damage(10, 0)
-		switch(target.getFireLoss())
-			if(0 to 25)
-				to_chat(target, SPAN_DANGER("Your blood boils as you force yourself to resist the corruption invading every corner of your mind."))
-			if(25 to 45)
-				to_chat(target, SPAN_DANGER("Your blood boils and your body burns as the corruption further forces itself into your body and mind."))
-				target.take_overall_damage(3, 5)
-			if(45 to 75)
-				to_chat(target, SPAN_DANGER("You begin to hallucinate images of a dark and incomprehensible being and your entire body feels like its engulfed in flame as your mental defenses crumble."))
-				target.take_overall_damage(5, 10)
-			if(75 to 100)
-				to_chat(target, SPAN_OCCULT("Your mind turns to ash as the burning flames engulf your very soul and images of an unspeakable horror begin to bombard the last remnants of mental resistance."))
-				target.take_overall_damage(10, 20)
-
-/obj/effect/rune/convert/proc/on_convert_success(list/mob/living/cultists, mob/living/carbon/target)
-	if(isWizard(target))
-		to_chat(target, SPAN_DANGER("Followers of the Blood God have tried to corrupt you. DEATH IS COMMING FOR THOSE FOOLS"))
-		GLOB.wizards.remove_antagonist(target.mind, TRUE)
-		GLOB.cult.add_antagonist(target.mind, ignore_role = TRUE, do_not_equip = TRUE)
-		for(var/mob/living/M in cultists)
-			to_chat(M, SPAN_DANGER("This person cant be converted. IT WAS A DEADLY MISTAKE"))
-			M.gib()
-			return
-	else if(isChangeling(target))
-		to_chat(target, SPAN("changeling", "We reject offer of these creatures"))
-		return
-	else if(isXenomorph(target))
-		to_chat(target, SPAN_DANGER("Hive mind rejects offer of those creatures"))
-		return
-	else if(istype(target, /mob/living/carbon/alien/diona))
-		to_chat(target, SPAN_DANGER("Hive mind rejects offer of those creatures"))
-		return
-	else
-		GLOB.cult.add_antagonist(target.mind, ignore_role = TRUE, do_not_equip = TRUE)
+			GLOB.cult.add_antagonist(usr.mind, ignore_role = 1, do_not_equip = 1)
 
 /obj/effect/rune/teleport
 	cultname = "teleport"

--- a/code/game/gamemodes/cult/runes.dm
+++ b/code/game/gamemodes/cult/runes.dm
@@ -205,55 +205,51 @@
 	spawn(30)
 		spamcheck = 0
 		if(!iscultist(target) && target.loc == get_turf(src) && GLOB.cult.can_become_antag(target.mind, 1) && cultists.len >= 2)
-			if(isWizard(target))
-				to_chat(target, SPAN_DANGER("Your magick powers resists being corupted. DEATH IS COMMING FOR THESE FOOLS AND YOU"))
-				target.gib()
-				for(var/mob/living/M in cultists)
-					to_chat(M, SPAN_DANGER("You have tried to mess with the power beyond your level. IT WAS A DEADLY MISTAKE"))
-					M.gib()
-				return
-			else if(isChangeling(target))
-				to_chat(target, SPAN("changeling", "Powers of these filthy creatures does not have effect on us"))
-				return
-			else if(istype(target, /mob/living/carbon/alien/diona))
-				to_chat(target, SPAN_DANGER("Hive mind rejects offer off these creatures"))
-				return
-			else
-				GLOB.cult.add_antagonist(target.mind, ignore_role = 1, do_not_equip = 1)
-		else // They hesitated, resisted, or can't join, and they are still on the rune - damage them
-			if(target.stat == CONSCIOUS)
-				target.take_overall_damage(10, 0)
-				switch(target.getFireLoss())
-					if(0 to 25)
-						to_chat(target, SPAN_DANGER("Your blood boils as you force yourself to resist the corruption invading every corner of your mind."))
-					if(25 to 45)
-						to_chat(target, SPAN_DANGER("Your blood boils and your body burns as the corruption further forces itself into your body and mind."))
-						target.take_overall_damage(3, 5)
-					if(45 to 75)
-						to_chat(target, SPAN_DANGER("You begin to hallucinate images of a dark and incomprehensible being and your entire body feels like its engulfed in flame as your mental defenses crumble."))
-						target.take_overall_damage(5, 10)
-					if(75 to 100)
-						to_chat(target, SPAN_OCCULT("Your mind turns to ash as the burning flames engulf your very soul and images of an unspeakable horror begin to bombard the last remnants of mental resistance."))
-						target.take_overall_damage(10, 20)
+			on_convert_success(cultists, target)
+		else
+			convert_penalty(target)
 
 /obj/effect/rune/convert/Topic(href, href_list)
 	var/list/mob/living/cultists = get_cultists()
 	if(href_list["join"] && cultists.len)
 		if(usr.loc == loc && !iscultist(usr))
-			if(isWizard(usr))
-				to_chat(usr, SPAN_DANGER("Your magick powers resists being corupted. DEATH IS COMMING FOR THESE FOOLS AND YOU"))
-				usr.gib()
-				for(var/mob/living/M in cultists)
-					to_chat(M, SPAN_DANGER("You have tried to mess with the power beyond your level. IT WAS A DEADLY MISTAKE"))
-					M.gib()
-			else if(isChangeling(usr))
-				to_chat(usr, SPAN("changeling", "Powers of these filthy creatures does not have effect on us"))
-				return
-			else if(istype(usr, /mob/living/carbon/alien/diona))
-				to_chat(usr, SPAN_DANGER("Hive mind rejects offer off these creatures"))
-				return
-			else
-				GLOB.cult.add_antagonist(usr.mind, ignore_role = 1, do_not_equip = 1)
+			on_convert_success(cultists, usr)
+
+/obj/effect/rune/convert/proc/convert_penalty(mob/living/carbon/target)
+	if(target.stat == CONSCIOUS)
+		target.take_overall_damage(10, 0)
+		switch(target.getFireLoss())
+			if(0 to 25)
+				to_chat(target, SPAN_DANGER("Your blood boils as you force yourself to resist the corruption invading every corner of your mind."))
+			if(25 to 45)
+				to_chat(target, SPAN_DANGER("Your blood boils and your body burns as the corruption further forces itself into your body and mind."))
+				target.take_overall_damage(3, 5)
+			if(45 to 75)
+				to_chat(target, SPAN_DANGER("You begin to hallucinate images of a dark and incomprehensible being and your entire body feels like its engulfed in flame as your mental defenses crumble."))
+				target.take_overall_damage(5, 10)
+			if(75 to 100)
+				to_chat(target, SPAN_OCCULT("Your mind turns to ash as the burning flames engulf your very soul and images of an unspeakable horror begin to bombard the last remnants of mental resistance."))
+				target.take_overall_damage(10, 20)
+
+/obj/effect/rune/convert/proc/on_convert_success(list/mob/living/cultists, mob/living/carbon/target)
+	if(isWizard(target))
+		to_chat(target, SPAN_DANGER("Your magick powers resists being corupted. DEATH IS COMMING FOR THESE FOOLS AND YOU"))
+		target.gib()
+		for(var/mob/living/M in cultists)
+			to_chat(M, SPAN_DANGER("You have tried to mess with the power beyond your level. IT WAS A DEADLY MISTAKE"))
+			M.gib()
+			return
+	else if(isChangeling(usr))
+		to_chat(target, SPAN("changeling", "Powers of these filthy creatures does not have effect on us"))
+		return
+	else if(isXenomorph(usr))
+		to_chat(target, SPAN_DANGER("Hive mind rejects offer of these creatures"))
+		return
+	else if(istype(target, /mob/living/carbon/alien/diona))
+		to_chat(target, SPAN_DANGER("Hive mind rejects offer of these creatures"))
+		return
+	else
+		GLOB.cult.add_antagonist(target.mind, ignore_role = TRUE, do_not_equip = TRUE)
 
 /obj/effect/rune/teleport
 	cultname = "teleport"


### PR DESCRIPTION
Добавил ограничение на вступление в культ различных существ: дион, генокрадов, магов
В связи с вводом насильного конверта и возможного абуза магами, который будет сложно отследить, культистов гиб и лишение способности мага, для ограничения желания рьяных культистов.

Добавил язык культа магу, так как если он захочет создавать конструкты то с новыми ограничениями никак не сможет их понять.

Прошлый ПР был успешно мной проебан, надеюсь этот не вызовет 12тысяч дифов

- [x] close  #1896
<details>
<summary>Чейнджлог</summary>

```yml
🆑
balance: Генокрад больше не может вступить в культ.
balance: Диона больше не может вступить в культ.
balance: Чужие больше не могут вступить в культ.
balance: При успешной конвертации мага в культ происходит гиб культистов и конвертация мага с потерей всех способностей.
tweak: Теперь маг понимает язык культистов.
/🆑
```

</details>

- [x] Pull Request полностью завершен, мне не нужна помощь чтобы его закончить.
- [x] Я внимательно прочитал все свои изменения и багов в них не нашел.
- [x] Я запускал сервер со своими изменениями локально и все протестировал.
- [x] Я ознакомился c [Guide to Contribute](https://github.com/ChaoticOnyx/OnyxBay/blob/dev/docs/contributing.md).
