### PR TITLE
меняем валюту в карго с поинтов на кредиты

### DIFF
--- a/code/datums/supplypacks/atmospherics.dm
+++ b/code/datums/supplypacks/atmospherics.dm
@@ -6,7 +6,7 @@
 	name = "Internals crate"
 	contains = list(/obj/item/clothing/mask/gas = 5,
 					/obj/item/weapon/tank/air = 5)
-	cost = 10
+	cost = 1000
 	containername = "\improper Internals crate"
 
 /decl/hierarchy/supply_pack/atmospherics/evacuation
@@ -18,49 +18,49 @@
 					/obj/item/clothing/head/helmet/space/emergency = 4,
 					/obj/item/clothing/mask/gas = 4,
 					/obj/item/device/flashlight/glowstick = 5)
-	cost = 30
+	cost = 3000
 
 	containername = "\improper Emergency crate"
 
 /decl/hierarchy/supply_pack/atmospherics/inflatable
 	name = "Inflatable barriers"
 	contains = list(/obj/item/weapon/storage/briefcase/inflatable = 5)
-	cost = 20
+	cost = 2000
 	containertype = /obj/structure/closet/crate
 	containername = "\improper Inflatable Barrier Crate"
 
 /decl/hierarchy/supply_pack/atmospherics/canister_empty
 	name = "Empty gas canister"
 	contains = list(/obj/machinery/portable_atmospherics/canister)
-	cost = 5
+	cost = 500
 	containername = "\improper Empty gas canister crate"
 	containertype = /obj/structure/largecrate
 
 /decl/hierarchy/supply_pack/atmospherics/canister_air
 	name = "Air canister"
 	contains = list(/obj/machinery/portable_atmospherics/canister/air)
-	cost = 10
+	cost = 1000
 	containername = "\improper Air canister crate"
 	containertype = /obj/structure/largecrate
 
 /decl/hierarchy/supply_pack/atmospherics/canister_oxygen
 	name = "Oxygen canister"
 	contains = list(/obj/machinery/portable_atmospherics/canister/oxygen)
-	cost = 15
+	cost = 1500
 	containername = "\improper Oxygen canister crate"
 	containertype = /obj/structure/largecrate
 
 /decl/hierarchy/supply_pack/atmospherics/canister_nitrogen
 	name = "Nitrogen canister"
 	contains = list(/obj/machinery/portable_atmospherics/canister/nitrogen)
-	cost = 10
+	cost = 1000
 	containername = "\improper Nitrogen canister crate"
 	containertype = /obj/structure/largecrate
 
 /decl/hierarchy/supply_pack/atmospherics/canister_plasma
 	name = "Plasma gas canister"
 	contains = list(/obj/machinery/portable_atmospherics/canister/plasma)
-	cost = 70
+	cost = 7000
 	containername = "\improper Plasma gas canister crate"
 	containertype = /obj/structure/closet/crate/secure/large
 	access = access_atmospherics
@@ -68,7 +68,7 @@
 /decl/hierarchy/supply_pack/atmospherics/canister_hydrogen
 	name = "Hydrogen canister"
 	contains = list(/obj/machinery/portable_atmospherics/canister/hydrogen)
-	cost = 25
+	cost = 2500
 	containername = "\improper Hydrogen canister crate"
 	containertype = /obj/structure/closet/crate/secure/large
 	access = access_atmospherics
@@ -76,7 +76,7 @@
 /decl/hierarchy/supply_pack/atmospherics/canister_sleeping_agent
 	name = "N2O gas canister"
 	contains = list(/obj/machinery/portable_atmospherics/canister/sleeping_agent)
-	cost = 40
+	cost = 4000
 	containername = "\improper N2O gas canister crate"
 	containertype = /obj/structure/closet/crate/secure/large
 	access = access_atmospherics
@@ -84,7 +84,7 @@
 /decl/hierarchy/supply_pack/atmospherics/canister_carbon_dioxide
 	name = "Carbon dioxide gas canister"
 	contains = list(/obj/machinery/portable_atmospherics/canister/carbon_dioxide)
-	cost = 40
+	cost = 4000
 	containername = "\improper CO2 canister crate"
 	containertype = /obj/structure/closet/crate/secure/large
 	access = access_atmospherics
@@ -92,13 +92,13 @@
 /decl/hierarchy/supply_pack/atmospherics/fuel
 	name = "Fuel tank crate"
 	contains = list(/obj/item/weapon/tank/hydrogen = 4)
-	cost = 15
+	cost = 1500
 	containername = "\improper Fuel tank crate"
 
 /decl/hierarchy/supply_pack/atmospherics/plasma
 	name = "Plasma tank crate"
 	contains = list(/obj/item/weapon/tank/plasma = 3)
-	cost = 30
+	cost = 3000
 	containername = "\improper Plasma tank crate"
 
 /decl/hierarchy/supply_pack/atmospherics/voidsuit
@@ -106,7 +106,7 @@
 	contains = list(/obj/item/clothing/suit/space/void/atmos/alt,
 					/obj/item/clothing/head/helmet/space/void/atmos/alt,
 					/obj/item/clothing/shoes/magboots)
-	cost = 60
+	cost = 6000
 	containername = "\improper Atmospherics voidsuit crate"
 	containertype = /obj/structure/closet/crate/secure/large
 	access = access_atmospherics

--- a/code/datums/supplypacks/engineering.dm
+++ b/code/datums/supplypacks/engineering.dm
@@ -4,42 +4,42 @@
 /decl/hierarchy/supply_pack/engineering/lightbulbs
 	name = "Replacement lights"
 	contains = list(/obj/item/weapon/storage/box/lights/mixed = 5)
-	cost = 10
+	cost = 1000
 	containertype = /obj/structure/closet/crate/engineering
 	containername = "\improper Replacement lights"
 
 /decl/hierarchy/supply_pack/engineering/smes_circuit
 	name = "Superconducting Magnetic Energy Storage Unit Circuitry"
 	contains = list(/obj/item/weapon/circuitboard/smes)
-	cost = 20
+	cost = 2000
 	containertype = /obj/structure/closet/crate/engineering
 	containername = "\improper Superconducting Magnetic Energy Storage Unit Circuitry"
 
 /decl/hierarchy/supply_pack/engineering/smescoil
 	name = "Superconductive Magnetic Coil"
 	contains = list(/obj/item/weapon/smes_coil)
-	cost = 35
+	cost = 3500
 	containertype = /obj/structure/closet/crate/engineering
 	containername = "\improper Superconductive Magnetic Coil crate"
 
 /decl/hierarchy/supply_pack/engineering/smescoil_weak
 	name = "Basic Superconductive Magnetic Coil"
 	contains = list(/obj/item/weapon/smes_coil/weak)
-	cost = 25
+	cost = 2500
 	containertype = /obj/structure/closet/crate/engineering
 	containername = "\improper Basic Superconductive Magnetic Coil crate"
 
 /decl/hierarchy/supply_pack/engineering/smescoil_super_capacity
 	name = "Superconductive Capacitance Coil"
 	contains = list(/obj/item/weapon/smes_coil/super_capacity)
-	cost = 45
+	cost = 4500
 	containertype = /obj/structure/closet/crate/engineering
 	containername = "\improper Superconductive Capacitance Coil crate"
 
 /decl/hierarchy/supply_pack/engineering/smescoil_super_io
 	name = "Superconductive Transmission Coil"
 	contains = list(/obj/item/weapon/smes_coil/super_io)
-	cost = 45
+	cost = 4500
 	containertype = /obj/structure/closet/crate/engineering
 	containername = "\improper Superconductive Transmission Coil crate"
 
@@ -49,7 +49,7 @@
 					/obj/item/clothing/gloves/insulated = 2,
 					/obj/item/weapon/cell = 2,
 					/obj/item/weapon/cell/high = 2)
-	cost = 15
+	cost = 1500
 	containertype = /obj/structure/closet/crate/engineering
 	containername = "\improper Electrical maintenance crate"
 
@@ -59,7 +59,7 @@
 					/obj/item/clothing/suit/storage/hazardvest = 3,
 					/obj/item/clothing/head/welding = 2,
 					/obj/item/clothing/head/hardhat)
-	cost = 10
+	cost = 1000
 	containertype = /obj/structure/closet/crate/engineering
 	containername = "\improper Mechanical maintenance crate"
 
@@ -70,21 +70,21 @@
 					/obj/item/weapon/tracker_electronics,
 					/obj/item/weapon/paper/solar
 					)
-	cost = 15
+	cost = 1500
 	containertype = /obj/structure/closet/crate/engineering
 	containername = "\improper Solar Pack crate"
 
 /decl/hierarchy/supply_pack/engineering/solar_assembly
 	name = "Solar Assembly crate"
 	contains  = list(/obj/item/solar_assembly = 16)
-	cost = 10
+	cost = 1000
 	containertype = /obj/structure/closet/crate/engineering
 	containername = "\improper Solar Assembly crate"
 
 /decl/hierarchy/supply_pack/engineering/emitter
 	name = "Emitter crate"
 	contains = list(/obj/machinery/power/emitter = 2)
-	cost = 10
+	cost = 1000
 	containertype = /obj/structure/closet/crate/secure/large
 	containername = "\improper Emitter crate"
 	access = access_engine_equip
@@ -93,14 +93,14 @@
 	name = "Field Generator crate"
 	contains = list(/obj/machinery/field_generator = 2)
 	containertype = /obj/structure/closet/crate/large
-	cost = 10
+	cost = 1000
 	containername = "\improper Field Generator crate"
 	access = access_ce
 
 /decl/hierarchy/supply_pack/engineering/sing_gen
 	name = "Singularity Generator crate"
 	contains = list(/obj/machinery/the_singularitygen)
-	cost = 10
+	cost = 1000
 	containertype = /obj/structure/closet/crate/secure/large
 	containername = "\improper Singularity Generator crate"
 	access = access_ce
@@ -108,7 +108,7 @@
 /decl/hierarchy/supply_pack/engineering/collector
 	name = "Collector crate"
 	contains = list(/obj/machinery/power/rad_collector = 2)
-	cost = 6
+	cost = 600
 	containertype = /obj/structure/closet/crate/secure/large
 	containername = "\improper Collector crate"
 	access = access_engine_equip
@@ -122,7 +122,7 @@
 					/obj/structure/particle_accelerator/particle_emitter/right,
 					/obj/structure/particle_accelerator/power_box,
 					/obj/structure/particle_accelerator/end_cap)
-	cost = 40
+	cost = 4000
 	containertype = /obj/structure/largecrate
 	containername = "\improper Particle Accelerator crate"
 	access = access_ce
@@ -133,7 +133,7 @@
 					/obj/item/weapon/stock_parts/capacitor,
 					/obj/item/weapon/stock_parts/matter_bin,
 					/obj/item/weapon/circuitboard/pacman)
-	cost = 45
+	cost = 4500
 	containertype = /obj/structure/closet/crate/secure/engineering
 	containername = "\improper P.A.C.M.A.N. Portable Generator Construction Kit"
 	access = access_tech_storage
@@ -144,7 +144,7 @@
 					/obj/item/weapon/stock_parts/capacitor,
 					/obj/item/weapon/stock_parts/matter_bin,
 					/obj/item/weapon/circuitboard/pacman/super)
-	cost = 55
+	cost = 5500
 	containertype = /obj/structure/closet/crate/secure/engineering
 	containername = "\improper Super P.A.C.M.A.N. portable generator construction kit"
 	access = access_tech_storage
@@ -152,7 +152,7 @@
 /decl/hierarchy/supply_pack/engineering/teg
 	name = "Mark I Thermoelectric Generator"
 	contains = list(/obj/machinery/power/generator)
-	cost = 75
+	cost = 7500
 	containertype = /obj/structure/closet/crate/secure/large
 	containername = "\improper Mk1 TEG crate"
 	access = access_engine_equip
@@ -160,7 +160,7 @@
 /decl/hierarchy/supply_pack/engineering/circulator
 	name = "Binary atmospheric circulator"
 	contains = list(/obj/machinery/atmospherics/binary/circulator)
-	cost = 60
+	cost = 6000
 	containertype = /obj/structure/closet/crate/secure/large
 	containername = "\improper Atmospheric circulator crate"
 	access = access_atmospherics
@@ -168,7 +168,7 @@
 /decl/hierarchy/supply_pack/engineering/air_dispenser
 	name = "Pipe Dispenser"
 	contains = list(/obj/machinery/pipedispenser/orderable)
-	cost = 35
+	cost = 3500
 	containertype = /obj/structure/closet/crate/secure/large
 	containername = "\improper Pipe Dispenser Crate"
 	access = access_atmospherics
@@ -176,7 +176,7 @@
 /decl/hierarchy/supply_pack/engineering/disposals_dispenser
 	name = "Disposals Pipe Dispenser"
 	contains = list(/obj/machinery/pipedispenser/disposal/orderable)
-	cost = 35
+	cost = 3500
 	containertype = /obj/structure/closet/crate/secure/large
 	containername = "\improper Disposal Dispenser Crate"
 	access = access_atmospherics
@@ -184,7 +184,7 @@
 /decl/hierarchy/supply_pack/engineering/shield_generator
 	name = "Shield Generator Construction Kit"
 	contains = list(/obj/item/weapon/circuitboard/shield_generator, /obj/item/weapon/stock_parts/capacitor, /obj/item/weapon/stock_parts/micro_laser, /obj/item/weapon/smes_coil, /obj/item/weapon/stock_parts/console_screen)
-	cost = 50
+	cost = 5000
 	containertype = /obj/structure/closet/crate/secure/engineering
 	containername = "\improper shield generator construction kit crate"
 	access = access_engine
@@ -192,7 +192,7 @@
 /decl/hierarchy/supply_pack/engineering/smbig
 	name = "Supermatter Core"
 	contains = list(/obj/machinery/power/supermatter)
-	cost = 200
+	cost = 20000
 	containertype = /obj/structure/closet/crate/secure/large/plasma
 	containername = "\improper Supermatter crate (CAUTION)"
 	access = access_ce
@@ -200,7 +200,7 @@
 /decl/hierarchy/supply_pack/engineering/fueltank
 	name = "Fuel tank crate"
 	contains = list(/obj/structure/reagent_dispensers/fueltank)
-	cost = 8
+	cost = 800
 	containertype = /obj/structure/largecrate
 	containername = "\improper fuel tank crate"
 
@@ -210,7 +210,7 @@
 					/obj/item/weapon/storage/toolbox/electrical,
 					/obj/item/device/flash = 4,
 					/obj/item/weapon/cell/high = 2)
-	cost = 10
+	cost = 1000
 	containertype = /obj/structure/closet/crate/secure/gear
 	containername = "\improper Robotics assembly"
 	access = access_robotics
@@ -219,7 +219,7 @@
 	name = "Radiation protection gear"
 	contains = list(/obj/item/clothing/suit/radiation = 6,
 			/obj/item/clothing/head/radiation = 6)
-	cost = 20
+	cost = 2000
 	containertype = /obj/structure/closet/radiation
 	containername = "\improper Radiation suit locker"
 
@@ -228,7 +228,7 @@
 	contains = list(/obj/item/device/pipe_painter = 2,
 					/obj/item/device/floor_painter = 2,
 					/obj/item/device/cable_painter = 2)
-	cost = 10
+	cost = 1000
 	containertype = /obj/structure/closet/crate/engineering
 	containername = "\improper painting supplies crate"
 
@@ -240,7 +240,7 @@
 					/obj/item/weapon/stock_parts/subspace/filter,
 					/obj/item/weapon/stock_parts/subspace/crystal,
 					/obj/item/weapon/storage/toolbox/electrical)
-	cost = 75
+	cost = 7500
 	containertype = /obj/structure/closet/crate/engineering
 	containername = "\improper emergency bluespace relay assembly kit"
 
@@ -251,7 +251,7 @@
 			/obj/item/weapon/tank/oxygen/red,
 			/obj/item/weapon/extinguisher,
 			/obj/item/clothing/head/hardhat/red)
-	cost = 20
+	cost = 2000
 	containertype = /obj/structure/closet/firecloset
 	containername = "\improper fire-safety closet"
 
@@ -260,7 +260,7 @@
 	contains = list(/obj/item/clothing/suit/space/void/engineering/alt,
 					/obj/item/clothing/head/helmet/space/void/engineering/alt,
 					/obj/item/clothing/shoes/magboots)
-	cost = 60
+	cost = 6000
 	containername = "\improper Engineering voidsuit crate"
 	containertype = /obj/structure/closet/crate/secure/large
 	access = access_engine
@@ -268,7 +268,7 @@
 /decl/hierarchy/supply_pack/engineering/rig
 	name = "EVA RIG"
 	contains = list(/obj/item/weapon/rig/eva)
-	cost = 240
+	cost = 24000
 	containername = "\improper EVA RIG crate"
 	containertype = /obj/structure/closet/crate/secure/engineering
 	access = access_engine_equip

--- a/code/datums/supplypacks/hospitality.dm
+++ b/code/datums/supplypacks/hospitality.dm
@@ -18,7 +18,7 @@
 			/obj/item/weapon/storage/box/glowsticks = 2,
 			/obj/item/weapon/clothingbag/rubbermask,
 			/obj/item/weapon/clothingbag/rubbersuit)
-	cost = 20
+	cost = 2000
 	containername = "\improper Party equipment"
 
 // TODO; Add more premium drinks at a later date. Could be useful for diplomatic events or fancy parties.
@@ -26,7 +26,7 @@
 	name = "Premium drinks crate"
 	contains = list(/obj/item/weapon/reagent_containers/food/drinks/bottle/premiumwine = 3,
 					/obj/item/weapon/reagent_containers/food/drinks/bottle/premiumvodka = 3)
-	cost = 60
+	cost = 6000
 	containertype = /obj/structure/closet/crate/freezer
 	containername = "\improper Premium drinks"
 
@@ -45,7 +45,7 @@
 			/obj/item/weapon/storage/box/glass_extras/straws,
 			/obj/item/weapon/storage/box/glass_extras/sticks
 			)
-	cost = 10
+	cost = 1000
 	containername = "crate of bar supplies"
 
 /decl/hierarchy/supply_pack/hospitality/lasertag
@@ -54,7 +54,7 @@
 					/obj/item/clothing/suit/redtag = 3,
 					/obj/item/weapon/gun/energy/lasertag/blue = 3,
 					/obj/item/clothing/suit/bluetag = 3)
-	cost = 20
+	cost = 2000
 	containertype = /obj/structure/closet
 	containername = "\improper Lasertag Closet"
 
@@ -65,7 +65,7 @@
 					/obj/item/pizzabox/mushroom,
 					/obj/item/pizzabox/meat,
 					/obj/item/pizzabox/vegetable)
-	cost = 15
+	cost = 1500
 	containertype = /obj/structure/closet/crate/freezer
 	containername = "\improper Pizza crate"
 	supply_method = /decl/supply_method/randomized
@@ -76,32 +76,32 @@
 	contains = list(/obj/item/weapon/reagent_containers/food/snacks/meat/beef = 6)
 	containertype = /obj/structure/closet/crate/freezer
 	containername = "\improper Beef crate"
-	cost = 10
+	cost = 1000
 
 /decl/hierarchy/supply_pack/hospitality/goat
 	name = "Goat meat crate"
 	contains = list(/obj/item/weapon/reagent_containers/food/snacks/meat/goat = 6)
 	containertype = /obj/structure/closet/crate/freezer
 	containername = "\improper Goat meat crate"
-	cost = 10
+	cost = 1000
 
 /decl/hierarchy/supply_pack/hospitality/chicken
 	name = "Chicken meat crate"
 	contains = list(/obj/item/weapon/reagent_containers/food/snacks/meat/chicken = 6)
 	containertype = /obj/structure/closet/crate/freezer
 	containername = "\improper Chicken meat crate"
-	cost = 10
+	cost = 1000
 
 /decl/hierarchy/supply_pack/hospitality/eggs
 	name = "Eggs crate"
 	contains = list(/obj/item/weapon/storage/fancy/egg_box = 4)
 	containertype = /obj/structure/closet/crate/freezer
 	containername = "\improper Egg crate"
-	cost = 15
+	cost = 1500
 
 /decl/hierarchy/supply_pack/hospitality/milk
 	name = "Milk crate"
 	contains = list(/obj/item/weapon/reagent_containers/food/drinks/milk = 6)
 	containertype = /obj/structure/closet/crate/freezer
 	containername = "\improper Milk crate"
-	cost = 15
+	cost = 1500

--- a/code/datums/supplypacks/hydroponics.dm
+++ b/code/datums/supplypacks/hydroponics.dm
@@ -5,42 +5,42 @@
 /decl/hierarchy/supply_pack/hydroponics/monkey
 	name = "Monkey crate"
 	contains = list (/obj/item/weapon/storage/box/monkeycubes)
-	cost = 20
+	cost = 2000
 	containertype = /obj/structure/closet/crate/freezer
 	containername = "\improper Monkey crate"
 
 /decl/hierarchy/supply_pack/hydroponics/farwa
 	name = "Farwa crate"
 	contains = list (/obj/item/weapon/storage/box/monkeycubes/farwacubes)
-	cost = 30
+	cost = 3000
 	containertype = /obj/structure/closet/crate/freezer
 	containername = "\improper Farwa crate"
 
 /decl/hierarchy/supply_pack/hydroponics/neaera
 	name = "Neaera crate"
 	contains = list (/obj/item/weapon/storage/box/monkeycubes/neaeracubes)
-	cost = 30
+	cost = 3000
 	containertype = /obj/structure/closet/crate/freezer
 	containername = "\improper Neaera crate"
 
 /decl/hierarchy/supply_pack/hydroponics/stok
 	name = "Stok crate"
 	contains = list (/obj/item/weapon/storage/box/monkeycubes/stokcubes)
-	cost = 30
+	cost = 3000
 	containertype = /obj/structure/closet/crate/freezer
 	containername = "\improper Stok crate"
 
 /decl/hierarchy/supply_pack/hydroponics/corgi
 	name = "Corgi crate"
 	contains = list(/mob/living/simple_animal/corgi)
-	cost = 50
+	cost = 5000
 	containertype = /obj/structure/largecrate/animal/corgi
 	containername = "\improper Corgi crate"
 
 /decl/hierarchy/supply_pack/hydroponics/parrot
 	name = "Parrot crate"
 	contains = list(/mob/living/simple_animal/parrot)
-	cost = 40
+	cost = 4000
 	containertype = /obj/structure/largecrate/animal/parrot
 	containername = "\improper Parrot crate"
 
@@ -48,7 +48,7 @@
 /decl/hierarchy/supply_pack/hydroponics/cow
 	name = "Cow crate"
 	contains = list(/mob/living/simple_animal/cow)
-	cost = 80
+	cost = 8000
 	containertype = /obj/structure/largecrate/animal/cow
 	containername = "\improper Cow crate"
 	access = access_hydroponics
@@ -56,7 +56,7 @@
 /decl/hierarchy/supply_pack/hydroponics/goat
 	name = "Goat crate"
 	contains = list(/mob/living/simple_animal/hostile/retaliate/goat)
-	cost = 75
+	cost = 7500
 	containertype = /obj/structure/largecrate/animal/goat
 	containername = "\improper Goat crate"
 	access = access_hydroponics
@@ -64,7 +64,7 @@
 /decl/hierarchy/supply_pack/hydroponics/chicken
 	name = "Chicken crate"
 	contains = list(/mob/living/simple_animal/chick = 5)
-	cost = 70
+	cost = 7000
 	containertype = /obj/structure/largecrate/animal/chick
 	containername = "\improper Chicken crate"
 	access = access_hydroponics
@@ -81,7 +81,7 @@
 					/obj/item/weapon/shovel/spade,
 					/obj/item/weapon/storage/box/botanydisk
 					)
-	cost = 15
+	cost = 1500
 	containername = "\improper Hydroponics crate"
 	access = access_hydroponics
 
@@ -104,7 +104,7 @@
 					/obj/item/seeds/chantermycelium,
 					/obj/item/seeds/potatoseed,
 					/obj/item/seeds/sugarcaneseed)
-	cost = 10
+	cost = 1000
 	containername = "\improper Seeds crate"
 	access = access_hydroponics
 
@@ -114,7 +114,7 @@
 					/obj/item/weapon/reagent_containers/spray/plantbgone = 4,
 					/obj/item/clothing/mask/gas = 2,
 					/obj/item/weapon/grenade/chem_grenade/antiweed = 2)
-	cost = 25
+	cost = 2500
 	containername = "\improper Weed control crate"
 	access = access_hydroponics
 
@@ -125,7 +125,7 @@
 					/obj/item/seeds/reishimycelium,
 					/obj/item/seeds/random = 6,
 					/obj/item/seeds/kudzuseed)
-	cost = 15
+	cost = 1500
 	containertype = /obj/structure/closet/crate/secure
 	containername = "\improper Exotic Seeds crate"
 	access = access_xenobiology
@@ -133,14 +133,14 @@
 /decl/hierarchy/supply_pack/hydroponics/watertank
 	name = "Water tank crate"
 	contains = list(/obj/structure/reagent_dispensers/watertank)
-	cost = 8
+	cost = 800
 	containertype = /obj/structure/largecrate
 	containername = "\improper water tank crate"
 
 /decl/hierarchy/supply_pack/hydroponics/composttank
 	name = "Compost tank crate"
 	contains = list(/obj/structure/reagent_dispensers/composttank)
-	cost = 10
+	cost = 1000
 	containertype = /obj/structure/largecrate
 	containername = "\improper compost tank crate"
 
@@ -150,14 +150,14 @@
 					/obj/item/bee_smoker,
 					/obj/item/honey_frame = 5,
 					/obj/item/bee_pack)
-	cost = 40
+	cost = 4000
 	containername = "\improper Beekeeping crate"
 	access = access_hydroponics
 
 /decl/hierarchy/supply_pack/hydroponics/hydrotray
 	name = "Empty hydroponics tray"
 	contains = list(/obj/machinery/portable_atmospherics/hydroponics{anchored = 0})
-	cost = 30
+	cost = 3000
 	containertype = /obj/structure/closet/crate/large/hydroponics
 	containername = "\improper Hydroponics tray crate"
 	access = access_hydroponics
@@ -192,7 +192,7 @@
 					/obj/structure/flora/pottedplant/tropical,
 					/obj/structure/flora/pottedplant/dead,
 					/obj/structure/flora/pottedplant/decorative)
-	cost = 6
+	cost = 600
 	containertype = /obj/structure/closet/crate/large/hydroponics
 	containername = "\improper Potted plant crate"
 	supply_method = /decl/supply_method/randomized

--- a/code/datums/supplypacks/materials.dm
+++ b/code/datums/supplypacks/materials.dm
@@ -5,62 +5,62 @@
 /decl/hierarchy/supply_pack/materials/steel50
 	name = "50 steel sheets"
 	contains = list(/obj/item/stack/material/steel/fifty)
-	cost = 10
+	cost = 1000
 	containername = "\improper Steel sheets crate"
 
 /decl/hierarchy/supply_pack/materials/glass50
 	name = "50 glass sheets"
 	contains = list(/obj/item/stack/material/glass/fifty)
-	cost = 10
+	cost = 1000
 	containername = "\improper Glass sheets crate"
 
 /decl/hierarchy/supply_pack/materials/wood50
 	name = "50 wooden planks"
 	contains = list(/obj/item/stack/material/wood/fifty)
-	cost = 10
+	cost = 1000
 	containername = "\improper Wooden planks crate"
 
 /decl/hierarchy/supply_pack/materials/plastic50
 	name = "50 plastic sheets"
 	contains = list(/obj/item/stack/material/plastic/fifty)
-	cost = 10
+	cost = 1000
 	containername = "\improper Plastic sheets crate"
 
 /decl/hierarchy/supply_pack/materials/marble50
 	name = "50 slabs of marble"
 	contains = list(/obj/item/stack/material/marble/fifty)
-	cost = 60
+	cost = 6000
 	containername = "\improper Marble slabs crate"
 
 /decl/hierarchy/supply_pack/materials/plasteel50
 	name = "50 plasteel sheets"
 	contains = list(/obj/item/stack/material/plasteel/fifty)
-	cost = 80
+	cost = 8000
 	containername = "\improper Plasteel sheets crate"
 
 /decl/hierarchy/supply_pack/materials/ocp50
 	name = "50 osmium carbide plasteel sheets"
 	contains = list(/obj/item/stack/material/ocp/fifty)
-	cost = 100
+	cost = 10000
 	containername = "\improper Osmium carbide plasteel sheets crate"
 
 // Material sheets (10 - Smaller amounts, less cost efficient)
 /decl/hierarchy/supply_pack/materials/marble10
 	name = "10 slabs of marble"
 	contains = list(/obj/item/stack/material/marble/ten)
-	cost = 20
+	cost = 2000
 	containername = "\improper Marble slabs crate"
 
 /decl/hierarchy/supply_pack/materials/plasteel10
 	name = "10 plasteel sheets"
 	contains = list(/obj/item/stack/material/plasteel/ten)
-	cost = 25
+	cost = 2500
 	containername = "\improper Plasteel sheets crate"
 
 /decl/hierarchy/supply_pack/materials/ocp10
 	name = "10 osmium carbide plasteel sheets"
 	contains = list(/obj/item/stack/material/ocp/ten)
-	cost = 30
+	cost = 3000
 	containername = "\improper Osmium carbide plasteel sheets crate"
 
 // Material sheets of expensive materials. These are very expensive and therefore pretty hard
@@ -68,29 +68,29 @@
 /decl/hierarchy/supply_pack/materials/plasma10
 	name = "10 plasma sheets"
 	contains = list(/obj/item/stack/material/plasma/ten)
-	cost = 75 // When sold yields 67 points.
+	cost = 7500 // When sold yields 67 points.
 	containername = "\improper Plasma sheets crate"
 
 /decl/hierarchy/supply_pack/materials/gold10
 	name = "10 gold sheets"
 	contains = list(/obj/item/stack/material/gold/ten)
-	cost = 100
+	cost = 10000
 	containername = "\improper Gold sheets crate"
 
 /decl/hierarchy/supply_pack/materials/silver10
 	name = "10 silver sheets"
 	contains = list(/obj/item/stack/material/silver/ten)
-	cost = 100
+	cost = 10000
 	containername = "\improper Silver sheets crate"
 
 /decl/hierarchy/supply_pack/materials/uranium10
 	name = "10 uranium sheets"
 	contains = list(/obj/item/stack/material/uranium/ten)
-	cost = 125
+	cost = 12500
 	containername = "\improper Uranium sheets crate"
 
 /decl/hierarchy/supply_pack/materials/diamond10
 	name = "10 diamond sheets"
 	contains = list(/obj/item/stack/material/diamond/ten)
-	cost = 200
+	cost = 20000
 	containername = "\improper Diamond sheets crate"

--- a/code/datums/supplypacks/medical.dm
+++ b/code/datums/supplypacks/medical.dm
@@ -14,32 +14,32 @@
 					/obj/item/weapon/reagent_containers/glass/bottle/stoxin,
 					/obj/item/weapon/storage/box/syringes,
 					/obj/item/weapon/storage/box/autoinjectors)
-	cost = 10
+	cost = 1000
 	containername = "\improper Medical crate"
 
 /decl/hierarchy/supply_pack/medical/somaticgel
 	name = "Somatic gel crate"
 	contains = list(/obj/item/stack/medical/advanced/bruise_pack = 5)
-	cost = 10
+	cost = 1000
 	containername = "\improper Somatic gel crate"
 
 /decl/hierarchy/supply_pack/medical/burngel
 	name = "Burn gel crate"
 	contains = list(/obj/item/stack/medical/advanced/ointment = 5)
-	cost = 10
+	cost = 1000
 	containername = "\improper Burn gel crate"
 
 /decl/hierarchy/supply_pack/medical/somaticgeltank
 	name = "Somatic gel tank"
 	contains = list(/obj/structure/geltank/somatic)
-	cost = 10
+	cost = 1000
 	containername = "\improper Somatic gel crate"
 	containertype = /obj/structure/largecrate
 
 /decl/hierarchy/supply_pack/medical/burngeltank
 	name = "Burn gel tank"
 	contains = list(/obj/structure/geltank/burn)
-	cost = 10
+	cost = 1000
 	containername = "\improper Burn gel crate"
 	containertype = /obj/structure/largecrate
 
@@ -59,7 +59,7 @@
 					/obj/item/weapon/storage/pill_bottle/hyronalin,
 					/obj/item/weapon/storage/pill_bottle/glucose)
 	name = "Surplus medical drugs"
-	cost = 30
+	cost = 3000
 	containername = "\improper Medical drugs crate"
 	supply_method = /decl/supply_method/randomized
 
@@ -69,7 +69,7 @@
 					/obj/item/weapon/storage/box/syringegun = 2,
 					/obj/item/weapon/storage/box/syringes = 2,
 					/obj/item/weapon/reagent_containers/glass/bottle/stoxin = 2)
-	cost = 50
+	cost = 5000
 	containertype = /obj/structure/closet/crate/secure
 	containername = "\improper Syringe guns crate"
 	access = access_medical
@@ -77,38 +77,38 @@
 /decl/hierarchy/supply_pack/medical/syringe_cartridge
 	name = "Syringe cartridges"
 	contains = list(/obj/item/weapon/storage/box/syringegun = 2)
-	cost = 25
+	cost = 2500
 	containername = "\improper Syringe cartridges crate"
 
 /decl/hierarchy/supply_pack/medical/bloodpack
 	name = "Blood pack crate"
 	contains = list(/obj/item/weapon/storage/box/bloodpacks = 3)
-	cost = 10
+	cost = 1000
 	containername = "\improper Blood pack crate"
 
 /decl/hierarchy/supply_pack/medical/blood
 	name = "Nanoblood crate"
 	contains = list(/obj/item/weapon/reagent_containers/ivbag/nanoblood = 4)
-	cost = 15
+	cost = 1500
 	containername = "\improper Nanoblood crate"
 
 /decl/hierarchy/supply_pack/medical/bodybag
 	name = "Body bag crate"
 	contains = list(/obj/item/weapon/storage/box/bodybags = 10)
-	cost = 10
+	cost = 1000
 	containername = "\improper Body bag crate"
 
 /decl/hierarchy/supply_pack/medical/cryobag
 	name = "Stasis bag crate"
 	contains = list(/obj/item/bodybag/cryobag = 5)
-	cost = 50
+	cost = 5000
 	containername = "\improper Stasis bag crate"
 
 /decl/hierarchy/supply_pack/medical/medicalextragear
 	name = "Medical surplus equipment"
 	contains = list(/obj/item/weapon/storage/belt/medical = 3,
 					/obj/item/clothing/glasses/hud/one_eyed/oneye/medical = 3)
-	cost = 15
+	cost = 1500
 	containertype = /obj/structure/closet/crate/secure
 	containername = "\improper Medical surplus equipment"
 	access = access_medical
@@ -130,7 +130,7 @@
 					/obj/item/device/healthanalyzer,
 					/obj/item/device/flashlight/pen,
 					/obj/item/weapon/reagent_containers/syringe)
-	cost = 60
+	cost = 6000
 	containertype = /obj/structure/closet/crate/secure
 	containername = "\improper Chief medical officer equipment"
 	access = access_cmo
@@ -151,7 +151,7 @@
 					/obj/item/device/healthanalyzer,
 					/obj/item/device/flashlight/pen,
 					/obj/item/weapon/reagent_containers/syringe)
-	cost = 20
+	cost = 2000
 	containertype = /obj/structure/closet/crate/secure
 	containername = "\improper Medical Doctor equipment"
 	access = access_medical_equip
@@ -172,7 +172,7 @@
 					/obj/item/device/healthanalyzer,
 					/obj/item/weapon/storage/box/pillbottles,
 					/obj/item/weapon/reagent_containers/syringe)
-	cost = 15
+	cost = 1500
 	containertype = /obj/structure/closet/crate/secure
 	containername = "\improper Chemist equipment"
 	access = access_chemistry
@@ -198,7 +198,7 @@
 					/obj/item/device/flashlight/pen,
 					/obj/item/weapon/reagent_containers/syringe,
 					/obj/item/clothing/accessory/storage/white_vest)
-	cost = 20
+	cost = 2000
 	containertype = /obj/structure/closet/crate/secure
 	containername = "\improper Paramedic equipment"
 	access = access_medical_equip
@@ -215,7 +215,7 @@
 					/obj/item/weapon/folder/white,
 					/obj/item/weapon/pen,
 					/obj/item/weapon/cartridge/medical)
-	cost = 15
+	cost = 1500
 	containertype = /obj/structure/closet/crate/secure
 	containername = "\improper Psychiatrist equipment"
 	access = access_psychiatrist
@@ -233,7 +233,7 @@
 					/obj/item/clothing/head/surgery/green,
 					/obj/item/weapon/storage/box/masks,
 					/obj/item/weapon/storage/box/gloves)
-	cost = 15
+	cost = 1500
 	containertype = /obj/structure/closet/crate/secure
 	containername = "\improper Medical scrubs crate"
 	access = access_medical_equip
@@ -248,7 +248,7 @@
 					/obj/item/weapon/storage/box/masks,
 					/obj/item/weapon/storage/box/gloves,
 					/obj/item/weapon/pen)
-	cost = 20
+	cost = 2000
 	containertype = /obj/structure/closet/crate/secure
 	containername = "\improper Autopsy equipment crate"
 	access = access_morgue
@@ -272,7 +272,7 @@
 					/obj/item/clothing/suit/storage/toggle/labcoat/chemist,
 					/obj/item/weapon/storage/box/masks,
 					/obj/item/weapon/storage/box/gloves)
-	cost = 15
+	cost = 1500
 	containertype = /obj/structure/closet/crate/secure
 	containername = "\improper Medical uniform crate"
 	access = access_medical_equip
@@ -287,7 +287,7 @@
 					/obj/item/weapon/tank/oxygen = 5,
 					/obj/item/weapon/storage/box/masks,
 					/obj/item/weapon/storage/box/gloves)
-	cost = 50
+	cost = 5000
 	containertype = /obj/structure/closet/crate/secure
 	containername = "\improper Medical biohazard equipment"
 	access = access_medical_equip
@@ -295,7 +295,7 @@
 /decl/hierarchy/supply_pack/medical/portablefreezers
 	name = "Portable freezers crate"
 	contains = list(/obj/item/weapon/storage/box/freezer = 7)
-	cost = 25
+	cost = 2500
 	containertype = /obj/structure/closet/crate/secure
 	containername = "\improper Portable freezers"
 	access = access_medical_equip
@@ -303,7 +303,7 @@
 /decl/hierarchy/supply_pack/medical/surgery
 	name = "Surgery crate"
 	contains = list(/obj/item/weapon/storage/firstaid/surgery)
-	cost = 25
+	cost = 2500
 	containertype = /obj/structure/closet/crate/secure
 	containername = "\improper Surgery crate"
 	access = access_medical
@@ -315,7 +315,7 @@
 					/obj/item/weapon/storage/box/masks,
 					/obj/item/weapon/storage/box/gloves,
 					/obj/item/weapon/storage/belt/medical = 3)
-	cost = 15
+	cost = 1500
 	containertype = /obj/structure/closet/crate
 	containername = "\improper Sterile equipment crate"
 
@@ -324,7 +324,7 @@
 	contains = list(/obj/item/clothing/suit/space/void/medical/alt,
 					/obj/item/clothing/head/helmet/space/void/medical/alt,
 					/obj/item/clothing/shoes/magboots)
-	cost = 120
+	cost = 12000
 	containername = "\improper Medical voidsuit crate"
 	containertype = /obj/structure/closet/crate/secure/large
 	access = access_medical_equip
@@ -332,19 +332,19 @@
 /decl/hierarchy/supply_pack/medical/rig
 	name = "Medical RIG"
 	contains = list(/obj/item/weapon/rig/medical)
-	cost = 360
+	cost = 36000
 	containername = "\improper Medical RIG crate"
 	containertype = /obj/structure/closet/crate/secure
 	access = access_medical_equip
 
 /decl/hierarchy/supply_pack/medical/vatgrownbodymale
 	name = "Blank vat-grown male body"
-	cost = 300
+	cost = 30000
 	containername = "\improper Vat-grown body crate"
 	containertype = /obj/structure/largecrate/animal/vatgrownbody/male
 
 /decl/hierarchy/supply_pack/medical/vatgrownbodyfemale
 	name = "Blank vat-grown female body"
-	cost = 300
+	cost = 30000
 	containername = "\improper Vat-grown body crate"
 	containertype = /obj/structure/largecrate/animal/vatgrownbody/female

--- a/code/datums/supplypacks/miscellaneous.dm
+++ b/code/datums/supplypacks/miscellaneous.dm
@@ -7,85 +7,85 @@
 					/obj/item/clothing/suit/wizrobe,
 					/obj/item/clothing/shoes/sandal,
 					/obj/item/clothing/head/wizard)
-	cost = 20
+	cost = 2000
 	containername = "\improper Wizard costume crate"
 
 /decl/hierarchy/supply_pack/miscellaneous/carpetbrown
 	name = "Brown carpet"
 	contains = list(/obj/item/stack/tile/carpet/fifty)
-	cost = 15
+	cost = 1500
 	containername = "\improper Brown carpet crate"
 
 /decl/hierarchy/supply_pack/miscellaneous/carpetblue
 	name = "Blue and gold carpet"
 	contains = list(/obj/item/stack/tile/carpetblue/fifty)
-	cost = 15
+	cost = 1500
 	containername = "\improper Blue and gold carpet crate"
 
 /decl/hierarchy/supply_pack/miscellaneous/carpetblue2
 	name = "Blue and silver carpet"
 	contains = list(/obj/item/stack/tile/carpetblue2/fifty)
-	cost = 15
+	cost = 1500
 	containername = "\improper Blue and silver carpet crate"
 
 /decl/hierarchy/supply_pack/miscellaneous/carpetpurple
 	name = "Purple carpet"
 	contains = list(/obj/item/stack/tile/carpetpurple/fifty)
-	cost = 15
+	cost = 1500
 	containername = "\improper Purple carpet crate"
 
 /decl/hierarchy/supply_pack/miscellaneous/carpetorange
 	name = "Orange carpet"
 	contains = list(/obj/item/stack/tile/carpetorange/fifty)
-	cost = 15
+	cost = 1500
 	containername = "\improper Orange carpet crate"
 
 /decl/hierarchy/supply_pack/miscellaneous/carpetgreen
 	name = "Green carpet"
 	contains = list(/obj/item/stack/tile/carpetgreen/fifty)
-	cost = 15
+	cost = 1500
 	containername = "\improper Green carpet crate"
 
 /decl/hierarchy/supply_pack/miscellaneous/carpetred
 	name = "Red carpet"
 	contains = list(/obj/item/stack/tile/carpetred/fifty)
-	cost = 15
+	cost = 1500
 	containername = "\improper Red carpet crate"
 
 /decl/hierarchy/supply_pack/miscellaneous/linoleum
 	name = "Linoleum"
 	contains = list(/obj/item/stack/tile/linoleum/fifty)
-	cost = 15
+	cost = 1500
 	containername = "\improper Linoleum crate"
 
 /decl/hierarchy/supply_pack/miscellaneous/white_tiles
 	name = "White floor tiles"
 	contains = list(/obj/item/stack/tile/floor_white/fifty)
-	cost = 15
+	cost = 1500
 	containername = "\improper White floor tile crate"
 
 /decl/hierarchy/supply_pack/miscellaneous/brown_tiles
 	name = "Brown floor tiles"
 	contains = list(/obj/item/stack/tile/floor_brown/fifty)
-	cost = 15
+	cost = 1500
 	containername = "\improper Brown floor tile crate"
 
 /decl/hierarchy/supply_pack/miscellaneous/dark_tiles
 	name = "Dark floor tiles"
 	contains = list(/obj/item/stack/tile/floor_dark/fifty)
-	cost = 15
+	cost = 1500
 	containername = "\improper Dark floor tile crate"
 
 /decl/hierarchy/supply_pack/miscellaneous/freezer_tiles
 	name = "Freezer floor tiles"
 	contains = list(/obj/item/stack/tile/floor_freezer/fifty)
-	cost = 15
+	cost = 1500
 	containername = "\improper Freezer floor tile crate"
 
 /decl/hierarchy/supply_pack/miscellaneous/darkwood_tiles
 	name = "Darkwood floor tiles"
 	contains = list(/obj/item/stack/tile/darkwood/fifty)
-	cost = 25
+	cost = 2500
 	containername = "\improper Darkwood floor tile crate"
 
 /decl/hierarchy/supply_pack/miscellaneous/costume
@@ -120,7 +120,7 @@
 					///obj/item/clothing/under/savage_hunter,
 					///obj/item/clothing/under/savage_hunter/female)
 	name = "Costumes crate"
-	cost = 10
+	cost = 1000
 	containername = "\improper Actor Costumes"
 	supply_method = /decl/supply_method/randomized
 
@@ -140,7 +140,7 @@
 					/obj/item/clothing/shoes/leather,
 					/obj/item/clothing/accessory/wcoat)
 	name = "Formalwear closet"
-	cost = 30
+	cost = 3000
 	containertype = /obj/structure/closet
 	containername = "\improper Formalwear for the best occasions."
 
@@ -150,14 +150,14 @@
 					/obj/item/weapon/pack/spaceball,
 					/obj/item/weapon/deck/holder)
 	name = "\improper Trading Card Crate"
-	cost = 20
+	cost = 2000
 	containername = "\improper cards crate"
 	supply_method = /decl/supply_method/randomized
 
 /decl/hierarchy/supply_pack/miscellaneous/eftpos
 	contains = list(/obj/item/device/eftpos)
 	name = "EFTPOS scanner"
-	cost = 10
+	cost = 1000
 	containername = "\improper EFTPOS crate"
 
 /decl/hierarchy/supply_pack/miscellaneous/hats
@@ -183,14 +183,14 @@
 					/obj/item/clothing/head/collectable/xenom,
 					/obj/item/clothing/head/collectable/petehat)
 	name = "Collectable hat crate!"
-	cost = 50
+	cost = 5000
 	containername = "\improper Collectable hats crate! Brought to you by Bass.inc!"
 	supply_method = /decl/supply_method/randomized
 
 /decl/hierarchy/supply_pack/miscellaneous/cardboard_sheets
 	name = "50 cardboard sheets"
 	contains = list(/obj/item/stack/material/cardboard/fifty)
-	cost = 10
+	cost = 1000
 	containername = "\improper Cardboard sheets crate"
 
 /decl/hierarchy/supply_pack/miscellaneous/witch
@@ -199,7 +199,7 @@
 					/obj/item/clothing/shoes/sandal,
 					/obj/item/clothing/head/wizard/marisa/fake,
 					/obj/item/weapon/staff/broom)
-	cost = 20
+	cost = 2000
 	containername = "\improper Witch costume"
 	containertype = /obj/structure/closet
 
@@ -212,7 +212,7 @@
 					/obj/item/clothing/suit/storage/black_jacket_NT,
 					/obj/item/clothing/shoes/workboots,
 					)
-	cost = 50
+	cost = 5000
 	containername = "\improper Soviet crate"
 	containertype = /obj/structure/closet
 
@@ -233,7 +233,7 @@
 					/obj/item/clothing/head/helmet/gladiator,
 					/obj/item/clothing/head/ushanka,
 					/obj/item/clothing/mask/spirit)
-	cost = 10
+	cost = 1000
 	containername = "\improper Actor hats crate"
 	containertype = /obj/structure/closet
 	num_contained = 2
@@ -252,7 +252,7 @@
 					/obj/item/clothing/under/dress/dress_orange,
 					/obj/item/clothing/under/dress/dress_yellow,
 					/obj/item/clothing/under/dress/dress_saloon)
-	cost = 15
+	cost = 1500
 	containername = "\improper Pretty dress locker"
 	containertype = /obj/structure/closet
 	num_contained = 1
@@ -267,7 +267,7 @@
 		/obj/item/device/kit/paint/ripley/flames_red,
 		/obj/item/device/kit/paint/ripley/flames_blue
 		)
-	cost = 200
+	cost = 20000
 	containername = "heavy crate"
 	supply_method = /decl/supply_method/randomized
 
@@ -279,7 +279,7 @@
 		/obj/item/device/kit/paint/durand/seraph,
 		/obj/item/device/kit/paint/durand/phazon
 		)
-	cost = 200
+	cost = 20000
 	containername = "heavy crate"
 	supply_method = /decl/supply_method/randomized
 
@@ -291,7 +291,7 @@
 		/obj/item/device/kit/paint/gygax/darkgygax,
 		/obj/item/device/kit/paint/gygax/recitence
 		)
-	cost = 200
+	cost = 20000
 	containername = "heavy crate"
 	supply_method = /decl/supply_method/randomized
 
@@ -307,13 +307,13 @@
 					/obj/item/clothing/under/wedding/bride_white,
 					/obj/item/weapon/storage/backpack/cultpack,
 					/obj/item/weapon/storage/fancy/candle_box = 3)
-	cost = 10
+	cost = 1000
 	containername = "\improper Chaplain equipment crate"
 
 /decl/hierarchy/supply_pack/miscellaneous/pigs
 	name = "Box of rubber pigs"
 	contains = list(/obj/item/toy/pig = 3)
-	cost = 100
+	cost = 10000
 	containername = "\improper Rubber Pigs Crate"
 	containertype = /obj/structure/closet/crate/pig
 
@@ -321,20 +321,20 @@
 	num_contained = 3
 	contains = list(/obj/item/weapon/storage/box/mousetraps)
 	name = "\improper Pest Control Crate"
-	cost = 10
+	cost = 1000
 	containername = "\improper Pest Control Crate"
 
 /decl/hierarchy/supply_pack/miscellaneous/bouquet
 	name = "Box of bouquets"
 	contains = list(/obj/item/weapon/storage/bouquet/shotgun = 3)
-	cost = 100
+	cost = 10000
 	containername = "\improper crate"
 	hidden = 1
 
 /decl/hierarchy/supply_pack/miscellaneous/tc3
 	name = "Telecrystals - 3"
 	contains = list(/obj/item/stack/telecrystal{amount = 3})
-	cost = 150
+	cost = 15000
 	containername = "\improper crate"
 	hidden = 1
 	contraband = 1
@@ -342,7 +342,7 @@
 /decl/hierarchy/supply_pack/miscellaneous/tc6
 	name = "Telecrystals - 6"
 	contains = list(/obj/item/stack/telecrystal{amount = 6})
-	cost = 300
+	cost = 30000
 	containername = "\improper crate"
 	hidden = 1
 	contraband = 1
@@ -350,7 +350,7 @@
 /decl/hierarchy/supply_pack/miscellaneous/tc9
 	name = "Telecrystals - 9"
 	contains = list(/obj/item/stack/telecrystal{amount = 9})
-	cost = 450
+	cost = 45000
 	containername = "\improper crate"
 	hidden = 1
 	contraband = 1
@@ -358,7 +358,7 @@
 /decl/hierarchy/supply_pack/miscellaneous/tc12
 	name = "Telecrystals - 12"
 	contains = list(/obj/item/stack/telecrystal{amount = 12})
-	cost = 600
+	cost = 60000
 	containername = "\improper crate"
 	hidden = 1
 	contraband = 1

--- a/code/datums/supplypacks/operations.dm
+++ b/code/datums/supplypacks/operations.dm
@@ -3,7 +3,7 @@
 
 /decl/hierarchy/supply_pack/operations/arts
 	name = "Arts Supplies"
-	cost = 10
+	cost = 1000
 	contains = list(
 		/obj/structure/easel,
 		/obj/item/canvas/twentythree_twentythree,
@@ -18,21 +18,21 @@
 /decl/hierarchy/supply_pack/operations/mule
 	name = "MULEbot Crate"
 	contains = list(/mob/living/bot/mulebot)
-	cost = 20
+	cost = 2000
 	containertype = /obj/structure/largecrate/animal/mulebot
 	containername = "Mulebot Crate"
 
 /decl/hierarchy/supply_pack/operations/cargotrain
 	name = "Cargo Train Tug"
 	contains = list(/obj/vehicle/train/cargo/engine)
-	cost = 45
+	cost = 4500
 	containertype = /obj/structure/largecrate
 	containername = "\improper Cargo Train Tug Crate"
 
 /decl/hierarchy/supply_pack/operations/cargotrailer
 	name = "Cargo Train Trolley"
 	contains = list(/obj/vehicle/train/cargo/trolley)
-	cost = 15
+	cost = 1500
 	containertype = /obj/structure/largecrate
 	containername = "\improper Cargo Train Trolley Crate"
 
@@ -52,7 +52,7 @@
 	/obj/item/weapon/reagent_containers/glass/paint/white,
 	/obj/item/weapon/contraband/poster,
 	/obj/item/weapon/wrapping_paper = 3)
-	cost = 10
+	cost = 1000
 	containername = "\improper Arts and Crafts crate"
 
 /decl/hierarchy/supply_pack/operations/contraband
@@ -63,7 +63,7 @@
 					/obj/item/weapon/reagent_containers/food/drinks/bottle/pwine)
 
 	name = "Contraband crate"
-	cost = 30
+	cost = 3000
 	containername = "\improper Unlabeled crate"
 	contraband = 1
 	supply_method = /decl/supply_method/randomized
@@ -71,7 +71,7 @@
 /decl/hierarchy/supply_pack/operations/hoverpod
 	name = "Hoverpod Shipment"
 	contains = list(/obj/mecha/working/hoverpod)
-	cost = 80
+	cost = 8000
 	containertype = /obj/structure/largecrate/hoverpod
 	containername = "\improper Hoverpod Crate"
 
@@ -86,5 +86,5 @@
 					/obj/item/clothing/accessory/storage/drop_pouches/brown,
 					/obj/item/clothing/accessory/storage/drop_pouches/white,
 					/obj/item/clothing/accessory/storage/webbing)
-	cost = 15
+	cost = 1500
 	containername = "\improper Webbing crate"

--- a/code/datums/supplypacks/science.dm
+++ b/code/datums/supplypacks/science.dm
@@ -4,7 +4,7 @@
 /decl/hierarchy/supply_pack/science/virus
 	name = "Virus sample crate"
 	contains = list(/obj/item/weapon/virusdish/random = 4)
-	cost = 25
+	cost = 2500
 	containertype = /obj/structure/closet/crate/secure/science
 	containername = "\improper Virus sample crate"
 	access = access_virology
@@ -12,7 +12,7 @@
 /decl/hierarchy/supply_pack/science/coolanttank
 	name = "Coolant tank crate"
 	contains = list(/obj/structure/reagent_dispensers/coolanttank)
-	cost = 16
+	cost = 1600
 	containertype = /obj/structure/largecrate
 	containername = "\improper coolant tank crate"
 
@@ -21,7 +21,7 @@
 	contains = list(/obj/item/weapon/book/wiki/robotics_cyborgs,
 					/obj/item/weapon/circuitboard/mecha/ripley/main, //TEMPORARY due to lack of circuitboard printer,
 					/obj/item/weapon/circuitboard/mecha/ripley/peripherals) //TEMPORARY due to lack of circuitboard printer
-	cost = 30
+	cost = 3000
 	containertype = /obj/structure/closet/crate/secure/science
 	containername = "\improper APLU \"Ripley\" Circuit Crate"
 	access = access_robotics
@@ -30,7 +30,7 @@
 	name = "Circuit Crate (\"Odysseus\")"
 	contains = list(/obj/item/weapon/circuitboard/mecha/odysseus/peripherals, //TEMPORARY due to lack of circuitboard printer,
 					/obj/item/weapon/circuitboard/mecha/odysseus/main) //TEMPORARY due to lack of circuitboard printer
-	cost = 25
+	cost = 2500
 	containertype = /obj/structure/closet/crate/secure/science
 	containername = "\improper \"Odysseus\" Circuit Crate"
 	access = access_robotics
@@ -42,7 +42,7 @@
 					/obj/item/device/assembly/prox_sensor = 3,
 					/obj/item/device/assembly/timer = 3,
 					/obj/item/device/transfer_valve = 3)
-	cost = 10
+	cost = 1000
 	containertype = /obj/structure/closet/crate/secure/plasma
 	containername = "\improper Plasma assembly crate"
 	access = access_tox_storage
@@ -50,7 +50,7 @@
 /decl/hierarchy/supply_pack/science/amirig
 	name = "AMI RIG crate"
 	contains = list(/obj/item/weapon/rig/hazmat)
-	cost = 480
+	cost = 48000
 	containertype = /obj/structure/closet/crate/secure/science
 	containername = "\improper AMI RIG crate"
 	access = access_research

--- a/code/datums/supplypacks/security.dm
+++ b/code/datums/supplypacks/security.dm
@@ -6,7 +6,7 @@
 	contains = list(/obj/item/weapon/storage/box/emps,
 					/obj/item/weapon/grenade/smokebomb = 3,
 					/obj/item/weapon/grenade/chem_grenade/incendiary)
-	cost = 20
+	cost = 2000
 	containername = "\improper Special Ops crate"
 	hidden = 1
 
@@ -14,7 +14,7 @@
 	name = "Armor - Light"
 	contains = list(/obj/item/clothing/suit/armor/pcarrier/light = 4,
 					/obj/item/clothing/head/helmet =4)
-	cost = 30
+	cost = 3000
 	containertype = /obj/structure/closet/crate/secure
 	containername = "\improper Light armor crate"
 	access = access_security
@@ -24,7 +24,7 @@
 	contains = list(/obj/item/clothing/suit/armor/pcarrier/medium = 2,
 					/obj/item/clothing/head/helmet = 2,
 					/obj/item/device/radio/headset/tactical = 2)
-	cost = 25
+	cost = 2500
 	containertype = /obj/structure/closet/crate/secure
 	containername = "\improper Armor crate"
 	access = access_security
@@ -33,7 +33,7 @@
 	name = "Armor - Arm and leg guards, black"
 	contains = list(/obj/item/clothing/accessory/armguards = 2,
 					/obj/item/clothing/accessory/legguards = 2)
-	cost = 20
+	cost = 2000
 	containertype = /obj/structure/closet/crate/secure
 	containername = "\improper Arm and leg guards crate"
 	access = access_armory
@@ -42,7 +42,7 @@
 	name = "Armor - Arm and leg guards, blue"
 	contains = list(/obj/item/clothing/accessory/armguards/blue = 2,
 					/obj/item/clothing/accessory/legguards/blue = 2)
-	cost = 20
+	cost = 2000
 	containertype = /obj/structure/closet/crate/secure
 	containername = "\improper Arm and leg guards crate"
 	access = access_armory
@@ -51,7 +51,7 @@
 	name = "Armor - Arm and leg guards, green"
 	contains = list(/obj/item/clothing/accessory/armguards/green = 2,
 					/obj/item/clothing/accessory/legguards/green = 2)
-	cost = 20
+	cost = 2000
 	containertype = /obj/structure/closet/crate/secure
 	containername = "\improper Arm and leg guards crate"
 	access = access_armory
@@ -60,7 +60,7 @@
 	name = "Armor - Arm and leg guards, navy blue"
 	contains = list(/obj/item/clothing/accessory/armguards/navy = 2,
 					/obj/item/clothing/accessory/legguards/navy = 2)
-	cost = 20
+	cost = 2000
 	containertype = /obj/structure/closet/crate/secure
 	containername = "\improper Arm and leg guards crate"
 	access = access_armory
@@ -69,7 +69,7 @@
 	name = "Armor - Arm and leg guards, tan"
 	contains = list(/obj/item/clothing/accessory/armguards/tan = 2,
 					/obj/item/clothing/accessory/legguards/tan = 2)
-	cost = 20
+	cost = 2000
 	containertype = /obj/structure/closet/crate/secure
 	containername = "\improper Arm and leg guards crate"
 	access = access_armory
@@ -81,7 +81,7 @@
 					/obj/item/clothing/suit/armor/riot = 4,
 					/obj/item/weapon/storage/box/flashbangs,
 					/obj/item/weapon/storage/box/teargas)
-	cost = 80
+	cost = 8000
 	containertype = /obj/structure/closet/crate/secure
 	containername = "\improper Riot armor crate"
 	access = access_armory
@@ -90,7 +90,7 @@
 	name = "Armor - Ballistic"
 	contains = list(/obj/item/clothing/head/helmet/ballistic = 4,
 					/obj/item/clothing/suit/armor/bulletproof = 4)
-	cost = 60
+	cost = 6000
 	containertype = /obj/structure/closet/crate/secure
 	containername = "\improper Ballistic suit crate"
 	access = access_armory
@@ -99,7 +99,7 @@
 	name = "Armor - Ablative"
 	contains = list(/obj/item/clothing/head/helmet/ablative = 4,
 					/obj/item/clothing/suit/armor/laserproof = 4)
-	cost = 60
+	cost = 6000
 	containertype = /obj/structure/closet/crate/secure
 	containername = "\improper Ablative suit crate"
 	access = access_armory
@@ -109,7 +109,7 @@
 	contains = list(/obj/item/clothing/suit/space/void/security/alt,
 					/obj/item/clothing/head/helmet/space/void/security/alt,
 					/obj/item/clothing/shoes/magboots)
-	cost = 120
+	cost = 12000
 	containername = "\improper Security voidsuit crate"
 	containertype = /obj/structure/closet/crate/secure/large
 	access = access_brig
@@ -117,7 +117,7 @@
 /decl/hierarchy/supply_pack/security/rig
 	name = "Armor - Security RIG"
 	contains = list(/obj/item/weapon/rig/security)
-	cost = 480
+	cost = 48000
 	containername = "\improper Security RIG crate"
 	containertype = /obj/structure/closet/crate/secure
 	access = access_brig
@@ -128,7 +128,7 @@
 					/obj/item/weapon/reagent_containers/spray/pepper = 4,
 					/obj/item/weapon/melee/baton/loaded = 4,
 					/obj/item/weapon/gun/energy/taser = 4)
-	cost = 50
+	cost = 5000
 	containertype = /obj/structure/closet/crate/secure/weapon
 	containername = "\improper Weapons crate"
 	access = access_security
@@ -137,7 +137,7 @@
 	name = "Weapons - Non-lethal energy weapons"
 	contains = list(/obj/item/weapon/gun/energy/taser/carbine = 2,
 					/obj/item/weapon/gun/energy/stunrevolver/rifle = 2)
-	cost = 50
+	cost = 5000
 	containertype = /obj/structure/closet/crate/secure/weapon
 	containername = "\improper Non-lethal energy weapons crate"
 	access = access_security
@@ -145,7 +145,7 @@
 /decl/hierarchy/supply_pack/security/egun
 	name = "Weapons - Energy sidearms"
 	contains = list(/obj/item/weapon/gun/energy/gun = 4)
-	cost = 40
+	cost = 4000
 	containertype = /obj/structure/closet/crate/secure/weapon
 	containername = "\improper Energy sidearms crate"
 	access = access_armory
@@ -154,7 +154,7 @@
 /decl/hierarchy/supply_pack/security/laser
 	name = "Weapons - Laser carbines"
 	contains = list(/obj/item/weapon/gun/energy/laser = 2)
-	cost = 40
+	cost = 4000
 	containertype = /obj/structure/closet/crate/secure/weapon
 	containername = "\improper Laser carbines crate"
 	access = access_armory
@@ -163,7 +163,7 @@
 /decl/hierarchy/supply_pack/security/marksman
 	name = "Weapons - Energy marksman rifles"
 	contains = list(/obj/item/weapon/gun/energy/sniperrifle = 2)
-	cost = 80
+	cost = 8000
 	containertype = /obj/structure/closet/crate/secure/weapon
 	containername = "\improper Energy marksman rifles crate"
 	access = access_armory
@@ -174,7 +174,7 @@
 	contains = list(/obj/item/weapon/gun/energy/ionrifle,
 					/obj/item/weapon/gun/energy/ionrifle/small,
 					/obj/item/weapon/storage/box/emps)
-	cost = 50
+	cost = 5000
 	containertype = /obj/structure/closet/crate/secure/weapon
 	containername = "\improper Electromagnetic weapons crate"
 	access = access_armory
@@ -183,7 +183,7 @@
 /decl/hierarchy/supply_pack/security/pistol
 	name = "Weapons - Ballistic sidearms"
 	contains = list(/obj/item/weapon/gun/projectile/pistol/vp78 = 4)
-	cost = 40
+	cost = 4000
 	containertype = /obj/structure/closet/crate/secure/weapon
 	containername = "\improper Ballistic sidearms crate"
 	access = access_armory
@@ -192,7 +192,7 @@
 /decl/hierarchy/supply_pack/security/shotgun
 	name = "Weapons - Shotgun"
 	contains = list(/obj/item/weapon/gun/projectile/shotgun/pump/combat = 2)
-	cost = 60
+	cost = 6000
 	containertype = /obj/structure/closet/crate/secure/weapon
 	containername = "\improper Shotgun crate"
 	access = access_armory
@@ -201,7 +201,7 @@
 /decl/hierarchy/supply_pack/security/smg
 	name = "Weapons - Ballistic PDW"
 	contains = list(/obj/item/weapon/gun/projectile/automatic/wt550 = 2)
-	cost = 50
+	cost = 5000
 	containertype = /obj/structure/closet/crate/secure/weapon
 	containername = "\improper Ballistic PDW crate"
 	access = access_armory
@@ -210,7 +210,7 @@
 /decl/hierarchy/supply_pack/security/rifle
 	name = "Weapons - Ballistic rifles"
 	contains = list(/obj/item/weapon/gun/projectile/automatic/z8 = 2)
-	cost = 80
+	cost = 8000
 	containertype = /obj/structure/closet/crate/secure/weapon
 	containername = "\improper Ballistic rifles crate"
 	access = access_armory
@@ -219,7 +219,7 @@
 /decl/hierarchy/supply_pack/security/flashbang
 	name = "Weapons - Flashbangs"
 	contains = list(/obj/item/weapon/storage/box/flashbangs = 2)
-	cost = 30
+	cost = 3000
 	containertype = /obj/structure/closet/crate/secure/weapon
 	containername = "\improper Flashbang crate"
 	access = access_security
@@ -227,7 +227,7 @@
 /decl/hierarchy/supply_pack/security/teargas
 	name = "Weapons - Tear gas grenades"
 	contains = list(/obj/item/weapon/storage/box/teargas = 2)
-	cost = 30
+	cost = 3000
 	containertype = /obj/structure/closet/crate/secure/weapon
 	containername = "\improper Tear gas grenades crate"
 	access = access_security
@@ -235,7 +235,7 @@
 /decl/hierarchy/supply_pack/security/frag
 	name = "Weapons - Frag grenades"
 	contains = list(/obj/item/weapon/storage/box/frags = 2)
-	cost = 50
+	cost = 5000
 	containertype = /obj/structure/closet/crate/secure/weapon
 	containername = "\improper Frag grenades crate"
 	access = access_armory
@@ -244,7 +244,7 @@
 /decl/hierarchy/supply_pack/security/pistolammo
 	name = "Ammunition - .45 magazines"
 	contains = list(/obj/item/ammo_magazine/c45m = 4)
-	cost = 20
+	cost = 2000
 	containertype = /obj/structure/closet/crate/secure/weapon
 	containername = "\improper .45 ammunition crate"
 	access = access_security
@@ -253,7 +253,7 @@
 /decl/hierarchy/supply_pack/security/pistolammorubber
 	name = "Ammunition - .45 rubber"
 	contains = list(/obj/item/ammo_magazine/c45m/rubber = 4)
-	cost = 15
+	cost = 1500
 	containertype = /obj/structure/closet/crate/secure/weapon
 	containername = "\improper .45 rubber ammunition crate"
 	access = access_security
@@ -261,7 +261,7 @@
 /decl/hierarchy/supply_pack/security/pistolammostun
 	name = "Ammunition - .45 stun"
 	contains = list(/obj/item/ammo_magazine/c45m/stun = 4)
-	cost = 15
+	cost = 1500
 	containertype = /obj/structure/closet/crate/secure/weapon
 	containername = "\improper .45 stun ammunition crate"
 	access = access_security
@@ -269,7 +269,7 @@
 /decl/hierarchy/supply_pack/security/pistolammopractice
 	name = "Ammunition - .45 practice"
 	contains = list(/obj/item/ammo_magazine/c45m/practice = 8)
-	cost = 15
+	cost = 1500
 	containertype = /obj/structure/closet/crate/secure/weapon
 	containername = "\improper .45 practice ammunition crate"
 	access = access_security
@@ -278,7 +278,7 @@
 	name = "Ammunition - Lethal shells"
 	contains = list(/obj/item/weapon/storage/box/shotgun/slugs = 2,
 					/obj/item/weapon/storage/box/shotgun/shells = 2)
-	cost = 60
+	cost = 6000
 	containertype = /obj/structure/closet/crate/secure/weapon
 	containername = "\improper Lethal shotgun shells crate"
 	access = access_security
@@ -287,7 +287,7 @@
 /decl/hierarchy/supply_pack/security/shotgunbeanbag
 	name = "Ammunition - Beanbag shells"
 	contains = list(/obj/item/weapon/storage/box/shotgun/beanbags = 3)
-	cost = 30
+	cost = 3000
 	containertype = /obj/structure/closet/crate/secure/weapon
 	containername = "\improper Beanbag shotgun shells crate"
 	access = access_security
@@ -295,7 +295,7 @@
 /decl/hierarchy/supply_pack/security/pdwammo
 	name = "Ammunition - 9mm top mounted"
 	contains = list(/obj/item/ammo_magazine/mc9mmt = 4)
-	cost = 40
+	cost = 4000
 	containertype = /obj/structure/closet/crate/secure/weapon
 	containername = "\improper 9mm ammunition crate"
 	access = access_security
@@ -304,7 +304,7 @@
 /decl/hierarchy/supply_pack/security/pdwammorubber
 	name = "Ammunition - 9mm top mounted rubber"
 	contains = list(/obj/item/ammo_magazine/mc9mmt/rubber = 4)
-	cost = 30
+	cost = 3000
 	containertype = /obj/structure/closet/crate/secure/weapon
 	containername = "\improper 9mm rubber ammunition crate"
 	access = access_security
@@ -312,7 +312,7 @@
 /decl/hierarchy/supply_pack/security/pdwammopractice
 	name = "Ammunition - 9mm top mounted practice"
 	contains = list(/obj/item/ammo_magazine/mc9mmt/practice = 8)
-	cost = 30
+	cost = 3000
 	containertype = /obj/structure/closet/crate/secure/weapon
 	containername = "\improper 9mm practice ammunition crate"
 	access = access_security
@@ -320,7 +320,7 @@
 /decl/hierarchy/supply_pack/security/bullpupammo
 	name = "Ammunition - 7.62"
 	contains = list(/obj/item/ammo_magazine/a762 = 4)
-	cost = 60
+	cost = 6000
 	containertype = /obj/structure/closet/crate/secure/weapon
 	containername = "\improper 7.62 ammunition crate"
 	access = access_security
@@ -329,7 +329,7 @@
 /decl/hierarchy/supply_pack/security/bullpupammopractice
 	name = "Ammunition - 7.62 practice"
 	contains = list(/obj/item/ammo_magazine/a762/practice = 8)
-	cost = 30
+	cost = 3000
 	containertype = /obj/structure/closet/crate/secure/weapon
 	containername = "\improper 7.62 practice ammunition crate"
 	access = access_security
@@ -337,7 +337,7 @@
 /decl/hierarchy/supply_pack/security/c44spec
 	name = "Ammunition - .44 SPEC 3in1"
 	contains = list(/obj/item/ammo_magazine/c44/spec = 3)
-	cost = 30
+	cost = 3000
 	containertype = /obj/structure/closet/crate/secure/weapon
 	containername = "\improper .44 SPEC ammunition crate"
 	access = access_forensics_lockers
@@ -345,7 +345,7 @@
 /decl/hierarchy/supply_pack/security/c44chem
 	name = "Ammunition - .44 CHEM 3in1"
 	contains = list(/obj/item/ammo_magazine/c44/chem = 3)
-	cost = 45
+	cost = 4500
 	containertype = /obj/structure/closet/crate/secure/weapon
 	containername = "\improper .44 CHEM ammunition crate"
 	access = access_forensics_lockers
@@ -356,7 +356,7 @@
 					/obj/item/weapon/forensics/sample_kit/powder,
 					/obj/item/weapon/storage/box/swabs = 3,
 					/obj/item/weapon/reagent_containers/spray/luminol)
-	cost = 30
+	cost = 3000
 	containername = "\improper Auxiliary forensic tools crate"
 
 /decl/hierarchy/supply_pack/security/detectivegear
@@ -376,7 +376,7 @@
 					/obj/item/weapon/storage/photo_album,
 					/obj/item/device/reagent_scanner,
 					/obj/item/weapon/storage/briefcase/crimekit = 2)
-	cost = 50
+	cost = 5000
 	containertype = /obj/structure/closet/crate/secure
 	containername = "\improper Forensic equipment crate"
 	access = access_forensics_lockers
@@ -384,7 +384,7 @@
 /decl/hierarchy/supply_pack/security/securitybarriers
 	name = "Misc - Barrier crate"
 	contains = list(/obj/machinery/deployable/barrier = 4)
-	cost = 20
+	cost = 2000
 	containertype = /obj/structure/closet/crate/secure/large
 	containername = "\improper Security barrier crate"
 	access = access_security
@@ -392,7 +392,7 @@
 /decl/hierarchy/supply_pack/security/securitybarriers
 	name = "Misc - Wall shield Generators"
 	contains = list(/obj/machinery/shieldwallgen = 2)
-	cost = 20
+	cost = 2000
 	containertype = /obj/structure/closet/crate/secure/large
 	containername = "\improper wall shield generators crate"
 	access = access_brig
@@ -404,7 +404,7 @@
 					/obj/item/clothing/mask/gas,
 					/obj/item/weapon/tank/oxygen,
 					/obj/item/clothing/gloves/latex)
-	cost = 30
+	cost = 3000
 	containertype = /obj/structure/closet/crate/secure
 	containername = "\improper Security biohazard gear crate"
 	access = access_security

--- a/code/datums/supplypacks/supply.dm
+++ b/code/datums/supplypacks/supply.dm
@@ -10,14 +10,14 @@
 					/obj/item/weapon/reagent_containers/food/snacks/tofu = 4,
 					/obj/item/weapon/reagent_containers/food/snacks/meat = 4
 					)
-	cost = 25
+	cost = 2500
 	containertype = /obj/structure/closet/crate/freezer
 	containername = "\improper Food crate"
 
 /decl/hierarchy/supply_pack/supply/toner
 	name = "Toner cartridges"
 	contains = list(/obj/item/device/toner = 6)
-	cost = 10
+	cost = 1000
 	containername = "\improper Toner cartridges"
 
 /decl/hierarchy/supply_pack/supply/janitor
@@ -31,14 +31,14 @@
 					/obj/item/weapon/reagent_containers/glass/rag,
 					/obj/item/weapon/grenade/chem_grenade/cleaner = 3,
 					/obj/structure/mopbucket)
-	cost = 10
+	cost = 1000
 	containertype = /obj/structure/closet/crate/large
 	containername = "\improper Janitorial supplies"
 
 /decl/hierarchy/supply_pack/supply/boxes
 	name = "Empty boxes"
 	contains = list(/obj/item/weapon/storage/box = 10)
-	cost = 10
+	cost = 1000
 	containername = "\improper Empty box crate"
 
 /decl/hierarchy/supply_pack/supply/bureaucracy
@@ -55,14 +55,14 @@
 					 /obj/structure/filingcabinet/chestdrawer{anchored = 0},
 					 /obj/item/weapon/paper_bin)
 	name = "Office supplies"
-	cost = 15
+	cost = 1500
 	containertype = /obj/structure/closet/crate/large
 	containername = "\improper Office supplies crate"
 
 /decl/hierarchy/supply_pack/supply/spare_pda
 	name = "Spare PDAs"
 	contains = list(/obj/item/device/pda = 5)
-	cost = 10
+	cost = 1000
 	containername = "\improper Spare PDA crate"
 
 /decl/hierarchy/supply_pack/supply/minergear
@@ -81,7 +81,7 @@
 					/obj/item/weapon/mining_scanner,
 					/obj/item/clothing/glasses/hud/standard/material,
 					/obj/item/clothing/glasses/hud/standard/meson)
-	cost = 15
+	cost = 1500
 	containertype = /obj/structure/closet/crate/secure
 	containername = "\improper Shaft miner equipment"
 	access = access_mining

--- a/code/game/jobs/job/civilian.dm
+++ b/code/game/jobs/job/civilian.dm
@@ -40,6 +40,7 @@
 //Cargo
 /datum/job/qm
 	title = "Quartermaster"
+	head_position = TRUE
 	department = "Supply"
 	department_flag = SUP
 	total_positions = 1

--- a/code/game/objects/structures/crates_lockers/crates.dm
+++ b/code/game/objects/structures/crates_lockers/crates.dm
@@ -15,7 +15,7 @@
 
 	storage_types = CLOSET_STORAGE_ITEMS
 
-	var/points_per_crate = 5
+	var/credits_per_crate = 500
 	var/rigged = 0
 
 /obj/structure/closet/crate/open()
@@ -103,7 +103,7 @@
 	icon_state = "plasticcrate"
 	icon_opened = "plasticcrateopen"
 	icon_closed = "plasticcrate"
-	points_per_crate = 1
+	credits_per_crate = 100
 	material = /obj/item/stack/material/plastic
 
 /obj/structure/closet/crate/handmade

--- a/code/modules/paperwork/misc.dm
+++ b/code/modules/paperwork/misc.dm
@@ -205,3 +205,8 @@
 	info += "NT departments codes: XXX-XXX-XXX\[br]"
 	info += "Organizations codes: XXX-(XX or XXX)-XXX\[br]"
 	. = ..()
+
+/obj/item/weapon/paper/cargo_note
+	name = "important cargo acceptance policy"
+	readonly = TRUE
+	info = @"[center]for all you hardworkers[br][b] basic rules of NT's jewish cargo acceptance policy[/b][/center][br]- these fuckers [i]only[/i] accept stuff that are [b]inside closed[/b] crates, everything else will be stolen forever and will not be repayed, excluding crates themselves of course. yes, i know how it sucks but we don't have any other choice[br]- they do [b]not[/b] accept closets. they [i]just[/i] don't wanna do this for some reason. crates only.[br]- platinum and plasma sheets are the [b]only[/b] resources which make some money for ya.[br]- don't forget to stamp incoming manifests and send them back, they have some value[br]- you can put cash in crates and it's value will be transfered to department balance[br]- there also some other ways how to make fast profits, but i don't really remember 'em[br][br]try not to waste all your money on hats and i guarantee you'll be doing good[br][br]best wishes,[br]your working Joe"

--- a/code/modules/reagents/dispenser/supply.dm
+++ b/code/modules/reagents/dispenser/supply.dm
@@ -6,7 +6,7 @@
 	contains = list(
 			/obj/machinery/chemical_dispenser{anchored = 0}
 		)
-	cost = 25
+	cost = 2500
 	containertype = /obj/structure/largecrate
 	containername = "reagent dispenser crate"
 
@@ -15,7 +15,7 @@
 	contains = list(
 			/obj/machinery/chemical_dispenser/bar_alc{anchored = 0}
 		)
-	cost = 25
+	cost = 2500
 	containertype = /obj/structure/largecrate
 	containername = "booze dispenser crate"
 
@@ -24,7 +24,7 @@
 	contains = list(
 			/obj/machinery/chemical_dispenser/bar_soft{anchored = 0}
 		)
-	cost = 25
+	cost = 2500
 	containertype = /obj/structure/largecrate
 	containername = "soda dispenser crate"
 
@@ -53,7 +53,7 @@
 			/obj/item/weapon/reagent_containers/chem_disp_cartridge/sacid,
 			/obj/item/weapon/reagent_containers/chem_disp_cartridge/tungsten
 		)
-	cost = 150
+	cost = 15000
 	containertype = /obj/structure/closet/crate/secure
 	containername = "chemical crate"
 	access = list(access_chemistry)
@@ -74,7 +74,7 @@
 			/obj/item/weapon/reagent_containers/chem_disp_cartridge/ale,
 			/obj/item/weapon/reagent_containers/chem_disp_cartridge/mead
 		)
-	cost = 50
+	cost = 5000
 	containertype = /obj/structure/closet/crate/secure
 	containername = "alcoholic drinks crate"
 	access = list(access_bar)
@@ -100,7 +100,7 @@
 			/obj/item/weapon/reagent_containers/chem_disp_cartridge/lime,
 			/obj/item/weapon/reagent_containers/chem_disp_cartridge/watermelon
 		)
-	cost = 50
+	cost = 5000
 	containertype = /obj/structure/closet/crate
 	containername = "soft drinks crate"
 
@@ -116,7 +116,7 @@
 			/obj/item/weapon/reagent_containers/chem_disp_cartridge/tea,
 			/obj/item/weapon/reagent_containers/chem_disp_cartridge/ice
 		)
-	cost = 50
+	cost = 5000
 	containertype = /obj/structure/closet/crate
 	containername = "coffee drinks crate"
 
@@ -134,7 +134,7 @@
 			/obj/item/weapon/reagent_containers/chem_disp_cartridge,
 			/obj/item/weapon/reagent_containers/chem_disp_cartridge
 		)
-	cost = 15
+	cost = 1500
 	containertype = /obj/structure/closet/crate
 	containername = "dispenser cartridge crate"
 
@@ -164,65 +164,65 @@
 	}
 
 // Chemistry-restricted (raw reagents excluding sugar/water)
-//      Datum path  Contents type                                                       Supply pack name                  Container name                         Cost  Container access
-SEC_PACK(hydrazine, /obj/item/weapon/reagent_containers/chem_disp_cartridge/hydrazine,  "Reagent refill - Hydrazine",     "hydrazine reagent cartridge crate",     15, access_chemistry)
-SEC_PACK(lithium,   /obj/item/weapon/reagent_containers/chem_disp_cartridge/lithium,    "Reagent refill - Lithium",       "lithium reagent cartridge crate",       15, access_chemistry)
-SEC_PACK(carbon,    /obj/item/weapon/reagent_containers/chem_disp_cartridge/carbon,     "Reagent refill - Carbon",        "carbon reagent cartridge crate",        15, access_chemistry)
-SEC_PACK(ammonia,   /obj/item/weapon/reagent_containers/chem_disp_cartridge/ammonia,    "Reagent refill - Ammonia",       "ammonia reagent cartridge crate",       15, access_chemistry)
-SEC_PACK(oxygen,    /obj/item/weapon/reagent_containers/chem_disp_cartridge/acetone,    "Reagent refill - Acetone",       "acetone reagent cartridge crate",       15, access_chemistry)
-SEC_PACK(sodium,    /obj/item/weapon/reagent_containers/chem_disp_cartridge/sodium,     "Reagent refill - Sodium",        "sodium reagent cartridge crate",        15, access_chemistry)
-SEC_PACK(aluminium, /obj/item/weapon/reagent_containers/chem_disp_cartridge/aluminum,   "Reagent refill - Aluminum",      "aluminum reagent cartridge crate",      15, access_chemistry)
-SEC_PACK(silicon,   /obj/item/weapon/reagent_containers/chem_disp_cartridge/silicon,    "Reagent refill - Silicon",       "silicon reagent cartridge crate",       15, access_chemistry)
-SEC_PACK(phosphorus,/obj/item/weapon/reagent_containers/chem_disp_cartridge/phosphorus, "Reagent refill - Phosphorus",    "phosphorus reagent cartridge crate",    15, access_chemistry)
-SEC_PACK(sulfur,    /obj/item/weapon/reagent_containers/chem_disp_cartridge/sulfur,     "Reagent refill - Sulfur",        "sulfur reagent cartridge crate",        15, access_chemistry)
-SEC_PACK(hclacid,   /obj/item/weapon/reagent_containers/chem_disp_cartridge/hclacid,    "Reagent refill - Hydrochloric Acid", "hydrochloric acid reagent cartridge crate", 15, access_chemistry)
-SEC_PACK(potassium, /obj/item/weapon/reagent_containers/chem_disp_cartridge/potassium,  "Reagent refill - Potassium",     "potassium reagent cartridge crate",     15, access_chemistry)
-SEC_PACK(iron,      /obj/item/weapon/reagent_containers/chem_disp_cartridge/iron,       "Reagent refill - Iron",          "iron reagent cartridge crate",          15, access_chemistry)
-SEC_PACK(copper,    /obj/item/weapon/reagent_containers/chem_disp_cartridge/copper,     "Reagent refill - Copper",        "copper reagent cartridge crate",        15, access_chemistry)
-SEC_PACK(mercury,   /obj/item/weapon/reagent_containers/chem_disp_cartridge/mercury,    "Reagent refill - Mercury",       "mercury reagent cartridge crate",       15, access_chemistry)
-SEC_PACK(radium,    /obj/item/weapon/reagent_containers/chem_disp_cartridge/radium,     "Reagent refill - Radium",        "radium reagent cartridge crate",        15, access_chemistry)
-SEC_PACK(ethanol,   /obj/item/weapon/reagent_containers/chem_disp_cartridge/ethanol,    "Reagent refill - Ethanol",       "ethanol reagent cartridge crate",       15, access_chemistry)
-SEC_PACK(sacid,     /obj/item/weapon/reagent_containers/chem_disp_cartridge/sacid,      "Reagent refill - Sulfuric Acid", "sulfuric acid reagent cartridge crate", 15, access_chemistry)
-SEC_PACK(tungsten,  /obj/item/weapon/reagent_containers/chem_disp_cartridge/tungsten,   "Reagent refill - Tungsten",      "tungsten reagent cartridge crate",      15, access_chemistry)
+//      Datum path  Contents type                                                       Supply pack name                      Container name                                   Cost  Container access
+SEC_PACK(hydrazine, /obj/item/weapon/reagent_containers/chem_disp_cartridge/hydrazine,  "Reagent refill - Hydrazine",         "hydrazine reagent cartridge crate",             1500, access_chemistry)
+SEC_PACK(lithium,   /obj/item/weapon/reagent_containers/chem_disp_cartridge/lithium,    "Reagent refill - Lithium",           "lithium reagent cartridge crate",               1500, access_chemistry)
+SEC_PACK(carbon,    /obj/item/weapon/reagent_containers/chem_disp_cartridge/carbon,     "Reagent refill - Carbon",            "carbon reagent cartridge crate",                1500, access_chemistry)
+SEC_PACK(ammonia,   /obj/item/weapon/reagent_containers/chem_disp_cartridge/ammonia,    "Reagent refill - Ammonia",           "ammonia reagent cartridge crate",               1500, access_chemistry)
+SEC_PACK(oxygen,    /obj/item/weapon/reagent_containers/chem_disp_cartridge/acetone,    "Reagent refill - Acetone",           "acetone reagent cartridge crate",               1500, access_chemistry)
+SEC_PACK(sodium,    /obj/item/weapon/reagent_containers/chem_disp_cartridge/sodium,     "Reagent refill - Sodium",            "sodium reagent cartridge crate",                1500, access_chemistry)
+SEC_PACK(aluminium, /obj/item/weapon/reagent_containers/chem_disp_cartridge/aluminum,   "Reagent refill - Aluminum",          "aluminum reagent cartridge crate",              1500, access_chemistry)
+SEC_PACK(silicon,   /obj/item/weapon/reagent_containers/chem_disp_cartridge/silicon,    "Reagent refill - Silicon",           "silicon reagent cartridge crate",               1500, access_chemistry)
+SEC_PACK(phosphorus,/obj/item/weapon/reagent_containers/chem_disp_cartridge/phosphorus, "Reagent refill - Phosphorus",        "phosphorus reagent cartridge crate",            1500, access_chemistry)
+SEC_PACK(sulfur,    /obj/item/weapon/reagent_containers/chem_disp_cartridge/sulfur,     "Reagent refill - Sulfur",            "sulfur reagent cartridge crate",                1500, access_chemistry)
+SEC_PACK(hclacid,   /obj/item/weapon/reagent_containers/chem_disp_cartridge/hclacid,    "Reagent refill - Hydrochloric Acid", "hydrochloric acid reagent cartridge crate",     1500, access_chemistry)
+SEC_PACK(potassium, /obj/item/weapon/reagent_containers/chem_disp_cartridge/potassium,  "Reagent refill - Potassium",         "potassium reagent cartridge crate",             1500, access_chemistry)
+SEC_PACK(iron,      /obj/item/weapon/reagent_containers/chem_disp_cartridge/iron,       "Reagent refill - Iron",              "iron reagent cartridge crate",                  1500, access_chemistry)
+SEC_PACK(copper,    /obj/item/weapon/reagent_containers/chem_disp_cartridge/copper,     "Reagent refill - Copper",            "copper reagent cartridge crate",                1500, access_chemistry)
+SEC_PACK(mercury,   /obj/item/weapon/reagent_containers/chem_disp_cartridge/mercury,    "Reagent refill - Mercury",           "mercury reagent cartridge crate",               1500, access_chemistry)
+SEC_PACK(radium,    /obj/item/weapon/reagent_containers/chem_disp_cartridge/radium,     "Reagent refill - Radium",            "radium reagent cartridge crate",                1500, access_chemistry)
+SEC_PACK(ethanol,   /obj/item/weapon/reagent_containers/chem_disp_cartridge/ethanol,    "Reagent refill - Ethanol",           "ethanol reagent cartridge crate",               1500, access_chemistry)
+SEC_PACK(sacid,     /obj/item/weapon/reagent_containers/chem_disp_cartridge/sacid,      "Reagent refill - Sulfuric Acid",     "sulfuric acid reagent cartridge crate",         1500, access_chemistry)
+SEC_PACK(tungsten,  /obj/item/weapon/reagent_containers/chem_disp_cartridge/tungsten,   "Reagent refill - Tungsten",          "tungsten reagent cartridge crate",              1500, access_chemistry)
 
 // Bar-restricted (alcoholic drinks)
-//      Datum path Contents type                                                     Supply pack name             Container name                    Cost  Container access
-SEC_PACK(beer,     /obj/item/weapon/reagent_containers/chem_disp_cartridge/beer,     "Reagent refill - Beer",     "beer reagent cartridge crate",     15, access_bar)
-SEC_PACK(kahlua,   /obj/item/weapon/reagent_containers/chem_disp_cartridge/kahlua,   "Reagent refill - Kahlua",   "kahlua reagent cartridge crate",   15, access_bar)
-SEC_PACK(whiskey,  /obj/item/weapon/reagent_containers/chem_disp_cartridge/whiskey,  "Reagent refill - Whiskey",  "whiskey reagent cartridge crate",  15, access_bar)
-SEC_PACK(wine,     /obj/item/weapon/reagent_containers/chem_disp_cartridge/wine,     "Reagent refill - Wine",     "wine reagent cartridge crate",     15, access_bar)
-SEC_PACK(vodka,    /obj/item/weapon/reagent_containers/chem_disp_cartridge/vodka,    "Reagent refill - Vodka",    "vodka reagent cartridge crate",    15, access_bar)
-SEC_PACK(gin,      /obj/item/weapon/reagent_containers/chem_disp_cartridge/gin,      "Reagent refill - Gin",      "gin reagent cartridge crate",      15, access_bar)
-SEC_PACK(rum,      /obj/item/weapon/reagent_containers/chem_disp_cartridge/rum,      "Reagent refill - Rum",      "rum reagent cartridge crate",      15, access_bar)
-SEC_PACK(tequila,  /obj/item/weapon/reagent_containers/chem_disp_cartridge/tequila,  "Reagent refill - Tequila",  "tequila reagent cartridge crate",  15, access_bar)
-SEC_PACK(vermouth, /obj/item/weapon/reagent_containers/chem_disp_cartridge/vermouth, "Reagent refill - Vermouth", "vermouth reagent cartridge crate", 15, access_bar)
-SEC_PACK(cognac,   /obj/item/weapon/reagent_containers/chem_disp_cartridge/cognac,   "Reagent refill - Cognac",   "cognac reagent cartridge crate",   15, access_bar)
-SEC_PACK(ale,      /obj/item/weapon/reagent_containers/chem_disp_cartridge/ale,      "Reagent refill - Ale",      "ale reagent cartridge crate",      15, access_bar)
-SEC_PACK(mead,     /obj/item/weapon/reagent_containers/chem_disp_cartridge/mead,     "Reagent refill - Mead",     "mead reagent cartridge crate",     15, access_bar)
+//      Datum path Contents type                                                     Supply pack name             Container name                      Cost  Container access
+SEC_PACK(beer,     /obj/item/weapon/reagent_containers/chem_disp_cartridge/beer,     "Reagent refill - Beer",     "beer reagent cartridge crate",     1500, access_bar)
+SEC_PACK(kahlua,   /obj/item/weapon/reagent_containers/chem_disp_cartridge/kahlua,   "Reagent refill - Kahlua",   "kahlua reagent cartridge crate",   1500, access_bar)
+SEC_PACK(whiskey,  /obj/item/weapon/reagent_containers/chem_disp_cartridge/whiskey,  "Reagent refill - Whiskey",  "whiskey reagent cartridge crate",  1500, access_bar)
+SEC_PACK(wine,     /obj/item/weapon/reagent_containers/chem_disp_cartridge/wine,     "Reagent refill - Wine",     "wine reagent cartridge crate",     1500, access_bar)
+SEC_PACK(vodka,    /obj/item/weapon/reagent_containers/chem_disp_cartridge/vodka,    "Reagent refill - Vodka",    "vodka reagent cartridge crate",    1500, access_bar)
+SEC_PACK(gin,      /obj/item/weapon/reagent_containers/chem_disp_cartridge/gin,      "Reagent refill - Gin",      "gin reagent cartridge crate",      1500, access_bar)
+SEC_PACK(rum,      /obj/item/weapon/reagent_containers/chem_disp_cartridge/rum,      "Reagent refill - Rum",      "rum reagent cartridge crate",      1500, access_bar)
+SEC_PACK(tequila,  /obj/item/weapon/reagent_containers/chem_disp_cartridge/tequila,  "Reagent refill - Tequila",  "tequila reagent cartridge crate",  1500, access_bar)
+SEC_PACK(vermouth, /obj/item/weapon/reagent_containers/chem_disp_cartridge/vermouth, "Reagent refill - Vermouth", "vermouth reagent cartridge crate", 1500, access_bar)
+SEC_PACK(cognac,   /obj/item/weapon/reagent_containers/chem_disp_cartridge/cognac,   "Reagent refill - Cognac",   "cognac reagent cartridge crate",   1500, access_bar)
+SEC_PACK(ale,      /obj/item/weapon/reagent_containers/chem_disp_cartridge/ale,      "Reagent refill - Ale",      "ale reagent cartridge crate",      1500, access_bar)
+SEC_PACK(mead,     /obj/item/weapon/reagent_containers/chem_disp_cartridge/mead,     "Reagent refill - Mead",     "mead reagent cartridge crate",     1500, access_bar)
 
 // Unrestricted (water, sugar, non-alcoholic drinks)
-//  Datum path   Contents type                                                       Supply pack name                        Container name                                          Cost
-PACK(water,      /obj/item/weapon/reagent_containers/chem_disp_cartridge/water,      "Reagent refill - Water",               "water reagent cartridge crate",                         15)
-PACK(sugar,      /obj/item/weapon/reagent_containers/chem_disp_cartridge/sugar,      "Reagent refill - Sugar",               "sugar reagent cartridge crate",                         15)
-PACK(ice,        /obj/item/weapon/reagent_containers/chem_disp_cartridge/ice,        "Reagent refill - Ice",                 "ice reagent cartridge crate",                           15)
-PACK(tea,        /obj/item/weapon/reagent_containers/chem_disp_cartridge/tea,        "Reagent refill - Tea",                 "tea reagent cartridge crate",                           15)
-PACK(icetea,     /obj/item/weapon/reagent_containers/chem_disp_cartridge/icetea,     "Reagent refill - Iced Tea",            "iced tea reagent cartridge crate",                      15)
-PACK(cola,       /obj/item/weapon/reagent_containers/chem_disp_cartridge/cola,       "Reagent refill - Space Cola",          "\improper Space Cola reagent cartridge crate",          15)
-PACK(smw,        /obj/item/weapon/reagent_containers/chem_disp_cartridge/smw,        "Reagent refill - Space Mountain Wind", "\improper Space Mountain Wind reagent cartridge crate", 15)
-PACK(dr_gibb,    /obj/item/weapon/reagent_containers/chem_disp_cartridge/dr_gibb,    "Reagent refill - Dr. Gibb",            "\improper Dr. Gibb reagent cartridge crate",            15)
-PACK(spaceup,    /obj/item/weapon/reagent_containers/chem_disp_cartridge/spaceup,    "Reagent refill - Space-Up",            "\improper Space-Up reagent cartridge crate",            15)
-PACK(tonic,      /obj/item/weapon/reagent_containers/chem_disp_cartridge/tonic,      "Reagent refill - Tonic Water",         "tonic water reagent cartridge crate",                   15)
-PACK(sodawater,  /obj/item/weapon/reagent_containers/chem_disp_cartridge/sodawater,  "Reagent refill - Soda Water",          "soda water reagent cartridge crate",                    15)
-PACK(lemon_lime, /obj/item/weapon/reagent_containers/chem_disp_cartridge/lemon_lime, "Reagent refill - Lemon-Lime Juice",    "lemon-lime juice reagent cartridge crate",              15)
-PACK(orange,     /obj/item/weapon/reagent_containers/chem_disp_cartridge/orange,     "Reagent refill - Orange Juice",        "orange juice reagent cartridge crate",                  15)
-PACK(lime,       /obj/item/weapon/reagent_containers/chem_disp_cartridge/lime,       "Reagent refill - Lime Juice",          "lime juice reagent cartridge crate",                    15)
-PACK(watermelon, /obj/item/weapon/reagent_containers/chem_disp_cartridge/watermelon, "Reagent refill - Watermelon Juice",    "watermelon juice reagent cartridge crate",              15)
-PACK(coffee,     /obj/item/weapon/reagent_containers/chem_disp_cartridge/coffee,     "Reagent refill - Coffee",              "coffee reagent cartridge crate",                        15)
-PACK(cafe_latte, /obj/item/weapon/reagent_containers/chem_disp_cartridge/cafe_latte, "Reagent refill - Cafe Latte",          "cafe latte reagent cartridge crate",                    15)
-PACK(soy_latte,  /obj/item/weapon/reagent_containers/chem_disp_cartridge/soy_latte,  "Reagent refill - Soy Latte",           "soy latte reagent cartridge crate",                     15)
-PACK(hot_coco,   /obj/item/weapon/reagent_containers/chem_disp_cartridge/hot_coco,   "Reagent refill - Hot Coco",            "hot coco reagent cartridge crate",                      15)
-PACK(milk,       /obj/item/weapon/reagent_containers/chem_disp_cartridge/milk,       "Reagent refill - Milk",                "milk reagent cartridge crate",                          15)
-PACK(cream,      /obj/item/weapon/reagent_containers/chem_disp_cartridge/cream,      "Reagent refill - Cream",               "cream reagent cartridge crate",                         15)
+//  Datum path   Contents type                                                       Supply pack name                        Container name                                           Cost
+PACK(water,      /obj/item/weapon/reagent_containers/chem_disp_cartridge/water,      "Reagent refill - Water",               "water reagent cartridge crate",                         1500)
+PACK(sugar,      /obj/item/weapon/reagent_containers/chem_disp_cartridge/sugar,      "Reagent refill - Sugar",               "sugar reagent cartridge crate",                         1500)
+PACK(ice,        /obj/item/weapon/reagent_containers/chem_disp_cartridge/ice,        "Reagent refill - Ice",                 "ice reagent cartridge crate",                           1500)
+PACK(tea,        /obj/item/weapon/reagent_containers/chem_disp_cartridge/tea,        "Reagent refill - Tea",                 "tea reagent cartridge crate",                           1500)
+PACK(icetea,     /obj/item/weapon/reagent_containers/chem_disp_cartridge/icetea,     "Reagent refill - Iced Tea",            "iced tea reagent cartridge crate",                      1500)
+PACK(cola,       /obj/item/weapon/reagent_containers/chem_disp_cartridge/cola,       "Reagent refill - Space Cola",          "\improper Space Cola reagent cartridge crate",          1500)
+PACK(smw,        /obj/item/weapon/reagent_containers/chem_disp_cartridge/smw,        "Reagent refill - Space Mountain Wind", "\improper Space Mountain Wind reagent cartridge crate", 1500)
+PACK(dr_gibb,    /obj/item/weapon/reagent_containers/chem_disp_cartridge/dr_gibb,    "Reagent refill - Dr. Gibb",            "\improper Dr. Gibb reagent cartridge crate",            1500)
+PACK(spaceup,    /obj/item/weapon/reagent_containers/chem_disp_cartridge/spaceup,    "Reagent refill - Space-Up",            "\improper Space-Up reagent cartridge crate",            1500)
+PACK(tonic,      /obj/item/weapon/reagent_containers/chem_disp_cartridge/tonic,      "Reagent refill - Tonic Water",         "tonic water reagent cartridge crate",                   1500)
+PACK(sodawater,  /obj/item/weapon/reagent_containers/chem_disp_cartridge/sodawater,  "Reagent refill - Soda Water",          "soda water reagent cartridge crate",                    1500)
+PACK(lemon_lime, /obj/item/weapon/reagent_containers/chem_disp_cartridge/lemon_lime, "Reagent refill - Lemon-Lime Juice",    "lemon-lime juice reagent cartridge crate",              1500)
+PACK(orange,     /obj/item/weapon/reagent_containers/chem_disp_cartridge/orange,     "Reagent refill - Orange Juice",        "orange juice reagent cartridge crate",                  1500)
+PACK(lime,       /obj/item/weapon/reagent_containers/chem_disp_cartridge/lime,       "Reagent refill - Lime Juice",          "lime juice reagent cartridge crate",                    1500)
+PACK(watermelon, /obj/item/weapon/reagent_containers/chem_disp_cartridge/watermelon, "Reagent refill - Watermelon Juice",    "watermelon juice reagent cartridge crate",              1500)
+PACK(coffee,     /obj/item/weapon/reagent_containers/chem_disp_cartridge/coffee,     "Reagent refill - Coffee",              "coffee reagent cartridge crate",                        1500)
+PACK(cafe_latte, /obj/item/weapon/reagent_containers/chem_disp_cartridge/cafe_latte, "Reagent refill - Cafe Latte",          "cafe latte reagent cartridge crate",                    1500)
+PACK(soy_latte,  /obj/item/weapon/reagent_containers/chem_disp_cartridge/soy_latte,  "Reagent refill - Soy Latte",           "soy latte reagent cartridge crate",                     1500)
+PACK(hot_coco,   /obj/item/weapon/reagent_containers/chem_disp_cartridge/hot_coco,   "Reagent refill - Hot Coco",            "hot coco reagent cartridge crate",                      1500)
+PACK(milk,       /obj/item/weapon/reagent_containers/chem_disp_cartridge/milk,       "Reagent refill - Milk",                "milk reagent cartridge crate",                          1500)
+PACK(cream,      /obj/item/weapon/reagent_containers/chem_disp_cartridge/cream,      "Reagent refill - Cream",               "cream reagent cartridge crate",                         1500)
 
 #undef SEC_PACK
 #undef PACK

--- a/code/modules/virus2/antibodyanalyser.dm
+++ b/code/modules/virus2/antibodyanalyser.dm
@@ -42,8 +42,8 @@
 				var/list/common_antibodies = known_antibodies & given_antibodies
 				var/list/unknown_antibodies = common_antibodies ^ given_antibodies
 				if(unknown_antibodies.len)
-					var/payout = unknown_antibodies.len * 45
-					SSsupply.add_points_from_source(payout, "virology")
+					var/payout = unknown_antibodies.len * 4500
+					SSsupply.add_credits_from_source(payout, "virology")
 					ping("\The [src] pings, \"Successfully uploaded new antibodies to the ExoNet.\"")
 					known_antibodies |= unknown_antibodies //Add the new antibodies to list
 				else

--- a/maps/exodus/exodus-2.dmm
+++ b/maps/exodus/exodus-2.dmm
@@ -5116,7 +5116,7 @@
 "bVf" = (/obj/machinery/power/apc{name = "south bump"; pixel_y = -24},/obj/structure/cable/green{d2 = 4; icon_state = "0-4"},/turf/simulated/floor/tiled,/area/quartermaster/office)
 "bVg" = (/obj/machinery/light,/obj/structure/disposalpipe/segment{dir = 1; icon_state = "pipe-c"},/obj/machinery/computer/guestpass{pixel_y = -28},/obj/structure/cable/green{d1 = 4; d2 = 8; icon_state = "4-8"},/obj/effect/floor_decal/corner/brown,/turf/simulated/floor/tiled,/area/quartermaster/office)
 "bVh" = (/obj/structure/disposalpipe/segment{dir = 2; icon_state = "pipe-c"},/obj/structure/cable/green{d1 = 1; d2 = 2; icon_state = "1-2"},/obj/structure/cable/green{d1 = 1; d2 = 8; icon_state = "1-8"},/obj/machinery/atmospherics/pipe/simple/hidden/supply,/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,/obj/effect/floor_decal/corner/brown{dir = 10},/turf/simulated/floor/tiled,/area/quartermaster/office)
-"bVi" = (/obj/structure/noticeboard{pixel_y = -27},/obj/effect/floor_decal/corner/brown{dir = 8},/turf/simulated/floor/tiled,/area/quartermaster/office)
+"bVi" = (/obj/structure/noticeboard{pixel_y = -27},/obj/effect/floor_decal/corner/brown{dir = 8},/obj/item/weapon/paper/cargo_note,/turf/simulated/floor/tiled,/area/quartermaster/office)
 "bVj" = (/obj/machinery/status_display/supply_display,/turf/simulated/wall,/area/quartermaster/qm)
 "bVk" = (/obj/effect/wingrille_spawn/reinforced/polarized,/turf/simulated/floor/plating,/area/quartermaster/qm)
 "bVl" = (/turf/simulated/wall,/area/quartermaster/qm)

--- a/maps/~mapsystem/maps.dm
+++ b/maps/~mapsystem/maps.dm
@@ -220,6 +220,8 @@ var/const/MAP_HAS_RANK = 2		//Rank system, also togglable
 	for(var/department in station_departments)
 		department_accounts[department] = create_account("[department] Account", department_money)
 
+	SSsupply.department_account = department_accounts["Supply"]
+
 	department_accounts["Vendor"] = create_account("Vendor Account", 0)
 	vendor_account = department_accounts["Vendor"]
 

--- a/nano/templates/supply.tmpl
+++ b/nano/templates/supply.tmpl
@@ -5,6 +5,11 @@
 		You are unauthenticated. Some functions may me unavailable.
 	{{/if}}
 </div>
+{{if data.account_suspended}}
+	<div class='notice'>
+		Supply department account suspended. Approving orders impossible until suspension is lifted. Contact your local financial administrator.
+	</div>
+{{/if}}
 <div class="item">
 	{{:helper.link('Browse Goods', 'cart', {'set_screen' : 1}, data.screen == 1 ? 'selected' : null)}}
 	{{:helper.link('View Statistics', 'calculator', {'set_screen' : 2}, data.screen == 2 ? 'selected' : null)}}
@@ -36,7 +41,7 @@
 				{{:value.desc}}:
 			</div>
 			<div class="itemContent">
-				{{:value.points}} {{:data.currency_short}}
+				{{:value.credits}} {{:data.currency_short}}
 			</div>
 		</div>
 	{{/for}}
@@ -86,7 +91,7 @@
 					<td>{{:value.orderer}}
 					<td>{{:value.reason}}
 					<td>{{:value.cost}} Cr.
-					<td>{{:helper.link('Approve', 'check', {'approve_order' : value.id}, value.cost > data.credits ? 'disabled' : null )}}{{:helper.link('Deny', 'cancel', {'deny_order' : value.id})}}
+					<td>{{:helper.link('Approve', 'check', {'approve_order' : value.id}, (value.cost > data.credits || data.account_suspended) ? 'disabled' : null )}}{{:helper.link('Deny', 'cancel', {'deny_order' : value.id})}}
 				{{/for}}
 			</table>
 		</div>


### PR DESCRIPTION
мостли сабж
- отныне для оплаты закупки карго использует существующий финансовый Supply account отдела
- из вышесказанного вытекает что счёт карго теперь можно заблокировать в ХоПской, запрещая тем самым покупку новых заказов
- айди и пинкод от каргосчёта теперь появляются у квартермейстера в голове, позволяя какой-никакой юз ефтпос сканнеров
- на каргосчёт всё так-же периодически приходят суммы с цк, только задержка изменена с 20 секунд до 5 минут, получка пропорционально
- все цены на товары умножены на 100 для соответствия с дефолтным балансом отдела на старте игры (50 поинтов -> 5000 кр)
- добавлена возможность вкидывания физических денег в шаттл и перевода их на счёт отдела
- в силу замечательного механа засчитывания продажи товара в карго добавлена пояснительная записка на нотисборд
- печатаемая бумажка со статистикой отдела теперь правильно печатается из консоли

цены на товары и выплаты возможно не финальные, ибо кому-то может захочется их поменять в силу того что у экипажа подобного бабла гораздо меньше, и при активной работе карго его счёт гипотетически может достаточно быстро разбухнуть больше станционного в 75 тысяч
если кому-то впрёт могут указать новый мультипликатор или потвикать цены ручками сами

но хэй, хотя бы богачами будут

```yml
🆑
tweak: Для оплаты заказов в карго теперь используются настоящие кредиты вместо эфемерных поинтов.
/🆑
```

- [x] Pull Request полностью завершен, мне не нужна помощь чтобы его закончить.
- [x] Я внимательно прочитал все свои изменения и багов в них не нашел.
- [x] Я запускал сервер со своими изменениями локально и все протестировал.
- [x] Я ознакомился c [Guide to Contribute](https://github.com/ChaoticOnyx/OnyxBay/blob/dev/docs/contributing.md).
