### PR TITLE
add(timing): add shared variant of throttle

### DIFF
--- a/code/_helpers/time.dm
+++ b/code/_helpers/time.dm
@@ -126,8 +126,26 @@ GLOBAL_VAR_INIT(rollovercheck_last_timeofday, 0)
 	Initial value is TRUE.
 	Using example:
 
-	THROTTLE(my_cooldown, 1 SECOND)
-	if(my_cooldown)
+	THROTTLE(cooldown, 1 SECOND)
+	if(cooldown)
 		do_something()
 */
-#define THROTTLE(variable, delay) var/static/__throttle##variable=list(); var/##variable = 0; if(__throttle##variable["\ref[src]"] == null){__throttle##variable["\ref[src]"] = world.time-delay-1} if(__throttle##variable["\ref[src]"] + delay < world.time) {__throttle##variable["\ref[src]"]=world.time; variable=TRUE} else{variable=FALSE}
+#define THROTTLE(variable, delay) var/static/__throttle##variable=list(); var/##variable = FALSE; if(__throttle##variable["\ref[src]"] == null) {__throttle##variable["\ref[src]"] = world.time-delay-1} if(world.time > __throttle##variable["\ref[src]"] + delay) {__throttle##variable["\ref[src]"] = world.time; variable = TRUE} else{variable = FALSE}
+
+/*
+	Works like THROTTLE but uses a shared counter.
+	Example:
+	/datum/foo
+		var/last_action = 0
+	
+	/datum/foo/proc/do()
+		THROTTLE_SHARED(cooldown, 1 SECOND, last_action)
+		if(cooldown)
+			do_something()
+	
+	/datum/foo/proc/do2()
+		THROTTLE_SHARED(cooldown, 1 SECOND, last_action)
+		if(cooldown)
+			do_something2()
+*/
+#define THROTTLE_SHARED(variable, delay, counter) var/##variable = (world.time > counter + delay); if(variable) {counter = world.time}


### PR DESCRIPTION
Добавил макрос для случаев когда нужно использовать один счётчик в разных местах и/или когда счётчик необходимо изменять (THROTTLE использует отдельный счётчик для каждого объекта и только в своей области видимости).

- [x] Pull Request полностью завершен, мне не нужна помощь чтобы его закончить.
- [x] Я внимательно прочитал все свои изменения и багов в них не нашел.
- [ ] Я запускал сервер со своими изменениями локально и все протестировал.
- [x] Я ознакомился c [Guide to Contribute](https://github.com/ChaoticOnyx/OnyxBay/blob/dev/docs/contributing.md).
