### PR TITLE
fix(customs): now custom things work as they should

### DIFF
--- a/code/_helpers/global_access.dm
+++ b/code/_helpers/global_access.dm
@@ -415,6 +415,8 @@
 			return global.gas_data;
 		if("gear_datums")
 			return global.gear_datums;
+		if("hash_to_gear")
+			return global.hash_to_gear;
 		if("gear_tweak_free_color_choice_")
 			return global.gear_tweak_free_color_choice_;
 		if("gender_datums")
@@ -1316,6 +1318,8 @@
 			global.gas_data=newval;
 		if("gear_datums")
 			global.gear_datums=newval;
+		if("hash_to_gear")
+			global.hash_to_gear=newval;
 		if("gear_tweak_free_color_choice_")
 			global.gear_tweak_free_color_choice_=newval;
 		if("gender_datums")
@@ -2018,6 +2022,7 @@
 	"gamemode_cache",
 	"gas_data",
 	"gear_datums",
+	"hash_to_gear",
 	"gear_tweak_free_color_choice_",
 	"gender_datums",
 	"ghost_darkness_images",

--- a/code/modules/client/preference_setup/loadout/lists/custom.dm
+++ b/code/modules/client/preference_setup/loadout/lists/custom.dm
@@ -12,7 +12,13 @@
 		if(slot_mask & slot_flags)
 			slot = text2num(slot_name)
 			break
-	display_name = "[data.name ? data.name : initial(A.name)] (Custom)"
+	display_name = data.name ? data.name : sanitize(initial(A.name))
+	var/item_id = 0
+	var/fixed_use_name = display_name
+	while(gear_datums["[fixed_use_name] (Custom)"])
+		fixed_use_name = "[display_name] [++item_id]"
+	display_name = fixed_use_name
+	display_name = "[display_name] (Custom)"
 	description = data.item_desc
 	ckey = key
 	path = item_path

--- a/code/modules/customitems/item_spawning.dm
+++ b/code/modules/customitems/item_spawning.dm
@@ -151,7 +151,7 @@
 			current_data.item_path_as_string = item_path
 			item_path = text2path(item_path)
 			ASSERT(ispath(item_path))
-			
+
 			current_data.name = item_data["item"]?["name"]
 			current_data.item_icon = item_data["item"]?["icon"]
 			current_data.item_desc = item_data["item"]?["desc"]
@@ -175,12 +175,8 @@
 			if(!loadout_categories[use_category])
 				loadout_categories[use_category] = new /datum/loadout_category(use_category)
 			var/datum/loadout_category/LC = loadout_categories[use_category]
-			var/item_id = 0
-			var/fixed_use_name = use_name
-			while(gear_datums[fixed_use_name])
-				fixed_use_name = "[use_name] [++item_id]"
-			use_name = fixed_use_name
 			gear_datums[use_name] = G
+			hash_to_gear[G.gear_hash] = G
 			LC.gear[use_name] = gear_datums[use_name]
 
 	return TRUE


### PR DESCRIPTION
Немного не туда засунул обработку "дубликатов", но теперь все работает.
Так же в названиях некоторых кастомках может встречаться злоебучий символ ```'```, что ломает hrefы из-за чего случаются рантаймы, захешировав названия проблема устранилась.
Так же это фиксит фляжки и прочие предметы с этим символом.

<details>
<summary>Чейнджлог</summary>

```yml
🆑
bugfix: Все игроки с кастомками смогут их получить*.
/🆑
```

</details>

- [x] Pull Request полностью завершен, мне не нужна помощь чтобы его закончить.
- [x] Я внимательно прочитал все свои изменения и багов в них не нашел.
- [x] Я запускал сервер со своими изменениями локально и все протестировал.
- [x] Я ознакомился c [Guide to Contribute](https://github.com/ChaoticOnyx/OnyxBay/blob/dev/docs/contributing.md).
