### PR TITLE
tweak(config): move round end and start timings settings to config

### DIFF
--- a/code/controllers/configuration.dm
+++ b/code/controllers/configuration.dm
@@ -290,6 +290,10 @@ var/list/gamemode_cache = list()
 	var/disable_ooc_roundstart = FALSE
 	var/disable_looc_roundstart = FALSE
 
+	// Timing settings
+	var/pregame_timeleft = 3 MINUTES
+	var/restart_timeout = 1 MINUTE
+
 	// Non-that-serious features that can be disabled for higher RP levels
 	var/fun_hydroponics = 2
 
@@ -974,6 +978,10 @@ var/list/gamemode_cache = list()
 					config.maximum_mushrooms = text2num(value)
 				if("use_loyalty_implants")
 					config.use_loyalty_implants = 1
+				if("pregame_timeleft")
+					config.pregame_timeleft = text2num(value)
+				if("restart_timeout")
+					config.restart_timeout = text2num(value)
 				if("fun_hydroponics")
 					config.fun_hydroponics = text2num(value)
 

--- a/code/controllers/subsystems/ticker.dm
+++ b/code/controllers/subsystems/ticker.dm
@@ -6,7 +6,6 @@ SUBSYSTEM_DEF(ticker)
 	flags = SS_NO_TICK_CHECK | SS_KEEP_TIMING
 	runlevels = RUNLEVEL_LOBBY | RUNLEVELS_DEFAULT
 
-	var/pregame_timeleft = 3 MINUTES
 	var/list/gamemode_vote_results  //Will be a list, in order of preference, of form list(config_tag = number of votes).
 	var/bypass_gamemode_vote = TRUE //Intended for use with admin tools. Will avoid voting and ignore any results.
 
@@ -20,7 +19,6 @@ SUBSYSTEM_DEF(ticker)
 	var/end_game_state = END_GAME_NOT_OVER
 	var/delay_end = 0               //Can be set true to postpone restart.
 	var/delay_notified = 0          //Spam prevention.
-	var/restart_timeout = 1 MINUTE
 
 	var/force_end = FALSE
 
@@ -28,7 +26,13 @@ SUBSYSTEM_DEF(ticker)
 	var/list/antag_pool = list()
 	var/looking_for_antags = 0
 
+	var/pregame_timeleft
+	var/restart_timeout
+
 /datum/controller/subsystem/ticker/Initialize()
+	pregame_timeleft = config.pregame_timeleft
+	restart_timeout = config.restart_timeout
+
 	to_world("<span class='info'><B>Welcome to the pre-game lobby!</B></span>")
 	to_world("Please, setup your character and select ready. Game will start in [round(pregame_timeleft/10)] seconds")
 	return ..()

--- a/config/example/config.txt
+++ b/config/example/config.txt
@@ -736,3 +736,14 @@ ERROR_SILENCE_TIME 6000
 
 ## How long to wait between messaging admins about occurrences of a unique error.
 ERROR_MSG_DELAY 50
+
+# # # # # # # # # # # # # # # # # # # # # #
+#             TIME SETTINGS               #
+# # # # # # # # # # # # # # # # # # # # # #
+# Time before a round starts
+# DEFAULT: 1800 (3 MINUTES)
+PREGAME_TIMELEFT 1800
+
+# Time left after round end before reboot.
+# DEFAULT: 600 (1 MINUTE)
+RESTART_TIMEOUT 600


### PR DESCRIPTION
<details>
<summary>Чейнджлог</summary>

```yml
🆑
admin: В конфиг добавлены настройки продолжительности пред/пост раундового времени.
/🆑
```

</details>

- [x] Pull Request полностью завершен, мне не нужна помощь чтобы его закончить.
- [x] Я внимательно прочитал все свои изменения и багов в них не нашел.
- [ ] Я запускал сервер со своими изменениями локально и все протестировал.
- [x] Я ознакомился c [Guide to Contribute](https://github.com/ChaoticOnyx/OnyxBay/blob/dev/docs/contributing.md).
