### PR TITLE
Reverts candrop removal

### DIFF
--- a/code/game/objects/items.dm
+++ b/code/game/objects/items.dm
@@ -55,6 +55,7 @@
 	var/slowdown_per_slot[slot_last] // How much clothing is slowing you down. This is an associative list: item slot - slowdown
 	var/slowdown_accessory // How much an accessory will slow you down when attached to a worn article of clothing.
 	var/canremove = 1 //Mostly for Ninja code at this point but basically will not allow the item to be removed if set to 0. /N
+	var/candrop = 1 //Mostly for the fake armblade code. Prevents drop_from_inventory(), making the wielder unable to drop it at all unless forced.
 	var/list/armor = list(melee = 0, bullet = 0, laser = 0,energy = 0, bomb = 0, bio = 0, rad = 0)
 	var/list/allowed = null //suit storage stuff.
 	var/obj/item/device/uplink/hidden_uplink = null // All items can have an uplink hidden inside, just remember to add the triggers.

--- a/code/game/objects/items/weapons/storage/briefcase.dm
+++ b/code/game/objects/items/weapons/storage/briefcase.dm
@@ -101,7 +101,7 @@
 		if(del_on_send)
 			if(ishuman(loc))
 				var/mob/living/carbon/human/H = loc
-				H.drop_from_inventory(src, get_turf(src))
+				H.drop_from_inventory(src, get_turf(src), TRUE)
 				to_chat(loc, SPAN("notice", "\The [src] fades away in a brief flash of light."))
 			qdel(src)
 

--- a/code/modules/augmentation/prosthetic/prosthetic.dm
+++ b/code/modules/augmentation/prosthetic/prosthetic.dm
@@ -2,6 +2,7 @@
 	var/prost_type = "prosthetic"
 	var/obj/item/organ/external/parent_hand
 	canremove = FALSE
+	candrop = FALSE
 
 /obj/item/weapon/melee/prosthetic/New(atom/location, obj/item/organ/external/limb)
 	attach_prosthetic(src,limb)
@@ -31,6 +32,7 @@
 	if(istype(prosthetic,/obj/item/weapon/melee/prosthetic))
 		var/obj/item/weapon/melee/prosthetic/P = prosthetic
 		P.parent_hand = null
+		P.candrop = TRUE
 		P.canremove = TRUE
 
 /proc/isProsthetic(A)

--- a/code/modules/mob/inventory.dm
+++ b/code/modules/mob/inventory.dm
@@ -151,8 +151,8 @@ var/list/slot_equipment_priority = list( \
 
 // Removes an item from inventory and places it in the target atom.
 // If canremove or other conditions need to be checked then use unEquip instead.
-/mob/proc/drop_from_inventory(obj/item/W, atom/target = null)
-	if(W)
+/mob/proc/drop_from_inventory(obj/item/W, atom/target = null,force = null)
+	if(W && (W.candrop || force))
 		remove_from_mob(W, target)
 		if(!(W && W.loc)) return 1 // self destroying objects (tk, grabs)
 		update_icons()

--- a/code/modules/mob/living/carbon/carbon.dm
+++ b/code/modules/mob/living/carbon/carbon.dm
@@ -299,7 +299,7 @@
 		return
 
 	var/obj/item/I = item
-	if(!I.canremove)
+	if(!I.candrop)
 		return
 
 	var/throw_range = item.throw_range

--- a/code/modules/mob/living/carbon/carbon.dm
+++ b/code/modules/mob/living/carbon/carbon.dm
@@ -299,13 +299,12 @@
 		return
 
 	var/obj/item/I = item
-	var/is_grab = istype(item, /obj/item/grab)
-	if(!I.canremove && !is_grab)
+	if(!I.canremove)
 		return
 
 	var/throw_range = item.throw_range
 	var/itemsize
-	if(is_grab)
+	if(istype(item, /obj/item/grab))
 		var/obj/item/grab/G = item
 		item = G.throw_held() // throw the person instead of the grab
 		if(ismob(item))

--- a/code/modules/mob/living/carbon/human/human.dm
+++ b/code/modules/mob/living/carbon/human/human.dm
@@ -6,6 +6,7 @@
 	icon_state = "body_m_s"
 
 	throw_range = 4
+	var/candrop = 1
 
 	var/equipment_slowdown = -1
 	var/list/hud_list[11]

--- a/code/modules/mob/living/carbon/human/human_organs.dm
+++ b/code/modules/mob/living/carbon/human/human_organs.dm
@@ -273,13 +273,13 @@
 		var/obj/item/organ/external/E = get_organ(BP_L_HAND) // We don't need to check for arms if we already have no hands
 		if(!E)
 			visible_message("<span class='danger'>Lacking a functioning left hand, \the [src] drops \the [l_hand].</span>")
-			drop_from_inventory(l_hand)
+			drop_from_inventory(l_hand, force = 1)
 
 	if(r_hand)
 		var/obj/item/organ/external/E = get_organ(BP_R_HAND)
 		if(!E)
 			visible_message("<span class='danger'>Lacking a functioning right hand, \the [src] drops \the [r_hand].</span>")
-			drop_from_inventory(r_hand)
+			drop_from_inventory(r_hand, force = 1)
 
 	// Check again...
 	if(!l_hand && !r_hand)

--- a/code/modules/ventcrawl/ventcrawl.dm
+++ b/code/modules/ventcrawl/ventcrawl.dm
@@ -186,6 +186,7 @@ var/list/ventcrawl_machinery = list(
 
 /mob/living/proc/add_ventcrawl(obj/machinery/atmospherics/starting_machine)
 	is_ventcrawling = 1
+	//candrop = 0
 	var/datum/pipe_network/network = starting_machine.return_network(starting_machine)
 	if(!network)
 		return
@@ -200,6 +201,7 @@ var/list/ventcrawl_machinery = list(
 
 /mob/living/proc/remove_ventcrawl()
 	is_ventcrawling = 0
+	//candrop = 1
 	if(client)
 		for(var/image/current_image in pipes_shown)
 			client.images -= current_image


### PR DESCRIPTION
Candrop и canremove использовались для разных вещей. Некоторые предметы нельзя было снять с моба, но сам моб может дропнуть. Или наоборот.

```yml
🆑
bugfix: Исправлена невозможность выкидывать армблейды.
/🆑
```

- [x] Pull Request полностью завершен, мне не нужна помощь чтобы его закончить.
- [x] Я внимательно прочитал все свои изменения и багов в них не нашел.
- [ ] Я запускал сервер со своими изменениями локально и все протестировал.
- [x] Я ознакомился c [Guide to Contribute](https://github.com/ChaoticOnyx/OnyxBay/blob/dev/docs/contributing.md).
