### PR TITLE
Removes brokenness of HUD drop icon

### DIFF
--- a/code/_onclick/hud/screen_objects.dm
+++ b/code/_onclick/hud/screen_objects.dm
@@ -339,8 +339,9 @@
 				usr.toggle_throw_mode()
 
 		if("drop")
-			if(usr.client)
-				usr.client.drop_item()
+			if(isliving(usr))
+				var/mob/living/L = usr
+				L.hotkey_drop()
 
 		if("block")
 			if(istype(usr,/mob/living/carbon/human))


### PR DESCRIPTION
В какой момент оно вообще решило сломаться?

```yml
🆑
bugfix: Исправлена работа кнопки "Drop" в HUDе. Теперь она работает точно так же, как и хоткейный дроп на клавишу Q.
/🆑
```

- [x] Pull Request полностью завершен, мне не нужна помощь чтобы его закончить.
- [x] Я внимательно прочитал все свои изменения и багов в них не нашел.
- [x] Я запускал сервер со своими изменениями локально и все протестировал.
- [x] Я ознакомился c [Guide to Contribute](https://github.com/ChaoticOnyx/OnyxBay/blob/dev/docs/contributing.md).
