### PR TITLE
Removes some fulltile objects related bugs

### DIFF
--- a/code/_onclick/adjacent.dm
+++ b/code/_onclick/adjacent.dm
@@ -10,11 +10,11 @@
 	Note that in all cases the neighbor is handled simply; this is usually the user's mob, in which case it is up to you
 	to check that the mob is not inside of something
 */
-/atom/proc/Adjacent(atom/neighbor) // basic inheritance, unused
+/atom/proc/Adjacent(atom/neighbor, atom/target) // basic inheritance, unused
 	return 0
 
 // Not a sane use of the function and (for now) indicative of an error elsewhere
-/area/Adjacent(atom/neighbor)
+/area/Adjacent(atom/neighbor, atom/target)
 	CRASH("Call to /area/Adjacent(), unimplemented proc")
 
 
@@ -25,18 +25,18 @@
 	* If you are diagonally adjacent, ensure you can pass through at least one of the mutually adjacent square.
 		* Passing through in this case ignores anything with the throwpass flag, such as tables, racks, and morgue trays.
 */
-/turf/Adjacent(atom/neighbor, atom/target = null)
+/turf/Adjacent(atom/neighbor, atom/target)
 	var/turf/T0 = get_turf(neighbor)
 	if(T0 == src)
-		return 1
+		return TRUE
 	if(!T0 || T0.z != z)
-		return 0
-	if(get_dist(src,T0) > 1)
-		return 0
+		return FALSE
+	if(get_dist(src, T0) > 1)
+		return FALSE
 
 	if(T0.x == x || T0.y == y)
 		// Check for border blockages
-		return T0.ClickCross(get_dir(T0,src), border_only = 1) && src.ClickCross(get_dir(src,T0), border_only = 1, target_atom = target)
+		return T0.ClickCross(get_dir(T0, src), TRUE, target) && ClickCross(get_dir(src, T0), TRUE, target)
 
 	// Not orthagonal
 	var/in_dir = get_dir(neighbor,src) // eg. northwest (1+8)
@@ -44,18 +44,21 @@
 	var/d2 = in_dir - d1			// eg north		(1+8) - 8 = 1
 
 	for(var/d in list(d1,d2))
-		if(!T0.ClickCross(d, border_only = 1))
+		if(!T0.ClickCross(d, TRUE, target))
 			continue // could not leave T0 in that direction
 
-		var/turf/T1 = get_step(T0,d)
-		if(!T1 || T1.density || !T1.ClickCross(get_dir(T1,T0) | get_dir(T1,src), border_only = 0))
+		var/turf/T1 = get_step(T0, d)
+		if(!T1 || T1.density)
+			continue
+
+		if(!T1.ClickCross(get_dir(T1, src), FALSE, target) || !T1.ClickCross(get_dir(T1, T0), FALSE, target))
 			continue // couldn't enter or couldn't leave T1
 
-		if(!src.ClickCross(get_dir(src,T1), border_only = 1, target_atom = target))
+		if(!ClickCross(get_dir(src, T1), TRUE, target))
 			continue // could not enter src
 
-		return 1 // we don't care about our own density
-	return 0
+		return TRUE // we don't care about our own density
+	return FALSE
 
 /*
 Quick adjacency (to turf):
@@ -80,69 +83,49 @@ Quick adjacency (to turf):
 	Note: Multiple-tile objects are created when the bound_width and bound_height are creater than the tile size.
 	This is not used in stock /tg/station currently.
 */
-/atom/movable/Adjacent(atom/neighbor)
-	if(neighbor == loc) return 1
-	if(!isturf(loc)) return 0
+/atom/movable/Adjacent(atom/neighbor, atom/target)
+	if(neighbor == loc|| neighbor.loc == loc)
+		return TRUE
+	if(!isturf(loc))
+		return FALSE
 	for(var/turf/T in locs)
-		if(isnull(T)) continue
-		if(T.Adjacent(neighbor,src)) return 1
-	return 0
+		if(isnull(T))
+			continue
+		if(T.Adjacent(neighbor, target))
+			return TRUE
+	return FALSE
 
 // This is necessary for storage items not on your person.
-/obj/item/Adjacent(atom/neighbor, recurse = 1)
-	if(neighbor == loc) return 1
-	if(istype(loc,/obj/item))
+/obj/item/Adjacent(atom/neighbor, atom/target, recurse = 1)
+	if(neighbor == loc)
+		return TRUE
+	if(istype(loc, /obj/item))
 		if(recurse > 0)
-			return loc.Adjacent(neighbor,recurse - 1)
-		return 0
+			return loc.Adjacent(neighbor, target, recurse - 1)
+		return FALSE
 	return ..()
-/*
-	Special case: This allows you to reach a door when it is visally on top of,
-	but technically behind, a fire door
-
-	You could try to rewrite this to be faster, but I'm not sure anything would be.
-	This can be safely removed if border firedoors are ever moved to be on top of doors
-	so they can be interacted with without opening the door.
-*/
-/obj/machinery/door/Adjacent(atom/neighbor)
-	var/obj/machinery/door/firedoor/border_only/BOD = locate() in loc
-	if(BOD)
-		BOD.throwpass = 1 // allow click to pass
-		. = ..()
-		BOD.throwpass = 0
-		return .
-	return ..()
-
 
 /*
 	This checks if you there is uninterrupted airspace between that turf and this one.
 	This is defined as any dense ATOM_FLAG_CHECKS_BORDER object, or any dense object without throwpass.
 	The border_only flag allows you to not objects (for source and destination squares)
 */
-/turf/proc/ClickCross(target_dir, border_only, atom/target_atom = null)
+/turf/proc/ClickCross(target_dir, border_only, atom/target)
 	for(var/obj/O in src)
-		if( !O.density || O == target_atom || O.throwpass) continue // throwpass is used for anything you can click through
+		if(!O.density || O == target || O.throwpass)
+			continue // throwpass is used for anything you can click through
 
 		if(O.atom_flags & ATOM_FLAG_CHECKS_BORDER) // windows have throwpass but are on border, check them first
-			if( O.dir & target_dir || O.dir&(O.dir-1) ) // full tile windows are just diagonals mechanically
-				var/obj/structure/window/W = target_atom
+			if(O.dir & target_dir || O.dir & (O.dir-1)) // full tile windows are just diagonals mechanically
+				var/obj/structure/window/W = target
 				if(istype(W) && !W.is_fulltile()) //exception for breaking full tile windows on top of single pane windows
 					return FALSE
-				if(istype(target_atom, /obj/structure/window_frame)) // the same as full tile windows exception, but for the new ones
+				if(istype(target, /obj/structure/window_frame)) // the same as full tile windows exception, but for the new ones
 					return TRUE
-				if(target_atom && (target_atom.atom_flags & ATOM_FLAG_ADJACENT_EXCEPTION)) // exception for atoms that should always be reachable
+				if(target && (target.atom_flags & ATOM_FLAG_ADJACENT_EXCEPTION)) // exception for atoms that should always be reachable
 					return TRUE
 				else
 					return FALSE
-
-		if(O.atom_flags & ATOM_FLAG_FULLTILE_OBJECT)
-			// exception for atoms that should always be reachable AND other fulltile objects, so we won't end up having a completely unreachable tile
-			if(target_atom && ((target_atom.atom_flags & ATOM_FLAG_ADJACENT_EXCEPTION) || (target_atom.atom_flags & ATOM_FLAG_FULLTILE_OBJECT)))
-				return TRUE
-			else if(istype(target_atom, /obj/item) || ismob(target_atom)) // Some day we'll deal with things sitting inside walls and fulltile windows.
-				return TRUE
-			else
-				return FALSE
 
 		else if(!border_only) // dense, not on border, cannot pass over
 			return FALSE

--- a/code/_onclick/click.dm
+++ b/code/_onclick/click.dm
@@ -130,7 +130,12 @@
 	// A is a turf or is on a turf, or in something on a turf (pen in a box); but not something in something on a turf (pen in a box in a backpack)
 	sdepth = A.storage_depth_turf()
 	if(isturf(A) || isturf(A.loc) || (sdepth != -1 && sdepth <= 1))
-		if(A.Adjacent(src)) // see adjacent.dm
+		if(Adjacent(A)) // see adjacent.dm
+			for(var/atom/movable/AM in get_turf(A)) // Checks if A is obscured by something
+				if(AM.layer > A.layer && AM.atom_flags & ATOM_FLAG_FULLTILE_OBJECT)
+					if((A.atom_flags & ATOM_FLAG_ADJACENT_EXCEPTION) || (A.atom_flags & ATOM_FLAG_FULLTILE_OBJECT))
+						continue
+					return FALSE
 			if(I)
 				// Return 1 in attackby() to prevent afterattack() effects (when safely moving items for example)
 				var/resolved = I.resolve_attackby(A,src, params)


### PR DESCRIPTION
- Adjacent() обновлён до состояния на ТГ, с некоторыми изменениями. Это говно мамонта давно надо было потрогать.
- Проверка ATOM_FLAG_FULLTILE_OBJECT перенесена из Adjacent() в ClickOn(), там оно работает куда лучше, не вызывая неожиданные эджкейс-баги.

```yml
🆑
bugfix: Исправлена невозможность взаимодействия с объектами, находящимися на одном тайле с угловыми стеклянными панелями (например, консоли в приёмной медбея).
bugfix: Исправлены некоторые баги при взаимодействии с фултайловыми объектами (разборка закрытых шлюзов с помощью RCD, сдувание надувных стенок, etc.).
/🆑
```

- [x] Pull Request полностью завершен, мне не нужна помощь чтобы его закончить.
- [x] Я внимательно прочитал все свои изменения и багов в них не нашел.
- [x] Я запускал сервер со своими изменениями локально и все протестировал.
- [x] Я ознакомился c [Guide to Contribute](https://github.com/ChaoticOnyx/OnyxBay/blob/dev/docs/contributing.md).
