### PR TITLE
Removes changelings' ability to spawn limb-monsters from vents

### DIFF
--- a/code/game/gamemodes/changeling/powers/detach_limb.dm
+++ b/code/game/gamemodes/changeling/powers/detach_limb.dm
@@ -18,6 +18,9 @@
 
 	var/mob/living/carbon/human/H = my_mob
 
+	if(H.is_ventcrawling)
+		return
+
 	var/list/detachable_limbs = H.organs.Copy()
 	for(var/obj/item/organ/external/E in detachable_limbs)
 		if(E.organ_tag == BP_R_HAND || E.organ_tag == BP_L_HAND || E.organ_tag == BP_R_FOOT || E.organ_tag == BP_L_FOOT || E.organ_tag == BP_CHEST || E.organ_tag == BP_GROIN || E.is_stump())

--- a/code/game/gamemodes/changeling/powers/disjunction.dm
+++ b/code/game/gamemodes/changeling/powers/disjunction.dm
@@ -17,6 +17,9 @@
 
 	var/mob/living/carbon/human/H = my_mob
 
+	if(H.is_ventcrawling)
+		return
+
 	H.visible_message(SPAN("danger", "You hear a loud cracking sound coming from \the [H]."), \
 					  SPAN("changeling", "We begin disjunction of our body."))
 


### PR DESCRIPTION

```yml
🆑
bugfix: Исправлена возожность создавать генкомобов, находясь в вентиляции.
/🆑
```

- [x] Pull Request полностью завершен, мне не нужна помощь чтобы его закончить.
- [x] Я внимательно прочитал все свои изменения и багов в них не нашел.
- [x] Я запускал сервер со своими изменениями локально и все протестировал.
- [x] Я ознакомился c [Guide to Contribute](https://github.com/ChaoticOnyx/OnyxBay/blob/dev/docs/contributing.md).
