### PR TITLE
refactor(code): replaces some time checks to THROTTLE_SHARED

### DIFF
--- a/code/game/objects/structures/stool_bed_chair_nest/alien_nests.dm
+++ b/code/game/objects/structures/stool_bed_chair_nest/alien_nests.dm
@@ -40,9 +40,9 @@
 					"<span class='notice'>You hear squelching...</span>")
 				unbuckle_mob()
 			else
-				if(world.time <= M.last_special + NEST_RESIST_TIME)
+				THROTTLE_SHARED(cooldown, NEST_RESIST_TIME, M.last_special)
+				if(!cooldown)
 					return
-				M.last_special = world.time
 				M.visible_message(\
 					"<span class='warning'>[buckled_mob.name] struggles to break free of the gelatinous resin...</span>",\
 					"<span class='warning'>You struggle to break free from the gelatinous resin...</span>",\

--- a/code/modules/mob/living/carbon/carbon.dm
+++ b/code/modules/mob/living/carbon/carbon.dm
@@ -49,27 +49,29 @@
 
 /mob/living/carbon/relaymove(mob/living/user, direction)
 	if((user in src.stomach_contents) && istype(user))
-		if(user.last_special <= world.time)
-			user.last_special = world.time + 50
-			src.visible_message("<span class='danger'>You hear something rumbling inside [src]'s stomach...</span>")
-			var/obj/item/I = user.get_active_hand()
-			var/dmg = (I && I.force) ? rand(round(I.force / 4), I.force) : rand(1, 6) //give a chance to creatures without hands
-			if(istype(src, /mob/living/carbon/human))
-				var/mob/living/carbon/human/H = src
-				var/obj/item/organ/external/organ = H.get_organ(BP_GROIN)
-				if (istype(organ))
-					organ.take_external_damage(dmg, 0)
-				H.updatehealth()
-			else
-				take_organ_damage(dmg)
-			user.visible_message("<span class='danger'>[user] attacks [src]'s stomach wall!</span>")
-			playsound(user.loc, 'sound/effects/attackblob.ogg', 50, 1)
+		THROTTLE_SHARED(cooldown, 50, user.last_special)
+		if(!cooldown)
+			return
 
-			if(prob(getBruteLoss() - 50))
-				for(var/atom/movable/A in stomach_contents)
-					A.loc = loc
-					stomach_contents.Remove(A)
-				gib()
+		src.visible_message("<span class='danger'>You hear something rumbling inside [src]'s stomach...</span>")
+		var/obj/item/I = user.get_active_hand()
+		var/dmg = (I && I.force) ? rand(round(I.force / 4), I.force) : rand(1, 6) //give a chance to creatures without hands
+		if(istype(src, /mob/living/carbon/human))
+			var/mob/living/carbon/human/H = src
+			var/obj/item/organ/external/organ = H.get_organ(BP_GROIN)
+			if (istype(organ))
+				organ.take_external_damage(dmg, 0)
+			H.updatehealth()
+		else
+			take_organ_damage(dmg)
+		user.visible_message("<span class='danger'>[user] attacks [src]'s stomach wall!</span>")
+		playsound(user.loc, 'sound/effects/attackblob.ogg', 50, 1)
+
+		if(prob(getBruteLoss() - 50))
+			for(var/atom/movable/A in stomach_contents)
+				A.loc = loc
+				stomach_contents.Remove(A)
+			gib()
 
 /mob/living/carbon/gib()
 	for(var/mob/M in src)

--- a/code/modules/mob/living/carbon/human/species/species_shapeshift.dm
+++ b/code/modules/mob/living/carbon/human/species/species_shapeshift.dm
@@ -102,11 +102,11 @@ var/list/wrapped_species_by_ref = list()
 	if(stat)
 		to_chat(usr, SPAN_WARNING("You can't use your abilities while you unconscious."))
 		return
-	if(world.time < last_special)
+
+	THROTTLE_SHARED(cooldown, 50, last_special)
+	if(!cooldown)
 		to_chat(usr, SPAN_WARNING("You can't use your abilities so fast!"))
 		return
-
-	last_special = world.time + 50
 
 	var/new_gender = input("Please select a gender.", "Shapeshifter Gender") as null|anything in list(FEMALE, MALE)
 	if(!new_gender)
@@ -124,11 +124,11 @@ var/list/wrapped_species_by_ref = list()
 	if(stat)
 		to_chat(usr, SPAN_WARNING("You can't use your abilities while you unconscious."))
 		return
-	if(world.time < last_special)
+
+	THROTTLE_SHARED(cooldown, 50, last_special)
+	if(!cooldown)
 		to_chat(usr, SPAN_WARNING("You can't use your abilities so fast!"))
 		return
-
-	last_special = world.time + 50
 
 	var/new_species = input("Please select a species to emulate.", "Shapeshifter Body") as null|anything in species.get_valid_shapeshifter_forms(src)
 	if(!new_species || !all_species[new_species] || wrapped_species_by_ref["\ref[src]"] == new_species)
@@ -147,11 +147,11 @@ var/list/wrapped_species_by_ref = list()
 	if(stat)
 		to_chat(usr, SPAN_WARNING("You can't use your abilities while you unconscious."))
 		return
-	if(world.time < last_special)
+
+	THROTTLE_SHARED(cooldown, 50, last_special)
+	if(!cooldown)
 		to_chat(usr, SPAN_WARNING("You can't use your abilities so fast!"))
 		return
-
-	last_special = world.time + 50
 
 	var/new_skin = input("Please select a new body color.", "Shapeshifter Colour") as color
 	if(!new_skin)
@@ -186,11 +186,11 @@ var/list/wrapped_species_by_ref = list()
 	if(stat)
 		to_chat(usr, SPAN_WARNING("You can't use your abilities while you unconscious."))
 		return
-	if(world.time < last_special)
+	
+	THROTTLE_SHARED(cooldown, 30, last_special)
+	if(!cooldown)
 		to_chat(usr, SPAN_WARNING("You can't use your abilities so fast!"))
 		return
-
-	last_special = world.time + 30
 
 	var/datum/species/S = all_species[wrapped_species_by_ref["\ref[src]"]]
 

--- a/code/modules/mob/living/living_powers.dm
+++ b/code/modules/mob/living/living_powers.dm
@@ -9,10 +9,10 @@
 	if(incapacitated())
 		return
 
-	if(world.time < last_special + 5 SECONDS)
+	THROTTLE_SHARED(cooldown, 5 SECONDS, last_special)
+	if(!cooldown)
 		to_chat(src, SPAN_WARNING("You need to wait a bit!"))
 		return
-	last_special = world.time
 
 	hiding = !hiding
 	if(hiding)

--- a/code/modules/mob/living/silicon/pai/pai.dm
+++ b/code/modules/mob/living/silicon/pai/pai.dm
@@ -236,10 +236,9 @@
 	if(src.loc != card)
 		return
 
-	if(world.time <= last_special)
+	THROTTLE_SHARED(cooldown, 100, last_special)
+	if(!cooldown)
 		return
-
-	last_special = world.time + 100
 
 	//I'm not sure how much of this is necessary, but I would rather avoid issues.
 	if(istype(card.loc, /obj/item/rig_module) || istype(card.loc, /obj/item/integrated_circuit/input/pAI_connector))

--- a/code/modules/recycling/disposal.dm
+++ b/code/modules/recycling/disposal.dm
@@ -640,10 +640,12 @@
 
 	var/mob/living/U = user
 
-	if (U.stat || U.last_special <= world.time)
+	if (U.stat)
 		return
 
-	U.last_special = world.time+100
+	THROTTLE_SHARED(cooldown, 100, U.last_special)
+	if(!cooldown)
+		return
 
 	if (src.loc)
 		for (var/mob/M in hearers(src.loc.loc))


### PR DESCRIPTION
Вот и небольшой демонстрационный рефакторинг проверок кулдаунов.
Со спрятанной сверкой времени и обновления счётчика - код выглядит не так 🍝

- [x] Pull Request полностью завершен, мне не нужна помощь чтобы его закончить.
- [x] Я внимательно прочитал все свои изменения и багов в них не нашел.
- [ ] Я запускал сервер со своими изменениями локально и все протестировал.
- [x] Я ознакомился c [Guide to Contribute](https://github.com/ChaoticOnyx/OnyxBay/blob/dev/docs/contributing.md).
