### PR TITLE
tweak(ai eye) fix moving on another z-level

### DIFF
--- a/code/datums/movement/mob.dm
+++ b/code/datums/movement/mob.dm
@@ -68,10 +68,11 @@
 		return
 	if(!mob.eyeobj)
 		return
-	var/turf/destination = (direction == UP) ? GetAbove(mob) : GetBelow(mob)
-	if(!destination)
-		to_chat(mob, SPAN("notice", "There is nothing of interest in this direction."))
-		return MOVEMENT_HANDLED
+	if(direction & (UP|DOWN))
+		var/turf/destination = (direction == UP) ? GetAbove(mob.eyeobj) : GetBelow(mob.eyeobj)
+		if(!destination)
+			to_chat(mob, SPAN("notice", "There is nothing of interest in this direction."))
+			return MOVEMENT_HANDLED
 	mob.eyeobj.EyeMove(direction)
 	return MOVEMENT_HANDLED
 


### PR DESCRIPTION
Оказывается, там нужно было не mobом перемещаться, mob.eye_obj, также сделал проверки только если направление вверх или вниз.

close #6461 

<details>
<summary>Чейнджлог</summary>

```yml
🆑
tweak: Теперь глаз ИИ может СВОБОДНО перемещаться по з-левелам станции.
/🆑
```

</details>

- [x] Pull Request полностью завершен, мне не нужна помощь чтобы его закончить.
- [x] Я внимательно прочитал все свои изменения и багов в них не нашел.
- [x] Я запускал сервер со своими изменениями локально и все протестировал.
- [x] Я ознакомился c [Guide to Contribute](https://github.com/ChaoticOnyx/OnyxBay/blob/dev/docs/contributing.md).
