### PR TITLE
Removes aliums' literacy

### DIFF
--- a/code/game/objects/items.dm
+++ b/code/game/objects/items.dm
@@ -239,7 +239,7 @@
 		return ..()
 	if(hasorgans(user))
 		var/mob/living/carbon/human/H = user
-		if(H.IsAdvancedToolUser(TRUE) == FALSE)
+		if(loc != H && H.IsAdvancedToolUser(TRUE) == FALSE)
 			to_chat(user, SPAN("notice", "I'm not smart enough to do that!"))
 			return
 		var/obj/item/organ/external/temp = H.organs_by_name[BP_R_HAND]

--- a/code/modules/paperwork/paper.dm
+++ b/code/modules/paperwork/paper.dm
@@ -209,6 +209,10 @@
 
 /obj/item/paper/proc/show_content(mob/user, forceshow)
 	var/can_read = (istype(user, /mob/living/carbon/human) || isghost(user) || istype(user, /mob/living/silicon)) || forceshow
+	if(can_read && ishuman(user))
+		var/mob/living/carbon/human/H = user
+		if(!H.IsAdvancedToolUser(TRUE))
+			can_read = FALSE
 	if(!forceshow && istype(user,/mob/living/silicon/ai))
 		var/mob/living/silicon/ai/AI = user
 		can_read = get_dist(src, AI.camera) < 2

--- a/code/modules/paperwork/paper_bundle.dm
+++ b/code/modules/paperwork/paper_bundle.dm
@@ -123,7 +123,12 @@
 
 	if(istype(pages[page], /obj/item/paper))
 		var/obj/item/paper/P = W
-		if(!(istype(usr, /mob/living/carbon/human) || isghost(usr) || istype(usr, /mob/living/silicon)))
+		var/can_read = (istype(user, /mob/living/carbon/human) || isghost(user) || istype(user, /mob/living/silicon))
+		if(can_read && ishuman(user))
+			var/mob/living/carbon/human/H = user
+			if(H.IsAdvancedToolUser(TRUE))
+				can_read = FALSE
+		if(!can_read)
 			dat+= "<HTML><HEAD><TITLE>[P.name]</TITLE></HEAD><BODY>[stars(P.info)][P.stamps]</BODY></HTML>"
 		else
 			dat+= "<HTML><HEAD><TITLE>[P.name]</TITLE></HEAD><BODY>[P.info][P.stamps]</BODY></HTML>"

--- a/code/modules/paperwork/paper_bundle.dm
+++ b/code/modules/paperwork/paper_bundle.dm
@@ -126,7 +126,7 @@
 		var/can_read = (istype(user, /mob/living/carbon/human) || isghost(user) || istype(user, /mob/living/silicon))
 		if(can_read && ishuman(user))
 			var/mob/living/carbon/human/H = user
-			if(H.IsAdvancedToolUser(TRUE))
+			if(!H.IsAdvancedToolUser(TRUE))
 				can_read = FALSE
 		if(!can_read)
 			dat+= "<HTML><HEAD><TITLE>[P.name]</TITLE></HEAD><BODY>[stars(P.info)][P.stamps]</BODY></HTML>"

--- a/code/modules/power/singularity/emitter.dm
+++ b/code/modules/power/singularity/emitter.dm
@@ -70,6 +70,10 @@
 
 /obj/machinery/power/emitter/attack_hand(mob/user)
 	add_fingerprint(user)
+	if(ishuman(user))
+		var/mob/living/carbon/human/H = user
+		if(!H.IsAdvancedToolUser())
+			return
 	activate(user)
 
 /obj/machinery/power/emitter/proc/activate(mob/user)


### PR DESCRIPTION
Fix #7422
Fix #7420
Fix #7419

```yml
🆑
bugfix: Испавлена возможность переключать эмиттеры, будучи ксеноморфом.
bugfix: Исправлена невозможность перекладывать лицехватов из руки в руку, будучи ксеноморфом.
tweak: Ксеноморфы больше не могут полноценно читать текст на бумаге.
/🆑
```

- [x] Pull Request полностью завершен, мне не нужна помощь чтобы его закончить.
- [x] Я внимательно прочитал все свои изменения и багов в них не нашел.
- [x] Я запускал сервер со своими изменениями локально и все протестировал.
- [x] Я ознакомился c [Guide to Contribute](https://github.com/ChaoticOnyx/OnyxBay/blob/dev/docs/contributing.md).
