### PR TITLE
fix-gravgen-destruction-by-singularity

### DIFF
--- a/code/modules/power/gravitygenerator.dm
+++ b/code/modules/power/gravitygenerator.dm
@@ -112,8 +112,10 @@ GLOBAL_VAR(station_gravity_generator)
 			qdel(P)
 	middle = null
 	lights = null
+	if(enabled)
+		enabled = FALSE
+		update_connectected_areas_gravity()
 	connected_areas = null
-	update_connectected_areas_gravity()
 	return ..()
 
 /obj/machinery/gravity_generator/main/examine(mob/user)


### PR DESCRIPTION
Добавлено удаление гравитации в Destroy() генератора гравитации.
Там вообще странный код был 0_0.
Как вообще должна была обновиться гравитация в зонах после присваивания их списку null?

fix #4741 

<details>
<summary>Чейнджлог</summary>

```yml
🆑
bugfix: Теперь гравитация больше не остаётся при поглощении гененератора гравитации сингулярностью.
/🆑
```

</details>

Не тестировал даже наличие бага, но сломать ничего не должно было. По запросу могу протестировать.

- [x] Pull Request полностью завершен, мне не нужна помощь чтобы его закончить.
- [x] Я внимательно прочитал все свои изменения и багов в них не нашел.
- [ ] Я запускал сервер со своими изменениями локально и все протестировал.
- [x] Я ознакомился c [Guide to Contribute](https://github.com/ChaoticOnyx/OnyxBay/blob/dev/docs/contributing.md).
