### PR TITLE
Исправление невзламываемости мед. холодильников

### DIFF
--- a/code/game/machinery/kitchen/smartfridge.dm
+++ b/code/game/machinery/kitchen/smartfridge.dm
@@ -355,7 +355,7 @@
 /obj/machinery/smartfridge/secure/Topic(href, href_list)
 	if(stat & (NOPOWER|BROKEN)) return 0
 	if(usr.contents.Find(src) || (in_range(src, usr) && istype(loc, /turf)))
-		if(!allowed(usr) && !emagged && scan_id)
+		if(!allowed(usr) && !emagged && scan_id && href_list["vend"])
 			to_chat(usr, "<span class='warning'>Access denied.</span>")
 			return 0
 	return ..()

--- a/code/game/machinery/kitchen/smartfridge.dm
+++ b/code/game/machinery/kitchen/smartfridge.dm
@@ -355,7 +355,7 @@
 /obj/machinery/smartfridge/secure/Topic(href, href_list)
 	if(stat & (NOPOWER|BROKEN)) return 0
 	if(usr.contents.Find(src) || (in_range(src, usr) && istype(loc, /turf)))
-		if(!allowed(usr) && !emagged && locked != -1 && href_list["vend"])
+		if(!allowed(usr) && !emagged && scan_id)
 			to_chat(usr, "<span class='warning'>Access denied.</span>")
 			return 0
 	return ..()


### PR DESCRIPTION
Исправил мед. холодильник. Теперь его можно взломать.


Вообще, я просто скопировал код вендинговых автоматов, но это вроде работает

upd: При переключении на жёлтую лампочку, доступ теперь имеют все, а не только врачи

<details>
<summary>Чейнджлог</summary>

```yml
🆑
bugfix: Мед. холодильник можно взломать.
/🆑
```

</details>

close #6505

- [x] Pull Request полностью завершен, мне не нужна помощь чтобы его закончить.
- [x] Я внимательно прочитал все свои изменения и багов в них не нашел.
- [x] Я запускал сервер со своими изменениями локально и все протестировал.
- [x] Я ознакомился c [Guide to Contribute](https://github.com/ChaoticOnyx/OnyxBay/blob/dev/docs/contributing.md).
