### PR TITLE
Описательно валлгридерное

### DIFF
--- a/code/game/objects/items/stacks/assemblies.dm
+++ b/code/game/objects/items/stacks/assemblies.dm
@@ -1,6 +1,7 @@
 /obj/item/stack/gassembly
 	name = "girder assemblies"
 	singular_name = "girder assembly"
+	plural_name = "assemblies"
 	desc = "A wall girder's embryo."
 	icon = 'icons/obj/structures.dmi'
 	icon_state = "gassembly"

--- a/code/game/objects/items/stacks/stack.dm
+++ b/code/game/objects/items/stacks/stack.dm
@@ -47,7 +47,10 @@
 	. = ..()
 	if(get_dist(src, user) <= 1)
 		if(!uses_charge)
-			. += "\nThere [src.amount == 1 ? "is" : "are"] [src.amount] [src.singular_name]\s in the stack."
+			if(istype(src, /obj/item/stack/gassembly))
+				. += "\nThere [src.amount == 1 ? "is" : "are"] [src.amount] [src.amount == 1 ? "[src.singular_name]" : "assemblies"] in the stack."
+			else
+				. += "\nThere [src.amount == 1 ? "is" : "are"] [src.amount] [src.singular_name]\s in the stack."
 		else
 			. += "\nThere is enough charge for [get_amount()]."
 	if(color)

--- a/code/game/objects/items/stacks/stack.dm
+++ b/code/game/objects/items/stacks/stack.dm
@@ -18,6 +18,7 @@
 	icon = 'icons/obj/materials.dmi'
 	var/list/datum/stack_recipe/recipes
 	var/singular_name
+	var/plural_name
 	var/amount = 1
 	var/max_amount //also see stack recipes initialisation, param "max_res_amount" must be equal to this max_amount
 	var/stacktype //determines whether different stack types can merge
@@ -47,10 +48,10 @@
 	. = ..()
 	if(get_dist(src, user) <= 1)
 		if(!uses_charge)
-			if(istype(src, /obj/item/stack/gassembly))
-				. += "\nThere [src.amount == 1 ? "is" : "are"] [src.amount] [src.amount == 1 ? "[src.singular_name]" : "assemblies"] in the stack."
+			if(plural_name)
+				. += "\nThere [amount == 1 ? "is" : "are"] [amount] [amount == 1 ? "[singular_name]" : "[plural_name]"] in the stack."
 			else
-				. += "\nThere [src.amount == 1 ? "is" : "are"] [src.amount] [src.singular_name]\s in the stack."
+				. += "\nThere [amount == 1 ? "is" : "are"] [amount] [singular_name]\s in the stack."
 		else
 			. += "\nThere is enough charge for [get_amount()]."
 	if(color)


### PR DESCRIPTION
Пришлось отдельную проверку делать в добавлении описания, ибо /s не знает про исключения из грамматики.
fix #7617
<details>
<summary>Чейнджлог</summary>

```yml
🆑KreeperHLC
bugfix: Теперь в описании нескольких основ гриндера используется правильное слово.
/🆑
```

</details>

- [x] Pull Request полностью завершен, мне не нужна помощь чтобы его закончить.
- [x] Я внимательно прочитал все свои изменения и багов в них не нашел.
- [ ] Я запускал сервер со своими изменениями локально и все протестировал.
- [x] Я ознакомился c [Guide to Contribute](https://github.com/ChaoticOnyx/OnyxBay/blob/dev/docs/contributing.md).
