### PR TITLE
add(event): add blob's biohazard oubtreak event

### DIFF
--- a/baystation12.dme
+++ b/baystation12.dme
@@ -1562,6 +1562,7 @@
 #include "code\modules\events\_event_container.dm"
 #include "code\modules\events\_event_dynamic.dm"
 #include "code\modules\events\apc_damage.dm"
+#include "code\modules\events\biohazard_outbreak.dm"
 #include "code\modules\events\brand_intelligence.dm"
 #include "code\modules\events\camera_damage.dm"
 #include "code\modules\events\carp_migration.dm"

--- a/code/modules/events/_event_container.dm
+++ b/code/modules/events/_event_container.dm
@@ -181,7 +181,8 @@ var/global/list/severity_to_string = list(EVENT_LEVEL_MUNDANE = "Mundane", EVENT
 		new /datum/event_meta(EVENT_LEVEL_MAJOR, "Space Vines",           /datum/event/spacevine,             0,     list(ASSIGNMENT_ENGINEER = 25)),
 		new /datum/event_meta(EVENT_LEVEL_MAJOR, "Electrical Storm",      /datum/event/electrical_storm,      0,     list(ASSIGNMENT_ENGINEER = 10, ASSIGNMENT_JANITOR = 5)),
 		new /datum/event_meta(EVENT_LEVEL_MAJOR, "Plague Infection",      /datum/event/virus_major,           0,     list(ASSIGNMENT_MEDICAL = 20), is_one_shot = 1),
-		new /datum/event_meta(EVENT_LEVEL_MAJOR, "Xenomorph Infestation", /datum/event/xenomorph_infestation, 0,     list(ASSIGNMENT_SECURITY = 2), is_one_shot = 1)
+		new /datum/event_meta(EVENT_LEVEL_MAJOR, "Xenomorph Infestation", /datum/event/xenomorph_infestation, 0,     list(ASSIGNMENT_SECURITY = 2), is_one_shot = 1),
+		new /datum/event_meta(EVENT_LEVEL_MAJOR, "Biohazard Outbreak",    /datum/event/biohazard_outbreak,    0,     list(ASSIGNMENT_ANY = 2),      is_one_shot = 1)
 	)
 
 

--- a/code/modules/events/biohazard_outbreak.dm
+++ b/code/modules/events/biohazard_outbreak.dm
@@ -1,0 +1,21 @@
+/datum/event/biohazard_outbreak
+	announceWhen = 30
+
+/datum/event/biohazard_outbreak/start()
+	var/counts = 0
+	var/turf/T = null
+	pick_subarea_turf(/area/maintenance, list(/proc/is_station_turf, /proc/not_turf_contains_dense_objects))
+
+	while(!T || counts < 5)
+		counts++
+		T = pick_subarea_turf(/area/maintenance, list(/proc/is_station_turf, /proc/not_turf_contains_dense_objects))
+
+	if(!T)
+		log_and_message_admins("Blob didn't found a space for spawning.")
+		return
+
+	new /obj/structure/blob/core(T.loc)
+	log_and_message_admins("Blob spawned in \the [get_area(T)]", location = T.loc)
+
+/datum/event/biohazard_outbreak/announce()
+	level_seven_announcement()


### PR DESCRIPTION
Ну вроде он так назывался.
Вес выпадания поставил `ASSIGNMENT_ANY = 2` (против `ASSIGNMENT_ANY = 1` у вормхолов), вроде не слишком часто должен выпадать.

<details>
<summary>Чейнджлог</summary>

```yml
🆑
rscadd: Блоб добавлен в список эвентов.
/🆑
```

</details>

- [x] Pull Request полностью завершен, мне не нужна помощь чтобы его закончить.
- [x] Я внимательно прочитал все свои изменения и багов в них не нашел.
- [x] Я запускал сервер со своими изменениями локально и все протестировал.
- [x] Я ознакомился c [Guide to Contribute](https://github.com/ChaoticOnyx/OnyxBay/blob/dev/docs/contributing.md).
