### PR TITLE
bugfix(ecig): fixed ecigs displaying on mobs

### DIFF
--- a/code/game/objects/items/weapons/ecigs.dm
+++ b/code/game/objects/items/weapons/ecigs.dm
@@ -34,6 +34,7 @@
 	icon_off = "ccigoff"
 	icon_empty = "ccigoff"
 	icon_on = "ccigon"
+	item_state = "ccigoff"
 
 /obj/item/clothing/mask/smokable/ecig/simple/examine(mob/user)
 	. = ..()
@@ -49,6 +50,7 @@
 	icon_off = "ecigoff1"
 	icon_empty = "ecigoff1"
 	icon_on = "ecigon"
+	item_state = "ecigoff1"
 	cell_type = /obj/item/weapon/cell/device/high //enough for four cartridges
 
 /obj/item/clothing/mask/smokable/ecig/util/New()
@@ -70,6 +72,7 @@
 	icon_off = "pcigoff1"
 	icon_empty = "pcigoff2"
 	icon_on = "pcigon"
+	item_state = "pcigoff1"
 	cell_type = /obj/item/weapon/cell/device/high //enough for four catridges
 
 /obj/item/clothing/mask/smokable/ecig/deluxe/examine(mob/user)


### PR DESCRIPTION
fix #6442

<details>
<summary>Чейнджлог</summary>

```yml
🆑
bugfix: Электронные сигареты теперь имеют нормальное отображение на мобах.
/🆑
```

</details>

- [x] Pull Request полностью завершен, мне не нужна помощь чтобы его закончить.
- [x] Я внимательно прочитал все свои изменения и багов в них не нашел.
- [x] Я запускал сервер со своими изменениями локально и все протестировал.
- [x] Я ознакомился c [Guide to Contribute](https://github.com/ChaoticOnyx/OnyxBay/blob/dev/docs/contributing.md).
