### PR TITLE
fix(xenoarcheaology): now suspension field generator correctly works with research cyborg

### DIFF
--- a/code/modules/xenoarcheaology/tools/suspension_generator.dm
+++ b/code/modules/xenoarcheaology/tools/suspension_generator.dm
@@ -25,7 +25,7 @@
 			M.weakened = max(M.weakened, 3)
 			cell.use(power_use * CELLRATE)
 			if(prob(5))
-				to_chat(M, "<span class='warning'>[pick("You feel tingly","You feel like floating","It is hard to speak","You can barely move")].</span>")
+				to_chat(M, SPAN("warning", "[pick("You feel tingly","You feel like floating","It is hard to speak","You can barely move")]."))
 
 		for(var/obj/item/I in T)
 			if(!suspension_field.contents.len)
@@ -63,7 +63,7 @@
 
 	dat += "<hr>"
 	dat += "<hr>"
-	dat += "<span class='info'><b>Always wear safety gear and consult a field manual before operation.</b></span><br>"
+	dat += SPAN("info", "<b>Always wear safety gear and consult a field manual before operation.</b><br>")
 	if(!locked)
 		dat += "<A href='?src=\ref[src];lock=1'>Lock console</A><br>"
 	else
@@ -80,20 +80,24 @@
 				if(anchored)
 					activate()
 				else
-					to_chat(user, "<span class='warning'>You are unable to activate [src] until it is properly secured on the ground.</span>")
+					to_chat(user, SPAN("warning", "You are unable to activate [src] until it is properly secured on the ground."))
 		else
 			deactivate()
 		. = TOPIC_REFRESH
 	else if(href_list["insertcard"])
 		var/obj/item/I = user.get_active_hand()
-		if (istype(I, /obj/item/weapon/card))
+		if(istype(I, /obj/item/weapon/card))
+			if(issilicon(user))
+				attackby(I, user)
+				interact(user)
+				return TOPIC_REFRESH
 			user.drop_item()
 			I.forceMove(src)
 			auth_card = I
 			if(attempt_unlock(I, user))
-				to_chat(user, "<span class='info'>You insert [I], the console flashes \'<i>Access granted.</i>\'</span>")
+				to_chat(user, SPAN("info", "You insert [I], the console flashes \'<i>Access granted.</i>\'"))
 			else
-				to_chat(user, "<span class='warning'>You insert [I], the console flashes \'<i>Access denied.</i>\'</span>")
+				to_chat(user, SPAN("warning", "You insert [I], the console flashes \'<i>Access denied.</i>\'"))
 		. = TOPIC_REFRESH
 	else if(href_list["ejectcard"])
 		if(auth_card)
@@ -126,7 +130,7 @@
 
 		icon_state = "suspension0"
 		cell = null
-		to_chat(user, "<span class='info'>You remove the power cell</span>")
+		to_chat(user, SPAN("info", "You remove the power cell."))
 
 /obj/machinery/suspension_gen/attackby(obj/item/weapon/W as obj, mob/user as mob)
 	if(!locked && !suspension_field && default_deconstruction_screwdriver(user, W))
@@ -137,38 +141,38 @@
 				anchored = 0
 			else
 				anchored = 1
-			to_chat(user, "<span class='info'>You wrench the stabilising legs [anchored ? "into place" : "up against the body"].</span>")
+			to_chat(user, SPAN("info", "You wrench the stabilising legs [anchored ? "into place" : "up against the body"]."))
 			if(anchored)
 				desc = "It is resting securely on four stubby legs."
 			else
 				desc = "It has stubby legs bolted up against it's body for stabilising."
 		else
-			to_chat(user, "<span class='warning'>You are unable to secure [src] while it is active!</span>")
+			to_chat(user, SPAN("warning", "You are unable to secure [src] while it is active!"))
 	else if (istype(W, /obj/item/weapon/cell))
 		if(panel_open)
 			if(cell)
-				to_chat(user, "<span class='warning'>There is a power cell already installed.</span>")
+				to_chat(user, SPAN("warning", "There is a power cell already installed."))
 			else
 				user.drop_item()
 				W.forceMove(src)
 				cell = W
-				to_chat(user, "<span class='info'>You insert the power cell.</span>")
+				to_chat(user, SPAN("info", "You insert the power cell."))
 				icon_state = "suspension1"
 	else if(istype(W, /obj/item/weapon/card))
 		var/obj/item/weapon/card/I = W
 		if(!auth_card)
 			if(attempt_unlock(I, user))
-				to_chat(user, "<span class='info'>You swipe [I], the console flashes \'<i>Access granted.</i>\'</span>")
+				to_chat(user, SPAN("info", "You swipe [I], the console flashes \'<i>Access granted.</i>\'"))
 			else
-				to_chat(user, "<span class='warning'>You swipe [I], console flashes \'<i>Access denied.</i>\'</span>")
+				to_chat(user, SPAN("warning", "You swipe [I], the console flashes \'<i>Access denied.</i>\'"))
 		else
-			to_chat(user, "<span class='warning'>Remove [auth_card] first.</span>")
+			to_chat(user, SPAN("warning", "Remove [auth_card] first."))
 
 /obj/machinery/suspension_gen/proc/attempt_unlock(obj/item/weapon/card/C, mob/user)
 	if(!panel_open)
 		if(istype(C, /obj/item/weapon/card/emag))
 			C.resolve_attackby(src, user)
-		else if(istype(C, /obj/item/weapon/card/id) && check_access(C))
+		else if(istype(C, /obj/item/weapon/card/id) && check_access(C) || istype(C, /obj/item/weapon/card/robot))
 			locked = 0
 		if(!locked)
 			return 1
@@ -185,10 +189,13 @@
 
 	for(var/mob/living/M in T)
 		M.weakened += 5
-		M.visible_message("<span class='notice'>\icon[M] [M] begins to float in the air!</span>","You feel tingly and light, but it is difficult to move.")
+		M.visible_message(
+			SPAN("notice", "\icon[M] [M] begins to float in the air!"),
+			SPAN("notice", "You feel tingly and light, but it is difficult to move.")
+		)
 
 	suspension_field = new(T)
-	src.visible_message("<span class='notice'>\icon[src] [src] activates with a low hum.</span>")
+	src.visible_message(SPAN("notice", "\icon[src] [src] activates with a low hum."))
 	icon_state = "suspension3"
 
 	for(var/obj/item/I in T)
@@ -198,7 +205,7 @@
 	if(collected)
 		suspension_field.icon_state = "energynet"
 		suspension_field.overlays += "shield2"
-		src.visible_message("<span class='notice'>\icon[suspension_field] [suspension_field] gently absconds [collected > 1 ? "something" : "several things"].</span>")
+		src.visible_message(SPAN("notice", "\icon[suspension_field] [suspension_field] gently absconds [collected > 1 ? "something" : "several things"]."))
 	else
 		if(istype(T,/turf/simulated/mineral) || istype(T,/turf/simulated/wall))
 			suspension_field.icon_state = "shieldsparkles"
@@ -210,10 +217,10 @@
 	var/turf/T = get_turf(suspension_field)
 
 	for(var/mob/living/M in T)
-		to_chat(M, "<span class='info'>You no longer feel like floating.</span>")
+		to_chat(M, SPAN("info", "You no longer feel like floating."))
 		M.weakened = min(M.weakened, 3)
 
-	src.visible_message("<span class='notice'>\icon[src] [src] deactivates with a gentle shudder.</span>")
+	src.visible_message(SPAN("notice", "\icon[src] [src] deactivates with a gentle shudder."))
 	qdel(suspension_field)
 	suspension_field = null
 	icon_state = "suspension2"
@@ -228,7 +235,7 @@
 	set category = "Object"
 
 	if(anchored)
-		to_chat(usr, "<span class='warning'>You cannot rotate [src], it has been firmly fixed to the floor.</span>")
+		to_chat(usr, SPAN("warning", "You cannot rotate [src], it has been firmly fixed to the floor."))
 	else
 		set_dir(turn(dir, 90))
 
@@ -238,7 +245,7 @@
 	set category = "Object"
 
 	if(anchored)
-		to_chat(usr, "<span class='warning'>You cannot rotate [src], it has been firmly fixed to the floor.</span>")
+		to_chat(usr, SPAN("warning", "You cannot rotate [src], it has been firmly fixed to the floor."))
 	else
 		set_dir(turn(dir, -90))
 


### PR DESCRIPTION
Добавлен код для обработки карты научного киборга.
Спаны заменены макросом.

close #2602 

<details>
<summary>Чейнджлог</summary>

```yml
🆑
bugfix: Генератор поля для археологии больше не съедает и не дублирует карту научного киборга.
bugfix: Научные киборги теперь могут пользоваться археологическим генератором поля.
/🆑
```

</details>


- [x] Pull Request полностью завершен, мне не нужна помощь чтобы его закончить.
- [x] Я внимательно прочитал все свои изменения и багов в них не нашел.
- [x] Я запускал сервер со своими изменениями локально и все протестировал.
- [x] Я ознакомился c [Guide to Contribute](https://github.com/ChaoticOnyx/OnyxBay/blob/dev/docs/contributing.md).
