### PR TITLE
add(EAMS): config flag to ignore proxy check

### DIFF
--- a/code/controllers/configuration.dm
+++ b/code/controllers/configuration.dm
@@ -72,6 +72,7 @@ var/list/gamemode_cache = list()
 	var/panic_bunker = 0
 	var/eams = 0
 	var/eams_blocks_ooc = 0
+	var/eams_ignore_proxy = 0
 	var/usewhitelist = 0
 	var/kick_inactive = 0				//force disconnect for inactive players after this many minutes, if non-0
 	var/mods_can_tempban = 0
@@ -882,6 +883,9 @@ var/list/gamemode_cache = list()
 
 				if("eams_blocks_ooc")
 					config.eams_blocks_ooc = TRUE
+
+				if("eams_ignore_proxy")
+					config.eams_ignore_proxy = TRUE
 
 				if("delist_when_no_admins")
 					config.delist_when_no_admins = TRUE

--- a/code/modules/admin/EAMS.dm
+++ b/code/modules/admin/EAMS.dm
@@ -257,7 +257,7 @@ SUBSYSTEM_DEF(eams)
 		return TRUE
 
 	if (C.eams_info.loaded)
-		if ((C.eams_info.ip_countryCode in __allowed_countries) && !C.eams_info.ip_proxy)
+		if ((C.eams_info.ip_countryCode in __allowed_countries) && (!C.eams_info.ip_proxy || config.eams_ignore_proxy))
 			return TRUE
 
 		// Bad IP and player isn't whitelisted.. so create a warning

--- a/config/example/config.txt
+++ b/config/example/config.txt
@@ -145,6 +145,9 @@ LOG_GAME
 ## Uncomment to prohibit sending in OOC for players blocked by EAMS.
 # EAMS_BLOCKS_OOC
 
+## Uncomment to let player in even if API detected a proxy IP.
+# EAMS_IGNORE_PROXY
+
 # # # # # # # # # # # # # # # # # # # # # #
 #          GAMEMODE PROBABILITIES         #
 # # # # # # # # # # # # # # # # # # # # # #


### PR DESCRIPTION
> Хмඞбеб — Today at 17:57
Бля, у нас еамс натурально хохлов притесняет, пацаны.
Человека с Луганска не пускал.
Разберитесь все же, а?
@[name] \the [rank]

моей дедукцией было определено что вероятнее всего во всём виноват проксичек айпиапия ( наппомню я не смотрел логи еамса((их нет))) который выдаёт один флажок в джоснчике а потом звони админу
данный пулл реквест (pull request) добавляет в конфиг ещё один флаг ~~чтобы плин повесился~~ чтобы можно было отрубать по желанию проверку на проксич

- [x] Pull Request полностью завершен, мне не нужна помощь чтобы его закончить.
- [x] Я внимательно прочитал все свои изменения и багов в них не нашел.
- [x] Я **НЕ** запускал сервер со своими изменениями локально и **НИЧЕГО** протестировал.
- [x] Я ознакомился c [Guide to Contribute](https://github.com/ChaoticOnyx/OnyxBay/blob/dev/docs/contributing.md).
