### PR TITLE
fix(vampires and synths)

### DIFF
--- a/code/game/gamemodes/vampire/vampire_helpers.dm
+++ b/code/game/gamemodes/vampire/vampire_helpers.dm
@@ -86,7 +86,7 @@
 				to_chat(src, SPAN_WARNING("You lack the power required to affect another creature of the Veil."))
 			return FALSE
 
-	if (isSynthetic(T))
+	if (T.isSynthetic())
 		if (notify)
 			to_chat(src, SPAN_WARNING("You lack the power interact with mechanical constructs."))
 		return FALSE

--- a/code/game/gamemodes/vampire/vampire_helpers.dm
+++ b/code/game/gamemodes/vampire/vampire_helpers.dm
@@ -86,7 +86,7 @@
 				to_chat(src, SPAN_WARNING("You lack the power required to affect another creature of the Veil."))
 			return FALSE
 
-	if (is_mechanical(T))
+	if (isSynthetic(T))
 		if (notify)
 			to_chat(src, SPAN_WARNING("You lack the power interact with mechanical constructs."))
 		return FALSE

--- a/code/game/gamemodes/vampire/vampire_powers.dm
+++ b/code/game/gamemodes/vampire/vampire_powers.dm
@@ -36,7 +36,7 @@
 		return
 
 	var/mob/living/carbon/human/T = G.affecting
-	if (!istype(T) || isSynthetic(T) || T.species.species_flags & SPECIES_FLAG_NO_BLOOD)
+	if (!istype(T) || T.isSynthetic() || T.species.species_flags & SPECIES_FLAG_NO_BLOOD)
 		//Added this to prevent vampires draining diona and IPCs
 		//Diona have 'blood' but its really green sap and shouldn't help vampires
 		//IPCs leak oil
@@ -751,7 +751,7 @@
 	if (!istype(T))
 		to_chat(src, SPAN_WARNING("[T] is not a creature you can enthrall."))
 		return
-	if(isSynthetic(T))
+	if(T.isSynthetic())
 		to_chat(src, SPAN_WARNING("[T] is not a creature you can enthrall."))
 		return
 	if (!vampire_can_affect_target(T, 1, 1))
@@ -864,7 +864,7 @@
 		return
 
 	var/mob/living/carbon/human/T = G.affecting
-	if (isSynthetic(T) || T.species.species_flags & SPECIES_FLAG_NO_BLOOD)
+	if (T.isSynthetic() || T.species.species_flags & SPECIES_FLAG_NO_BLOOD)
 		to_chat(src, SPAN_WARNING("[T] has no blood and can not be affected by your powers!"))
 		return
 
@@ -904,7 +904,7 @@
 	if (T.stat == 2)
 		to_chat(src, SPAN_WARNING("[T]'s body is broken and damaged beyond salvation. You have no use for them."))
 		return
-	if (isSynthetic(T) || T.species.species_flags & SPECIES_FLAG_NO_BLOOD)
+	if (T.isSynthetic() || T.species.species_flags & SPECIES_FLAG_NO_BLOOD)
 		to_chat(src, SPAN_WARNING("[T] has no blood and can not be affected by your powers!"))
 		return
 	if (vampire.status & VAMP_DRAINING)

--- a/code/game/gamemodes/vampire/vampire_powers.dm
+++ b/code/game/gamemodes/vampire/vampire_powers.dm
@@ -751,7 +751,7 @@
 	if (!istype(T))
 		to_chat(src, SPAN_WARNING("[T] is not a creature you can enthrall."))
 		return
-	if(is_mechanical(T) || isSynthetic(T))
+	if(isSynthetic(T))
 		to_chat(src, SPAN_WARNING("[T] is not a creature you can enthrall."))
 		return
 	if (!vampire_can_affect_target(T, 1, 1))

--- a/code/game/gamemodes/vampire/vampire_powers.dm
+++ b/code/game/gamemodes/vampire/vampire_powers.dm
@@ -751,9 +751,6 @@
 	if(!istype(T) || T.isSynthetic())
 		to_chat(src, SPAN_WARNING("[T] is not a creature you can enthrall."))
 		return
-	if(T.isSynthetic())
-		to_chat(src, SPAN_WARNING("[T] is not a creature you can enthrall."))
-		return
 	if (!vampire_can_affect_target(T, 1, 1))
 		return
 	if (!T.client || !T.mind)

--- a/code/game/gamemodes/vampire/vampire_powers.dm
+++ b/code/game/gamemodes/vampire/vampire_powers.dm
@@ -36,7 +36,7 @@
 		return
 
 	var/mob/living/carbon/human/T = G.affecting
-	if (!istype(T) || T.species.species_flags & SPECIES_FLAG_NO_BLOOD)
+	if (!istype(T) || isSynthetic(T) || T.species.species_flags & SPECIES_FLAG_NO_BLOOD)
 		//Added this to prevent vampires draining diona and IPCs
 		//Diona have 'blood' but its really green sap and shouldn't help vampires
 		//IPCs leak oil
@@ -748,10 +748,10 @@
 		return
 
 	var/mob/living/carbon/human/T = G.affecting
-	if(is_mechanical(T))
+	if (!istype(T))
 		to_chat(src, SPAN_WARNING("[T] is not a creature you can enthrall."))
 		return
-	if (!istype(T))
+	if(is_mechanical(T) || isSynthetic(T))
 		to_chat(src, SPAN_WARNING("[T] is not a creature you can enthrall."))
 		return
 	if (!vampire_can_affect_target(T, 1, 1))
@@ -864,7 +864,7 @@
 		return
 
 	var/mob/living/carbon/human/T = G.affecting
-	if (T.species.species_flags & SPECIES_FLAG_NO_BLOOD)
+	if (isSynthetic(T) || T.species.species_flags & SPECIES_FLAG_NO_BLOOD)
 		to_chat(src, SPAN_WARNING("[T] has no blood and can not be affected by your powers!"))
 		return
 
@@ -904,7 +904,7 @@
 	if (T.stat == 2)
 		to_chat(src, SPAN_WARNING("[T]'s body is broken and damaged beyond salvation. You have no use for them."))
 		return
-	if (T.species.species_flags & SPECIES_FLAG_NO_BLOOD)
+	if (isSynthetic(T) || T.species.species_flags & SPECIES_FLAG_NO_BLOOD)
 		to_chat(src, SPAN_WARNING("[T] has no blood and can not be affected by your powers!"))
 		return
 	if (vampire.status & VAMP_DRAINING)

--- a/code/game/gamemodes/vampire/vampire_powers.dm
+++ b/code/game/gamemodes/vampire/vampire_powers.dm
@@ -748,7 +748,7 @@
 		return
 
 	var/mob/living/carbon/human/T = G.affecting
-	if (!istype(T))
+	if(!istype(T) || T.isSynthetic())
 		to_chat(src, SPAN_WARNING("[T] is not a creature you can enthrall."))
 		return
 	if(T.isSynthetic())

--- a/code/modules/mob/mob.dm
+++ b/code/modules/mob/mob.dm
@@ -628,11 +628,6 @@
 /mob/proc/is_dead()
 	return stat == DEAD
 
-/mob/proc/is_mechanical()
-	if(mind && (mind.assigned_role == "Cyborg" || mind.assigned_role == "AI"))
-		return 1
-	return istype(src, /mob/living/silicon) || get_species() == SPECIES_IPC
-
 /mob/proc/is_ready()
 	return client && !!mind
 

--- a/code/modules/mob/mob_helpers.dm
+++ b/code/modules/mob/mob_helpers.dm
@@ -24,6 +24,8 @@
 	return 0
 
 /mob/living/carbon/human/isSynthetic()
+	if(istype(H.species, /datum/species/machine))
+		return 1
 	if(isnull(full_prosthetic))
 		robolimb_count = 0
 		for(var/obj/item/organ/external/E in organs)

--- a/code/modules/mob/mob_helpers.dm
+++ b/code/modules/mob/mob_helpers.dm
@@ -24,7 +24,7 @@
 	return 0
 
 /mob/living/carbon/human/isSynthetic()
-	if(istype(H.species, /datum/species/machine))
+	if(istype(species, /datum/species/machine))
 		return 1
 	if(isnull(full_prosthetic))
 		robolimb_count = 0


### PR DESCRIPTION
сам открыл, сам починил.

+ в функции траллирования почему-то проверка на существование проводится после проверки на синтетичность

+ обнаружил какую-то непонятную костыльную is_machine(), которая используется только тут. Вырезал, поскольку мы пользуемся православной isSynthetic(), добив ее функционал для IPC, которые, надеюсь, когда-нибудь будут.

resolves #7637

<details>
<summary>Чейнджлог</summary>

```yml
🆑
bugfix: Исправлена ошибка, из-за которой некоторая вампирская магия работала на синтетиков.
/🆑
```

</details>

- [x] Pull Request полностью завершен, мне не нужна помощь чтобы его закончить.
- [x] Я внимательно прочитал все свои изменения и багов в них не нашел.
- [x] Я запускал сервер со своими изменениями локально и все протестировал.
- [x] Я ознакомился c [Guide to Contribute](https://github.com/ChaoticOnyx/OnyxBay/blob/dev/docs/contributing.md).
