### PR TITLE
Removes xenomorphs' xenobugs

### DIFF
--- a/code/game/objects/effects/aliens.dm
+++ b/code/game/objects/effects/aliens.dm
@@ -118,6 +118,8 @@
 		icon_state = "egg"
 
 /obj/structure/alien/egg/proc/hatch()
+	set waitfor = 0
+
 	progress = -1
 	STOP_PROCESSING(SSobj, src)
 	update_icon()
@@ -129,8 +131,6 @@
 /*
  * Weeds
  */
-#define NODERANGE 3
-
 /obj/effect/alien/weeds
 	name = "weeds"
 	desc = "Weird purple weeds."
@@ -148,8 +148,7 @@
 	name = "purple sac"
 	desc = "Weird purple octopus-like thing."
 	layer = ABOVE_TILE_LAYER + 0.01
-	light_outer_range = NODERANGE
-	var/node_range = NODERANGE
+	var/node_range = 3
 
 /obj/effect/alien/weeds/node/New()
 	..(src.loc, src)
@@ -238,5 +237,3 @@
 /obj/effect/alien/weeds/fire_act(datum/gas_mixture/air, exposed_temperature, exposed_volume)
 	if(exposed_temperature > 300 + T0C && prob(80))
 		qdel(src)
-
-#undef NODERANGE

--- a/code/game/objects/effects/aliens.dm
+++ b/code/game/objects/effects/aliens.dm
@@ -11,9 +11,10 @@
 	icon_state = "acid"
 	icon = 'icons/mob/alien.dmi'
 
-	density = 0
-	opacity = 0
-	anchored = 1
+	density = FALSE
+	opacity = FALSE
+	anchored = TRUE
+	layer = ABOVE_WINDOW_LAYER
 
 	var/atom/target
 	var/acid_strength = ACID_WEAK

--- a/code/game/objects/effects/aliens.dm
+++ b/code/game/objects/effects/aliens.dm
@@ -25,6 +25,7 @@
 	..(loc)
 	target = supplied_target
 	melt_time = melt_time / acid_strength
+	desc += "\n<b>It's melting \the [target]!</b>"
 	START_PROCESSING(SSprocessing, src)
 
 /obj/effect/acid/Destroy()

--- a/code/game/objects/effects/aliens.dm
+++ b/code/game/objects/effects/aliens.dm
@@ -26,6 +26,8 @@
 	target = supplied_target
 	melt_time = melt_time / acid_strength
 	desc += "\n<b>It's melting \the [target]!</b>"
+	pixel_x = target.pixel_x
+	pixel_y = target.pixel_y
 	START_PROCESSING(SSprocessing, src)
 
 /obj/effect/acid/Destroy()

--- a/code/game/objects/structures/alien/alien.dm
+++ b/code/game/objects/structures/alien/alien.dm
@@ -3,6 +3,7 @@
 	desc = "There's something alien about this."
 	icon = 'icons/mob/alien.dmi'
 	layer = ABOVE_OBJ_LAYER
+	can_atmos_pass = ATMOS_PASS_DENSITY
 	var/health = 50
 
 	hitby_sound = 'sound/effects/attackblob.ogg'
@@ -55,8 +56,7 @@
 	healthcheck()
 	return
 
-/obj/structure/alien/CanPass(atom/movable/mover, turf/target, height=0, air_group=0)
-	if(air_group) return 0
+/obj/structure/alien/CanPass(atom/movable/mover, turf/target)
 	if(istype(mover) && mover.pass_flags & PASS_FLAG_GLASS)
 		return !opacity
 	return !density

--- a/code/game/objects/structures/alien/resin.dm
+++ b/code/game/objects/structures/alien/resin.dm
@@ -6,7 +6,7 @@
 	density = 1
 	opacity = 1
 	anchored = 1
-	health = 200
+	health = 230
 
 /obj/structure/alien/resin/wall
 	name = "resin wall"
@@ -18,7 +18,7 @@
 	desc = "Purple slime just thin enough to let light pass through."
 	icon_state = "resinmembrane"
 	opacity = 0
-	health = 120
+	health = 150
 
 /obj/structure/alien/resin/New()
 	..()
@@ -28,7 +28,6 @@
 /obj/structure/alien/resin/Destroy()
 	var/turf/T = get_turf(src)
 	T.thermal_conductivity = initial(T.thermal_conductivity)
-
 	return ..()
 
 /obj/structure/alien/resin/attack_hand(mob/user)
@@ -37,7 +36,7 @@
 		health = 0
 	else
 		// Aliens can get straight through these.
-		if(istype(user,/mob/living/carbon))
+		if(istype(user, /mob/living/carbon))
 			var/mob/living/carbon/M = user
 			if(M.a_intent == I_HURT && (locate(/obj/item/organ/internal/xenos/hivenode) in M.internal_organs))
 				visible_message("<span class='alium'>\The [user] strokes \the [name] and it melts away!</span>")

--- a/code/game/objects/structures/stool_bed_chair_nest/alien_nests.dm
+++ b/code/game/objects/structures/stool_bed_chair_nest/alien_nests.dm
@@ -16,7 +16,7 @@
 /obj/structure/bed/nest/Initialize()
 	. = ..()
 	over = image(icon, "nest_over")
-	over.layer = BASE_HUMAN_LAYER + 0.1
+	over.layer = LYING_HUMAN_LAYER + 0.1
 
 /obj/structure/bed/nest/Destroy()
 	QDEL_NULL(over)

--- a/code/modules/mob/living/carbon/human/human.dm
+++ b/code/modules/mob/living/carbon/human/human.dm
@@ -236,7 +236,7 @@
 /mob/living/carbon/human/show_inv(mob/user)
 	if(user.incapacitated() || !user.Adjacent(src))
 		return
-	if(!user.IsAdvancedToolUser())
+	if(!user.IsAdvancedToolUser(TRUE))
 		show_inv_reduced(user)
 		return
 	var/dat = "<B><HR><FONT size=3>[name]</FONT></B><BR><HR>"

--- a/code/modules/mob/living/carbon/human/species/xenomorphs/alien_powers.dm
+++ b/code/modules/mob/living/carbon/human/species/xenomorphs/alien_powers.dm
@@ -21,6 +21,8 @@
 	I.stored_plasma = max(0, min(I.stored_plasma, I.max_plasma))
 
 /mob/living/carbon/human/proc/check_alien_ability(cost, needs_organ = null, needs_foundation = FALSE, silent = FALSE) //Returns 1 if the ability is clear for usage.
+	if(incapacitated(INCAPACITATION_DISABLED))
+		return
 
 	var/obj/item/organ/internal/xenos/plasmavessel/P = internal_organs_by_name[BP_PLASMA]
 	if(!istype(P))

--- a/code/modules/mob/living/carbon/human/species/xenomorphs/alien_powers.dm
+++ b/code/modules/mob/living/carbon/human/species/xenomorphs/alien_powers.dm
@@ -21,7 +21,9 @@
 	I.stored_plasma = max(0, min(I.stored_plasma, I.max_plasma))
 
 /mob/living/carbon/human/proc/check_alien_ability(cost, needs_organ = null, needs_foundation = FALSE, silent = FALSE) //Returns 1 if the ability is clear for usage.
-	if(incapacitated(INCAPACITATION_DISABLED))
+	if(stat)
+		if(!silent)
+			to_chat(src, SPAN("danger", "I cannot to this while incapacitated!"))
 		return
 
 	var/obj/item/organ/internal/xenos/plasmavessel/P = internal_organs_by_name[BP_PLASMA]

--- a/code/modules/mob/living/carbon/human/stripping.dm
+++ b/code/modules/mob/living/carbon/human/stripping.dm
@@ -117,7 +117,7 @@
 	if(stripping)
 		if(unEquip(target_slot))
 			admin_attack_log(user, src, "Stripped \a [target_slot]", "Was stripped of \a [target_slot].", "stripped \a [target_slot] from")
-			if(!isAggresiveStrip(user))
+			if(!isAggresiveStrip(user) && user.IsAdvancedToolUser())
 				user.put_in_active_hand(target_slot)
 		else
 			admin_attack_log(user, src, "Attempted to strip \a [target_slot]", "Target of a failed strip of \a [target_slot].", "attempted to strip \a [target_slot] from")

--- a/code/modules/mob/living/carbon/human/stripping.dm
+++ b/code/modules/mob/living/carbon/human/stripping.dm
@@ -117,7 +117,7 @@
 	if(stripping)
 		if(unEquip(target_slot))
 			admin_attack_log(user, src, "Stripped \a [target_slot]", "Was stripped of \a [target_slot].", "stripped \a [target_slot] from")
-			if(!isAggresiveStrip(user) && user.IsAdvancedToolUser())
+			if(!isAggresiveStrip(user) && user.IsAdvancedToolUser(TRUE))
 				user.put_in_active_hand(target_slot)
 		else
 			admin_attack_log(user, src, "Attempted to strip \a [target_slot]", "Target of a failed strip of \a [target_slot].", "attempted to strip \a [target_slot] from")


### PR DESCRIPTION
Хоть кто-то наконец начал репортить баги. Хвала.

```yml
🆑
tweak: Ноды травы ксеноморфов больше не светятся.
tweak: Немного увеличен запас прочности у стен и окон ксеноморфов.
bugfix: Ксеноморфы больше не берут снятые при раздевании людей вещи в руки.
bugfix: Стены и окна ксеноморфов теперь правильно блокируют газы.
bugfix: Кислота чужих теперь отображается поверх большинства объектов.
tweak: С помощью Examine по кислоте можно узнать, что она плавит.
tweak: Кислота теперь сдвигается к объекту, который плавит. Например, если применить на табличку на стене - она будет отображаться поверх неё, а не на полу.
bugfix: Ксеноморфы больше не могут применять способности, будучи мёртвыми или без сознания.
/🆑
```

- [x] Pull Request полностью завершен, мне не нужна помощь чтобы его закончить.
- [x] Я внимательно прочитал все свои изменения и багов в них не нашел.
- [x] Я запускал сервер со своими изменениями локально и все протестировал.
- [x] Я ознакомился c [Guide to Contribute](https://github.com/ChaoticOnyx/OnyxBay/blob/dev/docs/contributing.md).
