### PR TITLE
Removese missing limbs grabbing

### DIFF
--- a/code/modules/mob/grab/grab_object.dm
+++ b/code/modules/mob/grab/grab_object.dm
@@ -30,10 +30,6 @@
 	affecting = victim
 	target_zone = attacker.zone_sel.selecting
 	var/obj/item/O = get_targeted_organ()
-	if(!O)
-		to_chat(assailant, SPAN("warning", "[affecting] is missing the body part you tried to grab!"))
-		qdel(src)
-		return
 
 	SetName("[name] ([O.name])")
 

--- a/code/modules/mob/grab/grab_object.dm
+++ b/code/modules/mob/grab/grab_object.dm
@@ -30,6 +30,11 @@
 	affecting = victim
 	target_zone = attacker.zone_sel.selecting
 	var/obj/item/O = get_targeted_organ()
+	if(!O)
+		to_chat(assailant, SPAN("warning", "[affecting] is missing the body part you tried to grab!"))
+		qdel(src)
+		return
+
 	SetName("[name] ([O.name])")
 
 	if(start_grab_name)
@@ -110,6 +115,11 @@
 	if(assailant.buckled || affecting.buckled)
 		return FALSE
 
+	var/obj/item/organ/external/O = get_targeted_organ()
+	if(!O)
+		to_chat(assailant, SPAN("warning", "[affecting] is missing the body part you were grabbing!"))
+		return FALSE
+
 	return TRUE
 
 /obj/item/grab/proc/can_grab()
@@ -147,6 +157,11 @@
 	if(assailant.grabbed_by.len)
 		to_chat(assailant, "<span class='notice'>You can't grab someone if you're being grabbed.</span>")
 		return 0
+
+	var/obj/item/organ/external/O = get_targeted_organ()
+	if(!O)
+		to_chat(assailant, SPAN("warning", "[affecting] is missing the body part you tried to grab!"))
+		return 0 // This check is kinda extra, but you can never be sure
 
 	return 1
 
@@ -229,7 +244,7 @@
 		current_grab.adjust_position(src)
 
 /obj/item/grab/proc/reset_position()
-	current_grab.reset_position(src)
+	current_grab?.reset_position(src)
 
 /obj/item/grab/proc/has_hold_on_organ(obj/item/organ/external/O)
 	if(!O)

--- a/code/modules/mob/living/carbon/human/human_helpers.dm
+++ b/code/modules/mob/living/carbon/human/human_helpers.dm
@@ -238,6 +238,9 @@
 		var/obj/item/grab/given_grab_type = all_grabobjects[grab_tag]
 		G = new given_grab_type(attacker, victim)
 
+	if(!G)
+		return 0
+
 	if(!G.pre_check())
 		qdel(G)
 		return 0

--- a/code/modules/mob/living/carbon/human/human_helpers.dm
+++ b/code/modules/mob/living/carbon/human/human_helpers.dm
@@ -232,14 +232,15 @@
 /mob/living/carbon/human/proc/make_grab(mob/living/carbon/human/attacker, mob/living/carbon/human/victim, grab_tag)
 	var/obj/item/grab/G
 
+	if(!victim.get_organ(attacker.zone_sel.selecting))
+		to_chat(attacker, SPAN("warning", "[victim] is missing the body part you tried to grab!"))
+		return 0
+
 	if(!grab_tag)
 		G = new attacker.current_grab_type(attacker, victim)
 	else
 		var/obj/item/grab/given_grab_type = all_grabobjects[grab_tag]
 		G = new given_grab_type(attacker, victim)
-
-	if(!G)
-		return 0
 
 	if(!G.pre_check())
 		qdel(G)


### PR DESCRIPTION
Теперь за отсутствующие конечности нельзя грабать. А ещё грабы будут сбрасываться, если жертва потеряет уже грабнутую конечность.

```yml
🆑
bugfix: Исправлена возможность грабать людей за отсутствующие конечности.
/🆑
```

- [x] Pull Request полностью завершен, мне не нужна помощь чтобы его закончить.
- [x] Я внимательно прочитал все свои изменения и багов в них не нашел.
- [x] Я запускал сервер со своими изменениями локально и все протестировал.
- [x] Я ознакомился c [Guide to Contribute](https://github.com/ChaoticOnyx/OnyxBay/blob/dev/docs/contributing.md).
