### PR TITLE
fix(emote-panel): collapse and vomit fixes

### DIFF
--- a/code/modules/emotes/definitions/_species.dm
+++ b/code/modules/emotes/definitions/_species.dm
@@ -48,7 +48,8 @@ GLOBAL_LIST_INIT(default_humanoid_emotes, list(
 	/decl/emote/audible/scream,
 	/decl/emote/audible/long_scream,
 	/decl/emote/audible/gasp,
-	/decl/emote/visible/faint))
+	/decl/emote/visible/faint,
+	/decl/emote/visible/collapse))
 
 GLOBAL_LIST_INIT(default_humanoid_emotes_proc, list(
 	/mob/proc/emote_pale,

--- a/code/modules/emotes/emotes_verb.dm
+++ b/code/modules/emotes/emotes_verb.dm
@@ -269,8 +269,12 @@
 /mob/proc/emote_vomit()
 	set name = "Induce vomit"
 	set category = "Emotes"
-	visible_message(SPAN("danger", "[src] puts two fingers in his mouth."))
-	usr.emote("vomit")
+	var/mob/living/carbon/human/H = src
+	if(H.isSynthetic())
+		visible_message(SPAN("danger", "[src] puts two fingers in his mouth, however nothing happens."))
+	else
+		visible_message(SPAN("danger", "[src] puts two fingers in his mouth."))
+		usr.emote("vomit")
 
 /mob/proc/emote_scratch()
 	set name = "Scratch"


### PR DESCRIPTION
Вернул *collapse, теперь всё работает как и должно.
При использовании *vomit синтами теперь не будет страшного текста с упоминанием *help.


close #6555
fix #6545
fix #6552
fix #6553

<details>
<summary>Чейнджлог</summary>

```yml
🆑Oubi
bugfix: Фиксы эмоут-панели
/🆑
```

</details>

- [x] Pull Request полностью завершен, мне не нужна помощь чтобы его закончить.
- [x] Я внимательно прочитал все свои изменения и багов в них не нашел.
- [x] Я запускал сервер со своими изменениями локально и все протестировал.
- [x] Я ознакомился c [Guide to Contribute](https://github.com/ChaoticOnyx/OnyxBay/blob/dev/docs/contributing.md).
