### PR TITLE
No more "gun"

### DIFF
--- a/code/datums/trading/weaponry.dm
+++ b/code/datums/trading/weaponry.dm
@@ -115,3 +115,4 @@
 								/obj/item/gun/energy/laser/dogan                                 = TRADER_THIS_TYPE,
 								/obj/item/gun/projectile/automatic/machine_pistol/mini_uzi/usi   = TRADER_THIS_TYPE,
 								/obj/item/clothing/accessory/holster                                    = TRADER_ALL)
+

--- a/code/datums/trading/weaponry.dm
+++ b/code/datums/trading/weaponry.dm
@@ -25,7 +25,7 @@
 								/obj/item/gun/projectile/revolver/detective      = TRADER_ALL,
 								/obj/item/gun/projectile/pistol                  = TRADER_SUBTYPES_ONLY,
 								/obj/item/gun/projectile/pistol/secgun/MK        = TRADER_BLACKLIST,
-								/obj/item/gun/projectile/shotgun                 = TRADER_ALL,
+								/obj/item/gun/projectile/shotgun                 = TRADER_SUBTYPES_ONLY,
 								/obj/item/gun/projectile/shotgun/pump/boomstick  = TRADER_BLACKLIST,
 								/obj/item/ammo_magazine									= TRADER_SUBTYPES_ONLY,
 								/obj/item/storage/box/blanks						= TRADER_THIS_TYPE,
@@ -115,4 +115,3 @@
 								/obj/item/gun/energy/laser/dogan                                 = TRADER_THIS_TYPE,
 								/obj/item/gun/projectile/automatic/machine_pistol/mini_uzi/usi   = TRADER_THIS_TYPE,
 								/obj/item/clothing/accessory/holster                                    = TRADER_ALL)
-


### PR DESCRIPTION
Пофиксил баг, описанный в #7457

<details>
<summary>Чейнджлог</summary>

```yml
🆑Tsurupeta
bugfix: Из пула оружия торговцев удалён базовый "Gun".
/🆑
```

</details>

- [x] Pull Request полностью завершен, мне не нужна помощь чтобы его закончить.
- [x] Я внимательно прочитал все свои изменения и багов в них не нашел.
- [x] Я запускал сервер со своими изменениями локально и все протестировал.
- [x] Я ознакомился c [Guide to Contribute](https://github.com/ChaoticOnyx/OnyxBay/blob/dev/docs/contributing.md).
