### PR TITLE
tweak(debugger): debugger can now lock assemblies by robot id

### DIFF
--- a/code/modules/integrated_electronics/core/assemblies.dm
+++ b/code/modules/integrated_electronics/core/assemblies.dm
@@ -843,9 +843,7 @@
 			choice.ask_for_input(user)
 
 /obj/item/device/electronic_assembly/proc/return_power()
-	if(battery)
-		return battery.charge * CELLRATE
-	return 0
+	return battery ? battery.charge * CELLRATE : 0
 
 /obj/item/device/electronic_assembly/emp_act(severity)
 	. = ..()

--- a/code/modules/integrated_electronics/core/assemblies.dm
+++ b/code/modules/integrated_electronics/core/assemblies.dm
@@ -842,6 +842,11 @@
 		if(choice)
 			choice.ask_for_input(user)
 
+/obj/item/device/electronic_assembly/proc/return_power()
+	if(battery)
+		return battery.charge * CELLRATE
+	return 0
+
 /obj/item/device/electronic_assembly/emp_act(severity)
 	. = ..()
 	for(var/I in src)

--- a/code/modules/integrated_electronics/core/debugger.dm
+++ b/code/modules/integrated_electronics/core/debugger.dm
@@ -70,13 +70,23 @@
 		accepting_refs = FALSE
 
 	else if(copy_id && proximity)
+		var/error_message = SPAN_NOTICE("You turn the id card scanner is off.")
 		if(istype(target,/obj/item/card/id))
 			src.idlock = weakref(target)
 			to_chat(user, SPAN_NOTICE("You set \the [src]'s card memory to [target.name].  The id card scanner is \
 			now off."))
 
+		else if(isrobot(user) && target == user)
+			var/mob/living/silicon/robot/robot = target
+			var/obj/item/card/id/card = robot.GetIdCard()
+			if(card)
+				src.idlock = weakref(card)
+				to_chat(user, SPAN_NOTICE("You set \the [src]'s card memory to [card?.name].  The id card scanner is \
+				now off."))
+			else
+				to_chat(user, error_message)
 		else
-			to_chat(user, SPAN_NOTICE("You turn the id card scanner is off."))
+			to_chat(user, error_message)
 
 		copy_id = FALSE
 		return


### PR DESCRIPTION
And so it begins... PR #5443

Опять у девелопера своровали интегралку и он решил это пофиксить, да, да, да.

<details>
<summary>Чейнджлог</summary>

```yml
🆑
rscadd: Теперь киборги могут блокировать возможность скопировать интегральные платы.
/🆑
```

</details>

- [x] Pull Request полностью завершен, мне не нужна помощь чтобы его закончить.
- [x] Я внимательно прочитал все свои изменения и багов в них не нашел.
- [x] Я запускал сервер со своими изменениями локально и все протестировал.
- [x] Я ознакомился c [Guide to Contribute](https://github.com/ChaoticOnyx/OnyxBay/blob/dev/docs/contributing.md).
