### PR TITLE
Bugfix(chair): holodeck metal dupe fix && folding chairs behind glass

### DIFF
--- a/code/game/objects/structures/stool_bed_chair_nest/chairs.dm
+++ b/code/game/objects/structures/stool_bed_chair_nest/chairs.dm
@@ -162,6 +162,8 @@
 /obj/structure/bed/chair/proc/fold(mob/user)
 	if(!foldable)
 		return
+	if(!user.Adjacent(src))
+		return
 
 	var/list/collapse_message = list(SPAN_WARNING("\The [src.name] has collapsed!"), null)
 

--- a/code/modules/holodeck/HolodeckObjects.dm
+++ b/code/modules/holodeck/HolodeckObjects.dm
@@ -199,9 +199,48 @@
 	return ..()
 
 /obj/structure/bed/chair/holochair/attackby(obj/item/weapon/W, mob/user)
-	if(istype(W, /obj/item/weapon/wrench))
-		to_chat(user, ("<span class='notice'>It's a holochair, you can't dismantle it!</span>"))
+	if(isWrench(W))
+		to_chat(user, SPAN("notice", "It's a holochair, you can't dismantle it!"))
 	return
+
+/obj/structure/bed/chair/holochair/fold(mob/user)
+	if(!foldable)
+		return
+
+	var/list/collapse_message = list(SPAN_WARNING("\The [src.name] has collapsed!"), null)
+
+	if(buckled_mob)
+		collapse_message = list(\
+			SPAN_WARNING("[buckled_mob] falls down [user ? "as [user] collapses" : "from collapsing"] \the [src.name]!"),\
+			user ? SPAN_NOTICE("You collapse \the [src.name] and made [buckled_mob] fall down!") : null)
+
+		var/mob/living/occupant = unbuckle_mob()
+		var/blocked = occupant.run_armor_check(BP_GROIN, "melee")
+
+		occupant.apply_effect(4, STUN, blocked)
+		occupant.apply_effect(4, WEAKEN, blocked)
+		occupant.apply_damage(rand(5,10), BRUTE, BP_GROIN, blocked)
+		playsound(src, 'sound/effects/fighting/punch1.ogg', 50, 1, -1)
+	else if(user)
+		collapse_message = list("[user] collapses \the [src.name].", "You collapse \the [src.name].")
+
+	visible_message(collapse_message[1], collapse_message[2])
+	var/obj/item/weapon/foldchair/holochair/O = new /obj/item/weapon/foldchair/holochair(get_turf(src))
+	if(user)
+		O.add_fingerprint(user)
+	QDEL_IN(src, 0)
+
+/obj/item/weapon/foldchair/holochair/attackby(obj/item/weapon/W as obj, mob/user as mob)
+	if(isWrench(W))
+		to_chat(user,SPAN("notice", "It's a holochair, you can't dismantle it!"))
+
+/obj/item/weapon/foldchair/holochair/attack_self(mob/user)
+	var/obj/structure/bed/chair/holochair/O = new /obj/structure/bed/chair/holochair(user.loc)
+	O.add_fingerprint(user)
+	O.dir = user.dir
+	O.update_icon()
+	visible_message("[user] unfolds \the [O.name].")
+	qdel(src)
 
 /obj/item/weapon/holo
 	damtype = PAIN

--- a/code/modules/holodeck/HolodeckObjects.dm
+++ b/code/modules/holodeck/HolodeckObjects.dm
@@ -207,12 +207,12 @@
 	if(!foldable)
 		return
 
-	var/list/collapse_message = list(SPAN_WARNING("\The [src.name] has collapsed!"), null)
+	var/list/collapse_message = list(SPAN_WARNING("\The [name] has collapsed!"), null)
 
 	if(buckled_mob)
 		collapse_message = list(\
-			SPAN_WARNING("[buckled_mob] falls down [user ? "as [user] collapses" : "from collapsing"] \the [src.name]!"),\
-			user ? SPAN_NOTICE("You collapse \the [src.name] and made [buckled_mob] fall down!") : null)
+			SPAN_WARNING("[buckled_mob] falls down [user ? "as [user] collapses" : "from collapsing"] \the [name]!"),\
+			user ? SPAN_NOTICE("You collapse \the [name] and made [buckled_mob] fall down!") : null)
 
 		var/mob/living/occupant = unbuckle_mob()
 		var/blocked = occupant.run_armor_check(BP_GROIN, "melee")
@@ -222,7 +222,7 @@
 		occupant.apply_damage(rand(5,10), BRUTE, BP_GROIN, blocked)
 		playsound(src, 'sound/effects/fighting/punch1.ogg', 50, 1, -1)
 	else if(user)
-		collapse_message = list("[user] collapses \the [src.name].", "You collapse \the [src.name].")
+		collapse_message = list("[user] collapses \the [name].", "You collapse \the [name].")
 
 	visible_message(collapse_message[1], collapse_message[2])
 	var/obj/item/weapon/foldchair/holochair/O = new /obj/item/weapon/foldchair/holochair(get_turf(src))
@@ -230,7 +230,7 @@
 		O.add_fingerprint(user)
 	QDEL_IN(src, 0)
 
-/obj/item/weapon/foldchair/holochair/attackby(obj/item/weapon/W as obj, mob/user as mob)
+/obj/item/weapon/foldchair/holochair/attackby(obj/item/weapon/W, mob/user)
 	if(isWrench(W))
 		to_chat(user,SPAN("notice", "It's a holochair, you can't dismantle it!"))
 


### PR DESCRIPTION
Два багфикса для стульчиков:
1. Теперь не получится дюпать металл с голостульев
2. Стулья теперь нельзя складывать через стекло
<details>
<summary>Чейнджлог</summary>

```yml
🆑
bugfix: Стулья теперь нельзя складывать через стекло;
bugfix: Исправлен дюп металла с помощью стульев из голодека;
/🆑
```

</details>

- [x] Pull Request полностью завершен, мне не нужна помощь чтобы его закончить.
- [x] Я внимательно прочитал все свои изменения и багов в них не нашел.
- [x] Я запускал сервер со своими изменениями локально и все протестировал.
- [x] Я ознакомился c [Guide to Contribute](https://github.com/ChaoticOnyx/OnyxBay/blob/dev/docs/contributing.md).
