### PR TITLE
Removes bats supremacy

### DIFF
--- a/code/game/objects/items/material/twohanded.dm
+++ b/code/game/objects/items/material/twohanded.dm
@@ -26,6 +26,7 @@
 	var/unwieldsound = null
 	var/base_icon
 	var/base_name
+	var/unwielded_force_const = 0
 	var/unwielded_force_divisor = 0.25
 	var/mod_handy_w
 	var/mod_weight_w
@@ -57,10 +58,10 @@
 		force_wielded = material.get_edge_damage()
 	else
 		force_wielded = material.get_blunt_damage()
-	force_wielded = force_const + round(force_wielded*force_divisor, 0.1)
-	force_unwielded = force_const + round(force_wielded*unwielded_force_divisor, 0.1)
+	force_wielded = force_const + round(force_wielded * force_divisor, 0.1)
+	force_unwielded = unwielded_force_const + round(force_wielded * unwielded_force_divisor, 0.1)
 	force = force_unwielded
-	throwforce = round(force*thrown_force_divisor)
+	throwforce = round(force * thrown_force_divisor)
 //	log_debug("[src] has unwielded force [force_unwielded], wielded force [force_wielded] and throwforce [throwforce] when made from default material [material.name]")
 
 
@@ -120,7 +121,7 @@
 	name = "spear"
 	desc = "A haphazardly-constructed yet still deadly weapon of ancient design."
 	force = 10
-	force_const = 5.5
+	force_const = 6.5
 	sharp = 1
 	edge = 1
 	w_class = ITEM_SIZE_HUGE
@@ -159,7 +160,7 @@
 	mod_handy_w = 1.0
 	mod_weight_w = 1.5
 	mod_reach_w = 1.0
-	mod_handy_u = 0.8
+	mod_handy_u = 0.75
 	mod_weight_u = 1.35
 	mod_reach_u = 1.0
 
@@ -167,8 +168,11 @@
 	attack_verb = list("smashed", "beaten", "slammed", "smacked", "struck", "battered", "bonked")
 	hitsound = SFX_FIGHTING_SWING
 	default_material = MATERIAL_WOOD
-	force_divisor = 1.0           // 20 when wielded with weight 20 (steel)
-	unwielded_force_divisor = 0.7 // 15 when unwielded based on above.
+
+	force_const = 6.0
+	force_divisor = 0.7           // 14 when wielded with weight 20 (steel)
+	unwielded_force_const = 5.0
+	unwielded_force_divisor = 0.5 // 15 when unwielded based on above.
 	slot_flags = SLOT_BACK
 
 //Predefined materials go here.

--- a/code/game/objects/items/material/twohanded.dm
+++ b/code/game/objects/items/material/twohanded.dm
@@ -121,6 +121,7 @@
 	name = "spear"
 	desc = "A haphazardly-constructed yet still deadly weapon of ancient design."
 	force = 10
+	unwielded_force_const = 5.5
 	force_const = 6.5
 	sharp = 1
 	edge = 1

--- a/code/game/objects/items/material/twohanded.dm
+++ b/code/game/objects/items/material/twohanded.dm
@@ -169,8 +169,8 @@
 	hitsound = SFX_FIGHTING_SWING
 	default_material = MATERIAL_WOOD
 
-	force_const = 6.0
-	force_divisor = 0.7           // 14 when wielded with weight 20 (steel)
+	force_const = 8.0
+	force_divisor = 0.6           // 14 when wielded with weight 20 (steel)
 	unwielded_force_const = 5.0
 	unwielded_force_divisor = 0.5 // 15 when unwielded based on above.
 	slot_flags = SLOT_BACK


### PR DESCRIPTION
- Изменён расчёт урона бейсбольных бит.
Раньше:
Одноручный хват - 0.7 * вес материала;
Двуручный хват - 1.0 * вес материала;
Теперь:
Одноручный хват - 5.0 + (0.5 * вес материала);
Двуручный хват - 8.0 + (0.6 * вес материала);
- Уменьшено удобство биты при одноручном хвате с 0.8 до 0.75.
- Урон копий увеличен на 1.0;

Следовательно, у деревянных и стальных бит урон остаётся старым +- 1, пластиковые биты в принципе могут наносить хоть какой-то урон, а золотые и урановые биты наносят не 40, а 32 урона.

```yml
🆑
tweak: Изменена формула рассчёта урона у бейсбольных бит.
/🆑
```

- [x] Pull Request полностью завершен, мне не нужна помощь чтобы его закончить.
- [x] Я внимательно прочитал все свои изменения и багов в них не нашел.
- [x] Я запускал сервер со своими изменениями локально и все протестировал.
- [x] Я ознакомился c [Guide to Contribute](https://github.com/ChaoticOnyx/OnyxBay/blob/dev/docs/contributing.md).
