### PR TITLE
fix(grab): grabs are now deleted instead of drop

### DIFF
--- a/code/datums/movement/mob.dm
+++ b/code/datums/movement/mob.dm
@@ -282,7 +282,8 @@
 	for(var/obj/item/grab/G in mob)
 		if(G.assailant_reverse_facing())
 			mob.set_dir(GLOB.reverse_dir[direction])
-		G.assailant_moved()
+		if(G.current_grab.downgrade_on_move)
+			G.downgrade()
 	for(var/obj/item/grab/G in mob.grabbed_by)
 		G.adjust_position()
 

--- a/code/game/gamemodes/godmode/god_altar.dm
+++ b/code/game/gamemodes/godmode/god_altar.dm
@@ -23,7 +23,7 @@
 			G.affecting.forceMove(get_turf(src))
 			G.affecting.Weaken(1)
 			user.visible_message("<span class='warning'>\The [user] throws \the [G.affecting] onto \the [src]!</span>")
-			user.drop_from_inventory(G)
+			G.delete_self()
 	else ..()
 
 /obj/structure/deity/altar/Process()

--- a/code/game/machinery/kitchen/cooking_machines/_cooker.dm
+++ b/code/game/machinery/kitchen/cooking_machines/_cooker.dm
@@ -91,14 +91,14 @@
 	else if(istype(I, /obj/item/weapon/reagent_containers/glass))
 		to_chat(user, SPAN_WARNING("That would probably break [src]."))
 		return 0
-	else if(istype(I, /obj/item/weapon/holder) || istype(I, /obj/item/grab))
-		if(istype(I, /obj/item/weapon/holder))
-			for(var/mob/living/M in I.contents)
-				inserted_mob = M
-				break
-		else
-			var/obj/item/grab/G = I
-			inserted_mob = G.affecting
+	else if(istype(I, /obj/item/weapon/holder))
+		for(var/mob/living/M in I.contents)
+			inserted_mob = M
+			break
+	else if(istype(I, /obj/item/grab))
+		var/obj/item/grab/G = I
+		inserted_mob = G.affecting
+		G.delete_self()
 	else
 		to_chat(user, SPAN_WARNING("That's not edible."))
 		return 0
@@ -112,7 +112,7 @@
 		return 0
 
 	// Not sure why a food item that passed the previous checks would fail to drop, but safety first.
-	if(!user.drop_from_inventory(I))
+	if(!istype(I, /obj/item/grab) && !user.drop_from_inventory(I))
 		return
 
 	if(inserted_mob)

--- a/code/game/machinery/kitchen/gibber.dm
+++ b/code/game/machinery/kitchen/gibber.dm
@@ -9,8 +9,8 @@
 	anchored = 1
 	req_access = list(access_kitchen,access_morgue)
 
-	var/operating = 0        //Is it on?
-	var/dirty = 0            // Does it need cleaning?
+	var/operating = FALSE        // Is it on?
+	var/dirty = FALSE            // Does it need cleaning?
 	var/mob/living/occupant  // Mob who has been put inside
 	var/gib_time = 40        // Time from starting until meat appears
 	var/gib_throw_dir = WEST // Direction to spit meat and gibs in.
@@ -85,8 +85,8 @@
 		if(!G.force_danger())
 			to_chat(user, SPAN("danger","You need a better grip to do that!"))
 			return
-		move_into_gibber(user,G.affecting)
-		user.drop_from_inventory(G)
+		move_into_gibber(user, G.affecting)
+		G.delete_self()
 	else if(istype(W, /obj/item/organ))
 		user.drop_from_inventory(W)
 		qdel(W)
@@ -243,5 +243,3 @@
 			thing.dropInto(loc) // Attempts to drop it onto the turf for throwing.
 			thing.throw_at(get_edge_target_turf(src,gib_throw_dir),rand(0,3),100) // Being pelted with bits of meat and bone would hurt.
 		update_icon()
-
-

--- a/code/game/objects/items.dm
+++ b/code/game/objects/items.dm
@@ -251,20 +251,23 @@
 			to_chat(user, SPAN("notice", "You try to use your hand, but realize it is no longer attached!"))
 			return
 
-	var/old_loc = src.loc
+	var/old_loc = loc
 
-	src.pickup(user)
-	if (istype(src.loc, /obj/item/weapon/storage))
-		var/obj/item/weapon/storage/S = src.loc
+	pickup(user)
+	if (istype(loc, /obj/item/weapon/storage))
+		var/obj/item/weapon/storage/S = loc
 		S.remove_from_storage(src)
 
-	src.throwing = 0
-	if (src.loc == user)
+	throwing = 0
+	if (loc == user)
 		if(!user.unEquip(src))
 			return
 	else
-		if(isliving(src.loc))
+		if(isliving(loc))
 			return
+
+	if(QDELING(src)) // Unequipping may change src gc_destroyed, so must check here
+		return
 
 	if(user.put_in_active_hand(src))
 		if(isturf(old_loc))
@@ -483,6 +486,9 @@ var/list/global/slot_flags_enumeration = list(
 	if(!M.slot_is_accessible(slot, src, disable_warning? null : M))
 		return 0
 	return 1
+
+/obj/item/proc/can_be_dropped_by_client(mob/M)
+	return M.canUnEquip(src)
 
 /obj/item/verb/verb_pickup()
 	set src in oview(1)

--- a/code/modules/mob/grab/grab_datum.dm
+++ b/code/modules/mob/grab/grab_datum.dm
@@ -7,8 +7,6 @@
 	var/datum/grab/upgrab						// The grab that this will upgrade to if it upgrades, null means no upgrade
 	var/datum/grab/downgrab						// The grab that this will downgrade to if it downgrades, null means break grab on downgrade
 
-	var/datum/time_counter						// For things that need to be timed
-
 	var/stop_move = 0							// Whether or not the grabbed person can move out of the grab
 	var/force_stand = 0							// Whether or not the grabbed person is forced to be standing
 	var/reverse_facing = 0						// Whether the person being grabbed is facing forwards or backwards.
@@ -87,21 +85,11 @@
 		return
 
 /datum/grab/proc/downgrade(obj/item/grab/G)
-	// Starts the process of letting go if there's no downgrade grab
-	if(can_downgrade())
-		downgrade_effect(G)
-		return downgrab
-	else
-		to_chat(G.assailant, "<span class='warning'>[string_process(G, fail_down)]</span>")
-		return
-
-/datum/grab/proc/let_go(obj/item/grab/G)
-	let_go_effect(G)
-	G.force_drop()
+	return downgrab
 
 /datum/grab/proc/process(obj/item/grab/G)
 	if(!G.is_eligible()) // In case if the grab wants to process, but there's no longer a mob grabbed by this exact grab
-		let_go(G)
+		G.delete_self()
 		return
 	var/diff_zone = G.target_change()
 	if(diff_zone && G.special_target_functional)
@@ -199,16 +187,9 @@
 		animate(affecting, pixel_x = 0, pixel_y = 0, 4, 1, LINEAR_EASING)
 	affecting.reset_plane_and_layer()
 
-// This is called whenever the assailant moves.
-/datum/grab/proc/assailant_moved(obj/item/grab/G)
-	adjust_position(G)
-	moved_effect(G)
-	if(downgrade_on_move)
-		G.downgrade()
-
 /*
 	Override these procs to set how the grab state will work. Some of them are best
-	overriden in the parent of the grab set (for example, the behaviour for on_hit_intent(var/obj/item/grab/G)
+	overriden in the parent of the grab set (for example, the behaviour for on_hit_intent(obj/item/grab/G)
 	procs is determined in /datum/grab/normal and then inherited by each intent).
 */
 
@@ -219,16 +200,9 @@
 /datum/grab/proc/can_upgrade(obj/item/grab/G)
 	return 1
 
-// What happens when you downgrade from one grab state to the next.
-/datum/grab/proc/downgrade_effect(obj/item/grab/G)
-
 // Conditions to see if downgrading is possible
 /datum/grab/proc/can_downgrade(obj/item/grab/G)
 	return 1
-
-// What happens when you let go of someone by either dropping the grab
-// or by downgrading from the lowest grab state.
-/datum/grab/proc/let_go_effect(obj/item/grab/G)
 
 // What happens each tic when process is called.
 /datum/grab/proc/process_effect(obj/item/grab/G)
@@ -322,10 +296,8 @@
 			return
 		else
 			affecting.visible_message("<span class='warning'>[affecting] has broken free of [assailant]'s grip!</span>")
-			let_go(G)
+			G.delete_self()
 			assailant.setClickCooldown(15)
 
 /datum/grab/proc/size_difference(mob/A, mob/B)
 	return mob_size_difference(A.mob_size, B.mob_size)
-
-/datum/grab/proc/moved_effect(obj/item/grab/G)

--- a/code/modules/mob/grab/grab_object.dm
+++ b/code/modules/mob/grab/grab_object.dm
@@ -1,6 +1,7 @@
 
 /obj/item/grab
 	name = "grab"
+	canremove = FALSE
 
 	var/mob/living/carbon/human/affecting = null
 	var/mob/living/carbon/human/assailant = null
@@ -17,6 +18,7 @@
 
 	var/attacking = 0
 	var/target_zone
+	var/done_struggle = FALSE // Used by struggle grab datum to keep track of state.
 
 	w_class = ITEM_SIZE_NO_CONTAINER
 	throw_range = 3
@@ -45,7 +47,7 @@
 	current_grab.process(src)
 
 /obj/item/grab/attack_self(mob/user)
-	if(!assailant)
+	if(!assailant || !affecting)
 		return
 	switch(assailant.a_intent)
 		if(I_HELP)
@@ -58,9 +60,14 @@
 
 /obj/item/grab/dropped()
 	..()
-	loc = null
-	if(!QDELETED(src))
+	delete_self()
+
+/obj/item/grab/proc/delete_self()
+	if(!QDELING(src))
 		qdel(src)
+
+/obj/item/grab/can_be_dropped_by_client(mob/M)
+	return M == assailant
 
 /obj/item/grab/Destroy()
 	if(affecting)
@@ -69,7 +76,10 @@
 		affecting.reset_plane_and_layer()
 		affecting = null
 	if(assailant)
+		assailant.u_equip(src)
+		assailant.client?.screen -= src
 		assailant = null
+		loc = null
 	return ..()
 
 /*
@@ -87,15 +97,6 @@
 		return hit_zone
 	else
 		return 0
-
-
-/obj/item/grab/proc/force_drop()
-	if(assailant)
-		assailant.drop_from_inventory(src)
-	else
-		loc = null
-		if(!QDELETED(src))
-			qdel(src)
 
 /obj/item/grab/proc/is_eligible()
 	// can't grab non-carbon/human/'s
@@ -201,7 +202,7 @@
 		current_grab.enter_as_up(src)
 
 /obj/item/grab/proc/downgrade()
-	var/datum/grab/downgrab = current_grab.downgrade(src)
+	var/datum/grab/downgrab = current_grab.downgrade()
 	if(downgrab)
 		current_grab = downgrab
 		update_icons()
@@ -229,13 +230,13 @@
 /obj/item/grab/proc/handle_resist()
 	current_grab.handle_resist(src)
 
-/obj/item/grab/proc/adjust_position(force = 0)
+/obj/item/grab/proc/adjust_position(force = FALSE)
 	if(force)
 		affecting.forceMove(assailant.loc)
 
 	if(!assailant || !affecting || !assailant.Adjacent(affecting))
-		qdel(src)
-		return 0
+		delete_self()
+		return FALSE
 	else
 		current_grab.adjust_position(src)
 
@@ -285,12 +286,8 @@
 /obj/item/grab/proc/ladder_carry()
 	return current_grab.ladder_carry
 
-/obj/item/grab/proc/assailant_moved()
-	current_grab.assailant_moved(src)
-
 /obj/item/grab/proc/restrains()
 	return current_grab.restrains
 
 /obj/item/grab/proc/resolve_openhand_attack()
 		return current_grab.resolve_openhand_attack(src)
-

--- a/code/modules/mob/grab/normal/grab_normal.dm
+++ b/code/modules/mob/grab/normal/grab_normal.dm
@@ -145,7 +145,7 @@
 			else
 				if(headbutt(G))
 					if(drop_headbutt)
-						let_go(G)
+						G.delete_self()
 					return 1
 		//else if(G.target_zone ==
 	return 0

--- a/code/modules/mob/grab/normal/norm_struggle.dm
+++ b/code/modules/mob/grab/normal/norm_struggle.dm
@@ -21,8 +21,6 @@
 
 	icon_state = "reinforce"
 
-	var/done_struggle = FALSE
-
 	break_chance_table = list(5, 20, 30, 80, 100)
 
 
@@ -32,7 +30,7 @@
 
 	if(affecting.incapacitated() || affecting.a_intent == I_HELP)
 		affecting.visible_message("<span class='warning'>[affecting] isn't prepared to fight back as [assailant] tightens \his grip!</span>")
-		done_struggle = TRUE
+		G.done_struggle = TRUE
 		G.upgrade(TRUE)
 
 /datum/grab/normal/struggle/enter_as_up(obj/item/grab/G)
@@ -41,20 +39,24 @@
 
 	if(affecting.incapacitated() || affecting.a_intent == I_HELP)
 		affecting.visible_message("<span class='warning'>[affecting] isn't prepared to fight back as [assailant] tightens \his grip!</span>")
-		done_struggle = TRUE
+		G.done_struggle = TRUE
 		G.upgrade(TRUE)
 	else
 		affecting.visible_message("<span class='warning'>[affecting] struggles against [assailant]!</span>")
-		spawn(10)
-			handle_resist(G)
-		if(do_after(assailant, upgrade_cooldown, G, can_move = 1))
-			done_struggle = TRUE
-			G.upgrade(TRUE)
-		else
-			G.downgrade()
+		G.done_struggle = FALSE
+		addtimer(CALLBACK(G, .proc/handle_resist), 1 SECOND)
+		resolve_struggle(G)
+
+/datum/grab/normal/struggle/proc/resolve_struggle(obj/item/grab/G)
+	set waitfor = FALSE
+	if(do_after(G.assailant, upgrade_cooldown, G, can_move = 1))
+		G.done_struggle = TRUE
+		G.upgrade(TRUE)
+	else
+		G.downgrade()
 
 /datum/grab/normal/struggle/can_upgrade(obj/item/grab/G)
-	return done_struggle
+	return G.done_struggle
 
 /datum/grab/normal/struggle/on_hit_disarm(obj/item/grab/normal/G)
 	to_chat(G.assailant, "<span class='warning'>Your grip isn't strong enough to pin.</span>")

--- a/code/modules/mob/living/carbon/human/human_attackhand.dm
+++ b/code/modules/mob/living/carbon/human/human_attackhand.dm
@@ -313,7 +313,7 @@
 	return 1
 
 //Breaks all grips and pulls that the mob currently has.
-/mob/living/carbon/human/proc/break_all_grabs(mob/living/carbon/user,silent = 0)
+/mob/living/carbon/human/proc/break_all_grabs(mob/living/carbon/user, silent = 0)
 	var/success = 0
 	if(pulling)
 		if(!silent)
@@ -327,18 +327,17 @@
 			if(!silent)
 				visible_message("<span class='danger'>[user] has broken [src]'s grip on [lgrab.affecting]!</span>")
 			success = 1
-		spawn(1)
-			qdel(lgrab)
+		lgrab.delete_self()
 	if(istype(r_hand, /obj/item/grab))
 		var/obj/item/grab/rgrab = r_hand
 		if(rgrab.affecting)
 			if(!silent)
 				visible_message("<span class='danger'>[user] has broken [src]'s grip on [rgrab.affecting]!</span>")
 			success = 1
-		spawn(1)
-			qdel(rgrab)
+		rgrab.delete_self()
 	return success
-/*
+
+/*	
 	We want to ensure that a mob may only apply pressure to one organ of one mob at any given time. Currently this is done mostly implicitly through
 	the behaviour of do_after() and the fact that applying pressure to someone else requires a grab:
 

--- a/code/modules/mob/mob_movement.dm
+++ b/code/modules/mob/mob_movement.dm
@@ -102,8 +102,9 @@
 /client/verb/drop_item()
 	set hidden = 1
 	if(!isrobot(mob) && mob.stat == CONSCIOUS && isturf(mob.loc))
-		return mob.drop_item()
-	return
+		var/obj/item/I = mob.get_active_hand()
+		if(I?.can_be_dropped_by_client(mob))
+			mob.drop_item()
 
 /atom/movable/proc/set_glide_size(glide_size_override = 0, min = 0.9, max = world.icon_size / 2)
 	if (!glide_size_override || glide_size_override > max)


### PR DESCRIPTION
TL;DR
- Граб не выпадает
- Граб не перекладывается из руки в руку

Closes https://github.com/ChaoticOnyx/OnyxBay/issues/4808


Не TL;DR версия:

Есть **Игрок**. Есть **Тело**, которое грабнул игрок. Есть **Граб**.
Граб выпадает при переходе между z-уровням.
Вот некоторые причины:
1) Граб проверяется при мувменте и может "выпасть", при проверке определенного множества условий.
![grab2](https://user-images.githubusercontent.com/2480466/142779233-fe54969a-e809-43ed-a5bd-7fc3fb0d43b9.JPG)

В случае перехода по z-уровням, игра считает, что больше Игрок и Тело Adjacent, и разрывает Граб.

2) Граб процессится, и раз в тик проверяется некоторое другое множество условий (пересекающееся с первым). Тут тоже может выпасть.
![grab](https://user-images.githubusercontent.com/2480466/142779239-0dfa1f87-51fb-4a43-a4d0-a868a0981854.JPG)

3) Вместо прямого удаления используется костыль с выкидыванием Граба.

Пофиксить тут нужно много вещей:
1) Граб - сам по себе один здоровый костыль. Это айтем, который, на самом деле, не айтем, а представление связки между двумя персонажами. Почему он не сделан так же, как пулл (с отражением в client.screen какой-нибудь картиночки о том, что рука занята и бла-бла) мне не ясно.

2) Граб надо не выкидывать, а просто удалять. И вообще его надо сделать невыкидываемым.

3) Граб хорошо бы не процессить. Не то чтобы он занимал много времени на проверку, но не ясно зачем ему вообще процессинг, если там всего-то пару ивентов надо слушать.

4) Хорошо бы переделать\сделать новую проверку Adjacent так, чтобы она осознавала z-уровни. Из-за этого сейчас тяжело протащить Грабом Тело по лестнице. Я попробовал сделать, но выяснил, что если Граб - спагетти код, то лестницы и движение по z-уровням - это таз рамена. Например, у нас есть хендлер для движения вверх или вниз, но он не работает для лестниц, которые передвигают тебя вверх или вниз. Круто?

5) Код выбрасывания айтемов (в том числе и Граба) рассортирован так себе, можно было бы и его поковырять.


Из всего этого многообразия я сделал только 2. Я попробовал сделать 3, но у нас хреново дела с ивентами. Затем попробовал 4, чтобы нормально двигаться по z-уровням, но, похоже, я буду доделывать это еще недели две, если вообще доделаю.

Короче, хотел сделать нормально, но сделал как всегда. Я подумаю еще над тем, чтобы унести код удаления в `inventory.dm` и переиспользовать.

- [x] Pull Request полностью завершен, мне не нужна помощь чтобы его закончить.
- [x] Я знаю, что делаю
- [x] Я запускал сервер со своими изменениями локально и все протестировал.
- [x] Я ознакомился c [Guide to Contribute](https://github.com/ChaoticOnyx/OnyxBay/blob/dev/docs/contributing.md).
