### PR TITLE
Removes fat humans' slowdown

### DIFF
--- a/code/__defines/mobs.dm
+++ b/code/__defines/mobs.dm
@@ -355,8 +355,10 @@
 #define HUMAN_POWER_LEAP    "Leap"
 #define HUMAN_POWER_TACKLE  "Tackle"
 
-#define HUMAN_MAX_POISE     75 // 100% healthy, non-druged human being with magboots and heavy armor.
-#define HUMAN_HIGH_POISE    55
-#define HUMAN_DEFAULT_POISE 50 // 100% healthy, non-drugged human being.
-#define HUMAN_LOW_POISE     45
-#define HUMAN_MIN_POISE     25 // Some balancing stuff here. Even drunk pirates should be able to fight.
+#define HUMAN_MAX_POISE       75 // 100% healthy, non-druged human being with magboots and heavy armor.
+#define HUMAN_VERY_HIGH_POISE 60
+#define HUMAN_HIGH_POISE      55
+#define HUMAN_DEFAULT_POISE   50 // 100% healthy, non-drugged human being.
+#define HUMAN_LOW_POISE       45
+#define HUMAN_VERY_LOW_POISE  40
+#define HUMAN_MIN_POISE       25 // Some balancing stuff here. Even drunk pirates should be able to fight.

--- a/code/__defines/mobs.dm
+++ b/code/__defines/mobs.dm
@@ -356,7 +356,7 @@
 #define HUMAN_POWER_TACKLE  "Tackle"
 
 #define HUMAN_MAX_POISE     75 // 100% healthy, non-druged human being with magboots and heavy armor.
-#define HUMAN_HIGH_POISE    60
+#define HUMAN_HIGH_POISE    55
 #define HUMAN_DEFAULT_POISE 50 // 100% healthy, non-drugged human being.
 #define HUMAN_LOW_POISE     45
 #define HUMAN_MIN_POISE     25 // Some balancing stuff here. Even drunk pirates should be able to fight.

--- a/code/modules/mob/living/carbon/human/body_build.dm
+++ b/code/modules/mob/living/carbon/human/body_build.dm
@@ -168,8 +168,6 @@ var/global/datum/body_build/default_body_build = new
 	dam_mask             = 'icons/mob/human_races/masks/dam_mask_human.dmi'
 
 	stomach_capacity   = STOMACH_CAPACITY_HIGH
-	slowdown           = 0.5
-	equipment_modifier = 0.5
 	poise_pool         = HUMAN_HIGH_POISE
 
 
@@ -252,7 +250,7 @@ var/global/datum/body_build/default_body_build = new
 	rig_back             = 'icons/inv_slots/rig/mob_fat.dmi'
 
 	slowdown           = 0.5
-	equipment_modifier = 0.5
+	equipment_modifier = 0
 	poise_pool         = HUMAN_HIGH_POISE
 
 /datum/body_build/unathi

--- a/code/modules/mob/living/carbon/human/body_build.dm
+++ b/code/modules/mob/living/carbon/human/body_build.dm
@@ -277,7 +277,7 @@ var/global/datum/body_build/default_body_build = new
 		)
 	dam_mask             = 'icons/mob/human_races/masks/dam_mask_lizard.dmi'
 
-	poise_pool         = HUMAN_HIGH_POISE
+	poise_pool         = HUMAN_VERY_HIGH_POISE
 
 /datum/body_build/vox
 	name                 = "Vox"


### PR DESCRIPTION
Сделать замедление меньше с нынешним кодом передвижения не представляется возможным, а минимальное замедление в 0.5 превращает бедолаг в инвалидов.
Стоит оставить эту затею до лучших времён, когда переработаем передвижение.

```yml
🆑
tweak: У жирных бодибилдов убрано как замедление, так и игнорирование веса снаряжения.
tweak: Запас устойчивости (пойза) у жирных бодибилдов снижен с 60 до 55.
/🆑
```

- [x] Pull Request полностью завершен, мне не нужна помощь чтобы его закончить.
- [x] Я внимательно прочитал все свои изменения и багов в них не нашел.
- [x] Я запускал сервер со своими изменениями локально и все протестировал.
- [x] Я ознакомился c [Guide to Contribute](https://github.com/ChaoticOnyx/OnyxBay/blob/dev/docs/contributing.md).
