### PR TITLE
Фикс дюпа при выходе из мехов

### DIFF
--- a/code/game/mecha/mecha.dm
+++ b/code/game/mecha/mecha.dm
@@ -1105,8 +1105,10 @@
 /obj/mecha/proc/go_out()
 	if(!src.occupant) return
 	var/atom/movable/mob_container
+	var/list/onmob_items //prevents duplication of objects with which the human interacted in the mech
 	if(ishuman(occupant))
 		mob_container = src.occupant
+		onmob_items = occupant.get_equipped_items(TRUE)
 	else if(istype(occupant, /mob/living/carbon/brain))
 		var/mob/living/carbon/brain/brain = occupant
 		mob_container = brain.container
@@ -1114,6 +1116,8 @@
 		return
 	for(var/item in dropped_items)
 		var/atom/movable/I = item
+		if(ishuman(occupant) && is_type_in_list(I, onmob_items))
+			break
 		I.forceMove(loc)
 	dropped_items.Cut()
 	if(mob_container.forceMove(src.loc))//ejecting mob container

--- a/code/game/mecha/mecha.dm
+++ b/code/game/mecha/mecha.dm
@@ -1117,7 +1117,7 @@
 	for(var/item in dropped_items)
 		var/atom/movable/I = item
 		if(ishuman(occupant) && is_type_in_list(I, onmob_items))
-			break
+			continue
 		I.forceMove(loc)
 	dropped_items.Cut()
 	if(mob_container.forceMove(src.loc))//ejecting mob container


### PR DESCRIPTION
close:  #5923

<details>
<summary>Чейнджлог</summary>

```yml
🆑
bugfix: При выходе из меха с вещами в руках больше не появляется дубликат предмета около меха.
/🆑
```

</details>


- [x] Pull Request полностью завершен, мне не нужна помощь чтобы его закончить.
- [x] Я внимательно прочитал все свои изменения и багов в них не нашел.
- [x] Я запускал сервер со своими изменениями локально и все протестировал.
- [x] Я ознакомился c [Guide to Contribute](https://github.com/ChaoticOnyx/OnyxBay/blob/dev/docs/contributing.md).
