### PR TITLE
Removes some biostructural bugs

### DIFF
--- a/code/game/gamemodes/changeling/biostructure.dm
+++ b/code/game/gamemodes/changeling/biostructure.dm
@@ -152,16 +152,18 @@
 	//deleteing biostructure from external organ so when that organ is deleted biostructure wont be deleted
 	if(istype(source, /mob/living/carbon/human))
 		var/mob/living/carbon/human/H = source
-		var/obj/item/organ/external/E = H.get_organ(parent_organ)
-		if(E)
-			E.internal_organs -= src
-		H.internal_organs_by_name.Remove(BP_CHANG)
-		H.internal_organs_by_name -= BP_CHANG // Yes this is intended, even after the previous line. Everything will get broken if you remove this.
-		H.internal_organs.Remove(src)
+		if(H == owner)
+			var/obj/item/organ/external/E = H.get_organ(parent_organ)
+			if(E)
+				E.internal_organs -= src
+			H.internal_organs_by_name.Remove(BP_CHANG)
+			H.internal_organs_by_name -= BP_CHANG // Yes this is intended, even after the previous line. Everything will get broken if you remove this.
+			H.internal_organs.Remove(src)
+		else
+			H.drop_from_inventory(src)
 	else if(istype(source, /obj/item/organ/external))
 		var/obj/item/organ/external/E = source
-		if(E)
-			E.internal_organs -= src
+		E.internal_organs.Remove(src)
 
 	forceMove(destination)
 

--- a/code/game/gamemodes/changeling/powers/detach_limb.dm
+++ b/code/game/gamemodes/changeling/powers/detach_limb.dm
@@ -28,7 +28,7 @@
 	if(!organ_to_remove)
 		detaching_now = FALSE
 		return
-	if(!H.organs.Find(organ_to_remove))
+	if(!(organ_to_remove in H.organs))
 		detaching_now = FALSE
 		to_chat(H, SPAN("changeling", "We don't have this limb!"))
 		return
@@ -54,8 +54,9 @@
 
 	var/obj/item/organ/internal/biostructure/BIO = H.internal_organs_by_name[BP_CHANG]
 	if(organ_to_remove.organ_tag == BIO.parent_organ)
+		organ_to_remove.internal_organs.Remove(BIO) // Preventing biostructure from going through an unnecessary removed() and risking to get bugged
 		H.mind.transfer_to(L)
-	BIO.parent_organ = BP_CHEST
+		BIO.parent_organ = BP_CHEST
 
 	organ_to_remove.droplimb(TRUE)
 	qdel(organ_to_remove)

--- a/code/game/gamemodes/changeling/powers/disjunction.dm
+++ b/code/game/gamemodes/changeling/powers/disjunction.dm
@@ -76,10 +76,10 @@
 	var/mob/living/simple_animal/hostile/little_changeling/chest_chan/chest_ling = new (get_turf(H))
 	if(BIO.parent_organ == BP_CHEST || BIO.parent_organ == BP_GROIN)
 		mob_to_receive_mind = chest_ling
-	BIO.parent_organ = BP_CHEST
 
 	if(mob_to_receive_mind)
 		H.mind.transfer_to(mob_to_receive_mind)
+		BIO.parent_organ = BP_CHEST
 
 	gibs(H.loc, H.dna)
 	for(var/obj/item/I in H.contents)

--- a/code/modules/organs/external/_external.dm
+++ b/code/modules/organs/external/_external.dm
@@ -140,6 +140,10 @@
 		for(var/obj/item/organ/external/C in children)
 			qdel(C)
 
+	var/obj/item/organ/internal/biostructure/BIO = locate() in src
+	if(BIO)
+		BIO.forceMove(loc) // Because we don't want biostructures to get wrecked so easily
+
 	if(internal_organs)
 		for(var/obj/item/organ/O in internal_organs)
 			qdel(O)

--- a/code/modules/organs/external/_external.dm
+++ b/code/modules/organs/external/_external.dm
@@ -901,7 +901,7 @@ Note that amputating the affected organ does in fact remove the infection from t
 			forceMove(victim.loc)
 			if(!clean) // Throw limb around.
 				spawn()
-					if(src && isturf(loc))
+					if(!QDELETED(src) && isturf(loc))
 						throw_at(get_edge_target_turf(src, pick(GLOB.alldirs)), rand(1, 3), rand(2, 4))
 					dir = 2
 		if(DROPLIMB_BURN)

--- a/code/modules/organs/external/_external.dm
+++ b/code/modules/organs/external/_external.dm
@@ -141,8 +141,7 @@
 			qdel(C)
 
 	var/obj/item/organ/internal/biostructure/BIO = locate() in src
-	if(BIO)
-		BIO.forceMove(loc) // Because we don't want biostructures to get wrecked so easily
+	BIO?.forceMove(loc) // Because we don't want biostructures to get wrecked so easily
 
 	if(internal_organs)
 		for(var/obj/item/organ/O in internal_organs)


### PR DESCRIPTION
- Исправлен баг, из-за которого при отцеплении нескольких конечностей подряд генка мог гостануться без возможности вернуться в тело.
- Исправлена возможность дюпа биоструктуры с последующим забаговыванием генки.
- Исправлена смерть генокрада в случае, если он держит в руках биоструктуру другого генокрада и тот прожимает Runaway.

- [x] Pull Request полностью завершен, мне не нужна помощь чтобы его закончить.
- [x] Я внимательно прочитал все свои изменения и багов в них не нашел.
- [x] Я запускал сервер со своими изменениями локально и все протестировал.
- [x] Я ознакомился c [Guide to Contribute](https://github.com/ChaoticOnyx/OnyxBay/blob/dev/docs/contributing.md).
