### PR TITLE
fix(paperwork): fixed paper show

### DIFF
--- a/code/modules/paperwork/paper.dm
+++ b/code/modules/paperwork/paper.dm
@@ -280,8 +280,8 @@
 
 /obj/item/paper/attack(mob/living/carbon/M, mob/living/carbon/user)
 	if(user.zone_sel.selecting == BP_EYES)
-		user.visible_message(SPAN_NOTICE("You show the paper to [M]."), \
-		                     SPAN_NOTICE("[user] holds up a paper and shows it to [M]."))
+		user.visible_message(SPAN_NOTICE("[user] holds up a paper and shows it to [M]."), \
+		                     SPAN_NOTICE("You show the paper to [M]."))
 		M.examinate(src)
 
 	else if(user.zone_sel.selecting == BP_MOUTH) // lipstick wiping


### PR DESCRIPTION
Поменял порядок аргументов в user.visible_message() на верный, а то он показывал сообщение для персонажа всем остальным и наоборот.

То же было в https://github.com/ChaoticOnyx/OnyxBay/pull/6566 у книги.

<details>
<summary>Чейнджлог</summary>

```yml
🆑
bugfix: При показе бумаги другим людям теперь выводятся правильные сообщения.
/🆑
```

</details>

- [x] Pull Request полностью завершен, мне не нужна помощь чтобы его закончить.
- [x] Я внимательно прочитал все свои изменения и багов в них не нашел.
- [ ] Я запускал сервер со своими изменениями локально и все протестировал.
- [x] Я ознакомился c [Guide to Contribute](https://github.com/ChaoticOnyx/OnyxBay/blob/dev/docs/contributing.md).
