### PR TITLE
Больше диона не сможет жить на вашей голове

### DIFF
--- a/code/modules/mob/holder.dm
+++ b/code/modules/mob/holder.dm
@@ -27,9 +27,12 @@ var/list/holder_mob_icon_cache = list()
 	qdel(src)
 
 /obj/item/holder/Destroy()
+	if(last_holder)
+		var/mob/M = last_holder
+		M.drop_from_inventory(src, get_turf(M))
+		last_holder = null
 	for(var/atom/movable/AM in src)
 		AM.forceMove(get_turf(src))
-	last_holder = null
 	STOP_PROCESSING(SSobj, src)
 	return ..()
 


### PR DESCRIPTION
Добавил холдеру проверку на моба перед удалением. Теперь диона и дрон должны появляться на полу при эволюции/гибе, а не оставаться на голове.
~~Подвяжите иссуй про дрона, мне его искать лень.~~
fix #5621, fix #6436
<details>
<summary>Чейнджлог</summary>

```yml
🆑KreeperHLC
bugfix: Диона и дроны больше не остаются на голове персонажа при эволюции или гибе.
/🆑
```

</details>

- [x] Pull Request полностью завершен, мне не нужна помощь чтобы его закончить.
- [x] Я внимательно прочитал все свои изменения и багов в них не нашел.
- [ ] Я запускал сервер со своими изменениями локально и все протестировал.
- [x] Я ознакомился c [Guide to Contribute](https://github.com/ChaoticOnyx/OnyxBay/blob/dev/docs/contributing.md).
