### PR TITLE
Шахтёрно возвращательное

### DIFF
--- a/code/modules/shuttles/shuttles_multi.dm
+++ b/code/modules/shuttles/shuttles_multi.dm
@@ -62,7 +62,7 @@
 
 /datum/shuttle/autodock/multi/antag/set_destination(destination_key, mob/user)
 	if(!return_warning && destination_key == home_waypoint.name)
-		to_chat(user, "<span class='danger'>Returning to your home base will end your mission. If you are sure, press the button again.</span>")
+		to_chat(user, "<span class='danger'>Are you sure you want to return to base? If you are sure, press the button again.</span>")
 		return_warning = 1
 		return
 	..()

--- a/code/modules/shuttles/shuttles_multi.dm
+++ b/code/modules/shuttles/shuttles_multi.dm
@@ -62,7 +62,7 @@
 
 /datum/shuttle/autodock/multi/antag/set_destination(destination_key, mob/user)
 	if(!return_warning && destination_key == home_waypoint.name)
-		to_chat(user, "<span class='danger'>Are you sure you want to return to base? If you are sure, press the button again.</span>")
+		to_chat(user, SPAN("danger", "Are you sure you want to return to base? If you are sure, press the button again.</span>"))
 		return_warning = 1
 		return
 	..()


### PR DESCRIPTION
fix #6603
<details>
<summary>Чейнджлог</summary>

```yml
🆑KreeperHLC
bugfix: Шахтёров ЕоСа больше не будет предупреждать про конец миссии, когда они будут возвращаться домой.
/🆑
```

</details>

- [x] Pull Request полностью завершен, мне не нужна помощь чтобы его закончить.
- [x] Я внимательно прочитал все свои изменения и багов в них не нашел.
- [ ] Я запускал сервер со своими изменениями локально и все протестировал.
- [x] Я ознакомился c [Guide to Contribute](https://github.com/ChaoticOnyx/OnyxBay/blob/dev/docs/contributing.md).
