### PR TITLE
tweak(grab): add forgotten return

### DIFF
--- a/code/modules/mob/living/carbon/human/human_helpers.dm
+++ b/code/modules/mob/living/carbon/human/human_helpers.dm
@@ -234,7 +234,7 @@
 
 	if(!victim.get_organ(attacker.zone_sel.selecting))
 		to_chat(attacker, SPAN("warning", "[victim] is missing the body part you tried to grab!"))
-		return 0
+		return FALSE
 
 	if(!grab_tag)
 		G = new attacker.current_grab_type(attacker, victim)
@@ -244,13 +244,14 @@
 
 	if(!G.pre_check())
 		qdel(G)
-		return 0
+		return FALSE
 
 	if(G.can_grab())
 		G.init()
+		return TRUE
 	else
 		qdel(G)
-		return 0
+		return FALSE
 
 /mob/living/carbon/human
 	var/list/cloaking_sources


### PR DESCRIPTION
Как я и предполагал, забытый ретурн в #7311, вызывает баги в некоторых местах (невозможность вызова определенного кода)

<details>
<summary>Чейнджлог</summary>

```yml
🆑
bugfix: Напы и лип ксеноморфов, и, возможно, иные фичи связанные с грабом вновь работают.
/🆑
```

</details>

- [x] Pull Request полностью завершен, мне не нужна помощь чтобы его закончить.
- [x] Я внимательно прочитал все свои изменения и багов в них не нашел.
- [x] Я запускал сервер со своими изменениями локально и все протестировал.
- [x] Я ознакомился c [Guide to Contribute](https://github.com/ChaoticOnyx/OnyxBay/blob/dev/docs/contributing.md).
