### PR TITLE
fix(grab): now kill grab does not reverse ppl

### DIFF
--- a/code/datums/movement/mob.dm
+++ b/code/datums/movement/mob.dm
@@ -280,8 +280,9 @@
 	HandleGrabs(direction, old_turf)
 
 	for(var/obj/item/grab/G in mob)
-		if(G.assailant_reverse_facing())
-			mob.set_dir(GLOB.reverse_dir[direction])
+		if(G.reverse_moving())
+			G.assailant.set_dir(GLOB.reverse_dir[direction])
+			G.affecting.set_dir(GLOB.reverse_dir[direction])
 		if(G.current_grab.downgrade_on_move)
 			G.downgrade()
 	for(var/obj/item/grab/G in mob.grabbed_by)

--- a/code/modules/mob/grab/grab_datum.dm
+++ b/code/modules/mob/grab/grab_datum.dm
@@ -9,7 +9,7 @@
 
 	var/stop_move = 0							// Whether or not the grabbed person can move out of the grab
 	var/force_stand = 0							// Whether or not the grabbed person is forced to be standing
-	var/reverse_facing = FALSE					// Whether the person being grabbed is facing forwards or backwards.
+	var/reverse_moving = FALSE					// Whether the persons involved will move backwards
 	var/can_absorb = 0							// Whether this grab state is strong enough to, as a changeling, absorb the person you're grabbing.
 	var/shield_assailant = 0					// Whether the person you're grabbing will shield you from bullets.,,
 	var/point_blank_mult = 1					// How much the grab increases point blank damage.

--- a/code/modules/mob/grab/grab_datum.dm
+++ b/code/modules/mob/grab/grab_datum.dm
@@ -9,7 +9,7 @@
 
 	var/stop_move = 0							// Whether or not the grabbed person can move out of the grab
 	var/force_stand = 0							// Whether or not the grabbed person is forced to be standing
-	var/reverse_facing = 0						// Whether the person being grabbed is facing forwards or backwards.
+	var/reverse_facing = FALSE					// Whether the person being grabbed is facing forwards or backwards.
 	var/can_absorb = 0							// Whether this grab state is strong enough to, as a changeling, absorb the person you're grabbing.
 	var/shield_assailant = 0					// Whether the person you're grabbing will shield you from bullets.,,
 	var/point_blank_mult = 1					// How much the grab increases point blank damage.

--- a/code/modules/mob/grab/grab_object.dm
+++ b/code/modules/mob/grab/grab_object.dm
@@ -272,8 +272,8 @@
 /obj/item/grab/proc/can_absorb()
 	return current_grab.can_absorb
 
-/obj/item/grab/proc/assailant_reverse_facing()
-	return current_grab.reverse_facing
+/obj/item/grab/proc/reverse_moving()
+	return current_grab.reverse_moving
 
 /obj/item/grab/proc/shield_assailant()
 	return current_grab.shield_assailant

--- a/code/modules/mob/grab/nab/grab_nab.dm
+++ b/code/modules/mob/grab/nab/grab_nab.dm
@@ -27,7 +27,7 @@
 
 	stop_move = 1
 	force_stand = 1
-	reverse_facing = 1
+	reverse_facing = TRUE
 	can_absorb = 1
 	shield_assailant = 1
 	point_blank_mult = 1

--- a/code/modules/mob/grab/nab/grab_nab.dm
+++ b/code/modules/mob/grab/nab/grab_nab.dm
@@ -27,7 +27,7 @@
 
 	stop_move = 1
 	force_stand = 1
-	reverse_facing = TRUE
+	reverse_moving = TRUE
 	can_absorb = 1
 	shield_assailant = 1
 	point_blank_mult = 1

--- a/code/modules/mob/grab/nab/nab_passive.dm
+++ b/code/modules/mob/grab/nab/nab_passive.dm
@@ -5,7 +5,7 @@
 
 	shift = -10
 
-	reverse_facing = 0
+	reverse_facing = FALSE
 	can_absorb = 0
 
 	grab_slowdown = 0

--- a/code/modules/mob/grab/nab/nab_passive.dm
+++ b/code/modules/mob/grab/nab/nab_passive.dm
@@ -5,7 +5,7 @@
 
 	shift = -10
 
-	reverse_facing = FALSE
+	reverse_moving = FALSE
 	can_absorb = 0
 
 	grab_slowdown = 0

--- a/code/modules/mob/grab/normal/norm_aggressive.dm
+++ b/code/modules/mob/grab/normal/norm_aggressive.dm
@@ -8,7 +8,6 @@
 
 
 	stop_move = 1
-	reverse_facing = 0
 	can_absorb = 0
 	shield_assailant = 0
 	point_blank_mult = 1

--- a/code/modules/mob/grab/normal/norm_kill.dm
+++ b/code/modules/mob/grab/normal/norm_kill.dm
@@ -6,7 +6,6 @@
 	shift = 0
 
 	stop_move = 1
-	reverse_facing = 1
 	can_absorb = 1
 	shield_assailant = 0
 	point_blank_mult = 1

--- a/code/modules/mob/grab/normal/norm_kill.dm
+++ b/code/modules/mob/grab/normal/norm_kill.dm
@@ -3,9 +3,10 @@
 
 	downgrab_name = NORM_NECK
 
-	shift = 0
+	shift = 8
 
 	stop_move = 1
+	reverse_moving = TRUE
 	can_absorb = 1
 	shield_assailant = 0
 	point_blank_mult = 1

--- a/code/modules/mob/grab/normal/norm_neck.dm
+++ b/code/modules/mob/grab/normal/norm_neck.dm
@@ -8,9 +8,8 @@
 
 	shift = -10
 
-
 	stop_move = 1
-	reverse_facing = 1
+	reverse_facing = TRUE
 	can_absorb = 1
 	shield_assailant = 1
 	point_blank_mult = 1

--- a/code/modules/mob/grab/normal/norm_neck.dm
+++ b/code/modules/mob/grab/normal/norm_neck.dm
@@ -6,10 +6,10 @@
 
 	drop_headbutt = 0
 
-	shift = -10
+	shift = 8
 
 	stop_move = 1
-	reverse_facing = TRUE
+	reverse_moving = TRUE
 	can_absorb = 1
 	shield_assailant = 1
 	point_blank_mult = 1

--- a/code/modules/mob/grab/normal/norm_passive.dm
+++ b/code/modules/mob/grab/normal/norm_passive.dm
@@ -7,7 +7,6 @@
 	shift = 8
 
 	stop_move = 0
-	reverse_facing = 0
 	can_absorb = 0
 	shield_assailant = 0
 	point_blank_mult = 1

--- a/code/modules/mob/grab/normal/norm_struggle.dm
+++ b/code/modules/mob/grab/normal/norm_struggle.dm
@@ -8,7 +8,6 @@
 	shift = 8
 
 	stop_move = 1
-	reverse_facing = 0
 	can_absorb = 0
 	point_blank_mult = 1
 	same_tile = 0


### PR DESCRIPTION
Теперь kill граб не разворачивает космонавтика спиной.

**FACE ME**

<details>
<summary>Чейнджлог</summary>

```yml
🆑
tweak: Теперь kill граб не разворачивает космонавтика спиной
/🆑
```

</details>

- [x] Pull Request полностью завершен, мне не нужна помощь чтобы его закончить.
- [x] Я внимательно прочитал все свои изменения и багов в них не нашел.
- [x] Я запускал сервер со своими изменениями локально и все протестировал.
- [x] Я ознакомился c [Guide to Contribute](https://github.com/ChaoticOnyx/OnyxBay/blob/dev/docs/contributing.md).
