### PR TITLE
fix(cyborg): fix null cyborg name then using rename board

### DIFF
--- a/code/modules/mob/living/silicon/robot/robot_upgrades.dm
+++ b/code/modules/mob/living/silicon/robot/robot_upgrades.dm
@@ -143,8 +143,8 @@
 /obj/item/borg/upgrade/rename/action(mob/living/silicon/robot/R)
 	if(..()) return 0
 	spawn(1)
-		if (heldname == initial(held_name))
-			heldname = sanitizeSafe(input(R, "Enter new robot name", "Robot Reclassification", held_name), MAX_NAME_LEN)
+		if (held_name == initial(held_name))
+			held_name = sanitizeSafe(input(R, "Enter new robot name", "Robot Reclassification", held_name), MAX_NAME_LEN)
 		R.notify_ai(ROBOT_NOTIFICATION_NEW_NAME, R.name, held_name)
 		R.SetName(held_name)
 		R.custom_name = held_name

--- a/code/modules/mob/living/silicon/robot/robot_upgrades.dm
+++ b/code/modules/mob/living/silicon/robot/robot_upgrades.dm
@@ -143,7 +143,7 @@
 /obj/item/borg/upgrade/rename/action(mob/living/silicon/robot/R)
 	if(..()) return 0
 	spawn(1)
-		if (heldname == "Default cyborg")
+		if (heldname == initial(held_name))
 			heldname = sanitizeSafe(input(R, "Enter new robot name", "Robot Reclassification", heldname), MAX_NAME_LEN)
 		R.notify_ai(ROBOT_NOTIFICATION_NEW_NAME, R.name, heldname)
 		R.SetName(heldname)

--- a/code/modules/mob/living/silicon/robot/robot_upgrades.dm
+++ b/code/modules/mob/living/silicon/robot/robot_upgrades.dm
@@ -135,7 +135,7 @@
 	name = "robot reclassification board"
 	desc = "Used to rename a cyborg."
 	icon_state = "cyborg_upgrade1"
-	var/heldname = ""
+	var/heldname = "Default cyborg"
 
 /obj/item/borg/upgrade/rename/attack_self(mob/user as mob)
 	heldname = sanitizeSafe(input(user, "Enter new robot name", "Robot Reclassification", heldname), MAX_NAME_LEN)
@@ -143,7 +143,7 @@
 /obj/item/borg/upgrade/rename/action(mob/living/silicon/robot/R)
 	if(..()) return 0
 	spawn(1)
-		if (heldname == "")
+		if (heldname == "Default cyborg")
 			heldname = sanitizeSafe(input(R, "Enter new robot name", "Robot Reclassification", heldname), MAX_NAME_LEN)
 		R.notify_ai(ROBOT_NOTIFICATION_NEW_NAME, R.name, heldname)
 		R.SetName(heldname)

--- a/code/modules/mob/living/silicon/robot/robot_upgrades.dm
+++ b/code/modules/mob/living/silicon/robot/robot_upgrades.dm
@@ -135,20 +135,20 @@
 	name = "robot reclassification board"
 	desc = "Used to rename a cyborg."
 	icon_state = "cyborg_upgrade1"
-	var/heldname = "Default cyborg"
+	var/held_name = "Default cyborg"
 
 /obj/item/borg/upgrade/rename/attack_self(mob/user as mob)
-	heldname = sanitizeSafe(input(user, "Enter new robot name", "Robot Reclassification", heldname), MAX_NAME_LEN)
+	held_name = sanitizeSafe(input(user, "Enter new robot name", "Robot Reclassification", held_name), MAX_NAME_LEN)
 
 /obj/item/borg/upgrade/rename/action(mob/living/silicon/robot/R)
 	if(..()) return 0
 	spawn(1)
 		if (heldname == initial(held_name))
-			heldname = sanitizeSafe(input(R, "Enter new robot name", "Robot Reclassification", heldname), MAX_NAME_LEN)
-		R.notify_ai(ROBOT_NOTIFICATION_NEW_NAME, R.name, heldname)
-		R.SetName(heldname)
-		R.custom_name = heldname
-		R.real_name = heldname
+			heldname = sanitizeSafe(input(R, "Enter new robot name", "Robot Reclassification", held_name), MAX_NAME_LEN)
+		R.notify_ai(ROBOT_NOTIFICATION_NEW_NAME, R.name, held_name)
+		R.SetName(held_name)
+		R.custom_name = held_name
+		R.real_name = held_name
 
 	return 1
 


### PR DESCRIPTION
fix #2930


<details>
<summary>Чейнджлог</summary>

```yml
🆑KreeperHLC
bugfix: Теперь плата переименовывания киборга имеет дефолтное название.
/🆑
```

</details>


- [x] Pull Request полностью завершен, мне не нужна помощь чтобы его закончить.
- [x] Я внимательно прочитал все свои изменения и багов в них не нашел.
- [x] Я запускал сервер со своими изменениями локально и все протестировал.
- [x] Я ознакомился c [Guide to Contribute](https://github.com/ChaoticOnyx/OnyxBay/blob/dev/docs/contributing.md).
