### PR TITLE
fixed bug with Change UI verb

### DIFF
--- a/code/modules/client/ui_style.dm
+++ b/code/modules/client/ui_style.dm
@@ -57,3 +57,10 @@
 		prefs.UI_style_color = UI_style_color_new
 		SScharacter_setup.queue_preferences_save(prefs)
 		to_chat(usr, "UI was saved")
+	else
+		ic = all_ui_styles[prefs.UI_style]
+		for(var/obj/screen/I in icons)
+			if(I.name in list(I_HELP, I_HURT, I_DISARM, I_GRAB)) continue
+			I.icon = ic
+			I.color = prefs.UI_style_color
+			I.alpha = prefs.UI_style_alpha


### PR DESCRIPTION
Исправил баг с Change UI, где изменения не откатываются в окне "Like it? Save changes?" при нажатии соответствующей кнопки. Просто добавил код, который при нажатии кнопки "No" обновляет UI до исходного, т.е. который был в префах игрока

fix #6656

<details>
<summary>Чейнджлог</summary>

```yml
🆑 Caraseeque
bugfix: Исправлен баг, при котором изменения Change UI не откатывались при нажатии соответствующей кнопки
/🆑
```

</details>

- [x] Pull Request полностью завершен, мне не нужна помощь чтобы его закончить.
- [x] Я внимательно прочитал все свои изменения и багов в них не нашел.
- [x] Я запускал сервер со своими изменениями локально и все протестировал.
- [x] Я ознакомился c [Guide to Contribute](https://github.com/ChaoticOnyx/OnyxBay/blob/dev/docs/contributing.md).
