### PR TITLE
Фикс пассивной регенерации у генок.

### DIFF
--- a/code/game/gamemodes/changeling/changeling_organs.dm
+++ b/code/game/gamemodes/changeling/changeling_organs.dm
@@ -101,6 +101,7 @@
 // Biostructure processing
 /obj/item/organ/internal/biostructure/Process()
 	. = ..()
+	check_damage()
 	if(damage > max_damage / 2 && healing_threshold)
 		if(owner)
 			alert(owner, "We have taken massive core damage! We need regeneration.", "Core Damaged")
@@ -110,7 +111,6 @@
 	else if (damage <= max_damage / 2 && !healing_threshold)
 		healing_threshold = 1
 	if(owner)
-		check_damage()
 		if(damage <= max_damage / 2 && healing_threshold && world.time < last_regen_time + 40)
 			owner.mind.changeling.chem_charges = max(owner.mind.changeling.chem_charges - 0.5, 0)
 			damage--

--- a/code/game/gamemodes/changeling/powers/rapid_heal.dm
+++ b/code/game/gamemodes/changeling/powers/rapid_heal.dm
@@ -19,7 +19,7 @@
 		to_chat(H, SPAN("changeling", "We activate our stemocyte pool and begin intensive fleshmending."))
 
 		spawn(0)
-			while(H && H.mind && H.mind.changeling.heal && !is_regenerating())
+			while(H && H.mind && && H.mind.changeling.damaged H.mind.changeling.heal && !is_regenerating())
 				H.mind.changeling.chem_charges = max(H.mind.changeling.chem_charges - 1, 0)
 				if(H.getBruteLoss())
 					H.adjustBruteLoss(-15 * config.organ_regeneration_multiplier) // Heal brute better than other ouchies.

--- a/code/game/gamemodes/changeling/powers/rapid_heal.dm
+++ b/code/game/gamemodes/changeling/powers/rapid_heal.dm
@@ -19,7 +19,7 @@
 		to_chat(H, SPAN("changeling", "We activate our stemocyte pool and begin intensive fleshmending."))
 
 		spawn(0)
-			while(H && H.mind && H.mind.changeling.heal && H.mind.changeling.damaged && !is_regenerating())
+			while(H && H.mind && H.mind.changeling.heal && !is_regenerating())
 				H.mind.changeling.chem_charges = max(H.mind.changeling.chem_charges - 1, 0)
 				if(H.getBruteLoss())
 					H.adjustBruteLoss(-15 * config.organ_regeneration_multiplier) // Heal brute better than other ouchies.


### PR DESCRIPTION
Был убран ненужный код из if, который ломал пассивную регенерацию и нужно было кликать на неё после получения ранения, а если тебя ранили во время действия пассивной регенерации, либо с полным хп, то она не работала.(Не знаю, чего это до сих пор никто не починил, ведь тут надо всего лишь одно условие if-а удалить)

close #7044 


<details>
<summary>Чейнджлог</summary>

```yml
🆑
bugfix: Починено Passive Regeneration и теперь оно не включается через раз.
/🆑
```
</details>


- [x] Pull Request полностью завершен, мне не нужна помощь чтобы его закончить.
- [x] Я внимательно прочитал все свои изменения и багов в них не нашел.
- [x] Я запускал сервер со своими изменениями локально и все протестировал.
- [x] Я ознакомился c [Guide to Contribute](https://github.com/ChaoticOnyx/OnyxBay/blob/dev/docs/contributing.md).
