### PR TITLE
tweak(ci): add changelog creation workflow

### DIFF
--- a/.github/workflows/changelog.yml
+++ b/.github/workflows/changelog.yml
@@ -1,0 +1,26 @@
+on:
+  workflow_dispatch
+
+name: Create Changelog
+
+jobs:
+  Main:
+    if: github.repository == 'ChaoticOnyx/OnyxBay' && github.ref == 'refs/heads/dev'
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@afe4af09a72596f47d806ee5f8b2674ec07fdc73
+        with:
+          fetch-depth: 25
+          token: ${{ secrets.GITHUB_TOKEN }}
+      - name: .NET SDK setup
+        uses: actions/setup-dotnet@v1
+        with:
+          dotnet-version: 5.0.x
+      - name: Install depends
+        run: dotnet tool install -g dotnet-script
+      - name: Fetch, compile and push changelogs
+        env:
+          TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        shell: pwsh
+        run: ./scripts/CreateChangelog.ps1

--- a/scripts/CreateChangelog.ps1
+++ b/scripts/CreateChangelog.ps1
@@ -1,0 +1,26 @@
+sudo timedatectl set-timezone 'Europe/Moscow' # Необходимо для даты в чейнджлогах
+$old_hash = Get-FileHash ./html/changelogs/.all_changelog.json | Select-Object -ExpandProperty Hash
+
+Write-Output 'Получение чейнджлогов...'
+dotnet script ./tools/ChangelogGenerator/Fetch.csx
+
+Write-Output 'Генерация чейнджлога...'
+dotnet script ./tools/ChangelogGenerator/Make.csx
+
+$new_hash = Get-FileHash ./html/changelogs/.all_changelog.json | Select-Object -ExpandProperty Hash
+
+Write-Output "Старый хэш .all_changelog.json: ${old_hash}"
+Write-Output "Новый хэш .all_changelog.json: ${new_hash}"
+
+if ($new_hash -eq $old_hash) {
+    Write-Output 'Изменений нет.'
+    return 0
+}
+
+$date = Get-Date -Format 'd.M.yyyy'
+
+git config user.name github-actions
+git config user.email github-actions@github.com
+git add --all
+git commit -m "update(changelog): ${date}"
+git push


### PR DESCRIPTION
Добавляет возможность создавать чейнджлог и сразу пушить в дев через интерфейс гитхаба:
![image](https://user-images.githubusercontent.com/55196698/136722800-98c7a706-519d-4530-84b6-dbe1fde090fb.png)
В экшоне стоит проверка на ветку - запустить не на `dev` (и вообще сделать не так) не получится.
Если изменений чейнджлога нет - лишний коммит не будет создан.
В результате в `dev` ветку попадёт примерно такой коммит:
![image](https://user-images.githubusercontent.com/55196698/136723021-775077e7-e7cb-4fc7-a54b-e4f9b015995a.png)
