### PR TITLE
fix(silicon): research manipulator can pick more item types

### DIFF
--- a/code/modules/mob/living/silicon/robot/drone/drone_items.dm
+++ b/code/modules/mob/living/silicon/robot/drone/drone_items.dm
@@ -160,11 +160,15 @@
 		/obj/item/mecha_parts,
 		/obj/item/weapon/computer_hardware,
 		/obj/item/device/transfer_valve,
-		/obj/item/device/assembly/signaler,
-		/obj/item/device/assembly/timer,
-		/obj/item/device/assembly/igniter,
-		/obj/item/device/assembly/infra,
+		/obj/item/device/assembly,
+		/obj/item/device/healthanalyzer,
+		/obj/item/device/analyzer/plant_analyzer,
+		/obj/item/weapon/material/minihoe,
+		/obj/item/weapon/storage/firstaid,
+		/obj/item/weapon/storage/toolbox,
 		/obj/item/weapon/tank,
+		/obj/item/weapon/smes_coil,
+		/obj/item/weapon/disk,
 		/obj/item/weapon/paper
 		)
 


### PR DESCRIPTION
В `can_hold` научного манипулятора добавлены вещи, необходимые для научной работы и постройки ботов и машинерии, за исключением ботов СБ.

close #4542

<details>
<summary>Чейнджлог</summary>

```yml
🆑
tweak: Научный киборг теперь может строить почти всех ботов(кроме СБ) и машинерию, а также переносить инфодиски.
/🆑
```

</details>

- [x] Pull Request полностью завершен, мне не нужна помощь чтобы его закончить.
- [x] Я внимательно прочитал все свои изменения и багов в них не нашел.
- [x] Я запускал сервер со своими изменениями локально и все протестировал.
- [x] Я ознакомился c [Guide to Contribute](https://github.com/ChaoticOnyx/OnyxBay/blob/dev/docs/contributing.md).
