### PR TITLE
fix(paper,nanoword) fixed table css

### DIFF
--- a/code/_helpers/text.dm
+++ b/code/_helpers/text.dm
@@ -418,7 +418,7 @@
 	t = replacetext(t, "\[/item\]", "</li>")
 	t = replacetext(t, "\[ord\]", "<ol [class]>")
 	t = replacetext(t, "\[/ord\]", "</ol>")
-	t = replacetext(t, "\[table\]", "<table [class] cellspacing=0 cellpadding=3")
+	t = replacetext(t, "\[table\]", "<table [class] cellspacing=0 cellpadding=3>")
 	t = replacetext(t, "\[/table\]", "</td></tr></table>")
 	t = replacetext(t, "\[grid\]", "<table [class]>")
 	t = replacetext(t, "\[/grid\]", "</td></tr></table>")

--- a/code/modules/modular_computers/file_system/programs/generic/wordprocessor.dm
+++ b/code/modules/modular_computers/file_system/programs/generic/wordprocessor.dm
@@ -213,11 +213,11 @@
 	else if(PRG.open_file)
 		data["filedata"] = pencode2html(PRG.loaded_data)
 		data["filename"] = PRG.is_edited ? "[PRG.open_file]*" : PRG.open_file
-		data["filedata"] = replacetext(data["filedata"], "<table", "<table class=\'nword\'")
+		data["filedata"] = replacetext(data["filedata"], "<table", "<table class='nword'")
 	else
 		data["filedata"] = pencode2html(PRG.loaded_data)
 		data["filename"] = "UNNAMED"
-		data["filedata"] = replacetext(data["filedata"], "<table", "<table class=\'nword\'")
+		data["filedata"] = replacetext(data["filedata"], "<table", "<table class='nword'")
 
 	ui = SSnano.try_update_ui(user, src, ui_key, ui, data, force_open)
 	if (!ui)

--- a/code/modules/modular_computers/file_system/programs/generic/wordprocessor.dm
+++ b/code/modules/modular_computers/file_system/programs/generic/wordprocessor.dm
@@ -213,9 +213,11 @@
 	else if(PRG.open_file)
 		data["filedata"] = pencode2html(PRG.loaded_data)
 		data["filename"] = PRG.is_edited ? "[PRG.open_file]*" : PRG.open_file
+		data["filedata"] = replacetext(data["filedata"], "<table", "<table class=\'nword\'")
 	else
 		data["filedata"] = pencode2html(PRG.loaded_data)
 		data["filename"] = "UNNAMED"
+		data["filedata"] = replacetext(data["filedata"], "<table", "<table class=\'nword\'")
 
 	ui = SSnano.try_update_ui(user, src, ui_key, ui, data, force_open)
 	if (!ui)

--- a/code/modules/paperwork/paper.dm
+++ b/code/modules/paperwork/paper.dm
@@ -53,7 +53,7 @@
 		font-display: swap;
 	}
 
-	table {
+	table,th,td{
 		border: 1px solid black;
 	}
 

--- a/nano/css/shared.css
+++ b/nano/css/shared.css
@@ -582,7 +582,11 @@ div.notice {
     color: #ff9225;
 }
 
-table.fixed { 
+table.nword, table.nword th, table.nword td{
+    border: 1px solid black;
+}
+
+table.fixed {
 	table-layout:fixed;
 }
 


### PR DESCRIPTION
Печатные таблицы в нановорде и на бумаге теперь отображаются с границами.
![изображение](https://user-images.githubusercontent.com/42303535/149799590-06138c97-58e6-44e5-929c-bb69ebb9da47.png)
![изображение](https://user-images.githubusercontent.com/42303535/149799608-e452373e-dfca-4903-ae5a-5611ff8eb3f1.png)

Обычные не сломались.
![изображение](https://user-images.githubusercontent.com/42303535/149799652-d9c4e639-92a1-43ba-b3e3-45270c003f4c.png)

close #7418 
<details>
<summary>Чейнджлог</summary>

```yml
🆑
bugfix: Печатные таблицы в нановорде и на бумаге теперь отображаются с границами
/🆑
```

</details>

- [x] Pull Request полностью завершен, мне не нужна помощь чтобы его закончить.
- [x] Я внимательно прочитал все свои изменения и багов в них не нашел.
- [x] Я запускал сервер со своими изменениями локально и все протестировал.
- [x] Я ознакомился c [Guide to Contribute](https://github.com/ChaoticOnyx/OnyxBay/blob/dev/docs/contributing.md).
