### PR TITLE
tweak(config): add schema for custom_sprites.json

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,6 +17,7 @@ config/*
 !config/names/
 !config/example/
 !config/warnings_templates/
+!config/schema/
 build_log.txt
 use_map
 stopserver

--- a/code/modules/mob/living/silicon/custom_sprites.dm
+++ b/code/modules/mob/living/silicon/custom_sprites.dm
@@ -1,4 +1,3 @@
-// look in config/custom_sprites.json for example.
 //list(ckey = real_name,)
 //Since the ckey is used as the icon_state, the current system will only permit a single custom robot sprite per ckey.
 //While it might be possible for a ckey to use that custom sprite for several real_names, it seems rather pointless to support it.
@@ -10,7 +9,7 @@ GLOBAL_LIST_EMPTY(ai_custom_icons)
 		return
 	var/list/config_json = json_decode(file2text("config/custom_sprites.json"))
 #ifdef CUSTOM_ITEM_AI_HOLO
-	for(var/list/item in config_json["aiholo"])
+	for(var/list/item in config_json["ai_holo"])
 		var/ckey = item["ckey"]
 		var/real_name = item["sprite"]
 
@@ -33,7 +32,7 @@ GLOBAL_LIST_EMPTY(ai_custom_icons)
 	var/list/custom_icon_states = icon_states(CUSTOM_ITEM_AI)
 	var/custom_index = 0
 
-	for(var/list/item in config_json["aicore"])
+	for(var/list/item in config_json["ai_core"])
 		var/ckey = item["ckey"]
 		var/real_name = item["sprite"]
 
@@ -67,4 +66,3 @@ GLOBAL_LIST_EMPTY(ai_custom_icons)
 			else
 				to_chat(src, SPAN_WARNING("Could not locate [ckey]-Standard sprite. Please report this to local developer"))
 				icon =  'icons/mob/robots.dmi'
-

--- a/config/example/custom_sprites.json
+++ b/config/example/custom_sprites.json
@@ -1,23 +1,6 @@
 {
-    "robot":
-    [
-        {
-            "ckey": "ckey",
-            "sprite": "sprite"
-        }
-    ],
-    "aiholo":
-    [
-        {
-            "ckey": "ckey",
-            "sprite": "sprite"
-        }
-    ],
-    "aicore":
-    [
-        {
-            "ckey": "ckey",
-            "sprite": "sprite name without -ai and -ai-crash"
-        }
-    ]
+  "$schema": "https://raw.githubusercontent.com/ChaoticOnyx/OnyxBay/dev/config/schema/custom_sprites.schema.json",
+  "robot": [],
+  "ai_holo": [],
+  "ai_core": []
 }

--- a/config/schema/custom_sprites.schema.json
+++ b/config/schema/custom_sprites.schema.json
@@ -1,0 +1,69 @@
+{
+  "$schema": "https://json-schema.org/draft-07/schema",
+  "type": "object",
+  "properties": {
+    "$schema": {
+      "type": "string"
+    },
+    "robot": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "properties": {
+          "ckey": {
+            "type": "string",
+            "description": "Player's ckey",
+            "pattern": "^[a-z]+$"
+          },
+          "sprite": {
+            "type": "string",
+            "description": "Name of icon state"
+          }
+        },
+        "required": ["ckey", "sprite"],
+        "additionalProperties": false
+      }
+    },
+    "ai_holo": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "properties": {
+          "ckey": {
+            "type": "string",
+            "description": "Player's ckey",
+            "pattern": "^[a-z]+$"
+          },
+          "sprite": {
+            "type": "string",
+            "description": "Name of icon state"
+          }
+        },
+        "required": ["ckey", "sprite"],
+        "additionalProperties": false
+      }
+    },
+    "ai_core": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "properties": {
+          "ckey": {
+            "type": "string",
+            "description": "Player's ckey",
+            "pattern": "^[a-z]+$"
+          },
+          "sprite": {
+            "type": "string",
+            "pattern": "^.+(?<!(-ai|-ai-crash))$",
+            "description": "Name of icon state without '-ai' and '-ai-crash' at the end"
+          }
+        },
+        "required": ["ckey", "sprite"],
+        "additionalProperties": false
+      }
+    }
+  },
+  "required": ["robot", "ai_holo", "ai_core"],
+  "additionalProperties": false
+}


### PR DESCRIPTION
Добавил схему для конфига `custom_sprites.json` и немного исправил наименование.
Вот новые правильные конфиги для каждого сервера:

<details>
<summary>Onyx</summary>

```json
{
  "$schema": "https://raw.githubusercontent.com/ChaoticOnyx/OnyxBay/dev/config/schema/custom_sprites.schema.json",
  "robot": [
    {
      "ckey": "partingglass",
      "sprite": "K3R8"
    }
  ],
  "ai_holo": [
    {
      "ckey": "hentaistorm",
      "sprite": "onyx"
    }
  ],
  "ai_core": []
}

```

</details>

<details>
<summary>EOS</summary>

```json
{
  "$schema": "https://raw.githubusercontent.com/ChaoticOnyx/OnyxBay/dev/config/schema/custom_sprites.schema.json",
  "robot": [],
  "ai_holo": [],
  "ai_core": []
}

```

</details>

- [x] Pull Request полностью завершен, мне не нужна помощь чтобы его закончить.
- [x] Я внимательно прочитал все свои изменения и багов в них не нашел.
- [x] Я запускал сервер со своими изменениями локально и все протестировал.
- [x] Я ознакомился c [Guide to Contribute](https://github.com/ChaoticOnyx/OnyxBay/blob/dev/docs/contributing.md).
