### PR TITLE
Removes lack of advanced melee armor checks

### DIFF
--- a/code/game/objects/items.dm
+++ b/code/game/objects/items.dm
@@ -29,6 +29,7 @@
 	var/mod_weight = 0.25 //Weight modifier. i.e. 0.33 - knives, 0.67 - hatchets, 1.0 - crowbars and batons, 1.33 - tanks, 1.66 - toolboxes, 2.0 - axes.
 	var/mod_speed = 1.0 //An artificial attack cooldown multiplier for certain weapons. Applied after the initial processing.
 	var/mod_shield = 1.0 //Higher values reduce blocks' poise consumption. Values >= 1.3 allow to absorb bullets. Values >= 2.5 allow to reflect bullets.
+	var/check_armour = "melee" // Defines what armor to use when it hits things.  Must be set to bullet/laser/energy/bomb/bio/rad
 
 	var/heat_protection = 0 //flags which determine which body parts are protected from heat. Use the HEAD, UPPER_TORSO, LOWER_TORSO, etc. flags. See setup.dm
 	var/cold_protection = 0 //flags which determine which body parts are protected from cold. Use the HEAD, UPPER_TORSO, LOWER_TORSO, etc. flags. See setup.dm

--- a/code/game/objects/items/weapons/melee/energy.dm
+++ b/code/game/objects/items/weapons/melee/energy.dm
@@ -30,6 +30,7 @@
 	mod_weight = mod_weight_a
 	mod_reach = mod_reach_a
 	mod_shield = mod_shield_a
+	check_armour = "laser"
 	playsound(user, activate_sound, 50, 1)
 
 /obj/item/weapon/melee/energy/proc/deactivate(mob/living/user)
@@ -46,6 +47,7 @@
 	mod_weight = initial(mod_weight)
 	mod_reach = initial(mod_reach)
 	mod_shield = initial(mod_shield)
+	check_armour = "melee"
 
 /obj/item/weapon/melee/energy/attack_self(mob/living/user)
 	if(active)
@@ -312,6 +314,7 @@
 	armor_penetration = 100
 	sharp = 1
 	edge = 1
+	check_armour = "laser"
 	anchored = TRUE    // Never spawned outside of inventory, should be fine.
 	throwforce = 1  //Throwing or dropping the item deletes it.
 	throw_speed = 1

--- a/code/game/objects/items/weapons/surgery_tools.dm
+++ b/code/game/objects/items/weapons/surgery_tools.dm
@@ -109,6 +109,7 @@
 	icon_state = "scalpel_laser1_on"
 	damtype = "fire"
 	surgery_speed = 0.8
+	check_armour = "laser"
 
 /obj/item/weapon/scalpel/laser2
 	name = "improved laser scalpel"
@@ -117,6 +118,7 @@
 	damtype = "fire"
 	force = 12.0
 	surgery_speed = 0.6
+	check_armour = "laser"
 
 /obj/item/weapon/scalpel/laser3
 	name = "advanced laser scalpel"
@@ -125,6 +127,7 @@
 	damtype = "fire"
 	force = 15.0
 	surgery_speed = 0.4
+	check_armour = "laser"
 
 /obj/item/weapon/scalpel/manager
 	name = "incision management system"

--- a/code/modules/mob/living/carbon/human/human_defense.dm
+++ b/code/modules/mob/living/carbon/human/human_defense.dm
@@ -476,19 +476,21 @@ meteor_act
 	if(!affecting)
 		return //should be prevented by attacked_with_item() but for sanity.
 
-	var/blocked = run_armor_check(hit_zone, "melee", I.armor_penetration, "Your armor has protected your [affecting.name].", "Your armor has softened the blow to your [affecting.name].")
+	var/blocked = run_armor_check(hit_zone, I.check_armour, I.armor_penetration, "Your armor has protected your [affecting.name].", "Your armor has softened the blow to your [affecting.name].")
 
-	if(istype(user,/mob/living/carbon/human))
+	if(istype(user, /mob/living/carbon/human))
 		var/mob/living/carbon/human/A = user
 		if(parrying)
-			if(handle_parry(A,I))
+			if(handle_parry(A, I))
 				return
 		if(blocking)
-			if(handle_block_weapon(A,I))
+			if(handle_block_weapon(A, I))
 				return
 		if(!atype)
 			standard_weapon_hit_effects(I, user, effective_force, blocked, hit_zone)
 		else
+			// We only check disarm attacks for melee armor since they are dealt w/ blunt parts/handles/etc.
+			blocked = run_armor_check(hit_zone, "melee", I.armor_penetration, "Your armor has protected your [affecting.name].", "Your armor has softened the blow to your [affecting.name].")
 			alt_weapon_hit_effects(I, user, effective_force, blocked, hit_zone)
 		return blocked
 
@@ -820,7 +822,13 @@ meteor_act
 		visible_message(SPAN("warning", "\The [src] has been hit in the [hit_area] by \the [O]."))
 		play_hitby_sound(AM)
 
-		var/armor = run_armor_check(affecting, "melee", O.armor_penetration, "Your armor has protected your [hit_area].", "Your armor has softened hit to your [hit_area].") //I guess "melee" is the best fit here
+		var/armor
+		if(istype(O, /obj/item))
+			var/obj/item/I = O
+			armor = run_armor_check(affecting, I.check_armour, O.armor_penetration, "Your armor has protected your [hit_area].", "Your armor has softened hit to your [hit_area].")
+		else
+			armor = run_armor_check(affecting, "melee", O.armor_penetration, "Your armor has protected your [hit_area].", "Your armor has softened hit to your [hit_area].") //I guess "melee" is the best fit here
+
 		if(armor < 100)
 			var/damage_flags = O.damage_flags()
 			if(prob(armor))

--- a/code/modules/paperwork/pen.dm
+++ b/code/modules/paperwork/pen.dm
@@ -211,6 +211,7 @@
 	item_state = "edagger0"
 	hitsound = 'sound/effects/fighting/energy1.ogg'
 	attack_verb = list("attacked", "slashed", "stabbed", "sliced", "torn", "ripped", "diced", "cut")
+	check_armour = "laser"
 	var/active_max_bright = 0.17
 	var/active_outer_range = 1.65
 	var/brightness_color = "#ff5959"

--- a/code/modules/projectiles/projectile.dm
+++ b/code/modules/projectiles/projectile.dm
@@ -10,6 +10,9 @@
 	anchored = 1 //There's a reason this is here, Mport. God fucking damn it -Agouri. Find&Fix by Pete. The reason this is here is to stop the curving of emitter shots.
 	pass_flags = PASS_FLAG_TABLE
 	mouse_opacity = 0
+
+	check_armour = "bullet" //Defines what armor to use when it hits things.  Must be set to bullet, laser, energy,or bomb	//Cael - bio and rad are also valid
+
 	var/bumped = 0		//Prevents it from hitting more than one guy at once
 	var/def_zone = ""	//Aiming at
 	var/mob/firer = null//Who shot it
@@ -34,7 +37,6 @@
 	var/damage = 10
 	var/damage_type = BRUTE //BRUTE, BURN, TOX, OXY, CLONE, PAIN are the only things that should be in here
 	var/nodamage = 0 //Determines if the projectile will skip any damage inflictions
-	var/check_armour = "bullet" //Defines what armor to use when it hits things.  Must be set to bullet, laser, energy,or bomb	//Cael - bio and rad are also valid
 	var/projectile_type = /obj/item/projectile
 	var/penetrating = 0 //If greater than zero, the projectile will pass through dense objects as specified by on_penetrate()
 	var/kill_count = 50 //This will de-increment every process(). When 0, it will delete the projectile.


### PR DESCRIPTION
```yml
🆑
tweak: Такие предметы как энергетическое оружие и лазерные скальпели теперь при ударах проверяют не защиту от ближнего боя, а защиту от лазеров. Следовательно, РИОТ-броня теперь не так хорошо защищает от есвордов, зато великолепно защищает от них абляционка.
/🆑
```

Fixes #6798

- [x] Pull Request полностью завершен, мне не нужна помощь чтобы его закончить.
- [x] Я внимательно прочитал все свои изменения и багов в них не нашел.
- [x] Я запускал сервер со своими изменениями локально и все протестировал.
- [x] Я ознакомился c [Guide to Contribute](https://github.com/ChaoticOnyx/OnyxBay/blob/dev/docs/contributing.md).
