### PR TITLE
Removes bees' left arms

### DIFF
--- a/baystation12.dme
+++ b/baystation12.dme
@@ -1985,6 +1985,7 @@
 #include "code\modules\mob\living\silicon\robot\drone\drone_remote_control.dm"
 #include "code\modules\mob\living\silicon\robot\drone\drone_say.dm"
 #include "code\modules\mob\living\simple_animal\bees.dm"
+#include "code\modules\mob\living\simple_animal\bodyparts.dm"
 #include "code\modules\mob\living\simple_animal\kobold.dm"
 #include "code\modules\mob\living\simple_animal\mob_ai.dm"
 #include "code\modules\mob\living\simple_animal\parrot.dm"

--- a/code/modules/mob/living/simple_animal/bodyparts.dm
+++ b/code/modules/mob/living/simple_animal/bodyparts.dm
@@ -1,0 +1,18 @@
+// Fake bodyparts
+
+/decl/simple_animal_bodyparts
+	var/list/hit_zones = list()
+
+/decl/simple_animal_bodyparts/humanoid // No need to specify bodyparts, uses default names.
+
+/decl/simple_animal_bodyparts/quadruped // Most subtypes have this basic body layout.
+	hit_zones = list("head", "torso", "left foreleg", "right foreleg", "left hind leg", "right hind leg", "tail")
+
+/decl/simple_animal_bodyparts/bird
+	hit_zones = list("head", "body", "right wing", "left wing", "right leg", "left leg")
+
+/decl/simple_animal_bodyparts/fish
+	hit_zones = list("head", "body", "dorsal fin", "left pectoral fin", "right pectoral fin", "tail fin")
+
+/decl/simple_animal_bodyparts/legless
+	hit_zones = list("head", "body", "right arm", "right hand", "left arm", "left hand")

--- a/code/modules/mob/living/simple_animal/borer/borer.dm
+++ b/code/modules/mob/living/simple_animal/borer/borer.dm
@@ -23,6 +23,7 @@
 	holder_type = /obj/item/weapon/holder/borer
 	mob_size = MOB_SMALL
 	can_escape = 1
+	bodyparts = /decl/simple_animal_bodyparts/borer
 
 	var/generation = 1
 	var/static/list/borer_names = list(
@@ -185,3 +186,6 @@
 /mob/living/simple_animal/borer/proc/request_player()
 	var/datum/ghosttrap/G = get_ghost_trap("cortical borer")
 	G.request_player(src, "A cortical borer needs a player.")
+
+/decl/simple_animal_bodyparts/borer
+	hit_zones = list("head", "central segment", "tail segment")

--- a/code/modules/mob/living/simple_animal/constructs/constructs.dm
+++ b/code/modules/mob/living/simple_animal/constructs/constructs.dm
@@ -113,6 +113,7 @@
 	resistance = 10
 	construct_spells = list(/datum/spell/aoe_turf/conjure/forcewall/lesser)
 	can_escape = 1
+	bodyparts = /decl/simple_animal_bodyparts/juggernaut
 
 /mob/living/simple_animal/construct/armoured/Life()
 	weakened = 0
@@ -139,6 +140,8 @@
 
 	return (..(P))
 
+/decl/simple_animal_bodyparts/juggernaut
+	hit_zones = list("body", "left pauldron", "right pauldron", "left arm", "right arm", "eye", "head", "crystaline spike")
 
 
 ////////////////////////Wraith/////////////////////////////////////////////
@@ -163,6 +166,10 @@
 	see_in_dark = 7
 	attack_sound = 'sound/weapons/rapidslice.ogg'
 	construct_spells = list(/datum/spell/targeted/ethereal_jaunt/shift)
+	bodyparts = /decl/simple_animal_bodyparts/wraith
+
+/decl/simple_animal_bodyparts/wraith
+	hit_zones = list("body", "eye", "crystaline spike", "left claw", "right claw")
 
 
 /////////////////////////////Artificer/////////////////////////
@@ -186,6 +193,7 @@
 	speed = 0
 	environment_smash = 1
 	attack_sound = 'sound/weapons/rapidslice.ogg'
+	bodyparts = /decl/simple_animal_bodyparts/artificer
 	construct_spells = list(/datum/spell/aoe_turf/conjure/construct/lesser,
 							/datum/spell/aoe_turf/conjure/wall,
 							/datum/spell/aoe_turf/conjure/floor,
@@ -193,6 +201,8 @@
 							/datum/spell/aoe_turf/conjure/pylon
 							)
 
+/decl/simple_animal_bodyparts/artificer
+	hit_zones = list("body", "carapace", "right manipulator", "left manipulator", "upper left appendage", "upper right appendage", "eye")
 
 /////////////////////////////Behemoth/////////////////////////
 
@@ -220,6 +230,7 @@
 	var/max_energy = 1000
 	construct_spells = list(/datum/spell/aoe_turf/conjure/forcewall/lesser)
 	can_escape = 1
+	bodyparts = /decl/simple_animal_bodyparts/juggernaut
 
 ////////////////////////Harvester////////////////////////////////
 
@@ -242,10 +253,14 @@
 	environment_smash = 1
 	see_in_dark = 7
 	attack_sound = 'sound/weapons/pierce.ogg'
+	bodyparts = /decl/simple_animal_bodyparts/harvester
 
 	construct_spells = list(
 			/datum/spell/targeted/harvest
 		)
+
+/decl/simple_animal_bodyparts/harvester
+	hit_zones = list("cephalothorax", "eye", "carapace", "energy crystal", "mandible")
 
 ////////////////Glow//////////////////
 /mob/living/simple_animal/construct/proc/add_glow()

--- a/code/modules/mob/living/simple_animal/familiars/familiars.dm
+++ b/code/modules/mob/living/simple_animal/familiars/familiars.dm
@@ -40,6 +40,7 @@
 	attacktext = "pinches"
 	resistance = 9
 	can_escape = 1 //snip snip
+	bodyparts = /decl/simple_animal_bodyparts/crab
 
 /*familiar version of the Pike w/o all the other hostile/carp stuff getting in the way (namely life)
 */
@@ -61,6 +62,7 @@
 	melee_damage_lower = 10
 	melee_damage_upper = 10
 	can_escape = 1
+	bodyparts = /decl/simple_animal_bodyparts/fish
 
 	min_gas = null
 
@@ -85,6 +87,7 @@
 	melee_damage_lower = 5
 	melee_damage_upper = 8
 	attacktext = "touches"
+	bodyparts = /decl/simple_animal_bodyparts/humanoid
 
 	wizardy_spells = list(/datum/spell/targeted/torment)
 
@@ -147,6 +150,7 @@
 	melee_damage_upper = 1
 	can_escape = 1
 	attacktext = "nibbles"
+	bodyparts = /decl/simple_animal_bodyparts/quadruped
 
 	wizardy_spells = list(/datum/spell/aoe_turf/smoke)
 
@@ -174,6 +178,7 @@
 	melee_damage_lower = 3
 	melee_damage_upper = 4
 	attacktext = "claws"
+	bodyparts = /decl/simple_animal_bodyparts/quadruped
 
 	wizardy_spells = list(/datum/spell/targeted/subjugation)
 
@@ -192,5 +197,6 @@
 	melee_damage_lower = 10
 	melee_damage_upper = 20
 	attacktext = "kicked"
+	bodyparts = /decl/simple_animal_bodyparts/quadruped
 
 	wizardy_spells = list(/datum/spell/targeted/projectile/magic_missile)

--- a/code/modules/mob/living/simple_animal/friendly/cat.dm
+++ b/code/modules/mob/living/simple_animal/friendly/cat.dm
@@ -25,6 +25,7 @@
 	holder_type = /obj/item/weapon/holder/cat
 	mob_size = MOB_SMALL
 	possession_candidate = 1
+	bodyparts = /decl/simple_animal_bodyparts/quadruped
 
 /mob/living/simple_animal/cat/Life()
 	if(!..() || incapacitated() || client)

--- a/code/modules/mob/living/simple_animal/friendly/chicken.dm
+++ b/code/modules/mob/living/simple_animal/friendly/chicken.dm
@@ -35,6 +35,7 @@ GLOBAL_VAR_INIT(chicken_count, 0) // Number of /mob/living/simple_animal/chicken
 	var/amount_grown = 0
 	pass_flags = PASS_FLAG_TABLE | PASS_FLAG_GRILLE
 	mob_size = MOB_MINISCULE
+	bodyparts = /decl/simple_animal_bodyparts/bird
 
 /mob/living/simple_animal/chick/Initialize()
 	. = ..()

--- a/code/modules/mob/living/simple_animal/friendly/corgi.dm
+++ b/code/modules/mob/living/simple_animal/friendly/corgi.dm
@@ -27,6 +27,7 @@
 	var/obj/item/hat
 	var/old_dir
 	var/obj/movement_target
+	bodyparts = /decl/simple_animal_bodyparts/quadruped
 
 //IAN! SQUEEEEEEEEE~
 /mob/living/simple_animal/corgi/Ian

--- a/code/modules/mob/living/simple_animal/friendly/crab.dm
+++ b/code/modules/mob/living/simple_animal/friendly/crab.dm
@@ -28,6 +28,7 @@
 	can_escape = TRUE //snip snip
 	controllable = TRUE
 	shy_animal = TRUE
+	bodyparts = /decl/simple_animal_bodyparts/crab
 
 	can_pull_size = ITEM_SIZE_TINY
 	can_pull_mobs = MOB_PULL_SAME
@@ -52,3 +53,6 @@
 	response_harm = "stomps"
 	possession_candidate = FALSE
 	controllable = FALSE
+
+/decl/simple_animal_bodyparts/crab
+	hit_zones = list("cephalothorax", "abdomen", "left walking legs", "right walking legs", "left swimming legs", "right swimming legs", "left pincer", "right pincer")

--- a/code/modules/mob/living/simple_animal/friendly/farm_animals.dm
+++ b/code/modules/mob/living/simple_animal/friendly/farm_animals.dm
@@ -22,6 +22,8 @@
 	health = 40
 	melee_damage_lower = 1
 	melee_damage_upper = 5
+	bodyparts = /decl/simple_animal_bodyparts/quadruped
+
 	var/datum/reagents/udder = null
 	var/isragemode = FALSE
 
@@ -134,6 +136,8 @@
 	response_harm   = "kicks"
 	attacktext = "kicked"
 	health = 50
+	bodyparts = /decl/simple_animal_bodyparts/quadruped
+
 	var/milktype = /datum/reagent/drink/milk
 	var/datum/reagents/udder = null
 

--- a/code/modules/mob/living/simple_animal/friendly/lizard.dm
+++ b/code/modules/mob/living/simple_animal/friendly/lizard.dm
@@ -31,6 +31,7 @@
 	can_escape = 1
 	shy_animal = 1
 	controllable = TRUE
+	bodyparts = /decl/simple_animal_bodyparts/quadruped
 
 	can_pull_size = ITEM_SIZE_TINY
 	can_pull_mobs = MOB_PULL_SAME

--- a/code/modules/mob/living/simple_animal/friendly/metroid.dm
+++ b/code/modules/mob/living/simple_animal/friendly/metroid.dm
@@ -12,6 +12,7 @@
 	response_disarm = "shoos"
 	response_harm   = "stomps on"
 	emote_see = list("jiggles", "bounces in place")
+	bodyparts = /decl/simple_animal_bodyparts/metroid
 	var/colour = "grey"
 
 /mob/living/simple_animal/metroid/can_force_feed(feeder, food, feedback)
@@ -32,6 +33,7 @@
 	response_disarm = "shoos"
 	response_harm   = "stomps on"
 	emote_see = list("jiggles", "bounces in place")
+	bodyparts = /decl/simple_animal_bodyparts/metroid
 	var/colour = "grey"
 
 /mob/living/simple_animal/adultmetroid/New()
@@ -51,3 +53,6 @@
 	S2.icon_dead = "[src.colour] baby metroid dead"
 	S2.colour = "[src.colour]"
 	qdel(src)
+
+/decl/simple_animal_bodyparts/metroid
+	hit_zones = list("cytoplasmic membrane", "core", "slimy body")

--- a/code/modules/mob/living/simple_animal/friendly/mouse.dm
+++ b/code/modules/mob/living/simple_animal/friendly/mouse.dm
@@ -34,6 +34,7 @@
 	can_escape = 1
 	shy_animal = 1
 	controllable = TRUE
+	bodyparts = /decl/simple_animal_bodyparts/quadruped
 	var/obj/item/holding_item = null
 	var/datum/disease2/disease/virus = null
 

--- a/code/modules/mob/living/simple_animal/friendly/thatdog.dm
+++ b/code/modules/mob/living/simple_animal/friendly/thatdog.dm
@@ -26,3 +26,4 @@
 	can_escape = 1
 	pixel_x = -128
 	pixel_y = -64
+	bodyparts = /decl/simple_animal_bodyparts/quadruped

--- a/code/modules/mob/living/simple_animal/hostile/alien.dm
+++ b/code/modules/mob/living/simple_animal/hostile/alien.dm
@@ -28,6 +28,7 @@
 	minbodytemp = 0
 	heat_damage_per_tick = 20
 	can_escape = 1
+	bodyparts = /decl/simple_animal_bodyparts/humanoid
 
 
 /mob/living/simple_animal/hostile/alien/drone

--- a/code/modules/mob/living/simple_animal/hostile/asteroid/goliath.dm
+++ b/code/modules/mob/living/simple_animal/hostile/asteroid/goliath.dm
@@ -26,6 +26,7 @@
 	melee_damage_upper = 25
 	attacktext = "pulverizes"
 	throw_message = "does nothing to the rocky hide of the"
+	bodyparts = /decl/simple_animal_bodyparts/goliath
 	aggro_vision_range = 9
 	idle_vision_range = 4
 	var/pre_attack = 0
@@ -188,3 +189,6 @@
 	. = ..()
 	if(.)
 		new /obj/item/clothing/head/helmet/space/goliath(loc)
+
+/decl/simple_animal_bodyparts/goliath
+	hit_zones = list("head", "body", "carapace", "mouthparts", "maw", "tendrils", "right leg", "left leg")

--- a/code/modules/mob/living/simple_animal/hostile/asteroid/sand_lurker.dm
+++ b/code/modules/mob/living/simple_animal/hostile/asteroid/sand_lurker.dm
@@ -28,9 +28,13 @@
 	attacktext = "bites into"
 	a_intent = "harm"
 	attack_sound = 'sound/weapons/bladeslice.ogg'
+	bodyparts = /decl/simple_animal_bodyparts/sand_lurker
 	meat_type = /obj/item/weapon/reagent_containers/food/snacks/meat/xeno
 
 /mob/living/simple_animal/hostile/asteroid/sand_lurker/Life()
 	. = ..()
 	if(.)
 		stop_automated_movement = 1
+
+/decl/simple_animal_bodyparts/sand_lurker
+	hit_zones = list("cephalothorax", "pedipalp", "tail segment", "mouthparts")

--- a/code/modules/mob/living/simple_animal/hostile/asteroid/shooter.dm
+++ b/code/modules/mob/living/simple_animal/hostile/asteroid/shooter.dm
@@ -26,6 +26,7 @@
 	attacktext = "bites into"
 	a_intent = "harm"
 	attack_sound = 'sound/weapons/bladeslice.ogg'
+	bodyparts = /decl/simple_animal_bodyparts/quadruped
 	ranged_cooldown_cap = 4
 	aggro_vision_range = 7
 	idle_vision_range = 2
@@ -86,6 +87,7 @@
 	melee_damage_lower = 22
 	melee_damage_upper = 22
 	attacktext = "gnaws and mauls"
+	bodyparts = /decl/simple_animal_bodyparts/beholder
 	aggro_vision_range = 9
 	idle_vision_range = 5
 	var/list/projectiletypes = list(/obj/item/projectile/beam/mindflayer,
@@ -126,6 +128,9 @@
 			var/obj/item/weapon/ore/diamond/D = new /obj/item/weapon/ore/diamond(src.loc)
 			D.layer = 4.1
 		new /obj/item/asteroid/beholder_eye(src.loc)
+
+/decl/simple_animal_bodyparts/beholder
+	hit_zones = list("giant eye", "maw", "far left eyestalk", "left eyestalk", "central eyestalk", "right eyestalk", "far right eyestalk", "chin", "cheek", "forehead")
 
 
 ////////////////Item: Beholder eye////////////////

--- a/code/modules/mob/living/simple_animal/hostile/bat.dm
+++ b/code/modules/mob/living/simple_animal/hostile/bat.dm
@@ -21,6 +21,7 @@
 	melee_damage_upper = 10
 	attacktext = "bites"
 	attack_sound = 'sound/weapons/bite.ogg'
+	bodyparts = /decl/simple_animal_bodyparts/bird
 
 	min_gas = null
 	max_gas = null

--- a/code/modules/mob/living/simple_animal/hostile/bear.dm
+++ b/code/modules/mob/living/simple_animal/hostile/bear.dm
@@ -23,6 +23,7 @@
 	melee_damage_lower = 20
 	melee_damage_upper = 30
 	can_escape = 1
+	bodyparts = /decl/simple_animal_bodyparts/quadruped
 
 	//Space bears aren't affected by atmos.
 	min_gas = null

--- a/code/modules/mob/living/simple_animal/hostile/carp.dm
+++ b/code/modules/mob/living/simple_animal/hostile/carp.dm
@@ -22,6 +22,7 @@
 	melee_damage_upper = 15
 	attacktext = "bitten"
 	attack_sound = 'sound/weapons/bite.ogg'
+	bodyparts = /decl/simple_animal_bodyparts/fish
 
 	//Space carp aren't affected by atmos.
 	min_gas = null

--- a/code/modules/mob/living/simple_animal/hostile/commanded/bear_companion.dm
+++ b/code/modules/mob/living/simple_animal/hostile/commanded/bear_companion.dm
@@ -24,6 +24,7 @@
 	response_help = "pets"
 	response_harm = "hits"
 	response_disarm = "pushes"
+	bodyparts = /decl/simple_animal_bodyparts/quadruped
 
 	known_commands = list("stay", "stop", "attack", "follow", "dance", "boogie", "boogy")
 

--- a/code/modules/mob/living/simple_animal/hostile/creature.dm
+++ b/code/modules/mob/living/simple_animal/hostile/creature.dm
@@ -15,6 +15,7 @@
 	faction = "creature"
 	speed = 4
 	supernatural = 1
+	bodyparts = /decl/simple_animal_bodyparts/otherthing
 
 /mob/living/simple_animal/hostile/creature/cult
 	faction = "cult"
@@ -24,3 +25,6 @@
 
 /mob/living/simple_animal/hostile/creature/cult/cultify()
 	return
+
+/decl/simple_animal_bodyparts/otherthing
+	hit_zones = list("fleshy mass", "maw", "eye(?)", "orifice(?)")

--- a/code/modules/mob/living/simple_animal/hostile/faithful_hound.dm
+++ b/code/modules/mob/living/simple_animal/hostile/faithful_hound.dm
@@ -20,6 +20,7 @@
 	var/last_check = 0
 	faction = "cute ghost dogs"
 	supernatural = 1
+	bodyparts = /decl/simple_animal_bodyparts/quadruped
 
 /mob/living/simple_animal/faithful_hound/death()
 	new /obj/item/weapon/ectoplasm (get_turf(src))

--- a/code/modules/mob/living/simple_animal/hostile/faithless.dm
+++ b/code/modules/mob/living/simple_animal/hostile/faithless.dm
@@ -26,6 +26,7 @@
 
 	faction = "faithless"
 	supernatural = 1
+	bodyparts = /decl/simple_animal_bodyparts/faithless
 
 /mob/living/simple_animal/hostile/faithless/Allow_Spacemove(check_drift = 0)
 	return 1
@@ -48,3 +49,6 @@
 
 /mob/living/simple_animal/hostile/faithless/cult/cultify()
 	return
+
+/decl/simple_animal_bodyparts/faithless
+	hit_zones = list("body", "left appendage", "right appendage", "shadowy tendrils", "head", "right stump", "left stump", "infernal eye")

--- a/code/modules/mob/living/simple_animal/hostile/giant_spider.dm
+++ b/code/modules/mob/living/simple_animal/hostile/giant_spider.dm
@@ -35,6 +35,7 @@
 	move_to_delay = 6
 	speed = 3
 	controllable = TRUE
+	bodyparts = /decl/simple_animal_bodyparts/spider
 
 //nursemaids - these create webs and eggs
 /mob/living/simple_animal/hostile/giant_spider/nurse
@@ -224,3 +225,6 @@
 #undef LAYING_EGGS
 #undef MOVING_TO_TARGET
 #undef SPINNING_COCOON
+
+/decl/simple_animal_bodyparts/spider
+	hit_zones = list("cephalothorax", "abdomen", "left forelegs", "right forelegs", "left hind legs", "right hind legs", "pedipalp", "mouthparts")

--- a/code/modules/mob/living/simple_animal/hostile/hivebot.dm
+++ b/code/modules/mob/living/simple_animal/hostile/hivebot.dm
@@ -21,6 +21,7 @@
 	max_gas = null
 	minbodytemp = 0
 	speed = 4
+	bodyparts = /decl/simple_animal_bodyparts/hivebot
 
 /mob/living/simple_animal/hostile/hivebot/range
 	name = "Hivebot"
@@ -100,3 +101,6 @@
 
 /mob/living/simple_animal/hostile/hivebot/tele/rapid
 	bot_type = /mob/living/simple_animal/hostile/hivebot/rapid
+
+/decl/simple_animal_bodyparts/hivebot
+	hit_zones = list("central chassis", "positioning servo", "head", "sensor suite", "manipulator arm", "shoulder weapon mount", "weapons array", "front right leg", "front left leg", "rear left leg", "rear right leg")

--- a/code/modules/mob/living/simple_animal/hostile/maneater.dm
+++ b/code/modules/mob/living/simple_animal/hostile/maneater.dm
@@ -21,6 +21,7 @@
 	melee_damage_upper = 30
 	attacktext = "chomped"
 	attack_sound = 'sound/weapons/bite.ogg'
+	bodyparts = /decl/simple_animal_bodyparts/maneater
 
 	break_stuff_probability = 35
 
@@ -66,3 +67,6 @@
 		if(prob(25))
 			L.Weaken(3)
 			L.visible_message("<span class='danger'>\The [src] knocks down \the [L]!</span>")
+
+/decl/simple_animal_bodyparts/maneater
+	hit_zones = list("flesh", "tendrils", "tentacles", "giant maw", "horrifying mouth", "mouth", "maw")

--- a/code/modules/mob/living/simple_animal/hostile/pirate.dm
+++ b/code/modules/mob/living/simple_animal/hostile/pirate.dm
@@ -20,6 +20,7 @@
 	melee_damage_upper = 30
 	attacktext = "slashed"
 	attack_sound = 'sound/weapons/bladeslice.ogg'
+	bodyparts = /decl/simple_animal_bodyparts/humanoid
 
 	unsuitable_atoms_damage = 15
 	var/corpse = /obj/effect/landmark/corpse/pirate

--- a/code/modules/mob/living/simple_animal/hostile/retaliate/clown.dm
+++ b/code/modules/mob/living/simple_animal/hostile/retaliate/clown.dm
@@ -24,8 +24,12 @@
 	can_escape = 1
 	attacktext = "attacked"
 	attack_sound = 'sound/items/bikehorn.ogg'
+	bodyparts = /decl/simple_animal_bodyparts/clown
 	minbodytemp = 270
 	maxbodytemp = 370
 	heat_damage_per_tick = 15	//amount of damage applied if animal's body temperature is higher than maxbodytemp
 	cold_damage_per_tick = 10	//same as heat_damage_per_tick, only if the bodytemperature it's lower than minbodytemp
 	unsuitable_atoms_damage = 10
+
+/decl/simple_animal_bodyparts/clown
+	hit_zones = list("head", "torso", "pie-hole", "honker", "left funny bone", "right funny bone", "left foot", "right foot", "unmentionables", "HONK", "honk", "honker")

--- a/code/modules/mob/living/simple_animal/hostile/retaliate/drone.dm
+++ b/code/modules/mob/living/simple_animal/hostile/retaliate/drone.dm
@@ -15,6 +15,7 @@
 	response_harm = "hits"
 	speak = list("ALERT.","Hostile-ile-ile entities dee-twhoooo-wected.","Threat parameterszzzz- szzet.","Bring sub-sub-sub-systems uuuup to combat alert alpha-a-a.")
 	emote_see = list("beeps menacingly","whirrs threateningly","scans its immediate vicinity")
+	bodyparts = /decl/simple_animal_bodyparts/malf_drone
 	a_intent = I_HURT
 	stop_automated_movement_when_pulled = 0
 	health = 300
@@ -275,3 +276,6 @@
 
 /obj/item/projectile/beam/pulse/drone
 	damage = 10
+
+/decl/simple_animal_bodyparts/malf_drone
+	hit_zones = list("chassis", "comms array", "sensor suite", "left weapons module", "right weapons module", "maneuvering thruster")

--- a/code/modules/mob/living/simple_animal/hostile/retaliate/exoplanet.dm
+++ b/code/modules/mob/living/simple_animal/hostile/retaliate/exoplanet.dm
@@ -57,6 +57,7 @@
 	speak = list("Hruuugh!","Hrunnph")
 	emote_see = list("paws the ground","shakes its mane","stomps")
 	emote_hear = list("snuffles")
+	bodyparts = /decl/simple_animal_bodyparts/quadruped
 
 /mob/living/simple_animal/hostile/retaliate/beast/diyaab
 	name = "diyaab"
@@ -77,6 +78,7 @@
 	speak = list("Awrr?","Aowrl!","Worrl")
 	emote_see = list("sniffs the air cautiously","looks around")
 	emote_hear = list("snuffles")
+	bodyparts = /decl/simple_animal_bodyparts/quadruped
 
 /mob/living/simple_animal/hostile/retaliate/beast/shantak
 	name = "shantak"
@@ -96,6 +98,7 @@
 	speak_chance = 2
 	speak = list("Shuhn","Shrunnph?","Shunpf")
 	emote_see = list("scratches the ground","shakes out it's mane","tinkles gently")
+	bodyparts = /decl/simple_animal_bodyparts/quadruped
 
 /mob/living/simple_animal/yithian
 	name = "yithian"

--- a/code/modules/mob/living/simple_animal/hostile/russian.dm
+++ b/code/modules/mob/living/simple_animal/hostile/russian.dm
@@ -20,6 +20,7 @@
 	can_escape = 1
 	attacktext = "punched"
 	a_intent = I_HURT
+	bodyparts = /decl/simple_animal_bodyparts/humanoid
 	var/corpse = /obj/effect/landmark/corpse/russian
 	var/weapon1 = /obj/item/weapon/material/knife
 	unsuitable_atoms_damage = 15

--- a/code/modules/mob/living/simple_animal/hostile/syndicate.dm
+++ b/code/modules/mob/living/simple_animal/hostile/syndicate.dm
@@ -20,6 +20,7 @@
 	can_escape = 1
 	attacktext = "punched"
 	a_intent = I_HURT
+	bodyparts = /decl/simple_animal_bodyparts/humanoid
 	var/corpse = /obj/effect/landmark/corpse/syndicate
 	var/weapon1
 	var/weapon2

--- a/code/modules/mob/living/simple_animal/hostile/tomato.dm
+++ b/code/modules/mob/living/simple_animal/hostile/tomato.dm
@@ -17,6 +17,7 @@
 	melee_damage_upper = 15
 	melee_damage_lower = 10
 	attacktext = "mauled"
+	bodyparts = /decl/simple_animal_bodyparts/tomato
 	possession_candidate = 1
 	controllable = TRUE
 	universal_speak = 0
@@ -30,3 +31,6 @@
 	if(name == initial(name))
 		name = "[name] ([sequential_id(/mob/living/simple_animal/hostile/tomato)])"
 	real_name = name
+
+/decl/simple_animal_bodyparts/tomato
+	hit_zones = list("flesh", "leaf", "mouth")

--- a/code/modules/mob/living/simple_animal/hostile/tree.dm
+++ b/code/modules/mob/living/simple_animal/hostile/tree.dm
@@ -23,6 +23,7 @@
 	melee_damage_upper = 12
 	attacktext = "bitten"
 	attack_sound = 'sound/weapons/bite.ogg'
+	bodyparts = /decl/simple_animal_bodyparts/tree
 
 	//Space carp aren't affected by atmos.
 	min_gas = null
@@ -48,3 +49,6 @@
 	..(null,"is hacked into pieces!", show_dead_message)
 	new /obj/item/stack/material/wood(loc)
 	qdel(src)
+
+/decl/simple_animal_bodyparts/tree
+	hit_zones = list("trunk", "branches", "twigs")

--- a/code/modules/mob/living/simple_animal/hostile/vagrant.dm
+++ b/code/modules/mob/living/simple_animal/hostile/vagrant.dm
@@ -27,6 +27,7 @@
 	min_gas = null
 	max_gas = null
 	minbodytemp = 0
+	bodyparts = /decl/simple_animal_bodyparts/metroid // Kinda close I guess
 	var/datum/disease2/disease/carried
 	var/cloaked = 0
 	var/mob/living/carbon/human/gripping = null

--- a/code/modules/mob/living/simple_animal/hostile/voxslug.dm
+++ b/code/modules/mob/living/simple_animal/hostile/voxslug.dm
@@ -26,6 +26,7 @@ Small, little HP, poisonous.
 	melee_damage_upper = 10
 	holder_type = /obj/item/weapon/holder/voxslug
 	faction = SPECIES_VOX
+	bodyparts = /decl/simple_animal_bodyparts/voxslug
 
 /mob/living/simple_animal/hostile/voxslug/ListTargets(dist = 7)
 	var/list/L = list()
@@ -87,3 +88,6 @@ Small, little HP, poisonous.
 		qdel(src)
 		return
 	..()
+
+/decl/simple_animal_bodyparts/voxslug
+	hit_zones = list("mouth", "tail")

--- a/code/modules/mob/living/simple_animal/kobold.dm
+++ b/code/modules/mob/living/simple_animal/kobold.dm
@@ -24,6 +24,7 @@
 	universal_speak = 1
 	universal_understand = 1
 	possession_candidate = 1
+	bodyparts = /decl/simple_animal_bodyparts/humanoid
 
 /mob/living/simple_animal/kobold/Life()
 	..()

--- a/code/modules/mob/living/simple_animal/parrot.dm
+++ b/code/modules/mob/living/simple_animal/parrot.dm
@@ -87,6 +87,7 @@
 	can_pull_mobs = MOB_PULL_SAME
 
 	holder_type = /obj/item/weapon/holder/parrot
+	bodyparts = /decl/simple_animal_bodyparts/bird
 
 
 /mob/living/simple_animal/parrot/New()

--- a/code/modules/mob/living/simple_animal/shade.dm
+++ b/code/modules/mob/living/simple_animal/shade.dm
@@ -27,6 +27,7 @@
 	faction = "cult"
 	supernatural = 1
 	status_flags = CANPUSH
+	bodyparts = /decl/simple_animal_bodyparts/shade
 
 /mob/living/simple_animal/shade/cultify()
 	return
@@ -44,3 +45,6 @@
 				ghostize()
 		qdel(src)
 		return
+
+/decl/simple_animal_bodyparts/shade
+	hit_zones = list("spectral robe", "featureless visage", "haunting glow")

--- a/code/modules/mob/living/simple_animal/simple_animal.dm
+++ b/code/modules/mob/living/simple_animal/simple_animal.dm
@@ -66,6 +66,7 @@
 
 	var/damtype = BRUTE
 	var/defense = "melee"
+	var/bodyparts = /decl/simple_animal_bodyparts // Fake bodyparts that can be shown when hit by projectiles.
 
 	//Null rod stuff
 	var/supernatural = 0
@@ -84,6 +85,9 @@
 	else
 		mob_ai = new()
 	mob_ai.holder = src
+
+	if(bodyparts)
+		bodyparts = decls_repository.get_decl(bodyparts)
 
 /mob/living/simple_animal/Destroy()
 	QDEL_NULL(mob_ai)

--- a/code/modules/projectiles/projectile.dm
+++ b/code/modules/projectiles/projectile.dm
@@ -233,11 +233,28 @@
 				admin_victim_log(target_mob, "was shot by an <b>UNKNOWN SUBJECT (No longer exists)</b> using \a [src] (blocked)")
 		return 1
 
+	var/impacted_organ = parse_zone(def_zone)
+	if(istype(target_mob, /mob/living/simple_animal))
+		var/mob/living/simple_animal/SM = target_mob
+		var/decl/simple_animal_bodyparts/body_plan = SM.bodyparts
+		if(body_plan != decls_repository.get_decl(/decl/simple_animal_bodyparts/humanoid)) // No need to override
+			if(length(body_plan.hit_zones))
+				impacted_organ = pick(body_plan.hit_zones)
+			else
+				impacted_organ = null
+
 	//hit messages
 	if(silenced)
-		to_chat(target_mob, "<span class='danger'>You've been hit in the [parse_zone(def_zone)] by \the [src]!</span>")
+		if(impacted_organ)
+			to_chat(target_mob, SPAN("danger", "You've been hit in the [parse_zone(def_zone)] by \the [src]!"))
+		else
+			to_chat(target_mob, SPAN("danger", "You've been hit by \the [src]!"))
 	else
-		target_mob.visible_message("<span class='danger'>\The [target_mob] is hit by \the [src] in the [parse_zone(def_zone)]!</span>")//X has fired Y is now given by the guns so you cant tell who shot you if you could not see the shooter
+		if(impacted_organ)
+			target_mob.visible_message(SPAN("danger", "\The [target_mob] is hit by \the [src] in the [parse_zone(def_zone)]!"))//X has fired Y is now given by the guns so you cant tell who shot you if you could not see the shooter
+		else
+			target_mob.visible_message(SPAN("danger", "\The [target_mob] is hit by \the [src]!"))
+
 		new /obj/effect/effect/hitmarker(target_mob.loc)
 		for(var/mob/O in hearers(7, get_turf(target_mob)))
 			if(O.client)

--- a/code/modules/projectiles/projectile.dm
+++ b/code/modules/projectiles/projectile.dm
@@ -246,12 +246,12 @@
 	//hit messages
 	if(silenced)
 		if(impacted_organ)
-			to_chat(target_mob, SPAN("danger", "You've been hit in the [parse_zone(def_zone)] by \the [src]!"))
+			to_chat(target_mob, SPAN("danger", "You've been hit in the [impacted_organ] by \the [src]!"))
 		else
 			to_chat(target_mob, SPAN("danger", "You've been hit by \the [src]!"))
 	else
 		if(impacted_organ)
-			target_mob.visible_message(SPAN("danger", "\The [target_mob] is hit by \the [src] in the [parse_zone(def_zone)]!"))//X has fired Y is now given by the guns so you cant tell who shot you if you could not see the shooter
+			target_mob.visible_message(SPAN("danger", "\The [target_mob] is hit by \the [src] in the [impacted_organ]!"))//X has fired Y is now given by the guns so you cant tell who shot you if you could not see the shooter
 		else
 			target_mob.visible_message(SPAN("danger", "\The [target_mob] is hit by \the [src]!"))
 


### PR DESCRIPTION
Добавлены фейковые органы для сообщений, показываемых при попадании пуль в симпл_животных. К примеру, крабы теперь ловят пули клешнями, головогрудями и ногами, а не гроинами и пятками.

До:
![image](https://user-images.githubusercontent.com/45202681/141664688-bec003ec-0bb6-4ddb-8049-fe239933540c.png)
После:
![image](https://user-images.githubusercontent.com/45202681/141664837-dc748a46-4b5b-4703-ad98-d833525cfdbb.png)
![image](https://user-images.githubusercontent.com/45202681/141664851-ae4b2817-d686-4bfb-85e5-806f6f90a159.png)

При этом гуманоидные мобы вроде косморусских и синдикатовских NPC всё так же используют те же сообщения, что и люди.

```yml
🆑
rscadd: Улучшены сообщениия при выстрелах по различным мобам. Больше никаких пуль, попадающих улиткам в правые пятки и левые кисти.
/🆑
```

- [x] Pull Request полностью завершен, мне не нужна помощь чтобы его закончить.
- [x] Я внимательно прочитал все свои изменения и багов в них не нашел.
- [x] Я запускал сервер со своими изменениями локально и все протестировал.
- [x] Я ознакомился c [Guide to Contribute](https://github.com/ChaoticOnyx/OnyxBay/blob/dev/docs/contributing.md).
