### PR TITLE
Removes impossibility of qdeling items dropped inside mechas

### DIFF
--- a/code/game/mecha/mecha.dm
+++ b/code/game/mecha/mecha.dm
@@ -1122,6 +1122,8 @@
 		var/atom/movable/I = item
 		if(ishuman(occupant) && is_type_in_list(I, onmob_items))
 			continue
+		if(QDELETED(I)) // The pilot may use Eject before dropped_items go through QDELETED() check via onDropInto().
+			continue
 		I.forceMove(loc)
 	dropped_items.Cut()
 	if(mob_container.forceMove(src.loc))//ejecting mob container
@@ -1732,6 +1734,9 @@
 
 /obj/mecha/onDropInto(atom/movable/AM)
 	dropped_items |= AM
+	spawn(5) // Wait a bit as the dropped atom may be trying to get deleted.
+		if(QDELETED(AM))
+			dropped_items -= AM
 
 //////////////////////////////////////////
 ////////  Mecha global iterators  ////////


### PR DESCRIPTION

```yml
🆑
bugfix: Исправлена ошибка, из-за которой предметы внутри мехов не могли правильно удаляться. Теперь стазис генокрада не будет создавать внутри мехов кучу забагованных органов.
/🆑
```

- [x] Pull Request полностью завершен, мне не нужна помощь чтобы его закончить.
- [x] Я внимательно прочитал все свои изменения и багов в них не нашел.
- [x] Я запускал сервер со своими изменениями локально и все протестировал.
- [x] Я ознакомился c [Guide to Contribute](https://github.com/ChaoticOnyx/OnyxBay/blob/dev/docs/contributing.md).
