### PR TITLE
fix(blob): fix destroy overriding

### DIFF
--- a/code/game/objects/structures/blob/blob.dm
+++ b/code/game/objects/structures/blob/blob.dm
@@ -37,11 +37,6 @@
 
 	START_PROCESSING(SSobj, src)
 
-/obj/structure/blob/core/Destroy()
-	. = ..()
-
-	STOP_PROCESSING(SSobj, src)
-
 /obj/structure/blob/proc/can_expand()
 	if(QDELETED(core))
 		return FALSE


### PR DESCRIPTION
Данный функционал уже есть в
```dm
/obj/Destroy()
	CAN_BE_REDEFINED(TRUE)
	var/obj/item/smallDelivery/delivery = loc

	if (istype(delivery))
		delivery.wrapped = null

	STOP_PROCESSING(SSobj, src)
	return ..()
```

- [x] Pull Request полностью завершен, мне не нужна помощь чтобы его закончить.
- [x] Я внимательно прочитал все свои изменения и багов в них не нашел.
- [ ] Я запускал сервер со своими изменениями локально и все протестировал.
- [x] Я ознакомился c [Guide to Contribute](https://github.com/ChaoticOnyx/OnyxBay/blob/dev/docs/contributing.md).
