### PR TITLE
Fix see_in_dark being reset in spite of seeDarkness

### DIFF
--- a/code/modules/mob/living/carbon/human/species/species.dm
+++ b/code/modules/mob/living/carbon/human/species/species.dm
@@ -518,7 +518,11 @@ The slots that you can use are found in items_clothing.dm and are the inventory 
 		return 1
 
 	if(!H.druggy)
-		H.set_see_in_dark((H.sight == (SEE_TURFS|SEE_MOBS|SEE_OBJS)) ? 8 : min(darksight_range + H.equipment_darkness_modifier, 8))
+		H.set_see_in_dark(max(
+			H.see_in_dark,
+			H.sight == (SEE_TURFS|SEE_MOBS|SEE_OBJS) ? 8 : H.see_in_dark,
+			darksight_range + H.equipment_darkness_modifier
+		))
 		if(H.equipment_see_invis)
 			H.set_see_invisible(min(H.see_invisible, H.equipment_see_invis))
 


### PR DESCRIPTION
Фикс говна от дедфили: запутанная иерархия обновления зрения приводила к тому, что все рольки, которые могли включать/выключать ночнозрение действительно получали ночное зрение... которое мгновенно переписывалось кодом, идущим дальше, который забивал хуй на предыдущее значение.

fix #6953

<details>
<summary>Чейнджлог</summary>

```yml
🆑 EditorRUS
bugfix: Абилки на ночное зрение у генок, вампиров и алиенов пофикшены
balance: Ночное зрение больше не имеет ограничения на 8 тайлов
/🆑
```

</details>

- [X] Pull Request полностью завершен, мне не нужна помощь чтобы его закончить.
- [X] Я внимательно прочитал все свои изменения и багов в них не нашел.
- [X] Я запускал сервер со своими изменениями локально и все протестировал.
- [ ] Я ознакомился c [Guide to Contribute](https://github.com/ChaoticOnyx/OnyxBay/blob/dev/docs/contributing.md).
