### PR TITLE
allow to put obj inside closets

### DIFF
--- a/code/game/area/areas.dm
+++ b/code/game/area/areas.dm
@@ -374,3 +374,9 @@ var/list/mob/living/forced_ambiance_list = new
 
 /area/proc/has_turfs()
 	return !!(locate(/turf) in src)
+
+/area/allow_drop()
+	CRASH("Bad op: area/allow_drop() called")
+
+/area/drop_location()
+	CRASH("Bad op: area/drop_location() called")

--- a/code/game/atoms.dm
+++ b/code/game/atoms.dm
@@ -79,6 +79,12 @@
 /atom/proc/LateInitialize()
 	return
 
+/atom/proc/drop_location()
+	var/atom/L = loc
+	if(!L)
+		return null
+	return L.allow_drop() ? L : get_turf(L)
+
 /atom/Entered(atom/movable/enterer, atom/old_loc)
 	..()
 
@@ -137,6 +143,9 @@
 	proc/can_add_container()
 		return flags & INSERT_CONTAINER
 */
+
+/atom/proc/allow_drop()
+	return FALSE
 
 /atom/proc/CheckExit()
 	return 1

--- a/code/game/objects/items/storage/storage.dm
+++ b/code/game/objects/items/storage/storage.dm
@@ -309,6 +309,9 @@
 	W.add_fingerprint(user)
 	return handle_item_insertion(W)
 
+/obj/item/storage/allow_drop()
+	return TRUE
+
 /obj/item/storage/attack_hand(mob/user)
 	if(ishuman(user))
 		var/mob/living/carbon/human/H = user

--- a/code/game/objects/structures/crates_lockers/closets.dm
+++ b/code/game/objects/structures/crates_lockers/closets.dm
@@ -164,15 +164,17 @@
 	return TRUE
 
 /obj/structure/closet/proc/dump_contents()
+	var/atom/L = drop_location()
+
 	for(var/mob/M in src)
-		M.forceMove(loc)
+		M.forceMove(L)
 		if(M.client)
 			M.client.eye = M.client.mob
 			M.client.perspective = MOB_PERSPECTIVE
 
 	for(var/atom/movable/AM in src)
-		if(!istype(AM,/obj/item/shield/closet))
-			AM.forceMove(loc)
+		if(!istype(AM, /obj/item/shield/closet))
+			AM.forceMove(L)
 
 /obj/structure/closet/proc/store_contents()
 	var/stored_units = 0
@@ -781,3 +783,6 @@
 	playsound(src.loc, 'sound/weapons/blade1.ogg', 50, 1)
 	playsound(src.loc, "spark", 50, 1)
 	open()
+
+/obj/structure/closet/allow_drop()
+	return TRUE

--- a/code/game/turfs/turf.dm
+++ b/code/game/turfs/turf.dm
@@ -272,3 +272,6 @@ var/const/enterloopsanity = 100
 		if(isliving(AM))
 			var/mob/living/M = AM
 			M.turf_collision(src, speed)
+
+/turf/allow_drop()
+	return TRUE

--- a/code/modules/integrated_electronics/core/printer.dm
+++ b/code/modules/integrated_electronics/core/printer.dm
@@ -285,7 +285,7 @@
 		if(!debug && !subtract_material_costs(cost, usr))
 			return
 
-		var/obj/item/built = new build_type(get_turf(src))
+		var/obj/item/built = new build_type(drop_location())
 		usr.put_in_hands(built)
 
 		if(istype(built, /obj/item/device/electronic_assembly))

--- a/code/modules/recycling/disposal.dm
+++ b/code/modules/recycling/disposal.dm
@@ -1606,6 +1606,9 @@
 	else
 		return 0
 
+/obj/structure/disposalholder/allow_drop()
+	return TRUE
+
 // a broken pipe
 /obj/structure/disposalpipe/broken
 	icon_state = "pipe-b"


### PR DESCRIPTION
Теперь можно класть предметы внутри ящика в этот ящик, предметы в мусорку внутри мусорке + багфикс передвижения через стену, опять

<details>
<summary>Чейнджлог</summary>

```yml
🆑
tweak: Добавлена возможность класть предметы в ящик внутри ящика, в мусорку внутри мусорки.
bugfix: Очередной фикс прохождения через стену.
/🆑
```

</details>


- [x] Pull Request полностью завершен, мне не нужна помощь чтобы его закончить.
- [x] Я внимательно прочитал все свои изменения и багов в них не нашел.
- [x] Я запускал сервер со своими изменениями локально и все протестировал.
- [x] Я ознакомился c [Guide to Contribute](https://github.com/ChaoticOnyx/OnyxBay/blob/dev/docs/contributing.md).
