### PR TITLE
tweak(mining): core stabilizers

### DIFF
--- a/code/modules/mining/machine_vending.dm
+++ b/code/modules/mining/machine_vending.dm
@@ -8,6 +8,7 @@ var/global/list/minevendor_list = list( //keep in order of price
 	new /datum/data/mining_equipment("Food Ration",                  /obj/item/reagent_containers/food/snacks/liquidfood,   10,     5),
 	new /datum/data/mining_equipment("Poster",                       /obj/item/contraband/poster,                           10,    20),
 	new /datum/data/mining_equipment("Thermostabilizine Pill",       /obj/item/reagent_containers/pill/leporazine,          15,    35),
+	new /datum/data/mining_equipment("Anomalous Core Stabilizer",    /obj/item/hoverheadstabilizer,                         20,    400),
 	new /datum/data/mining_equipment("Ore Scanner Pad",              /obj/item/ore_radar,                                   10,    50),
 	new /datum/data/mining_equipment("5 Red Flags",                  /obj/item/stack/flag/red,                                     10,    50),
 	new /datum/data/mining_equipment("5 Green Flags",                /obj/item/stack/flag/green,                                   10,    50),

--- a/code/modules/mining/mine_items.dm
+++ b/code/modules/mining/mine_items.dm
@@ -525,7 +525,7 @@
 	layer = 5
 	anchored = TRUE
 	mouse_opacity = 0
-	var/resonance_damage = 10
+	var/resonance_damage = 15
 	var/creator
 	var/obj/item/resonator/res
 
@@ -540,7 +540,7 @@
 	var/pressure = environment.return_pressure()
 	if(pressure < 50)
 		name = "strong resonance field"
-		resonance_damage = 30
+		resonance_damage = 60
 
 	addtimer(CALLBACK(src, .proc/burst, loc), timetoburst)
 

--- a/code/modules/mob/living/simple_animal/hostile/asteroid/hoverhead.dm
+++ b/code/modules/mob/living/simple_animal/hostile/asteroid/hoverhead.dm
@@ -114,7 +114,7 @@
 	inert = 0
 	preserved = 1
 	icon_state = "psychecore"
-	desc = "All that remains of a hivelord. It is preserved, allowing you to use it to heal completely without danger of decay."
+	desc = "Strange biostructure that looks as if it possesed some energy but then was drained out. It has two flaps and a husked core. It is preserved, allowing you to use it to heal completely without danger of decay."
 
 /obj/item/asteroid/anomalous_core/attack(mob/living/M, mob/living/user)
 	if(ishuman(M))

--- a/code/modules/mob/living/simple_animal/hostile/asteroid/hoverhead.dm
+++ b/code/modules/mob/living/simple_animal/hostile/asteroid/hoverhead.dm
@@ -94,15 +94,27 @@
 	icon = 'icons/mob/asteroid/psychekinetic.dmi'
 	icon_state = "psychecore"
 	var/inert = 0
+	var/preserved = 0
+	w_class = 2
 
 /obj/item/asteroid/anomalous_core/New()
 	. = ..()
-	addtimer(CALLBACK(src, .proc/make_inert), 1200)
+	addtimer(CALLBACK(src, .proc/inert_check), 1200)
+
+/obj/item/asteroid/anomalous_core/proc/inert_check()
+	if(preserved != 1)
+		make_inert()
 
 /obj/item/asteroid/anomalous_core/proc/make_inert()
 	inert = 1
 	icon_state = "psychecore_used"
 	desc = "Strange biostructure that looks as if it possesed some energy but then was drained out. It has two flaps and a husked core."
+
+/obj/item/asteroid/anomalous_core/proc/preserved()
+	inert = 0
+	preserved = 1
+	icon_state = "psychecore"
+	desc = "All that remains of a hivelord. It is preserved, allowing you to use it to heal completely without danger of decay."
 
 /obj/item/asteroid/anomalous_core/attack(mob/living/M, mob/living/user)
 	if(ishuman(M))
@@ -122,3 +134,23 @@
 			make_inert(src)
 			qdel(src)
 	..()
+
+/obj/item/hoverheadstabilizer
+	name = "stabilizing serum"
+	icon = 'icons/obj/chemical.dmi'
+	icon_state = "bottle19"
+	desc = "Inject hoverhead's cores with this stabilizer to preserve their healing powers indefinitely."
+	w_class = 2
+
+/obj/item/hoverheadstabilizer/afterattack(obj/item/M, mob/user, proximity)
+	. = ..()
+	if(!proximity)
+		return
+	var/obj/item/asteroid/anomalous_core/C = M
+	if(!istype(C, /obj/item/asteroid/anomalous_core))
+		to_chat(user, "<span class='warning'>The stabilizer only works on certain types of artifacts, generally regenerative in nature.</span>")
+		return
+
+	C.preserved()
+	to_chat(user, "<span class='notice'>You inject the [M] with the stabilizer. It will no longer go inert.</span>")
+	qdel(src)

--- a/code/modules/mob/living/simple_animal/hostile/asteroid/hoverhead.dm
+++ b/code/modules/mob/living/simple_animal/hostile/asteroid/hoverhead.dm
@@ -114,7 +114,7 @@
 	inert = 0
 	preserved = 1
 	icon_state = "psychecore"
-	desc = "Strange biostructure that looks as if it possesed some energy but then was drained out. It has two flaps and a husked core. It is preserved, allowing you to use it to heal completely without danger of decay."
+	desc = "Strange biostructure that constantly emits bursts of energy. It has two flaps and a juicy core that looks squeezable. It is preserved, allowing you to use it to heal completely without danger of decay."
 
 /obj/item/asteroid/anomalous_core/attack(mob/living/M, mob/living/user)
 	if(ishuman(M))

--- a/code/modules/mob/living/simple_animal/hostile/asteroid/sand_lurker.dm
+++ b/code/modules/mob/living/simple_animal/hostile/asteroid/sand_lurker.dm
@@ -16,8 +16,8 @@
 	aggro_vision_range = 6
 	idle_vision_range = 2
 	speed = 3
-	maxHealth = 50
-	health = 50
+	maxHealth = 100
+	health = 100
 	harm_intent_damage = 15
 	melee_damage_lower = 20
 	melee_damage_upper = 20

--- a/code/modules/mob/living/simple_animal/hostile/asteroid/shooter.dm
+++ b/code/modules/mob/living/simple_animal/hostile/asteroid/shooter.dm
@@ -18,8 +18,8 @@
 	throw_message = "does nothing against the hard shell of"
 	vision_range = 2
 	speed = 3
-	maxHealth = 75
-	health = 75
+	maxHealth = 150
+	health = 150
 	harm_intent_damage = 5
 	melee_damage_lower = 12
 	melee_damage_upper = 12
@@ -79,8 +79,8 @@
 	icon_dead = "Spectator_dead"
 	vision_range = 5
 	speed = 4
-	maxHealth = 250
-	health = 250
+	maxHealth = 450
+	health = 450
 	ranged_message = "stares cruelly"
 	ranged_cooldown_cap = 3
 	harm_intent_damage = 15

--- a/code/modules/projectiles/guns/energy/mining.dm
+++ b/code/modules/projectiles/guns/energy/mining.dm
@@ -74,7 +74,7 @@
 /obj/item/projectile/kinetic
 	name = "kinetic force"
 	icon_state = null
-	damage = 15
+	damage = 40
 	damage_type = BRUTE
 	check_armour = "bomb"
 	kill_count = 2


### PR DESCRIPTION
Спустя огромное количество времени, наконец-то добавляет стабилизаторы ядер ~~хайвлордов~~ ховерхедов; добавляет их в шахтёрский раздатчик в количестве двадцати штук, с ценой аля /тг/.
Баффает урон резонаторов (10 -> 15 в атмосфере, 30 -> 60 в вакууме) и кинетических ускорителей (15 -> 40), чтобы бой с фауной был более возможным.
Баффает количество здоровья у некоторой шахтёрской фауны: люркеров (50 -> 100), шокзардов (75 -> 150), бехолдеров (250 -> 450) в соответствии с увеличенным уроном инструментов.

<details>
<summary>Чейнджлог</summary>

```yml
🆑Stalkeros
balance: Увеличен урон резонаторов и кинетических ускорителей.
rscadd: Добавлены стабилизаторы ядер ховерхедов.
balance: Увеличено здоровье некоторой фауны астероида.
/🆑
```

</details>

- [x] Pull Request полностью завершен, мне не нужна помощь чтобы его закончить.
- [x] Я внимательно прочитал все свои изменения и багов в них не нашел.
- [x] Я запускал сервер со своими изменениями локально и все протестировал.
- [x] Я ознакомился c [Guide to Contribute](https://github.com/ChaoticOnyx/OnyxBay/blob/dev/docs/contributing.md).
