### PR TITLE
Removes grabbing supremacy

### DIFF
--- a/code/modules/mob/grab/grab_datum.dm
+++ b/code/modules/mob/grab/grab_datum.dm
@@ -304,9 +304,12 @@
 
 	//assailant.visible_message("Debug: [assailant] lost [p_lost] poise | now: [assailant.poise]/[assailant.poise_pool]") //Debug message
 
-	var/p_diff = 20.0 // If difference is less than equal 5.0 then the break chance is at minimum (10/6,6 for normal and agressive grabs respectively).
+	var/p_diff = 25.0 // If difference is less than 5.0 then the break chance is capped (12.5%/8.33% for normal and agressive grabs respectively).
 	if((affecting.poise - assailant.poise) > 5.0)
-		p_diff = (affecting.poise - assailant.poise) * 4
+		p_diff = (affecting.poise - assailant.poise) * 5
+	else if(assailant.poise - affecting.poise > 20.0) // HUGE difference, tiny chance to escape
+		p_diff = 10.0
+
 	p_diff /= breakability // 2 for a normal grab, 3 for agressive and kill grabs
 
 	//assailant.visible_message("Debug: p_diff = [p_diff] | breakability = [breakability]") //Debug message

--- a/code/modules/mob/grab/normal/grab_normal.dm
+++ b/code/modules/mob/grab/normal/grab_normal.dm
@@ -145,7 +145,7 @@
 			else
 				if(headbutt(G))
 					if(drop_headbutt)
-						let_go()
+						let_go(G)
 					return 1
 		//else if(G.target_zone ==
 	return 0
@@ -178,7 +178,7 @@
 	if(target.lying)
 		return
 
-	var/damage = 20
+	var/damage = 15
 	var/obj/item/clothing/hat = attacker.head
 	var/damage_flags = 0
 	if(istype(hat))

--- a/code/modules/mob/living/carbon/human/human_attackhand.dm
+++ b/code/modules/mob/living/carbon/human/human_attackhand.dm
@@ -180,7 +180,7 @@
 							switch(hit_zone)
 								if(BP_MOUTH)
 									attack_message = "[H] lands a jab against [src]'s jaw!"
-									specmod = 2
+									specmod = 1.5
 								if(BP_CHEST)
 									if(G.target_zone == BP_CHEST && O.damage > O.max_damage && should_have_organ(BP_HEART))
 										H.visible_message(SPAN("danger", "[H] shoves \his hand into [src]'s chest!"))


### PR DESCRIPTION
Беедебилы неправильно прописали функцию, которая должна ронять граб после удара лбом, а мы всё ещё жрём говно с рантаймами. Как, собственно, и сами бейцы: https://github.com/Baystation12/Baystation12/blob/16934e45d5eda9cd5a5ae054fe5b8eeb84c79a2f/code/modules/mob/grab/normal/grab_normal.dm#L142

```yml
🆑
balance: Увеличен шанс и влияние разницы в устойчивости при попытке освободиться из граба резистом.
balance: Уменьшен урон по устойчивости от джебов в грабе. 
balance: Уменьшен урон от ударов лбом в грабе.
bugfix: Исправлена ошибка, из-за которой после удара лбом граб не сбрасывался.
/🆑
```

- [x] Pull Request полностью завершен, мне не нужна помощь чтобы его закончить.
- [x] Я внимательно прочитал все свои изменения и багов в них не нашел.
- [x] Я запускал сервер со своими изменениями локально и все протестировал.
- [x] Я ознакомился c [Guide to Contribute](https://github.com/ChaoticOnyx/OnyxBay/blob/dev/docs/contributing.md).
