### PR TITLE
fix(runtime): replace turf coords by eye coords

### DIFF
--- a/code/_onclick/hud/skybox.dm
+++ b/code/_onclick/hud/skybox.dm
@@ -41,9 +41,9 @@
 		else
 			view_maxx = view_maxy = view_size + 1
 
-		var/turf/T = get_turf(owner.client.eye)
-		var/normalized_x = (T.x - MAP_PADDING) / (world.maxx - (MAP_PADDING * 2))
-		var/normalized_y = (T.y - MAP_PADDING) / (world.maxy - (MAP_PADDING * 2))
+		var/atom/position = owner.client.eye
+		var/normalized_x = (position.x - MAP_PADDING) / (world.maxx - (MAP_PADDING * 2))
+		var/normalized_y = (position.y - MAP_PADDING) / (world.maxy - (MAP_PADDING * 2))
 		var/result_x = round(view_maxx * WORLD_ICON_SIZE * normalized_x)
 		var/result_y = round(view_maxy * WORLD_ICON_SIZE * normalized_y)
 		screen_loc = "BOTTOM:[-result_y],LEFT:[-result_x]"


### PR DESCRIPTION
Иногда по воле бйонда прилетает нулл вместо турфа - поэтому проще брать сразу координаты глаза игрока.

- [x] Pull Request полностью завершен, мне не нужна помощь чтобы его закончить.
- [x] Я внимательно прочитал все свои изменения и багов в них не нашел.
- [x] Я запускал сервер со своими изменениями локально и все протестировал.
- [x] Я ознакомился c [Guide to Contribute](https://github.com/ChaoticOnyx/OnyxBay/blob/dev/docs/contributing.md).
