### PR TITLE
fix(integrated_circuit): integrated_circuit/output/light now correctly updates lighting when not powered

### DIFF
--- a/code/modules/integrated_electronics/subtypes/output.dm
+++ b/code/modules/integrated_electronics/subtypes/output.dm
@@ -73,6 +73,7 @@
 	inputs = list()
 	outputs = list()
 	activators = list("toggle light" = IC_PINTYPE_PULSE_IN)
+	power_draw_per_use = 1
 	spawn_flags = IC_SPAWN_DEFAULT|IC_SPAWN_RESEARCH
 	var/light_toggled = FALSE
 	var/light_brightness = 6
@@ -82,6 +83,10 @@
 /obj/item/integrated_circuit/output/light/do_work()
 	light_toggled = !light_toggled
 	update_lighting()
+
+/obj/item/integrated_circuit/output/light/removed_from_assembly()
+	power_fail()
+	..()
 
 /obj/item/integrated_circuit/output/light/proc/update_lighting()
 	if(light_toggled)


### PR DESCRIPTION
close #6741

<details>
<summary>Чейнджлог</summary>

```yml
🆑
bugfix: Лампочки в интегралках теперь не горят вне батареи и без заряда батареи.
/🆑
```

</details>

- [x] Pull Request полностью завершен, мне не нужна помощь чтобы его закончить.
- [x] Я знаю, что я делаю.
- [x] Я запускал сервер со своими изменениями локально и проверил, что баг не воспроизводится.
- [x] Я ознакомился c [Guide to Contribute](https://github.com/ChaoticOnyx/OnyxBay/blob/dev/docs/contributing.md).
