### PR TITLE
refact(turrets): use signals in portable turrets

### DIFF
--- a/code/datums/datum.dm
+++ b/code/datums/datum.dm
@@ -25,6 +25,9 @@
 /datum/proc/Destroy(force=FALSE)
 	SHOULD_CALL_PARENT(TRUE)
 
+	SEND_SIGNAL(src, SIGNAL_DESTROY, src)
+	SEND_GLOBAL_SIGNAL(SIGNAL_DESTROY, src)
+
 	tag = null
 	SSnano && SSnano.close_uis(src)
 	var/list/timers = active_timers

--- a/code/datums/datum.dm
+++ b/code/datums/datum.dm
@@ -23,11 +23,6 @@
 // This should be overridden to remove all references pointing to the object being destroyed.
 // Return the appropriate QDEL_HINT; in most cases this is QDEL_HINT_QUEUE.
 /datum/proc/Destroy(force=FALSE)
-	SHOULD_CALL_PARENT(TRUE)
-
-	SEND_SIGNAL(src, SIGNAL_DESTROY, src)
-	SEND_GLOBAL_SIGNAL(SIGNAL_DESTROY, src)
-
 	tag = null
 	SSnano && SSnano.close_uis(src)
 	var/list/timers = active_timers

--- a/code/game/machinery/portable_turret.dm
+++ b/code/game/machinery/portable_turret.dm
@@ -545,8 +545,14 @@ var/list/turret_icons
 /obj/machinery/porta_turret/proc/assess_and_assign(mob/living/L)
 	switch(assess_living(L))
 		if(TURRET_PRIORITY_TARGET)
+			if(L in targets)
+				return
+
 			targets += L
 		if(TURRET_SECONDARY_TARGET)
+			if(L in secondary_targets)
+				return
+
 			secondary_targets += L
 
 /obj/machinery/porta_turret/proc/assess_living(mob/living/L)

--- a/code/game/machinery/portable_turret.dm
+++ b/code/game/machinery/portable_turret.dm
@@ -130,8 +130,11 @@
 	turfs_in_view_range = list()
 	turfs_not_in_view_range = list()
 
+	// Lummox says `view` has caching, anyway lets be sure).
+	var/list/cached_view = view(world.view, src)
+
 	for(var/turf/T in range(world.view, src))
-		if(T in view(world.view, src))
+		if(T in cached_view)
 			_register_visible_turf(T)
 			turfs_in_view_range += T
 		else

--- a/code/game/turfs/simulated/walls.dm
+++ b/code/game/turfs/simulated/walls.dm
@@ -44,9 +44,10 @@
 	. = ..()
 
 /turf/simulated/wall/Destroy()
-	STOP_PROCESSING(SSturf, src)
 	dismantle_wall(null,null,1)
-	. = ..()
+	
+	// At this point `src` is a new instance, the old one was destroyed in `dismantle_wall`.
+	return QDEL_HINT_LETMELIVE
 
 // Walls always hide the stuff below them.
 /turf/simulated/wall/levelupdate()

--- a/code/game/turfs/turf_changing.dm
+++ b/code/game/turfs/turf_changing.dm
@@ -54,7 +54,16 @@
 		A.forceMove(null)
 
 	var/old_opaque_counter = opaque_counter
+	var/old_lookups = comp_lookup.Copy()
+	var/old_components = datum_components.Copy()
+	var/old_signals = signal_procs.Copy()
+
 	var/turf/simulated/W = new N( locate(src.x, src.y, src.z) )
+
+	comp_lookup = old_lookups
+	datum_components = old_components
+	signal_procs = old_signals
+
 	for(var/atom/movable/A in old_contents)
 		A.forceMove(W)
 
@@ -95,8 +104,7 @@
 			else
 				lighting_clear_overlay()
 
-	if(.)
-		SEND_SIGNAL(src, SIGNAL_TURF_CHANGED, src, old_density, density, old_opacity, opacity)
+	SEND_SIGNAL(src, SIGNAL_TURF_CHANGED, src, old_density, density, old_opacity, opacity)
 
 /turf/proc/transport_properties_from(turf/other)
 	if(!istype(other, src.type))


### PR DESCRIPTION
Теперь турели бесплатны по производительности если в их зоне видимости никого нет и почти бесплатны когда кто-то есть.

<details>

<summary>Не актуально</summary>

Заменил вызов на каждый процессинг прока `mobs_in_view` на вызов `view` только когда вокруг кто-то ходит.

Профайлы за минуту:

| Proc | Self CPU | Total CPU | Real Time | Overtime | Calls |
| ---------------------- | ------ | ------ | ------ | ------ | ---- |
| /proc/mobs_in_view | 0.130 | 0.135 | 0.136 | 0.000 | 992 |
| /obj/machinery/porta_turret/proc/_on_turf_entered | 0.007 | 0.007 | 0.008 | 0.000 | 94 |

</details>

Ещё немного изменил код `/turf/simulated/wall/Destroy()`.

- [x] Pull Request полностью завершен, мне не нужна помощь чтобы его закончить.
- [x] Я внимательно прочитал все свои изменения и багов в них не нашел.
- [x] Я запускал сервер со своими изменениями локально и все протестировал.
- [x] Я ознакомился c [Guide to Contribute](https://github.com/ChaoticOnyx/OnyxBay/blob/dev/docs/contributing.md).
