### PR TITLE
tweak(ci): better changelog check error handling

### DIFF
--- a/tools/ChangelogGenerator/ClCheck.csx
+++ b/tools/ChangelogGenerator/ClCheck.csx
@@ -35,12 +35,6 @@ if (pullRequest is null)
     return 1;
 }
 
-if (pullRequest.Labels.Any(l => l.Name == Settings.ChangelogNotRequiredLabel))
-{
-    WriteLine("✅ Чейнджлог не требуется.");
-    return 0;
-}
-
 public async Task RemoveAllClLabelsExcept(string except)
 {
     string[] clLabels = { Settings.ChangelogCheckedLabel, Settings.ChangelogNotRequiredLabel, Settings.ChangelogRequiredLabel };
@@ -60,9 +54,9 @@ try
 {
     changelog = pullRequest.ParseChangelog();
 }
-catch (Exceptions.ChangelogNotFound)
+catch (Exceptions.ChangelogNotFound e)
 {
-    WriteLine("Чейнджлог не найден.");
+    WriteLine(e.Message);
     await RemoveAllClLabelsExcept(Settings.ChangelogNotRequiredLabel);
     // Добавление плашки о ненужности чейнджлога.
     var putResponse = await client.PostAsync($"repos/{githubRepository}/issues/{pullRequest.Number}/labels", new StringContent($"{{ \"labels\": [\"{Settings.ChangelogNotRequiredLabel}\"] }}"));

--- a/tools/ChangelogGenerator/Models.csx
+++ b/tools/ChangelogGenerator/Models.csx
@@ -240,15 +240,21 @@ public static class Github
         {
             if (String.IsNullOrEmpty(Body))
             {
-                throw new Exceptions.ChangelogNotFound("  🚫 Чейнджлог не обнаружен.");
+                throw new Exceptions.ChangelogNotFound("  🚫 Тело пулл реквеста пустое.");
             }
 
             var changesBody = s_clBody.Match(Body);
+
+            if (!changesBody.Success)
+            {
+                throw new Exceptions.ChangelogNotFound("  🚫 Чейнджлог не обнаружен.");
+            }
+
             var matches = s_clSplit.Matches(changesBody.Value);
 
             if (matches.Count == 0)
             {
-                throw new Exceptions.ChangelogNotFound("  🚫 Чейнджлог не обнаружен.");
+                throw new Exceptions.ChangelogIsEmpty("  🚫 Чейнджлог пустой или имеет неверный формат.");
             }
 
             var author = changesBody.Groups[2].Value.Trim();
@@ -351,5 +357,12 @@ public static class Exceptions
         public ChangelogNotFound() : base() {}
         public ChangelogNotFound(string message) : base(message) {}
         public ChangelogNotFound(string message, Exception inner) : base(message, inner) {}
+    }
+
+    public class ChangelogIsEmpty : Exception
+    {
+        public ChangelogIsEmpty() : base() { }
+        public ChangelogIsEmpty(string message) : base(message) { }
+        public ChangelogIsEmpty(string message, Exception inner) : base(message, inner) { }
     }
 }


### PR DESCRIPTION
Чуть более корректные сообщения об ошибках.
Наличие плашек теперь никак не влияет на скрипты.
Любой не закрытый PR может иметь плашки:
- `📜 CL не требуется` - если шаблон чейнджлога (🆑) не удалось распарсить или в пре нет текста.
- `📜 Требуется CL` - если шаблон есть но в нём ничего нет или написаны неправильные префиксы.
- `📜 Есть CL` - если ни один из случаев выше не выполнен.