### PR TITLE
fix(paper): Now print of paper correctly updates icon

### DIFF
--- a/code/modules/paperwork/paper.dm
+++ b/code/modules/paperwork/paper.dm
@@ -126,8 +126,8 @@
 	if(!rawhtml)
 		info = html_encode(text)
 	info = parsepencode(info, is_init = TRUE)
-	update_icon()
 	update_space()
+	update_icon()
 	generateinfolinks()
 
 /obj/item/weapon/paper/update_icon()


### PR DESCRIPTION
Теперь печать бумаги на консолях корректно обновляет её иконку(наверно).

fix #6570 

<details>
<summary>Чейнджлог</summary>

```yml
🆑
bugfix: Теперь печать бумаги на консолях корректно обновляет её иконку.
/🆑
```

</details>

- [x] Pull Request полностью завершен, мне не нужна помощь чтобы его закончить.
- [x] Я внимательно прочитал все свои изменения и багов в них не нашел.
- [ ] Я запускал сервер со своими изменениями локально и все протестировал.
- [x] Я ознакомился c [Guide to Contribute](https://github.com/ChaoticOnyx/OnyxBay/blob/dev/docs/contributing.md).
