### PR TITLE
tweak(SpaceLaw): now has red icon

### DIFF
--- a/code/modules/library/manuals.dm
+++ b/code/modules/library/manuals.dm
@@ -88,7 +88,7 @@
 
 /obj/item/weapon/book/wiki/nt_regs
 	desc = "A set of corporate guidelines for employees of NanoTrasen."
-	icon_state = "booknanoregs"
+	icon_state = "bookRedSpaceLaw"
 	author = "NanoTrasen"
 	title = "NanoTrasen Regulations"
 	topic = "Space Law/Onyx"


### PR DESCRIPTION
По просьбе уважаемого человека заменил спрайт космозакона на красненький.
![spacelaw](https://user-images.githubusercontent.com/63081538/146961387-037b5ad4-9b3e-4219-a004-7728a696e042.png)

<details>

<summary>Чейнджлог</summary>

```yml
🆑
imageadd: Космозакон теперь имеет красный цвет.
/🆑
```

</details>

- [x] Pull Request полностью завершен, мне не нужна помощь чтобы его закончить.
- [x] Я внимательно прочитал все свои изменения и багов в них не нашел.
- [x] Я запускал сервер со своими изменениями локально и все протестировал.
- [x] Я ознакомился c [Guide to Contribute](https://github.com/ChaoticOnyx/OnyxBay/blob/dev/docs/contributing.md).
