### PR TITLE
Removes mend bones slowdown

### DIFF
--- a/code/game/gamemodes/changeling/powers/rapid_heal.dm
+++ b/code/game/gamemodes/changeling/powers/rapid_heal.dm
@@ -54,7 +54,7 @@
 			continue
 		if(istype(regen_organ))
 			if(!regen_organ.damage && (regen_organ.status & ORGAN_BROKEN))
-				regen_organ.status &= ~ORGAN_BROKEN
+				regen_organ.mend_fracture()
 				to_chat(H, SPAN("changeling", "Bones in our [regen_organ] snap in place."))
 			else if(regen_organ.damage > 0 && !(regen_organ.status & ORGAN_DEAD))
 				regen_organ.damage = max(regen_organ.damage - 10, 0)

--- a/code/game/gamemodes/changeling/powers/rapid_heal.dm
+++ b/code/game/gamemodes/changeling/powers/rapid_heal.dm
@@ -54,8 +54,8 @@
 			continue
 		if(istype(regen_organ))
 			if(!regen_organ.damage && (regen_organ.status & ORGAN_BROKEN))
-				regen_organ.mend_fracture()
-				to_chat(H, SPAN("changeling", "Bones in our [regen_organ] snap in place."))
+				regen_organ.status &= ~ORGAN_BROKEN
+				to_chat(H, SPAN("changeling", "Our [regen_organ] regains its integrity."))
 			else if(regen_organ.damage > 0 && !(regen_organ.status & ORGAN_DEAD))
 				regen_organ.damage = max(regen_organ.damage - 10, 0)
 				if(prob(5))

--- a/code/game/gamemodes/cult/runes.dm
+++ b/code/game/gamemodes/cult/runes.dm
@@ -628,10 +628,10 @@
 		if(!charges)
 			return statuses
 	if(charges >= 15)
-		for(var/obj/item/organ/external/e in user.organs)
-			if(e && e.status & ORGAN_BROKEN)
-				e.status &= ~ORGAN_BROKEN
-				statuses += "bones in your [e.name] snap into place"
+		for(var/obj/item/organ/external/E in user.organs)
+			if(E && (E.status & ORGAN_BROKEN))
+				E.mend_fracture()
+				statuses += "bones in your [E.name] snap into place"
 				charges -= 15
 				if(charges < 15)
 					break

--- a/code/game/gamemodes/vampire/vampire_powers.dm
+++ b/code/game/gamemodes/vampire/vampire_powers.dm
@@ -626,7 +626,7 @@
 				E.status &= ~ORGAN_TENDON_CUT
 				blood_used += 12
 			if(E.status & ORGAN_BROKEN)
-				E.status &= ~ORGAN_BROKEN
+				E.mend_fracture()
 				E.stage = 0
 				blood_used += 12
 				healed = TRUE

--- a/code/game/gamemodes/wizard/wizard_heals.dm
+++ b/code/game/gamemodes/wizard/wizard_heals.dm
@@ -18,7 +18,7 @@
 		if(E.status & ORGAN_TENDON_CUT && heal.heal_bones)
 			E.status &= ~ORGAN_TENDON_CUT
 		if(E.status & ORGAN_BROKEN && heal.heal_bones) // some calcium
-			E.status &= ~ORGAN_BROKEN
+			E.mend_fracture()
 			E.stage = 0
 	for(var/A in internal_organs)
 		var/obj/item/organ/internal/E = A

--- a/code/modules/mob/living/carbon/human/human_organs.dm
+++ b/code/modules/mob/living/carbon/human/human_organs.dm
@@ -28,7 +28,7 @@
 			visible_message("<span class='danger'>With a shower of fresh blood, a length of biomass shoots from [src]'s [O.amputation_point], forming a new [O.name]!</span>")
 		return 1
 	else if (E.damage > 0 || E.status & (ORGAN_BROKEN) || E.status & (ORGAN_ARTERY_CUT))
-		E.status &= ~ORGAN_BROKEN
+		E.mend_fracture()
 		E.status &= ~ORGAN_ARTERY_CUT
 		for(var/datum/wound/W in E.wounds)
 			if(W.wound_damage() == 0 && prob(50))

--- a/code/modules/organs/external/_external_damage.dm
+++ b/code/modules/organs/external/_external_damage.dm
@@ -185,7 +185,7 @@ obj/item/organ/external/take_general_damage(amount, silent = FALSE)
 			brute = W.heal_damage(brute)
 
 	if(internal)
-		status &= ~ORGAN_BROKEN
+		mend_fracture(TRUE)
 
 	//Sync the organ's damage with its wounds
 	src.update_damages()

--- a/code/modules/reagents/Chemistry-Reagents/Chemistry-Reagents-Toxins.dm
+++ b/code/modules/reagents/Chemistry-Reagents/Chemistry-Reagents-Toxins.dm
@@ -593,7 +593,7 @@
 		E.s_tone = null
 		E.s_col = ReadRGB("#05ff9b")
 		E.s_col_blend = ICON_ADD
-		E.status &= ~ORGAN_BROKEN
+		E.mend_fracture()
 		E.status |= ORGAN_MUTATED
 		E.limb_flags &= ~ORGAN_FLAG_CAN_BREAK
 		E.dislocated = -1

--- a/code/modules/surgery/bones.dm
+++ b/code/modules/surgery/bones.dm
@@ -164,9 +164,10 @@
 /datum/surgery_step/finish_bone/end_step(mob/living/user, mob/living/carbon/human/target, target_zone, obj/item/tool)
 	var/obj/item/organ/external/affected = target.get_organ(target_zone)
 	var/bone = affected.encased ? "[target]'s [affected.encased]" : "bones in [target]'s [affected.name]"
-	user.visible_message(SPAN_NOTICE("[user] has mended the damaged [bone] with \the [tool].")  , \
-		SPAN_NOTICE("You have mended the damaged [bone] with \the [tool].") )
-	affected.status &= ~ORGAN_BROKEN
+
+	user.visible_message(SPAN("notice", "[user] has mended the damaged [bone] with \the [tool]."), \
+						 SPAN("notice", "You have mended the damaged [bone] with \the [tool].") )
+	affected.mend_fracture()
 	affected.stage = 0
 
 /datum/surgery_step/finish_bone/fail_step(mob/living/user, mob/living/carbon/human/target, target_zone, obj/item/tool)
@@ -204,7 +205,7 @@
 	var/obj/item/organ/external/affected = target.get_organ(target_zone)
 	user.visible_message(SPAN_NOTICE("[user] has grasped the damaged bone edges in [target]'s [affected.name] with \the [tool].")  , \
 	SPAN_NOTICE("You have grasped the damaged bone edges in [target]'s [affected.name] with \the [tool].") )
-	affected.status &= ~ORGAN_BROKEN
+	affected.mend_fracture()
 	affected.stage = 0
 
 /datum/surgery_step/bone_mender/fail_step(mob/living/user, mob/living/carbon/human/target, target_zone, obj/item/tool)

--- a/code/modules/surgery/limb_reattach.dm
+++ b/code/modules/surgery/limb_reattach.dm
@@ -97,6 +97,8 @@
 	if(E.children)
 		for(var/obj/item/organ/external/C in E.children)
 			C.status &= ~ORGAN_CUT_AWAY
+			C.update_tally()
+	E.update_tally()
 	target.update_body()
 	target.updatehealth()
 	target.UpdateDamageIcon()


### PR DESCRIPTION
```yml
🆑
bugfix: Скорость передвижения теперь правильно обновляется после ломания/сращивания костей и наложения/снятия шины.
/🆑
```

- [x] Pull Request полностью завершен, мне не нужна помощь чтобы его закончить.
- [x] Я внимательно прочитал все свои изменения и багов в них не нашел.
- [x] Я запускал сервер со своими изменениями локально и все протестировал.
- [x] Я ознакомился c [Guide to Contribute](https://github.com/ChaoticOnyx/OnyxBay/blob/dev/docs/contributing.md).
