### PR TITLE
tweak(silicon):"Drop Item" verb of grippers is renamed to "Drop Content"

### DIFF
--- a/code/modules/mob/living/silicon/robot/drone/drone_items.dm
+++ b/code/modules/mob/living/silicon/robot/drone/drone_items.dm
@@ -261,7 +261,7 @@
 
 /obj/item/gripper/verb/drop_item()
 
-	set name = "Drop Item"
+	set name = "Drop Content"
 	set desc = "Release an item from your magnetic gripper."
 	set category = "Silicon Commands"
 


### PR DESCRIPTION
close #6985

<details>
<summary>Чейнджлог</summary>

```yml
🆑
tweak: Вёрб манипуляторов "Drop Item" переименован в "Drop Content".
/🆑
```

</details>

- [x] Pull Request полностью завершен, мне не нужна помощь чтобы его закончить.
- [x] Я внимательно прочитал все свои изменения и багов в них не нашел.
- [x] Я запускал сервер со своими изменениями локально и все протестировал.
- [ ] Я ознакомился c [Guide to Contribute](https://github.com/ChaoticOnyx/OnyxBay/blob/dev/docs/contributing.md).
