### PR TITLE
Removes inability to kick BODA

### DIFF
--- a/code/_onclick/item_attack.dm
+++ b/code/_onclick/item_attack.dm
@@ -124,7 +124,7 @@ avoid code duplication. This includes items that may sometimes act as a standard
 		obj_attack_sound(W)
 
 /atom/proc/obj_attack_sound(obj/item/W)
-	if(W.hitsound == 'sound/effects/fighting/smash.ogg')
+	if(W?.hitsound == 'sound/effects/fighting/smash.ogg')
 		playsound(loc, 'sound/effects/fighting/smash.ogg', 50, 1, -1)
 		return
 	playsound(loc, 'sound/effects/metalhit2.ogg', rand(45,65), 1, -1)

--- a/code/game/machinery/vending.dm
+++ b/code/game/machinery/vending.dm
@@ -1395,6 +1395,39 @@
 	contraband = list(/obj/item/weapon/reagent_containers/food/drinks/bottle/cola = 20) // TODO Russian cola can
 	idle_power_usage = 211 //refrigerator - believe it or not, this is actually the average power consumption of a refrigerated vending machine according to NRCan.
 
+/obj/machinery/vending/sovietsoda/attack_hand(mob/user)
+	if(user.lying || user.stat)
+		return TRUE
+
+	if(ishuman(user) && user.a_intent == I_HURT)
+		user.visible_message("<b>[user]</b> kicks \the [src]!")
+		user.setClickCooldown(DEFAULT_ATTACK_COOLDOWN)
+		user.do_attack_animation(src)
+		obj_attack_sound()
+		shake_animation(stime = 1)
+		if(seconds_electrified != 0)
+			shock(user, 100)
+		free_drop_lottery()
+		return TRUE
+
+	return ..()
+
+/obj/machinery/vending/sovietsoda/take_damage(force)
+	free_drop_lottery(force)
+	..()
+
+/obj/machinery/vending/sovietsoda/proc/free_drop_lottery(prob = 5)
+	if(!prob(prob))
+		return
+	if(prob(33) && !(stat & (BROKEN|NOPOWER)))
+		throw_item()
+	else
+		var/obj/drop_item = null
+		for(var/datum/stored_items/vending_products/R in shuffle(product_records))
+			drop_item = R.get_product(loc)
+		if(drop_item)
+			visible_message(SPAN("notice", "\The [src] clunks as \the [drop_item] suddenly drops out of it!"))
+
 /obj/machinery/vending/tool
 	name = "YouTool"
 	desc = "Tools for tools."

--- a/code/game/machinery/vending.dm
+++ b/code/game/machinery/vending.dm
@@ -1425,8 +1425,9 @@
 		var/obj/drop_item = null
 		for(var/datum/stored_items/vending_products/R in shuffle(product_records))
 			drop_item = R.get_product(loc)
-		if(drop_item)
-			visible_message(SPAN("notice", "\The [src] clunks as \the [drop_item] suddenly drops out of it!"))
+			if(drop_item)
+				visible_message(SPAN("notice", "\The [src] clunks as \the [drop_item] suddenly drops out of it!"))
+				return
 
 /obj/machinery/vending/tool
 	name = "YouTool"


### PR DESCRIPTION
Добавлена возможность пинать BODA кликом на харме. После пинка BODA есть шанс в 5%, что BODA уронит товар. 
В трети случаев BODA не уронит товар, а кинет им в кого-нибудь (но только в случае, если BODA работает). 
При получении урона иным способом (удары предметами или выстрелы) BODA уронит товар с шансом, зависящим от урона.
BODA.

```yml
🆑
tweak: Теперь автомат BODA можно пинать.
/🆑
```

- [x] Pull Request полностью завершен, мне не нужна помощь чтобы его закончить.
- [x] Я внимательно прочитал все свои изменения и багов в них не нашел.
- [x] Я запускал сервер со своими изменениями локально и все протестировал.
- [x] Я ознакомился c [Guide to Contribute](https://github.com/ChaoticOnyx/OnyxBay/blob/dev/docs/contributing.md).
