### PR TITLE
tweak(brain):removing character name from brain name

### DIFF
--- a/code/modules/organs/internal/brain.dm
+++ b/code/modules/organs/internal/brain.dm
@@ -93,9 +93,6 @@
 	if(!istype(owner))
 		return ..()
 
-	if(name == initial(name))
-		name = "\the [owner.real_name]'s [initial(name)]"
-
 	var/mob/living/simple_animal/borer/borer = owner.has_brain_worms()
 
 	if(borer)


### PR DESCRIPTION
Убрано имя персонажа у мозга.

close #5825



<details>
<summary>Чейнджлог</summary>

```yml
🆑 MACTEP ABATAP
- tweak: у мозга не отображается имя персонажа.
/🆑
```

</details>

- [x] Pull Request полностью завершен, мне не нужна помощь чтобы его закончить.
- [x] Я внимательно прочитал все свои изменения и багов в них не нашел.
- [x] Я запускал сервер со своими изменениями локально и все протестировал.
- [x] Я ознакомился c [Guide to Contribute](https://github.com/ChaoticOnyx/OnyxBay/blob/dev/docs/contributing.md).
