### PR TITLE
tweak(forensics_fiber_id)

### DIFF
--- a/code/modules/clothing/clothing.dm
+++ b/code/modules/clothing/clothing.dm
@@ -59,7 +59,9 @@ GLOBAL_LIST_EMPTY(clothing_blood_icons)
 	gunshot_residue = null
 
 /obj/item/clothing/proc/get_fibers()
-	. = "material from \a [name]"
+	var/fiber_id = copytext(md5("\ref[src] fiber"), 1, 6)
+
+	. = "material from \a [name] ([fiber_id])"
 	var/list/acc = list()
 	for(var/obj/item/clothing/accessory/A in accessories)
 		if(prob(40) && A.get_fibers())
@@ -254,7 +256,9 @@ BLIND     // can't see anything
 		overlays += image(icon, "gloves_wire")
 
 /obj/item/clothing/gloves/get_fibers()
-	return "material from a pair of [name]."
+	var/fiber_id = copytext(md5("\ref[src] fiber"), 1, 6)
+
+	return "material from a pair of [name] ([fiber_id])"
 
 // Called just before an attack_hand(), in mob/UnarmedAttack()
 /obj/item/clothing/gloves/proc/Touch(atom/A, proximity)


### PR DESCRIPTION
Дефектив теперь может видеть уникальный ID фибры, так что можно определить, с какого конкретного предмета она была снята.

resolves #6222

<details>
<summary>Чейнджлог</summary>

```yml
🆑
tweak: Дефектив теперь может видеть уникальный ID фибры.
/🆑
```

</details>

- [x] Pull Request полностью завершен, мне не нужна помощь чтобы его закончить.
- [x] Я внимательно прочитал все свои изменения и багов в них не нашел.
- [x] Я запускал сервер со своими изменениями локально и все протестировал.
- [x] Я ознакомился c [Guide to Contribute](https://github.com/ChaoticOnyx/OnyxBay/blob/dev/docs/contributing.md).
