### PR TITLE
Removes the ability to feed tanks with any amounts of cables

### DIFF
--- a/code/game/objects/items/tanks/tanks.dm
+++ b/code/game/objects/items/tanks/tanks.dm
@@ -126,9 +126,9 @@ var/list/global/tank_gauge_cache = list()
 
 	if(isCoil(W))
 		var/obj/item/stack/cable_coil/C = W
-		if(C.use(1))
-			wired = 1
-			to_chat(user, "<span class='notice'>You attach the wires to the tank.</span>")
+		if(!wired && C.use(1))
+			wired = TRUE
+			to_chat(user, SPAN("notice", "You attach the wires to the tank."))
 			update_icon(TRUE)
 
 	if(isWirecutter(W))


### PR DESCRIPTION
Fix #3731

```yml
🆑
bugfix: Исправлена возможность бесконечно скармливать провода баллонам.
/🆑
```

- [x] Pull Request полностью завершен, мне не нужна помощь чтобы его закончить.
- [x] Я внимательно прочитал все свои изменения и багов в них не нашел.
- [ ] Я запускал сервер со своими изменениями локально и все протестировал.
- [x] Я ознакомился c [Guide to Contribute](https://github.com/ChaoticOnyx/OnyxBay/blob/dev/docs/contributing.md).
