### PR TITLE
Removes disposal units duping mob holders

### DIFF
--- a/code/modules/recycling/disposal.dm
+++ b/code/modules/recycling/disposal.dm
@@ -108,6 +108,17 @@
 		update_icon()
 		return
 
+	if(istype(I, /obj/item/holder))
+		var/obj/item/holder/H = I
+		user.visible_message("[user] stuffs [H] into \the [src]!", \
+							 "You stuff [H] into \the [src].")
+		for(var/atom/movable/AM in H)
+			AM.forceMove(src)
+		user.drop_from_inventory(H)
+		playsound(src, SFX_DISPOSAL, 75, 0)
+		update_icon()
+		return
+
 	var/obj/item/grab/G = I
 	if(istype(G))	// handle grabbed mob
 		if(ismob(G.affecting))


### PR DESCRIPTION
```yml
🆑
bugfix: Мусорки больше не дюпают макак.
/🆑
```

- [x] Pull Request полностью завершен, мне не нужна помощь чтобы его закончить.
- [x] Я внимательно прочитал все свои изменения и багов в них не нашел.
- [x] Я запускал сервер со своими изменениями локально и все протестировал.
- [x] Я ознакомился c [Guide to Contribute](https://github.com/ChaoticOnyx/OnyxBay/blob/dev/docs/contributing.md).
