### PR TITLE
tweak(message_server): fix visibility of the servers with same name in input

### DIFF
--- a/code/game/machinery/computer/message.dm
+++ b/code/game/machinery/computer/message.dm
@@ -305,7 +305,15 @@
 	//Find a server
 	if (href_list["find"])
 		if(message_servers && message_servers.len > 1)
-			src.linkedServer = input(usr,"Please select a server.", "Select a server.", null) as null|anything in message_servers
+			var/list/obj/machinery/message_server/servers = list()
+			var/server_count = 0
+			for(var/obj/machinery/message_server/server in message_servers)
+				server_count += 1
+				servers["[server.name] [server_count]"] = server
+			var/server_name = input(usr,"Please select a server.", "Select a server.", null) as null|anything in servers
+			if(!server_name)
+				return
+			src.linkedServer = servers[server_name]
 			message = "<span class='alert'>NOTICE: Server selected.</span>"
 		else if(message_servers && message_servers.len > 0)
 			linkedServer = message_servers[1]


### PR DESCRIPTION
Смотри проблему в [здесь](https://github.com/ChaoticOnyx/OnyxBay/pull/6769)
Этот ПР мой вариант решения данной проблемы при помощи фикса линка.

<details>
<summary>Чейнджлог</summary>

```yml
🆑
bugfix: Исправлена работа консоли сообщений при помощи добавления числа к имени сервера сообщения при выборе.
/🆑
```

</details>

- [x] Pull Request полностью завершен, мне не нужна помощь чтобы его закончить.
- [x] Я внимательно прочитал все свои изменения и багов в них не нашел.
- [x] Я запускал сервер со своими изменениями локально и все протестировал.
- [x] Я ознакомился c [Guide to Contribute](https://github.com/ChaoticOnyx/OnyxBay/blob/dev/docs/contributing.md).
