### PR TITLE
Removes changeling's inability to divide into unconscious people

### DIFF
--- a/code/game/antagonist/antagonist_add.dm
+++ b/code/game/antagonist/antagonist_add.dm
@@ -1,7 +1,7 @@
-/datum/antagonist/proc/add_antagonist(datum/mind/player, ignore_role, do_not_equip, move_to_spawn, do_not_announce, preserve_appearance)
+/datum/antagonist/proc/add_antagonist(datum/mind/player, ignore_role, do_not_equip, move_to_spawn, do_not_announce, preserve_appearance, max_stat)
 
-	if(!add_antagonist_mind(player, ignore_role))
-		return
+	if(!add_antagonist_mind(player, ignore_role, max_stat = max_stat))
+		return FALSE
 
 	//do this again, just in case
 	if(flags & ANTAG_OVERRIDE_JOB)
@@ -16,17 +16,17 @@
 			equip(player.current)
 
 	player.current.faction = faction
-	return 1
+	return TRUE
 
-/datum/antagonist/proc/add_antagonist_mind(datum/mind/player, ignore_role, nonstandard_role_type, nonstandard_role_msg)
+/datum/antagonist/proc/add_antagonist_mind(datum/mind/player, ignore_role, nonstandard_role_type, nonstandard_role_msg, max_stat)
 	if(!istype(player))
-		return 0
+		return FALSE
 	if(!player.current)
-		return 0
+		return FALSE
 	if(player in current_antagonists)
-		return 0
-	if(!can_become_antag(player, ignore_role))
-		return 0
+		return FALSE
+	if(!can_become_antag(player, ignore_role, max_stat = max_stat))
+		return FALSE
 	current_antagonists |= player
 
 	if(faction_verb)
@@ -56,7 +56,7 @@
 		if(nonstandard_role_msg)
 			to_chat(player.current, "<span class='notice'>[nonstandard_role_msg]</span>")
 		update_icons_added(player)
-	return 1
+	return TRUE
 
 /datum/antagonist/proc/remove_antagonist(datum/mind/player, show_message, implanted)
 	if(!istype(player))

--- a/code/game/antagonist/antagonist_helpers.dm
+++ b/code/game/antagonist/antagonist_helpers.dm
@@ -1,11 +1,13 @@
-/datum/antagonist/proc/can_become_antag(datum/mind/player, ignore_role)
+/datum/antagonist/proc/can_become_antag(datum/mind/player, ignore_role, max_stat = CONSCIOUS)
 	if(player.current && jobban_isbanned(player.current, id))
-		return 0
-	if(isliving(player.current) && player.current.stat)
-		return 0
+		return FALSE
+
+	if(isliving(player.current) && (player.current.stat > max_stat))
+		return FALSE
+
 	var/datum/job/J = job_master.GetJob(player.assigned_role)
-	if(is_type_in_list(J,blacklisted_jobs))
-		return 0
+	if(is_type_in_list(J, blacklisted_jobs))
+		return FALSE
 
 	if(!ignore_role)
 		if(player.current && player.current.client)

--- a/code/game/antagonist/station/changeling.dm
+++ b/code/game/antagonist/station/changeling.dm
@@ -41,7 +41,7 @@ GLOBAL_DATUM_INIT(changelings, /datum/antagonist/changeling, new)
 	return "<br><b>Changeling ID:</b> [player.changeling.changelingID].<br><b>Genomes Absorbed:</b> [player.changeling.absorbedcount]<br><b>Purchased Powers:</b> [powers_purchased]"
 
 /datum/antagonist/changeling/update_antag_mob(datum/mind/player)
-	..()
+	. = ..()
 	player.current.make_changeling()
 
 /datum/antagonist/changeling/create_objectives(datum/mind/changeling)
@@ -77,7 +77,7 @@ GLOBAL_DATUM_INIT(changelings, /datum/antagonist/changeling, new)
 				changeling.objectives += survive_objective
 	return
 
-/datum/antagonist/changeling/can_become_antag(datum/mind/player, ignore_role)
+/datum/antagonist/changeling/can_become_antag(datum/mind/player, ignore_role, max_stat)
 	if(!..())
 		return FALSE
 

--- a/code/game/antagonist/station/changeling.dm
+++ b/code/game/antagonist/station/changeling.dm
@@ -77,7 +77,7 @@ GLOBAL_DATUM_INIT(changelings, /datum/antagonist/changeling, new)
 				changeling.objectives += survive_objective
 	return
 
-/datum/antagonist/changeling/can_become_antag(datum/mind/player, ignore_role, max_stat, max_stat = CONSCIOUS)
+/datum/antagonist/changeling/can_become_antag(datum/mind/player, ignore_role, max_stat)
 	if(!..())
 		return FALSE
 

--- a/code/game/antagonist/station/changeling.dm
+++ b/code/game/antagonist/station/changeling.dm
@@ -77,7 +77,7 @@ GLOBAL_DATUM_INIT(changelings, /datum/antagonist/changeling, new)
 				changeling.objectives += survive_objective
 	return
 
-/datum/antagonist/changeling/can_become_antag(datum/mind/player, ignore_role, max_stat)
+/datum/antagonist/changeling/can_become_antag(datum/mind/player, ignore_role, max_stat, max_stat = CONSCIOUS)
 	if(!..())
 		return FALSE
 

--- a/code/game/antagonist/station/cult_god.dm
+++ b/code/game/antagonist/station/cult_god.dm
@@ -27,7 +27,7 @@ GLOBAL_DATUM_INIT(godcult, /datum/antagonist/godcultist, new)
 	if(config.godcultist_min_age)
 		min_player_age = config.godcultist_min_age
 
-/datum/antagonist/godcultist/add_antagonist_mind(datum/mind/player, ignore_role, nonstandard_role_type, nonstandard_role_msg, mob/living/deity/specific_god)
+/datum/antagonist/godcultist/add_antagonist_mind(datum/mind/player, ignore_role, nonstandard_role_type, nonstandard_role_msg, max_stat, mob/living/deity/specific_god)
 	if(!..())
 		return 0
 

--- a/code/game/antagonist/station/cultist.dm
+++ b/code/game/antagonist/station/cultist.dm
@@ -109,7 +109,7 @@ GLOBAL_DATUM_INIT(cult, /datum/antagonist/cultist, new)
 	remove_cult_magic(player.current)
 	remove_cultiness(CULTINESS_PER_CULTIST)
 
-/datum/antagonist/cultist/add_antagonist(datum/mind/player, ignore_role, do_not_equip, move_to_spawn, do_not_announce, preserve_appearance)
+/datum/antagonist/cultist/add_antagonist(datum/mind/player, ignore_role, do_not_equip, move_to_spawn, do_not_announce, preserve_appearance, max_stat)
 	. = ..()
 	if(.)
 		to_chat(player, "<span class='cult'>[conversion_blurb]</span>")

--- a/code/game/antagonist/station/rogue_ai.dm
+++ b/code/game/antagonist/station/rogue_ai.dm
@@ -21,7 +21,7 @@ GLOBAL_DATUM_INIT(malf, /datum/antagonist/rogue_ai, new)
 	if(config.malf_min_age)
 		min_player_age = config.malf_min_age
 
-/datum/antagonist/rogue_ai/can_become_antag(datum/mind/player, ignore_role, max_stat = CONSCIOUS)
+/datum/antagonist/rogue_ai/can_become_antag(datum/mind/player, ignore_role, max_stat)
 	. = ..()
 	if(jobban_isbanned(player.current, "AI"))
 		return FALSE

--- a/code/game/antagonist/station/rogue_ai.dm
+++ b/code/game/antagonist/station/rogue_ai.dm
@@ -21,10 +21,10 @@ GLOBAL_DATUM_INIT(malf, /datum/antagonist/rogue_ai, new)
 	if(config.malf_min_age)
 		min_player_age = config.malf_min_age
 
-/datum/antagonist/rogue_ai/can_become_antag(datum/mind/player, ignore_role)
-	. = ..(player, ignore_role)
+/datum/antagonist/rogue_ai/can_become_antag(datum/mind/player, ignore_role, max_stat = CONSCIOUS)
+	. = ..()
 	if(jobban_isbanned(player.current, "AI"))
-		return 0
+		return FALSE
 	return .
 
 /datum/antagonist/rogue_ai/build_candidate_list()

--- a/code/game/antagonist/station/vampire.dm
+++ b/code/game/antagonist/station/vampire.dm
@@ -78,7 +78,7 @@ GLOBAL_DATUM_INIT(vampires, /datum/antagonist/vampire, new)
 	player.current.make_vampire()
 
 
-/datum/antagonist/vampire/can_become_antag(datum/mind/player, ignore_role)
+/datum/antagonist/vampire/can_become_antag(datum/mind/player, ignore_role, max_stat)
 	if(..())
 		if(player.current)
 			if(ishuman(player.current))

--- a/code/game/gamemodes/changeling/powers/division.dm
+++ b/code/game/gamemodes/changeling/powers/division.dm
@@ -77,7 +77,7 @@
 	changeling.using_proboscis = FALSE
 	var/datum/mind/M = T.mind
 	var/datum/antagonist/changeling/CH = GLOB.all_antag_types_[MODE_CHANGELING]
-	CH.add_antagonist(M, ignore_role = TRUE, do_not_equip = TRUE)
+	CH.add_antagonist(M, ignore_role = TRUE, do_not_equip = TRUE, max_stat = UNCONSCIOUS)
 
 	M.changeling.geneticpoints = 7
 	M.changeling.chem_charges = 40


### PR DESCRIPTION

```yml
🆑
bugfix: Исправлена ошибка, из-за которой способность Division у генокрадов не срабатывала, если цель находилась без сознания.
/🆑
```

Fix #7417 

- [x] Pull Request полностью завершен, мне не нужна помощь чтобы его закончить.
- [x] Я внимательно прочитал все свои изменения и багов в них не нашел.
- [x] Я запускал сервер со своими изменениями локально и все протестировал.
- [x] Я ознакомился c [Guide to Contribute](https://github.com/ChaoticOnyx/OnyxBay/blob/dev/docs/contributing.md).
