### PR TITLE
Removes the ability to drop fake armblades via bushes

### DIFF
--- a/code/game/gamemodes/changeling/powers/sting_fake_armblade.dm
+++ b/code/game/gamemodes/changeling/powers/sting_fake_armblade.dm
@@ -37,5 +37,4 @@
 					failed = TRUE
 		if(!failed)
 			target.visible_message(SPAN("danger", "The flesh is torn around the [target.name]\'s arm!"))
-			var/obj/item/weapon/W = new /obj/item/weapon/melee/prosthetic/bio/fake_arm_blade
-			target.put_in_hands(W)
+			new /obj/item/weapon/melee/prosthetic/bio/fake_arm_blade(target, target.organs_by_name[hand])

--- a/code/game/objects/structures/flora.dm
+++ b/code/game/objects/structures/flora.dm
@@ -288,6 +288,9 @@
 		return 0
 	if(istype(W, /obj/item/weapon/holder))
 		return 0 //no hiding mobs in there
+	if(!W.canremove)
+		shake_animation(stime = 4)
+		return ..()
 	user.visible_message("[user] begins digging around inside of \the [src].", "You begin digging around in \the [src], trying to hide \the [W].")
 	playsound(loc, 'sound/effects/plantshake.ogg', rand(50, 75), TRUE)
 	user.setClickCooldown(DEFAULT_QUICK_COOLDOWN)


### PR DESCRIPTION
- Исправлена возможность прятать фейковые армбляди в кустах. Снова. Вот надо было кендроп выпиливать, а.
- Исправлена невозможность бить людей фейковыми армблейдами.

- [x] Pull Request полностью завершен, мне не нужна помощь чтобы его закончить.
- [x] Я внимательно прочитал все свои изменения и багов в них не нашел.
- [x] Я запускал сервер со своими изменениями локально и все протестировал.
- [x] Я ознакомился c [Guide to Contribute](https://github.com/ChaoticOnyx/OnyxBay/blob/dev/docs/contributing.md).
