### PR TITLE
Fixed bug with rotating full windows (#6852)

### DIFF
--- a/code/game/objects/structures/window.dm
+++ b/code/game/objects/structures/window.dm
@@ -312,6 +312,9 @@
 	if(usr.incapacitated())
 		return 0
 
+	if(is_full_window()) // No point in rotating a window if it is full
+		return 0
+
 	if(anchored)
 		to_chat(usr, "It is fastened to the floor therefore you can't rotate it!")
 		return 0
@@ -329,6 +332,9 @@
 	set src in oview(1)
 
 	if(usr.incapacitated())
+		return 0
+
+	if(is_full_window()) // No point in rotating a window if it is full
 		return 0
 
 	if(anchored)


### PR DESCRIPTION
Пофиксил баг с исчезновением полных окон при их повороте (Rotate Window Clockwise и Rotate Window Counter-Clockwise). Функция поворота проверяет, является ли окно полным, и если да, то ничего не делает и возвращает 0 (ибо полное окно не должно меняться при повороте)

fix #6852 

<details>
<summary>Чейнджлог</summary>

```yml
🆑bernmarx
bugfix: Исправлен баг с исчезновением полных окон при их повороте
/🆑
```

</details>

- [x] Pull Request полностью завершен, мне не нужна помощь чтобы его закончить.
- [x] Я внимательно прочитал все свои изменения и багов в них не нашел.
- [x] Я запускал сервер со своими изменениями локально и все протестировал.
- [x] Я ознакомился c [Guide to Contribute](https://github.com/ChaoticOnyx/OnyxBay/blob/dev/docs/contributing.md).
