### PR TITLE
tweak(wizard): balances wizard classes

### DIFF
--- a/code/modules/clothing/spacesuits/void/wizard.dm
+++ b/code/modules/clothing/spacesuits/void/wizard.dm
@@ -7,22 +7,22 @@
 		slot_l_hand_str = "wiz_helm",
 		slot_r_hand_str = "wiz_helm",
 		)
-	unacidable = 1 //No longer shall our kind be foiled by lone chemists with spray bottles!
-	armor = list(melee = 40, bullet = 20, laser = 20,energy = 20, bomb = 35, bio = 100, rad = 60)
+	unacidable = TRUE //No longer shall our kind be foiled by lone chemists with spray bottles!
+	armor = list(melee = 40, bullet = 30, laser = 30, energy = 30, bomb = 35, bio = 100, rad = 60)
 	siemens_coefficient = 0.7
 	sprite_sheets_obj = null
-	wizard_garb = 1
+	wizard_garb = TRUE
 
 /obj/item/clothing/suit/space/void/wizard
 	icon_state = "rig-wiz"
 	name = "gem-encrusted voidsuit"
 	desc = "A bizarre gem-encrusted suit that radiates magical energies."
 	w_class = ITEM_SIZE_LARGE //normally voidsuits are bulky but this one is magic I suppose
-	unacidable = 1
-	armor = list(melee = 40, bullet = 20, laser = 20,energy = 20, bomb = 35, bio = 100, rad = 60)
+	unacidable = TRUE
+	armor = list(melee = 50, bullet = 30, laser = 30,energy = 30, bomb = 35, bio = 100, rad = 60)
 	siemens_coefficient = 0.7
 	sprite_sheets_obj = null
-	wizard_garb = 1
+	wizard_garb = TRUE
 	flags_inv = HIDESHOES|HIDEJUMPSUIT|HIDETAIL //For gloves.
 	body_parts_covered = UPPER_TORSO|LOWER_TORSO|LEGS|FEET|ARMS
 	cold_protection = UPPER_TORSO | LOWER_TORSO | LEGS | FEET | ARMS
@@ -42,13 +42,13 @@
 	..()
 	slowdown_per_slot[slot_wear_suit] = 0
 
-/obj/item/clothing/shoes/magboots/magic
+/obj/item/clothing/shoes/magboots/wizard
 	name = "magic magboots"
 	desc = "A pair of reinforced boots that radiate energy. They resemble regular magboots but don't seem to have any magnets."
 	icon_state = "magboots-magic0"
 	icon_base = "magboots-magic"
 	traction_system = "magic"
-	wizard_garb = 1
+	wizard_garb = TRUE
 
 /obj/item/clothing/gloves/wizard
 	name = "mystical gloves"
@@ -63,6 +63,6 @@
 	gender = PLURAL
 	gas_transfer_coefficient = 0.01
 	permeability_coefficient = 0.02
-	unacidable = 1
+	unacidable = TRUE
 	armor = list(melee = 40, bullet = 20, laser = 20,energy = 20, bomb = 35, bio = 100, rad = 60)
 	siemens_coefficient = 0.7

--- a/code/modules/mob/living/simple_animal/hostile/bat.dm
+++ b/code/modules/mob/living/simple_animal/hostile/bat.dm
@@ -31,6 +31,8 @@
 	faction = "scarybat"
 	var/mob/living/owner
 
+	stance = HOSTILE_STANCE_ALERT
+
 /mob/living/simple_animal/hostile/scarybat/New(loc, mob/living/L as mob)
 	..()
 	if(istype(L))

--- a/code/modules/mob/living/simple_animal/hostile/commanded/bear_companion.dm
+++ b/code/modules/mob/living/simple_animal/hostile/commanded/bear_companion.dm
@@ -1,6 +1,8 @@
 /mob/living/simple_animal/hostile/commanded/bear
 	name = "bear"
 	desc = "A large brown bear."
+	stance = HOSTILE_STANCE_ALERT
+
 
 	icon_state = "brownbear"
 	icon_living = "brownbear"

--- a/code/modules/mob/living/simple_animal/hostile/commanded/commanded.dm
+++ b/code/modules/mob/living/simple_animal/hostile/commanded/commanded.dm
@@ -8,19 +8,19 @@
 	var/list/known_commands = list("stay", "stop", "attack", "follow")
 	var/mob/master = null //undisputed master. Their commands hold ultimate sway and ultimate power.
 	var/list/allowed_targets = list() //WHO CAN I KILL D:
-	var/retribution = 1 //whether or not they will attack us if we attack them like some kinda dick.
+	var/retribution = TRUE //whether or not they will attack us if we attack them like some kinda dick.
 
 /mob/living/simple_animal/hostile/commanded/hear_say(message, verb = "says", datum/language/language = null, alt_name = "", italics = 0, mob/speaker = null, sound/speech_sound, sound_vol)
 	if((weakref(speaker) in friends) || speaker == master)
 		command_buffer.Add(speaker)
 		command_buffer.Add(lowertext(html_decode(message)))
-	return 0
+	return FALSE
 
 /mob/living/simple_animal/hostile/commanded/hear_radio(message, verb="says", datum/language/language=null, part_a, part_b, part_c, mob/speaker = null, hard_to_hear = 0)
 	if((weakref(speaker) in friends) || speaker == master)
 		command_buffer.Add(speaker)
 		command_buffer.Add(lowertext(html_decode(message)))
-	return 0
+	return FALSE
 
 /mob/living/simple_animal/hostile/commanded/Life()
 	while(command_buffer.len > 0)
@@ -73,7 +73,7 @@
 
 
 /mob/living/simple_animal/hostile/commanded/proc/follow_target()
-	stop_automated_movement = 1
+	stop_automated_movement = TRUE
 	if(!target_mob)
 		return
 	if(target_mob in ListTargets(10))
@@ -101,7 +101,7 @@
 				else
 					misc_command(speaker,text) //for specific commands
 
-	return 1
+	return TRUE
 
 //returns a list of everybody we wanna do stuff with.
 /mob/living/simple_animal/hostile/commanded/proc/get_targets_by_name(text, filter_friendlies = 0)
@@ -110,16 +110,16 @@
 	for(var/mob/M in possible_targets)
 		if(filter_friendlies && ((weakref(M) in friends) || M.faction == faction || M == master))
 			continue
-		var/found = 0
+		var/found = FALSE
 		if(findtext(text, "[M]"))
-			found = 1
+			found = TRUE
 		else
 			var/list/parsed_name = splittext(replace_characters(lowertext(html_decode("[M]")),list("-"=" ", "."=" ", "," = " ", "'" = " ")), " ") //this big MESS is basically 'turn this into words, no punctuation, lowercase so we can check first name/last name/etc'
 			for(var/a in parsed_name)
 				if(a == "the" || length(a) < 2) //get rid of shit words.
 					continue
 				if(findtext(text,"[a]"))
-					found = 1
+					found = TRUE
 					break
 		if(found)
 			. += M
@@ -127,7 +127,7 @@
 
 /mob/living/simple_animal/hostile/commanded/proc/attack_command(mob/speaker,text)
 	target_mob = null //want me to attack something? Well I better forget my old target.
-	walk_to(src,0)
+	walk_to(src, 0)
 	stance = HOSTILE_STANCE_IDLE
 	if(text == "attack" || findtext(text,"everyone") || findtext(text,"anybody") || findtext(text, "somebody") || findtext(text, "someone")) //if its just 'attack' then just attack anybody, same for if they say 'everyone', somebody, anybody. Assuming non-pickiness.
 		allowed_targets = list("everyone")//everyone? EVERYONE
@@ -140,17 +140,17 @@
 /mob/living/simple_animal/hostile/commanded/proc/stay_command(mob/speaker,text)
 	target_mob = null
 	stance = COMMANDED_STOP
-	stop_automated_movement = 1
-	walk_to(src,0)
+	stop_automated_movement = TRUE
+	walk_to(src, 0)
 	return 1
 
 /mob/living/simple_animal/hostile/commanded/proc/stop_command(mob/speaker,text)
 	allowed_targets = list()
-	walk_to(src,0)
+	walk_to(src, 0)
 	target_mob = null //gotta stop SOMETHIN
 	stance = HOSTILE_STANCE_IDLE
-	stop_automated_movement = 0
-	return 1
+	stop_automated_movement = FALSE
+	return TRUE
 
 /mob/living/simple_animal/hostile/commanded/proc/follow_command(mob/speaker,text)
 	//we can assume 'stop following' is handled by stop_command
@@ -165,10 +165,10 @@
 	stance = COMMANDED_FOLLOW //GOT SOMEBODY. BETTER FOLLOW EM.
 	target_mob = targets[1] //YEAH GOOD IDEA
 
-	return 1
+	return TRUE
 
 /mob/living/simple_animal/hostile/commanded/proc/misc_command(mob/speaker,text)
-	return 0
+	return FALSE
 
 
 /mob/living/simple_animal/hostile/commanded/hit_with_weapon(obj/item/O, mob/living/user, effective_force, hit_zone)

--- a/code/modules/spells/artifacts/storage.dm
+++ b/code/modules/spells/artifacts/storage.dm
@@ -21,7 +21,7 @@
 
 /obj/structure/closet/wizard/armor/New()
 	..()
-	new /obj/item/clothing/shoes/magboots/magic(src)
+	new /obj/item/clothing/shoes/magboots/wizard(src)
 	new /obj/item/clothing/gloves/wizard(src)//To complete the outfit
 	new /obj/item/clothing/suit/space/void/wizard(src)
 	new /obj/item/clothing/head/helmet/space/void/wizard(src)

--- a/code/modules/spells/classes/battlemage.dm
+++ b/code/modules/spells/classes/battlemage.dm
@@ -2,11 +2,11 @@
 	name = "Battlemage"
 	feedback_tag = "BM"
 	description = "Mix physical with the mystical in head to head combat."
-	points = 6
+	points = 7
 	can_make_contracts = TRUE
 
 	spells = list(
-		SPELL_DATA(/datum/spell/targeted/projectile/dumbfire/passage,  1),
+		SPELL_DATA(/datum/spell/mark_recall,                           1),
 		SPELL_DATA(/datum/spell/targeted/equip_item/dyrnwyn,           1),
 		SPELL_DATA(/datum/spell/targeted/equip_item/shield,            1),
 		SPELL_DATA(/datum/spell/targeted/projectile/dumbfire/fireball, 1),

--- a/code/modules/spells/classes/druid.dm
+++ b/code/modules/spells/classes/druid.dm
@@ -2,7 +2,7 @@
 	name = "Druid"
 	feedback_tag = "DL"
 	description = "Summons, nature, and a bit o' healin."
-	points = 6
+	points = 8
 	can_make_contracts = TRUE
 
 	spells = list(

--- a/code/modules/spells/classes/spatial.dm
+++ b/code/modules/spells/classes/spatial.dm
@@ -2,14 +2,12 @@
 	name = "Spatial"
 	feedback_tag = "SP"
 	description = "Movement and teleportation. Run from your problems!"
-	points = 11
+	points = 9
 	can_make_contracts = TRUE
 
 	spells = list(
 		SPELL_DATA(/datum/spell/targeted/ethereal_jaunt,              1),
-		SPELL_DATA(/datum/spell/aoe_turf/blink,                       1),
 		SPELL_DATA(/datum/spell/area_teleport,                        1),
-		SPELL_DATA(/datum/spell/targeted/projectile/dumbfire/passage, 1),
 		SPELL_DATA(/datum/spell/mark_recall,                          1),
 		SPELL_DATA(/datum/spell/targeted/swap,                        1),
 		SPELL_DATA(/datum/spell/targeted/shapeshift/avian,            1),

--- a/code/modules/spells/classes/standard.dm
+++ b/code/modules/spells/classes/standard.dm
@@ -2,13 +2,13 @@
 	name = "Standard"
 	feedback_tag = "SB"
 	description = "All its spells are easy to use but hard to master."
-	points = 6
+	points = 8
 	can_make_contracts = TRUE
 
 	spells = list(
 		SPELL_DATA(/datum/spell/targeted/projectile/magic_missile,     1),
-		SPELL_DATA(/datum/spell/acid_spray,                            0),
-		SPELL_DATA(/datum/spell/hand/slippery_surface,                 0),
+		SPELL_DATA(/datum/spell/acid_spray,                            1),
+		SPELL_DATA(/datum/spell/hand/slippery_surface,                 1),
 		SPELL_DATA(/datum/spell/targeted/projectile/dumbfire/fireball, 1),
 		SPELL_DATA(/datum/spell/targeted/disintegrate,                 2),
 		SPELL_DATA(/datum/spell/aoe_turf/disable_tech,                 1),

--- a/code/modules/spells/classes/warlock.dm
+++ b/code/modules/spells/classes/warlock.dm
@@ -7,9 +7,9 @@
 
 	spells = list(
 		SPELL_DATA(/datum/spell/targeted/projectile/magic_missile,     1),
-		SPELL_DATA(/datum/spell/hand/charges/blood_shard,              0),
-		SPELL_DATA(/datum/spell/acid_spray,                            0),
-		SPELL_DATA(/datum/spell/hand/slippery_surface,                 0),
+		SPELL_DATA(/datum/spell/hand/charges/blood_shard,              1),
+		SPELL_DATA(/datum/spell/acid_spray,                            1),
+		SPELL_DATA(/datum/spell/hand/slippery_surface,                 1),
 		SPELL_DATA(/datum/spell/targeted/projectile/dumbfire/fireball, 1),
 		SPELL_DATA(/datum/spell/targeted/disintegrate,                 2),
 		SPELL_DATA(/datum/spell/aoe_turf/smoke,                        1),


### PR DESCRIPTION
Правим баланс магу, убрал бесплатные заклинания которые в конечном итоге приводили к некоторому дизбалансу, а именно армии последователей с десантом в оружейную и выпилом всего живого. Теперь все заклинания стоят минимум 1 очков навыков, добавил несколько поинтов различным классам, поменял пассаж у боевого мага на марк энд рекалл. немного баффнул броню ему, сделал саммонов друида агрессивными сразу первыми они не атакуют, но если подойти близко то загрызут.  

- [x] #6361
- [x] #6357
- [x] #6358
- [x] #6359
- [x] #6360


<details>
<summary>Чейнджлог</summary>

```yml
🆑
balance: Перераспределены очки навыков для мага: Druid - 8, Spatial - 9, Battlemage - 7, Standard  - 8.
balance: Усилена броня боевого мага.
balance: Теперь саммоны друида будут более агрессивны. 
balance: Убраны бесплатные заклинания у мага, минимальная цена - 1.
balance: У Battlemage убран навык Passage и заменен на Mark and Recall
balance: Spattial потерял способности Passage и Blink.
/🆑
```

</details>

- [x] Pull Request полностью завершен, мне не нужна помощь чтобы его закончить.
- [x] Я внимательно прочитал все свои изменения и багов в них не нашел.
- [x] Я запускал сервер со своими изменениями локально и все протестировал.
- [x] Я ознакомился c [Guide to Contribute](https://github.com/ChaoticOnyx/OnyxBay/blob/dev/docs/contributing.md).
