### PR TITLE
tweak(changelog) readd changelog hash

### DIFF
--- a/code/game/world.dm
+++ b/code/game/world.dm
@@ -71,13 +71,12 @@ var/server_name = "OnyxBay"
 /world/New()
 	SetupLogs()
 
-	// Used for telling if the changelog has changed recently
-	changelog_hash = md5('html/changelogs/.all_changelog.json')
-
 	if(byond_version < RECOMMENDED_VERSION)
 		to_world_log("Your server's byond version does not meet the recommended requirements for this server. Please update BYOND")
 
 	load_configuration()
+
+	update_changelog()
 
 	if(config.server_port)
 		var/port = OpenPort(config.server_port)
@@ -111,6 +110,21 @@ var/server_name = "OnyxBay"
 
 	Master.Initialize(10, FALSE)
 	webhook_send_roundstatus("lobby", "[config.server_id]")
+
+/proc/update_changelog()
+	// black magic
+	// use sleep in world/New() will cause world termination, so we return control as soon as update changelog proc start http request and sleeps.
+	set waitfor = FALSE
+	_update_changelog()
+
+/proc/_update_changelog()
+	if(config.changelogurl)
+		var/list/changelog_http = world.Export(config.changelogurl)
+		if(changelog_http)
+			var/changelog_content = changelog_http["CONTENT"]
+			if(changelog_content)
+				// Used for telling if the changelog has changed recently
+				changelog_hash = md5(changelog_content)
 
 #undef RECOMMENDED_VERSION
 

--- a/interface/interface.dm
+++ b/interface/interface.dm
@@ -62,10 +62,13 @@
 /client/verb/changelog()
 	set name = "Changelog"
 	set category = "OOC"
-	
+
 
 	if(config.changelogurl)
 		send_link(src, "[config.changelogurl]")
+		if(prefs.lastchangelog != changelog_hash)
+			prefs.lastchangelog = changelog_hash
+			SScharacter_setup.queue_preferences_save(prefs)
 	else
 		to_chat(src, SPAN("warning", "The Github URL is not set in the server configuration."))
 


### PR DESCRIPTION
Многих игроков бесит, что при агрессивном ченджлоге им при каждом заходе открывают бразуер с ченджлогом.
Теперь (снова) есть хеш ченджлога и жопа боль прекратилась.
При кодинге была одна проблема, что в ворлд нью засыпал из-за world.Export, но я нашел решение.

<details>
<summary>Чейнджлог</summary>

```yml
🆑
tweak: В ченджлог возвращен хэш, теперь не будет открываться каждый раз
/🆑
```

</details>

- [x] Pull Request полностью завершен, мне не нужна помощь чтобы его закончить.
- [x] Я внимательно прочитал все свои изменения и багов в них не нашел.
- [x] Я запускал сервер со своими изменениями локально и все протестировал.
- [x] Я ознакомился c [Guide to Contribute](https://github.com/ChaoticOnyx/OnyxBay/blob/dev/docs/contributing.md).
