### PR TITLE
убираем дубликат ворлдфпс вар из конфига

### DIFF
--- a/code/controllers/configuration.dm
+++ b/code/controllers/configuration.dm
@@ -710,9 +710,6 @@ var/list/gamemode_cache = list()
 					if(ticklag > 0)
 						fps = 10 / ticklag
 
-				if("fps")
-					fps = text2num(value)
-
 				if("clientfps")
 					clientfps = text2num(value)
 

--- a/config/example/config.txt
+++ b/config/example/config.txt
@@ -31,11 +31,8 @@ PLAYER_LIMIT 0
 ## Write 0 to toggle limit off. Must be more than PLAYER_LIMIT in order to work correctly.
 HARD_PLAYER_LIMIT 0
 
-## Defines the ticklag for the world. 0.9 is the normal one, 0.5 is smoother.
+## Defines the ticklag for the world. 0.9 is the normal one, 0.5 is smoother. If you wonder, world.fps makes from 10 / TICKLAG.
 TICKLAG 0.625
-
-## Defines world FPS. Defaults to 20. Should be 10 / TICKLAG = FPS
-FPS 16
 
 ##Defines the fps for the players with 0 in preferences. -1 for synced with server fps. 65 recommended
 CLIENTFPS 65


### PR DESCRIPTION
два вара которые по своей сути устанавливают одно и то же значение тикрейта в конфиге сильно запутывают

e.g. если значения будут в результате отличаться FPS заоверрайдит TICKLAG

<details>
<summary>log of changes</summary>

```yml
🆑
tweak: Убран дубликат значения отвечающего за тикрейт мира в конфиге.
/🆑
```

</details>

- [x] Pull Request полностью завершен, мне не нужна помощь чтобы его закончить.
- [x] Я внимательно прочитал все свои изменения и багов в них не нашел.
- [ ] Я запускал сервер со своими изменениями локально и все протестировал.
- [ ] Я ознакомился c [Guide to Contribute](https://github.com/ChaoticOnyx/OnyxBay/blob/dev/docs/contributing.md).
