### PR TITLE
tweak(nuke): timer are now using seconds not shit

### DIFF
--- a/code/game/machinery/nuclear_bomb.dm
+++ b/code/game/machinery/nuclear_bomb.dm
@@ -24,6 +24,7 @@ var/bomb_set
 	var/previous_level = ""
 	var/datum/wires/nuclearbomb/wires = null
 	var/decl/security_level/original_level
+	var/timer_created = FALSE
 
 /obj/machinery/nuclearbomb/New()
 	..()
@@ -39,10 +40,19 @@ var/bomb_set
 
 /obj/machinery/nuclearbomb/Process(wait)
 	if(timing)
-		timeleft = max(timeleft - (wait / 10), 0)
 		if(timeleft <= 0)
 			addtimer(CALLBACK(src, .proc/explode), 0)
+			return
+		if(!timer_created)
+			addtimer(CALLBACK(src, .proc/do_timing), 1 SECONDS)
+			timer_created = TRUE
 		SSnano.update_uis(src)
+
+/obj/machinery/nuclearbomb/proc/do_timing()
+	timer_created = FALSE
+	if(!timing)
+		return
+	timeleft -= 1
 
 /obj/machinery/nuclearbomb/attackby(obj/item/weapon/O as obj, mob/user as mob, params)
 	if(isScrewdriver(O))


### PR DESCRIPTION
close #6801

<details>
<summary>Чейнджлог</summary>

```yml
🆑
tweak: Таймер ядерных бомб теперь считают по секундам, а не по нечто.
/🆑
```

</details>

- [x] Pull Request полностью завершен, мне не нужна помощь чтобы его закончить.
- [x] Я внимательно прочитал все свои изменения и багов в них не нашел.
- [x] Я запускал сервер со своими изменениями локально и все протестировал.
- [x] Я ознакомился c [Guide to Contribute](https://github.com/ChaoticOnyx/OnyxBay/blob/dev/docs/contributing.md).
