### PR TITLE
Операционный стол не перестаёт раздевать

### DIFF
--- a/code/game/machinery/OpTable.dm
+++ b/code/game/machinery/OpTable.dm
@@ -82,7 +82,7 @@
 
 /obj/machinery/optable/verb/remove_clothes()
 	set name = "Remove Clothes"
-	set category = "IC"
+	set category = "Object"
 	set src in oview(1)
 
 	if(!ishuman(usr) && !issilicon(usr))
@@ -113,6 +113,7 @@
 						SPAN_NOTICE("You begin to undress [victim] on the table with the built-in tool."))
 	if(do_after(usr, time_to_strip, victim))
 		if(!victim)
+			busy = FALSE
 			return
 		for(var/obj/item/clothing/C in victim.contents)
 			if(istype(C, /obj/item/clothing/mask/breath/anesthetic))


### PR DESCRIPTION
- Исправлен баг, после определённых действий с пациентом не позволявший больше никого раздевать на операционном столе из-за того, что `busy` не устанавливалась на FALSE в одной из проверок.
- Верб "Remove Clothes" перемещён в категорию "Object", ибо принадлежит операционному столу.

fixes #7131 

<details>
<summary>Чейнджлог</summary>

```yml
🆑TheUnknownOne
bugfix: Исправлен баг, после определённых действий с пациентом не позволявший больше никого раздевать на операционном столе.
tweak: Верб операционного стола "Remove Clothes" перемещён во вкладку "Object".
/🆑
```

</details>

- [x] Pull Request полностью завершен, мне не нужна помощь чтобы его закончить.
- [x] Я внимательно прочитал все свои изменения и багов в них не нашел.
- [x] Я запускал сервер со своими изменениями локально и все протестировал.
- [x] Я ознакомился c [Guide to Contribute](https://github.com/ChaoticOnyx/OnyxBay/blob/dev/docs/contributing.md).