### PR TITLE
Фикс сохранения хэша чейнджлога

### DIFF
--- a/code/modules/mob/new_player/login.dm
+++ b/code/modules/mob/new_player/login.dm
@@ -61,6 +61,18 @@
 	else
 		deferred_login()
 
+/mob/new_player/proc/handle_changelog()
+	if(client.prefs.lastchangelog == changelog_hash)
+		return
+	
+	client.prefs.lastchangelog = changelog_hash
+	SScharacter_setup.queue_preferences_save(client.prefs)
+
+	to_chat(client, SPAN("info", "You have unread updates in the changelog."))
+
+	if(config.aggressive_changelog)
+		client.changelog()
+
 // This is called when the charcter setup system has been sufficiently initialized and prefs are available.
 // Do not make any calls in mob/Login which may require prefs having been loaded.
 // It is safe to assume that any UI or sound related calls will fall into that category.
@@ -72,9 +84,4 @@
 	client.playtitlemusic()
 
 	new_player_panel(TRUE)
-
-	// bolds the changelog button on the interface so we know there are updates.
-	if(client.prefs.lastchangelog != changelog_hash)
-		to_chat(client, SPAN("info", "You have unread updates in the changelog."))
-		if(config.aggressive_changelog)
-			client.changelog()
+	handle_changelog()


### PR DESCRIPTION
fixes #6427 

<details>
<summary>Чейнджлог</summary>

```yml
🆑
bugfix: Чейнджлог больше не открывается постоянно.
/🆑
```

</details>

- [x] Pull Request полностью завершен, мне не нужна помощь чтобы его закончить.
- [x] Я внимательно прочитал все свои изменения и багов в них не нашел.
- [x] Я запускал сервер со своими изменениями локально и все протестировал.
- [x] Я ознакомился c [Guide to Contribute](https://github.com/ChaoticOnyx/OnyxBay/blob/dev/docs/contributing.md).
