### PR TITLE
Пофиксил описание при создании стан перчаток

### DIFF
--- a/code/modules/clothing/clothing.dm
+++ b/code/modules/clothing/clothing.dm
@@ -294,7 +294,7 @@ BLIND     // can't see anything
 			wired = TRUE
 			wire_color = C.color
 			update_icon(TRUE)
-			user.visible_message(SPAN("warning", "\The [user] attaches some wires to \the [W]."), SPAN("notice", "You attach some wires to \the [src]."))
+			user.visible_message(SPAN("warning", "\The [user] attaches some wires to \the [src]."), SPAN("notice", "You attach some wires to \the [src]."))
 			return
 
 	if(istype(W, /obj/item/tape_roll) && wired)


### PR DESCRIPTION
Я больше времени потратил на поиск нужных файлов
fix #7609
<details>
<summary>Чейнджлог</summary>

```yml
🆑KreeperHLC
bugfix: Провода теперь прикрепляются не к проводам, а к перчаткам при создании стан перчаток.
/🆑
```

</details>

- [x] Pull Request полностью завершен, мне не нужна помощь чтобы его закончить.
- [x] Я внимательно прочитал все свои изменения и багов в них не нашел.
- [ ] Я запускал сервер со своими изменениями локально и все протестировал.
- [x] Я ознакомился c [Guide to Contribute](https://github.com/ChaoticOnyx/OnyxBay/blob/dev/docs/contributing.md).
