### PR TITLE
Removes hunters extra speed, drones and queens lack of speed, tweaks damage dealt to simple_animals

### DIFF
--- a/code/modules/mob/living/carbon/human/species/species.dm
+++ b/code/modules/mob/living/carbon/human/species/species.dm
@@ -89,6 +89,7 @@
 	var/flash_mod =      1                    // Stun from blindness modifier.
 	var/metabolism_mod = 1                    // Reagent metabolism modifier
 	var/vision_flags = SEE_SELF               // Same flags as glasses.
+	var/generic_attack_mod = 1.0              // Damage dealt to simple animals with unarmed attacks multiplier.
 
 	// Death vars.
 	var/meat_type = /obj/item/weapon/reagent_containers/food/snacks/meat/human

--- a/code/modules/mob/living/carbon/human/species/station/golem.dm
+++ b/code/modules/mob/living/carbon/human/species/station/golem.dm
@@ -7,6 +7,7 @@
 
 	language = "Sol Common" //todo?
 	unarmed_types = list(/datum/unarmed_attack/stomp, /datum/unarmed_attack/kick, /datum/unarmed_attack/punch)
+	generic_attack_mod = 1.5
 	species_flags = SPECIES_FLAG_NO_PAIN | SPECIES_FLAG_NO_SCAN | SPECIES_FLAG_NO_POISON | SPECIES_FLAG_NO_BLOOD
 	spawn_flags = SPECIES_IS_RESTRICTED
 	siemens_coefficient = 0

--- a/code/modules/mob/living/carbon/human/species/station/lizard.dm
+++ b/code/modules/mob/living/carbon/human/species/station/lizard.dm
@@ -7,6 +7,7 @@
 	tail_animation = 'icons/mob/species/unathi/tail.dmi'
 
 	unarmed_types = list(/datum/unarmed_attack/stomp, /datum/unarmed_attack/tail, /datum/unarmed_attack/claws, /datum/unarmed_attack/bite/sharp)
+	generic_attack_mod = 2.0
 	primitive_form = "Stok"
 	darksight_range = 3
 	darksight_tint = DARKTINT_MODERATE

--- a/code/modules/mob/living/carbon/human/species/station/station.dm
+++ b/code/modules/mob/living/carbon/human/species/station/station.dm
@@ -86,6 +86,7 @@
 	tail_animation = 'icons/mob/species/tajaran/tail.dmi'
 	default_h_style = "Tajaran Ears"
 	unarmed_types = list(/datum/unarmed_attack/stomp, /datum/unarmed_attack/kick, /datum/unarmed_attack/claws, /datum/unarmed_attack/bite/sharp)
+	generic_attack_mod = 2.0
 	darksight_range = 8
 	darksight_tint = DARKTINT_GOOD
 	slowdown = -0.5

--- a/code/modules/mob/living/carbon/human/species/xenomorphs/alien_species.dm
+++ b/code/modules/mob/living/carbon/human/species/xenomorphs/alien_species.dm
@@ -7,6 +7,7 @@
 	genders = list(NEUTER)
 	assisted_langs = list()
 	unarmed_types = list(/datum/unarmed_attack/claws/strong/xeno, /datum/unarmed_attack/bite/strong/xeno)
+	generic_attack_mod = 4.0
 	hud_type = /datum/hud_data/alien
 	meat_type = /obj/item/weapon/reagent_containers/food/snacks/meat/xeno
 	rarity_value = 3
@@ -111,11 +112,9 @@
 	var/turf/T = H.loc
 	if(!T)
 		return
-	var/datum/gas_mixture/environment = T.return_air()
-	if(!environment)
-		return
 
-	if(environment.gas["plasma"] > 0 || locate(/obj/effect/alien/weeds) in T)
+	var/datum/gas_mixture/environment = T.return_air()
+	if(environment?.gas["plasma"] > 0 || locate(/obj/effect/alien/weeds) in T)
 		if(!regenerate(H))
 			var/obj/item/organ/internal/xenos/plasmavessel/P = H.internal_organs_by_name[BP_PLASMA]
 			P.stored_plasma += weeds_plasma_rate
@@ -198,13 +197,14 @@
 	name = SPECIES_XENO_DRONE
 	caste_name = "drone"
 	weeds_plasma_rate = 15
-	slowdown = 1
+	slowdown = 0.5
 	total_health = 150
 	tail = "xenos_drone_tail"
 	rarity_value = 5
 	strength = STR_MEDIUM
 	brute_mod = 0.85
 	burn_mod  = 1.75
+	generic_attack_mod = 3.5
 
 	icobase = 'icons/mob/human_races/xenos/r_xenos_drone.dmi'
 	deform =  'icons/mob/human_races/xenos/r_xenos_drone.dmi'
@@ -255,12 +255,13 @@
 	name = SPECIES_XENO_HUNTER
 	weeds_plasma_rate = 5
 	caste_name = "hunter"
-	slowdown = -1
+	slowdown = -0.5
 	total_health = 200
 	tail = "xenos_hunter_tail"
 	strength = STR_HIGH
 	brute_mod = 0.75
 	burn_mod  = 1.65
+	generic_attack_mod = 4.5
 
 	icobase = 'icons/mob/human_races/xenos/r_xenos_hunter.dmi'
 	deform =  'icons/mob/human_races/xenos/r_xenos_hunter.dmi'
@@ -293,6 +294,7 @@
 	icobase = 'icons/mob/human_races/xenos/r_xenos_hunter_feral.dmi'
 	deform =  'icons/mob/human_races/xenos/r_xenos_hunter_feral.dmi'
 	tail = "xenos_hunter_feral_tail"
+	slowdown = -1
 
 /datum/species/xenos/sentinel
 	name = SPECIES_XENO_SENTINEL
@@ -348,13 +350,14 @@
 	weeds_heal_rate = 20
 	weeds_plasma_rate = 20
 	caste_name = "queen"
-	slowdown = 4
+	slowdown = 3.5
 	tail = "xenos_queen_tail"
 	rarity_value = 10
 	strength = STR_VHIGH
 	brute_mod = 0.5
 	burn_mod  = 1.25
 	icon_scale = 1.3
+	generic_attack_mod = 4.5
 
 	icobase = 'icons/mob/human_races/xenos/r_xenos_queen.dmi'
 	deform =  'icons/mob/human_races/xenos/r_xenos_queen.dmi'

--- a/code/modules/mob/living/carbon/human/species/xenomorphs/alien_species.dm
+++ b/code/modules/mob/living/carbon/human/species/xenomorphs/alien_species.dm
@@ -197,7 +197,7 @@
 	name = SPECIES_XENO_DRONE
 	caste_name = "drone"
 	weeds_plasma_rate = 15
-	slowdown = 0.5
+	slowdown = 0
 	total_health = 150
 	tail = "xenos_drone_tail"
 	rarity_value = 5

--- a/code/modules/mob/living/simple_animal/constructs/constructs.dm
+++ b/code/modules/mob/living/simple_animal/constructs/constructs.dm
@@ -101,7 +101,7 @@
 	health = 250
 	speak_emote = list("rumbles")
 	response_harm   = "harmlessly punches"
-	harm_intent_damage = 0
+	harm_intent_damage = 2.5
 	melee_damage_lower = 30
 	melee_damage_upper = 30
 	attacktext = "smashed their armoured gauntlet into"

--- a/code/modules/mob/living/simple_animal/hostile/asteroid/goliath.dm
+++ b/code/modules/mob/living/simple_animal/hostile/asteroid/goliath.dm
@@ -21,7 +21,6 @@
 	speed = 3
 	maxHealth = 300
 	health = 300
-	harm_intent_damage = 0
 	melee_damage_lower = 25
 	melee_damage_upper = 25
 	attacktext = "pulverizes"

--- a/code/modules/mob/living/simple_animal/simple_animal.dm
+++ b/code/modules/mob/living/simple_animal/simple_animal.dm
@@ -213,7 +213,7 @@
 			//TODO: Push the mob away or something
 
 		if(I_HURT)
-			adjustBruteLoss(harm_intent_damage)
+			adjustBruteLoss(harm_intent_damage * M.species.generic_attack_mod)
 			M.visible_message("<span class='warning'>[M] [response_harm] \the [src]!</span>")
 			M.do_attack_animation(src)
 


### PR DESCRIPTION
```yml
🆑
bugfix: Исправлена ошибка, из-за которой ксеноморфы не могли регенерировать на траве, если в помещении отсутствовала атмосфера.
balance: Снижена скорость передвижения ксеноморфов-охотников. У подвида Feral скорость осталась прежней.
balance: Скорость передвижения ксеноморфов-рабочих увеличена до человеческой.
balance: Слегка увеличена скорость передвижения королевы ксеноморфов.
tweak: Добавлены множители урона по симпл_животным при атаках голыми руками. У големов - х1.5, у таяран и унатхов - х2, у ксеноморфов-рабочих - х3.5, у ксеноморфов-стражей - х4.0, у ксеноморфов-охотников и королевы - х4.5.
/🆑
```

- [x] Pull Request полностью завершен, мне не нужна помощь чтобы его закончить.
- [x] Я внимательно прочитал все свои изменения и багов в них не нашел.
- [x] Я запускал сервер со своими изменениями локально и все протестировал.
- [x] Я ознакомился c [Guide to Contribute](https://github.com/ChaoticOnyx/OnyxBay/blob/dev/docs/contributing.md).
