### PR TITLE
Fixes non-standard-poise UI icon and some indescribable shit 

### DIFF
--- a/code/modules/mob/living/carbon/human/life.dm
+++ b/code/modules/mob/living/carbon/human/life.dm
@@ -999,7 +999,7 @@
 
 // Stance is being used in the Onyx fighting system. I wanted to call it stamina, but screw it.
 /mob/living/carbon/human/proc/handle_poise()
-	poise_pool = body_build
+	poise_pool = body_build.poise_pool
 	if(poise >= poise_pool)
 		return
 	var/pregen = 5
@@ -1013,11 +1013,11 @@
 	poise += pregen
 	poise = between(0, poise+pregen, poise_pool)
 
-	poise_icon?.icon_state = "[round(poise)]"
+	poise_icon?.icon_state = "[round((poise/poise_pool) * 50)]"
 
 /mob/living/carbon/human/proc/damage_poise(dmg = 1)
 	poise -= dmg
-	poise_icon?.icon_state = "[round(poise)]"
+	poise_icon?.icon_state = "[round((poise/poise_pool) * 50)]"
 
 /*
 	Called by life(), instead of having the individual hud items update icons each tick and check for status changes


### PR DESCRIPTION
- Исправлен дебилизм, произошедший из-за залипающего ctrl+z.
- Исправлено отображение пойза на интерфейсе при нестандартных значениях (у бодибилдов).

- [x] Pull Request полностью завершен, мне не нужна помощь чтобы его закончить.
- [x] Я внимательно прочитал все свои изменения и багов в них не нашел.
- [x] Я запускал сервер со своими изменениями локально и все протестировал.
- [x] Я ознакомился c [Guide to Contribute](https://github.com/ChaoticOnyx/OnyxBay/blob/dev/docs/contributing.md).
