### PR TITLE
Removes absence of roundend contracts counter

### DIFF
--- a/code/game/antagonist/station/traitor.dm
+++ b/code/game/antagonist/station/traitor.dm
@@ -25,6 +25,21 @@ GLOBAL_DATUM_INIT(traitors, /datum/antagonist/traitor, new)
 		spawn_uplink(locate(href_list["spawn_uplink"]))
 		return 1
 
+/datum/antagonist/traitor/get_special_objective_text(datum/mind/player)
+	var/contracts_num = player.completed_contracts
+	if(!contracts_num)
+		return "<br>The traitor hasn't completed a single contract. <b>[pick("What a shame", "Loser", "Sorry sight", "Lame duck", "Schlimazel", "Pantywaist", "We will talk about it later")].</b>"
+
+	var/contracts_text = ""
+	for(var/datum/antag_contract/AC in GLOB.all_contracts)
+		if(AC.completed_by == player)
+			contracts_text += "[AC.name], "
+	contracts_text = copytext(contracts_text, 1, length(contracts_text) - 1)
+	if(contracts_num == 1)
+		return "<br>The traitor has completed a single contract: [contracts_text]."
+	else
+		return "<br>The traitor has completed <b>[contracts_num] contracts: [contracts_text]."
+
 /datum/antagonist/traitor/create_objectives(datum/mind/traitor)
 	if(!..())
 		return


### PR DESCRIPTION
```yml
🆑
tweak: Теперь в конце раунда показывается количество и список выполненных предателем контрактов.
/🆑
```

- [x] Pull Request полностью завершен, мне не нужна помощь чтобы его закончить.
- [x] Я внимательно прочитал все свои изменения и багов в них не нашел.
- [ ] Я запускал сервер со своими изменениями локально и все протестировал.
- [x] Я ознакомился c [Guide to Contribute](https://github.com/ChaoticOnyx/OnyxBay/blob/dev/docs/contributing.md).
