### PR TITLE
Removes yet another changeling bugs batch

### DIFF
--- a/code/game/gamemodes/changeling/biostructure.dm
+++ b/code/game/gamemodes/changeling/biostructure.dm
@@ -155,7 +155,6 @@
 			if(affected)
 				affected.internal_organs.Remove(src)
 				status |= ORGAN_CUT_AWAY
-				affected.implants.Remove(src)
 		else
 			H.drop_from_inventory(src)
 

--- a/code/game/gamemodes/changeling/biostructure.dm
+++ b/code/game/gamemodes/changeling/biostructure.dm
@@ -155,6 +155,7 @@
 			if(affected)
 				affected.internal_organs.Remove(src)
 				status |= ORGAN_CUT_AWAY
+				affected.implants.Remove(src)
 		else
 			H.drop_from_inventory(src)
 
@@ -162,7 +163,8 @@
 		var/obj/item/organ/external/E = source
 		E.internal_organs.Remove(src)
 
-	forceMove(destination)
+	if(!istype(destination, /mob/living/carbon/brain))
+		forceMove(destination)
 
 	// Connecting biostructure as an organ.
 	if(ishuman(destination))

--- a/code/game/gamemodes/changeling/helpcode/mobs.dm
+++ b/code/game/gamemodes/changeling/helpcode/mobs.dm
@@ -43,6 +43,17 @@
 	var/obj/item/organ/internal/biostructure/BIO = loc
 
 	var/mob/living/simple_animal/hostile/little_changeling/headcrab/HC = new (get_turf(src))
+
+	// Edge case handling. It's intended to be here instead of datum/changeling/transfer_to() for reasons.
+	var/obj/item/organ/external/E
+	if(ishuman(BIO.loc))
+		var/mob/living/carbon/human/H = BIO.loc
+		E = H.get_organ(BIO.parent_organ)
+	else if(istype(BIO.loc, /obj/item/organ/external))
+		E = BIO.loc
+	E?.implants -= BIO
+
+	BIO.parent_organ = BP_CHEST // So we DEFINITELY won't end up inside a prosthetic limb.
 	mind.transfer_to(HC)
 
 	HC.visible_message(SPAN("danger", "[BIO] suddenly grows tiny eyes and reforms it's appendages into legs!"), \

--- a/code/game/gamemodes/changeling/powers/no_pain.dm
+++ b/code/game/gamemodes/changeling/powers/no_pain.dm
@@ -9,8 +9,8 @@
 	required_chems = 20
 	chems_drain = 1
 
-	text_activate = "We are able to feel pain now."
-	text_deactivate = "We are unable to feel pain anymore."
+	text_activate = "We are unable to feel pain anymore."
+	text_deactivate = "We are able to feel pain now."
 	text_nochems = "We feel pain once again as we have no chemicals left."
 
 /datum/changeling_power/toggled/no_pain/activate()


### PR DESCRIPTION
```yml
🆑
bugfix: Исправлены перепутанные сообщения об активации и деактивации у способности No Pain у генокрада.
bugfix: Исправлен баг, который мог приводить к необъяснимому поведению биоструктуры в случае, если генокрад использовал способность Runaway Form, когда биоструктура была уже хирургически отрезана от тела, но ещё не изъята из него.
bugfix: Исправлен баг, при некоторых обстоятельствах приводивший к рекурсивному нахождению биоструктуры и брейнмоба генокрада друг в друге, что в некоторых случаях могло приводить к паранормальныму.
/🆑
```

Fix #7411 
^ ПР _должен_ исправить этот иссуй. Я _очень_ долго всё дебажил. Но в случае с генокрадами я не могу быть ни в чём уверен.

- [x] Pull Request полностью завершен, мне не нужна помощь чтобы его закончить.
- [x] Я внимательно прочитал все свои изменения и багов в них не нашел.
- [x] Я запускал сервер со своими изменениями локально и все протестировал.
- [x] Я ознакомился c [Guide to Contribute](https://github.com/ChaoticOnyx/OnyxBay/blob/dev/docs/contributing.md).
