### PR TITLE
Removes space dust overlay

### DIFF
--- a/code/game/turfs/space/space.dm
+++ b/code/game/turfs/space/space.dm
@@ -7,26 +7,12 @@
 	dynamic_lighting = 0
 	temperature = T20C
 	thermal_conductivity = OPEN_HEAT_TRANSFER_COEFFICIENT
-	var/static/list/dust_cache
 	var/dirt = 0
-
-/turf/space/proc/build_dust_cache()
-	LAZYINITLIST(dust_cache)
-	for (var/i in 0 to 25)
-		var/image/im = image('icons/turf/space_dust.dmi',"[i]")
-		im.plane = DUST_PLANE
-		im.alpha = 80
-		im.blend_mode = BLEND_ADD
-		dust_cache["[i]"] = im
-
 
 /turf/space/Initialize()
 	. = ..()
 	icon_state = "white"
 	update_starlight()
-	if (!dust_cache)
-		build_dust_cache()
-	overlays += dust_cache["[((x + y) ^ ~(x * y) + z) % 25]"]
 
 	if(!HasBelow(z))
 		return


### PR DESCRIPTION
Убран оверлей космической пыли с тайлов космоса. Выглядит данная фича довольно сомнительно. Со старым потайловым космосом проблем не было, но сейчас - выглядит странно и визуально сильно убивает ощущение глубины, будто станция стоит на куске стекла.

До:
![spess_dust_befure](https://user-images.githubusercontent.com/45202681/140629012-c75f706a-3eb5-48d2-9e40-c27de12e318b.gif)

После:  
![spess_dust_aftur](https://user-images.githubusercontent.com/45202681/140629018-82591632-46d4-4468-bcb8-f7c45bb376bf.gif)

```yml
🆑
rscdel: С тайлов космоса убран оверлей пыли.
/🆑
```

- [x] Pull Request полностью завершен, мне не нужна помощь чтобы его закончить.
- [x] Я внимательно прочитал все свои изменения и багов в них не нашел.
- [x] Я запускал сервер со своими изменениями локально и все протестировал.
- [x] Я ознакомился c [Guide to Contribute](https://github.com/ChaoticOnyx/OnyxBay/blob/dev/docs/contributing.md).
