### PR TITLE
fix(assembly): now signaller works into grippers

### DIFF
--- a/code/modules/assembly/signaler.dm
+++ b/code/modules/assembly/signaler.dm
@@ -71,7 +71,7 @@
 
 
 /obj/item/device/assembly/signaler/Topic(href, href_list, state = GLOB.physical_state)
-	if(usr.stat || !(src in usr.contents))
+	if((!istype(loc, /obj/item/gripper) || !(loc in usr.contents)) && (usr.stat || !(src in usr.contents)))
 		return
 	if((. = ..()))
 		close_browser(usr, "window=radio")


### PR DESCRIPTION
Добавил проверку на нахождение сигналлера в манипуляторе.
fix  #7669

<details>
<summary>Чейнджлог</summary>

```yml
🆑
bugfix: Теперь сигналлер работает в манипуляторах киборгов.
/🆑
```

</details>

- [x] Pull Request полностью завершен, мне не нужна помощь чтобы его закончить.
- [x] Я внимательно прочитал все свои изменения и багов в них не нашел.
- [x] Я запускал сервер со своими изменениями локально и все протестировал.
- [x] Я ознакомился c [Guide to Contribute](https://github.com/ChaoticOnyx/OnyxBay/blob/dev/docs/contributing.md).
