### PR TITLE
fix(naming): message server has clear unique name

### DIFF
--- a/code/modules/research/message_server.dm
+++ b/code/modules/research/message_server.dm
@@ -69,6 +69,7 @@ var/global/list/obj/machinery/message_server/message_servers = list()
 	var/spamfilter_limit = MESSAGE_SERVER_DEFAULT_SPAM_LIMIT	//Maximal amount of tokens
 
 /obj/machinery/message_server/New()
+	name = "[name] ([get_area(src)])"
 	message_servers += src
 	decryptkey = GenerateKey()
 	send_pda_message("System Administrator", "system", "This is an automated message. The messaging system is functioning correctly.")


### PR DESCRIPTION
fix #6710
fix #4937
close #6775
close #6769

![image](https://user-images.githubusercontent.com/55196698/140311461-1f4a611c-d3d9-4106-9e00-5d4b49ebb400.png)

<details>
<summary>Чейнджлог</summary>

```yml
🆑
bugfix: Message Server имеет понятное название в зависимости от зоны в которой он расположен.
/🆑
```

</details>

- [x] Pull Request полностью завершен, мне не нужна помощь чтобы его закончить.
- [x] Я внимательно прочитал все свои изменения и багов в них не нашел.
- [x] Я запускал сервер со своими изменениями локально и все протестировал.
- [x] Я ознакомился c [Guide to Contribute](https://github.com/ChaoticOnyx/OnyxBay/blob/dev/docs/contributing.md).
