### PR TITLE
Исправление раскрутки стульев ММИ. Сиквел

### DIFF
--- a/code/game/objects/structures/stool_bed_chair_nest/chairs.dm
+++ b/code/game/objects/structures/stool_bed_chair_nest/chairs.dm
@@ -89,8 +89,8 @@
 	if(!usr || !Adjacent(usr))
 		return
 
-	if(istype(usr, /mob/living/carbon/brain))
-		return
+	if(istype(usr, /mob/living/carbon/brain/incapacitated()))
+		return TRUE
 
 	if(usr.stat == DEAD)
 		var/area/A = get_area(src)

--- a/code/game/objects/structures/stool_bed_chair_nest/chairs.dm
+++ b/code/game/objects/structures/stool_bed_chair_nest/chairs.dm
@@ -89,6 +89,9 @@
 	if(!usr || !Adjacent(usr))
 		return
 
+	if(istype(usr, /mob/living/carbon/brain))
+		return
+
 	if(usr.stat == DEAD)
 		var/area/A = get_area(src)
 		if(A?.holy)

--- a/code/game/objects/structures/stool_bed_chair_nest/chairs.dm
+++ b/code/game/objects/structures/stool_bed_chair_nest/chairs.dm
@@ -89,9 +89,6 @@
 	if(!usr || !Adjacent(usr))
 		return
 
-	if(istype(usr, /mob/living/carbon/brain/incapacitated()))
-		return TRUE
-
 	if(usr.stat == DEAD)
 		var/area/A = get_area(src)
 		if(A?.holy)

--- a/code/modules/mob/living/carbon/brain/brain.dm
+++ b/code/modules/mob/living/carbon/brain/brain.dm
@@ -20,6 +20,9 @@
 		ghostize()		//Ghostize checks for key so nothing else is necessary.
 	. = ..()
 
+/mob/living/carbon/brain/incapacitated()
+	return TRUE
+
 /mob/living/carbon/brain/say_understands(other)//Goddamn is this hackish, but this say code is so odd
 	if (istype(other, /mob/living/silicon/ai))
 		if(!(container && istype(container, /obj/item/device/mmi)))


### PR DESCRIPTION
Теперь ММИ не могут крутить стулья через альт-клик (немного переделал, теперь ММИ были добавлены в список incapacitated)



<details>
<summary>Чейнджлог</summary>

```yml
🆑
bugfix: ММИ теперь не умеют крутить стулья
/🆑
```

</details>

close #3703

- [x] Pull Request полностью завершен, мне не нужна помощь чтобы его закончить.
- [x] Я внимательно прочитал все свои изменения и багов в них не нашел.
- [ ] Я запускал сервер со своими изменениями локально и все протестировал.
- [x] Я ознакомился c [Guide to Contribute](https://github.com/ChaoticOnyx/OnyxBay/blob/dev/docs/contributing.md).
