### PR TITLE
Removes fun hydroponics (configurable)

### DIFF
--- a/code/controllers/configuration.dm
+++ b/code/controllers/configuration.dm
@@ -291,7 +291,7 @@ var/list/gamemode_cache = list()
 	var/disable_looc_roundstart = FALSE
 
 	// Non-that-serious features that can be disabled for higher RP levels
-	var/fun_hydroponics = TRUE
+	var/fun_hydroponics = 2
 
 /datum/configuration/proc/Initialize()
 	var/list/L = typesof(/datum/game_mode) - /datum/game_mode

--- a/code/controllers/configuration.dm
+++ b/code/controllers/configuration.dm
@@ -290,6 +290,9 @@ var/list/gamemode_cache = list()
 	var/disable_ooc_roundstart = FALSE
 	var/disable_looc_roundstart = FALSE
 
+	// Non-that-serious features that can be disabled for higher RP levels
+	var/fun_hydroponics = TRUE
+
 /datum/configuration/proc/Initialize()
 	var/list/L = typesof(/datum/game_mode) - /datum/game_mode
 	for (var/T in L)
@@ -696,7 +699,7 @@ var/list/gamemode_cache = list()
 
 				if("forbid_singulo_possession")
 					forbid_singulo_possession = 1
-				
+
 				if("forbid_singulo_following")
 					forbid_singulo_following = 1
 
@@ -971,6 +974,8 @@ var/list/gamemode_cache = list()
 					config.maximum_mushrooms = text2num(value)
 				if("use_loyalty_implants")
 					config.use_loyalty_implants = 1
+				if("fun_hydroponics")
+					config.fun_hydroponics = text2num(value)
 
 				else
 					log_misc("Unknown setting in configuration: '[name]'")

--- a/code/controllers/configuration.dm
+++ b/code/controllers/configuration.dm
@@ -119,7 +119,7 @@ var/list/gamemode_cache = list()
 	var/secondtopiclimit
 
 	var/forbid_singulo_possession = 0
-	var/forbid_singulo_following = 0
+	var/forbid_singulo_following = 1
 
 	//game_options.txt configs
 
@@ -701,7 +701,7 @@ var/list/gamemode_cache = list()
 					forbid_singulo_possession = 1
 
 				if("forbid_singulo_following")
-					forbid_singulo_following = 1
+					forbid_singulo_following = text2num(value)
 
 				if("popup_admin_pm")
 					config.popup_admin_pm = 1

--- a/code/modules/hydroponics/seed.dm
+++ b/code/modules/hydroponics/seed.dm
@@ -26,7 +26,7 @@
 	var/force_layer
 	var/customsprite = 0		   // Set to 1 if you want to use a non-paintable harvest icon.
 	var/planter_ckey			   // ckey of player that plant seed.
-	var/is_fun = FALSE             // Set to TRUE if it isn't considered roleplayable enough
+	var/fun_level = 0              // Disables this mutation if it's higher than config.fun_hydroponics. 0 - regular plants, 1 - joke plants, 2 - somewhat OOC-related stuff.
 
 /datum/seed/New()
 

--- a/code/modules/hydroponics/seed.dm
+++ b/code/modules/hydroponics/seed.dm
@@ -26,6 +26,7 @@
 	var/force_layer
 	var/customsprite = 0		   // Set to 1 if you want to use a non-paintable harvest icon.
 	var/planter_ckey			   // ckey of player that plant seed.
+	var/is_fun = FALSE             // Set to TRUE if it isn't considered roleplayable enough
 
 /datum/seed/New()
 

--- a/code/modules/hydroponics/seed.dm
+++ b/code/modules/hydroponics/seed.dm
@@ -26,7 +26,7 @@
 	var/force_layer
 	var/customsprite = 0		   // Set to 1 if you want to use a non-paintable harvest icon.
 	var/planter_ckey			   // ckey of player that plant seed.
-	var/fun_level = 0              // Disables this mutation if it's higher than config.fun_hydroponics. 0 - regular plants, 1 - joke plants, 2 - somewhat OOC-related stuff.
+	var/fun_level = 1              // Disables this mutation if it's higher than config.fun_hydroponics. 0 - regular plants, 1 - joke plants, 2 - somewhat OOC-related stuff.
 
 /datum/seed/New()
 

--- a/code/modules/hydroponics/seed_datums.dm
+++ b/code/modules/hydroponics/seed_datums.dm
@@ -41,7 +41,7 @@
 	mutants = null
 	chems = list(/datum/reagent/fuel = list(5,10))
 	kitchen_tag = "flamechili"
-	is_fun = TRUE
+	fun_level = 1
 
 /datum/seed/chili/flame/New()
 	..()
@@ -227,7 +227,7 @@
 	mutants = null
 	chems = list(/datum/reagent/nanites = list(1,10))
 	splat_type = /obj/effect/decal/cleanable/blood/oil
-	is_fun = TRUE
+	fun_level = 1
 
 /datum/seed/tomato/automato/New()
 	..()
@@ -243,6 +243,7 @@
 	mutants = null
 	can_self_harvest = 1
 	has_mob_product = /mob/living/simple_animal/hostile/tomato
+	fun_level = 1
 
 /datum/seed/tomato/killer/New()
 	..()
@@ -274,6 +275,7 @@
 	display_name = "bluespace tomato plant"
 	mutants = null
 	chems = list(/datum/reagent/nutriment = list(1,20), /datum/reagent/ethanol/singulo = list(10,5))
+	fun_level = 1
 
 /datum/seed/tomato/blue/teleport/New()
 	..()
@@ -310,7 +312,7 @@
 	display_name = "egg plants"
 	mutants = null
 	has_custom_product = /obj/item/weapon/reagent_containers/food/snacks/egg/randomcolor
-	is_fun = TRUE
+	fun_level = 1
 
 /datum/seed/eggplant/realeggplant/New()
 	..()
@@ -368,6 +370,7 @@
 	display_name = "radioactive apple tree"
 	mutants = null
 	chems = list(/datum/reagent/radium = list(1,15))
+	fun_level = 1
 
 /datum/seed/apple/rapple/New()
 	..()
@@ -380,6 +383,7 @@
 	mutants = null
 	chems = list(/datum/reagent/nutriment = list(1,10), /datum/reagent/gold = list(1,5))
 	kitchen_tag = "goldapple"
+	fun_level = 1
 
 /datum/seed/apple/gold/New()
 	..()
@@ -489,6 +493,7 @@
 	mutants = null
 	can_self_harvest = 1
 	has_mob_product = /mob/living/simple_animal/mushroom
+	fun_level = 1
 
 /datum/seed/mushroom/plump/walking/New()
 	..()
@@ -846,6 +851,7 @@
 	display_name = "bunana tree"
 	chems = list(/datum/reagent/drink/juice/banana = list(20,20))
 	mutants = null
+	fun_level = 1
 
 /datum/seed/banana/bunana/New()
 	..()
@@ -858,6 +864,7 @@
 	display_name = "lubanana tree"
 	chems = list(/datum/reagent/lube = list(10,10))
 	mutants = list("banbanana")
+	fun_level = 1
 
 /datum/seed/banana/lubanana/New()
 	..()
@@ -871,7 +878,7 @@
 	display_name = "BANana tree"
 	mutants = null
 	has_custom_product = /obj/item/toy/banbanana
-	is_fun = TRUE
+	fun_level = 2
 
 /datum/seed/banana/banbanana/New()
 	..()
@@ -925,7 +932,7 @@
 	display_name = "electric potatoes"
 	mutants = null
 	has_custom_product = /obj/item/weapon/cell/potato
-	is_fun = TRUE
+	fun_level = 1
 
 /datum/seed/potato/cell/New()
 	..()
@@ -1258,7 +1265,7 @@
 	has_mob_product = /mob/living/simple_animal/cow/cowcownut
 	chems = null
 	mutants = null
-	is_fun = TRUE
+	fun_level = 1
 
 /datum/seed/coconut/cowcownut/New()
 	..()
@@ -1334,6 +1341,7 @@
 	has_mob_product = /mob/living/simple_animal/hostile/maneater
 	mutants = null
 	customsprite = 1
+	fun_level = 1
 
 /datum/seed/diona/maneater/New()
 	..()

--- a/code/modules/hydroponics/seed_datums.dm
+++ b/code/modules/hydroponics/seed_datums.dm
@@ -41,6 +41,7 @@
 	mutants = null
 	chems = list(/datum/reagent/fuel = list(5,10))
 	kitchen_tag = "flamechili"
+	is_fun = TRUE
 
 /datum/seed/chili/flame/New()
 	..()
@@ -226,6 +227,7 @@
 	mutants = null
 	chems = list(/datum/reagent/nanites = list(1,10))
 	splat_type = /obj/effect/decal/cleanable/blood/oil
+	is_fun = TRUE
 
 /datum/seed/tomato/automato/New()
 	..()
@@ -308,6 +310,7 @@
 	display_name = "egg plants"
 	mutants = null
 	has_custom_product = /obj/item/weapon/reagent_containers/food/snacks/egg/randomcolor
+	is_fun = TRUE
 
 /datum/seed/eggplant/realeggplant/New()
 	..()
@@ -868,6 +871,7 @@
 	display_name = "BANana tree"
 	mutants = null
 	has_custom_product = /obj/item/toy/banbanana
+	is_fun = TRUE
 
 /datum/seed/banana/banbanana/New()
 	..()
@@ -921,6 +925,7 @@
 	display_name = "electric potatoes"
 	mutants = null
 	has_custom_product = /obj/item/weapon/cell/potato
+	is_fun = TRUE
 
 /datum/seed/potato/cell/New()
 	..()
@@ -1253,6 +1258,7 @@
 	has_mob_product = /mob/living/simple_animal/cow/cowcownut
 	chems = null
 	mutants = null
+	is_fun = TRUE
 
 /datum/seed/coconut/cowcownut/New()
 	..()

--- a/code/modules/hydroponics/trays/tray.dm
+++ b/code/modules/hydroponics/trays/tray.dm
@@ -401,7 +401,7 @@
 	var/newseed = seed.get_mutant_variant()
 	if(newseed in SSplants.seeds)
 		var/datum/seed/mut_seed = SSplants.seeds[newseed]
-		if(mut_seed.is_fun && !config.fun_hydroponics)
+		if(mut_seed.fun_level > config.fun_hydroponics) // Too fun to be true
 			return
 		seed = mut_seed
 	else

--- a/code/modules/hydroponics/trays/tray.dm
+++ b/code/modules/hydroponics/trays/tray.dm
@@ -400,7 +400,10 @@
 	var/previous_plant = seed.display_name
 	var/newseed = seed.get_mutant_variant()
 	if(newseed in SSplants.seeds)
-		seed = SSplants.seeds[newseed]
+		var/datum/seed/mut_seed = SSplants.seeds[newseed]
+		if(mut_seed.is_fun && !config.fun_hydroponics)
+			return
+		seed = mut_seed
 	else
 		return
 

--- a/config/example/config.txt
+++ b/config/example/config.txt
@@ -712,4 +712,5 @@ ERROR_SILENCE_TIME 6000
 ERROR_MSG_DELAY 50
 
 ## FUN features that may be considered inappropriate for high RP servers
+## 0 - allows ONLY regular plants, 1 - allows not-so-realistic plants (i.e. bluespace tomatoes, walking mushrooms), 2 - allows somewhat OOC-related stuff (i.e. BANanas)
 FUN_HYDROPONICS 2

--- a/config/example/config.txt
+++ b/config/example/config.txt
@@ -564,6 +564,13 @@ ALLOW_HOLIDAYS
 ## Uncomment to allow catching projectiles and throwing them.
 # PROJECTILE_BASKETBALL
 
+## FUN features that may be considered inappropriate for high RP servers
+## 0 - allows ONLY regular plants, 1 - allows not-so-realistic plants (i.e. bluespace tomatoes, walking mushrooms), 2 - allows somewhat OOC-related stuff (i.e. BANanas)
+FUN_HYDROPONICS 1
+
+## Uncomment to prevent singularities from following ghosts.
+## FORBID_SINGULO_FOLLOWING
+
 # # # # # # # # # # # # # # # # # # # # # #
 #               VOTE ACTIONS              #
 # # # # # # # # # # # # # # # # # # # # # #
@@ -710,7 +717,3 @@ ERROR_SILENCE_TIME 6000
 
 ## How long to wait between messaging admins about occurrences of a unique error.
 ERROR_MSG_DELAY 50
-
-## FUN features that may be considered inappropriate for high RP servers
-## 0 - allows ONLY regular plants, 1 - allows not-so-realistic plants (i.e. bluespace tomatoes, walking mushrooms), 2 - allows somewhat OOC-related stuff (i.e. BANanas)
-FUN_HYDROPONICS 1

--- a/config/example/config.txt
+++ b/config/example/config.txt
@@ -710,3 +710,7 @@ ERROR_SILENCE_TIME 6000
 
 ## How long to wait between messaging admins about occurrences of a unique error.
 ERROR_MSG_DELAY 50
+
+## FUN features that may be considered inappropriate for high RP servers
+FUN_HYDROPONICS 1
+

--- a/config/example/config.txt
+++ b/config/example/config.txt
@@ -712,5 +712,4 @@ ERROR_SILENCE_TIME 6000
 ERROR_MSG_DELAY 50
 
 ## FUN features that may be considered inappropriate for high RP servers
-FUN_HYDROPONICS 1
-
+FUN_HYDROPONICS 2

--- a/config/example/config.txt
+++ b/config/example/config.txt
@@ -713,4 +713,4 @@ ERROR_MSG_DELAY 50
 
 ## FUN features that may be considered inappropriate for high RP servers
 ## 0 - allows ONLY regular plants, 1 - allows not-so-realistic plants (i.e. bluespace tomatoes, walking mushrooms), 2 - allows somewhat OOC-related stuff (i.e. BANanas)
-FUN_HYDROPONICS 2
+FUN_HYDROPONICS 1

--- a/config/example/config.txt
+++ b/config/example/config.txt
@@ -568,8 +568,8 @@ ALLOW_HOLIDAYS
 ## 0 - allows ONLY regular plants, 1 - allows not-so-realistic plants (i.e. bluespace tomatoes, walking mushrooms), 2 - allows somewhat OOC-related stuff (i.e. BANanas)
 FUN_HYDROPONICS 1
 
-## Uncomment to prevent singularities from following ghosts.
-## FORBID_SINGULO_FOLLOWING
+## Set to 0 to allow singularities to follow ghosts.
+FORBID_SINGULO_FOLLOWING 1
 
 # # # # # # # # # # # # # # # # # # # # # #
 #               VOTE ACTIONS              #


### PR DESCRIPTION
В конфиг добавлена опция FUN_HYDROPONICS. По умолчанию выставлена на 2. В зависимости от значения отключает некоторые мутации растений. Отключаются только мутации, семена всё ещё можно получить другими способами (щитспавн).
2 - Стандартный режим: доступны все мутации;
1 - Здравый режим, без ООС-контента: отключен BANana;
0 - Строгий режим, без несерьёзных/нереалистичных растений: flame chili, automato, killer tomato, bluespace tomato, egg plant, radioactive apple, golden apple, walking mushroom, bunana, lubanana, electric potato, cowcownut, man-eating plant;

Попутно изменён конфиг, отвечающий за преследование гостов сингой. По умолчанию данная фича теперь отключена, так Плин сказал.

```yml
🆑
admin: Добавлена возможность отключать определённый набор мутаций у растений через конфиг. 
/🆑
```

- [x] Pull Request полностью завершен, мне не нужна помощь чтобы его закончить.
- [x] Я внимательно прочитал все свои изменения и багов в них не нашел.
- [ ] Я запускал сервер со своими изменениями локально и все протестировал.
- [x] Я ознакомился c [Guide to Contribute](https://github.com/ChaoticOnyx/OnyxBay/blob/dev/docs/contributing.md).
