### PR TITLE
Фикс годмода с сваркой

### DIFF
--- a/code/game/objects/items/weapons/tools.dm
+++ b/code/game/objects/items/weapons/tools.dm
@@ -529,7 +529,8 @@
 //Decides whether or not to damage a player's eyes based on what they're wearing as protection
 //Note: This should probably be moved to mob
 /obj/item/weldingtool/proc/eyecheck(mob/user as mob)
-	if(!iscarbon(user))	return 1
+	if(!iscarbon(user) || (status_flags & GODMODE))
+		return 1
 	if(istype(user, /mob/living/carbon/human))
 		var/mob/living/carbon/human/H = user
 		var/obj/item/organ/internal/eyes/E = H.internal_organs_by_name[BP_EYES]

--- a/code/game/objects/items/weapons/tools.dm
+++ b/code/game/objects/items/weapons/tools.dm
@@ -529,7 +529,7 @@
 //Decides whether or not to damage a player's eyes based on what they're wearing as protection
 //Note: This should probably be moved to mob
 /obj/item/weldingtool/proc/eyecheck(mob/user as mob)
-	if(!iscarbon(user) || (status_flags & GODMODE))
+	if(!iscarbon(user) || (user.status_flags & GODMODE))
 		return 1
 	if(istype(user, /mob/living/carbon/human))
 		var/mob/living/carbon/human/H = user


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/14943437/155076705-5b81489b-0e13-4310-b1fc-02e4681436d7.png)
Даааа, обязательно перенесу позже (Десять лет никто не трогает).
fix #7606 
<details>
<summary>Чейнджлог</summary>

```yml
🆑KreeperHLC
bugfix: Сварка больше не слепит при годмоде.
/🆑
```

</details>

- [x] Pull Request полностью завершен, мне не нужна помощь чтобы его закончить.
- [x] Я внимательно прочитал все свои изменения и багов в них не нашел.
- [ ] Я запускал сервер со своими изменениями локально и все протестировал.
- [x] Я ознакомился c [Guide to Contribute](https://github.com/ChaoticOnyx/OnyxBay/blob/dev/docs/contributing.md).
