### PR TITLE
Пора выйти из симуляции

### DIFF
--- a/code/game/turfs/unsimulated.dm
+++ b/code/game/turfs/unsimulated.dm
@@ -1,5 +1,6 @@
 GLOBAL_LIST_EMPTY(self_cleaning_list)
 /turf/unsimulated
+	simulated = 0
 	name = "command"
 	initial_gas = list("oxygen" = MOLES_O2STANDARD, "nitrogen" = MOLES_N2STANDARD)
 


### PR DESCRIPTION
Теперь не будет происходить симуляции в турфах, где она быть не должна.
Как минимум, fix #7705
<details>
<summary>Чейнджлог</summary>

```yml
🆑KreeperHLC
bugfix: Блюспейс космос больше не жрёт сам себя.
experiment: Теперь ансимулейтед турфы (Как на ЦК) больше не симулируются. Ожидайте багов.
/🆑
```

</details>

- [x] Pull Request полностью завершен, мне не нужна помощь чтобы его закончить.
- [x] Я внимательно прочитал все свои изменения и багов в них не нашел.
- [ ] Я запускал сервер со своими изменениями локально и все протестировал.
- [x] Я ознакомился c [Guide to Contribute](https://github.com/ChaoticOnyx/OnyxBay/blob/dev/docs/contributing.md).
