### PR TITLE
fix(grab): not allow grabbing while lying

### DIFF
--- a/code/modules/mob/grab/grab_object.dm
+++ b/code/modules/mob/grab/grab_object.dm
@@ -143,6 +143,9 @@
 	if(!assailant || !affecting)
 		return 0
 
+	if(assailant.lying)
+		return 0
+
 	if(assailant == affecting)
 		to_chat(assailant, "<span class='notice'>You can't grab yourself.</span>")
 		return 0


### PR DESCRIPTION
вообще грабать людей лёжа сейчас это не настолько серьёзно чем было в момент написания ишью поскольку если отойти от моба которого пытался грабнуть то эффект спадает, но тем не менее неприятно ибо хрен чё возьмёшь и вообще медленный ходишь в этот момент времени

fix #5588 

<details>
<summary>chngl</summary>

```yml
🆑
bugfix: Больше нельзя грабать лежа.
/🆑
```

</details>

- [x] Pull Request полностью завершен, мне не нужна помощь чтобы его закончить.
- [x] Я внимательно прочитал все свои изменения и багов в них не нашел.
- [x] Я запускал сервер со своими изменениями локально и все протестировал.
- [x] Я ознакомился c [Guide to Contribute](https://github.com/ChaoticOnyx/OnyxBay/blob/dev/docs/contributing.md).
