### PR TITLE
tweak(surgery): cut_with_laser with laser scalpel chance increased to 100

### DIFF
--- a/code/modules/surgery/generic.dm
+++ b/code/modules/surgery/generic.dm
@@ -31,9 +31,9 @@
 //////////////////////////////////////////////////////////////////
 /datum/surgery_step/generic/cut_with_laser
 	allowed_tools = list(
-	/obj/item/scalpel/laser3 = 95, \
-	/obj/item/scalpel/laser2 = 85, \
-	/obj/item/scalpel/laser1 = 75, \
+	/obj/item/scalpel/laser3 = 100, \
+	/obj/item/scalpel/laser2 = 100, \
+	/obj/item/scalpel/laser1 = 100, \
 	/obj/item/melee/energy/sword/one_hand = 50
 	)
 	priority = 2


### PR DESCRIPTION
Эти инструменты является улучшением стандартного набора бай дезигн, но из-за шансов операции проводимые с их помощью, их никто не берет. Это обидно, исправляем.

<details>
<summary>Чейнджлог</summary>

```yml
🆑
tweak: Успех на разрез с использованием лазерного скальпеля теперь имеет шанс равным 100% 
/🆑
```

</details>

- [x] Pull Request полностью завершен, мне не нужна помощь чтобы его закончить.
- [x] Я внимательно прочитал все свои изменения и багов в них не нашел.
- [x] Я запускал сервер со своими изменениями локально и все протестировал.
- [x] Я ознакомился c [Guide to Contribute](https://github.com/ChaoticOnyx/OnyxBay/blob/dev/docs/contributing.md).
