### PR TITLE
Аккаунтное

### DIFF
--- a/code/game/jobs/job/captain.dm
+++ b/code/game/jobs/job/captain.dm
@@ -31,8 +31,9 @@ var/datum/announcement/minor/captain_announcement = new(do_newscast = 1)
 
 /datum/job/hop
 	title = "Head of Personnel"
+	department = "Civilian"
 	head_position = 1
-	department_flag = COM|CIV
+	department_flag = COM|CIV|SRV
 
 	total_positions = 1
 	spawn_positions = 1

--- a/code/game/jobs/job/job.dm
+++ b/code/game/jobs/job/job.dm
@@ -96,9 +96,10 @@
 	var/datum/money_account/M = create_account(H.real_name, money_amount, null, off_station)
 	if(H.mind)
 		var/remembered_info = ""
-		remembered_info += "<b>Your account number is:</b> #[M.account_number]<br>"
-		remembered_info += "<b>Your account pin is:</b> [M.remote_access_pin]<br>"
-		remembered_info += "<b>Your account funds are:</b> T[M.money]<br>"
+		remembered_info += "<b>Your account:</b><br>"
+		remembered_info += "<b>Number:</b> #[M.account_number]<br>"
+		remembered_info += "<b>Pin:</b> [M.remote_access_pin]<br>"
+		remembered_info += "<b>Funds:</b> [M.money]cr.<br>"
 
 		if(M.transaction_log.len)
 			var/datum/transaction/T = M.transaction_log[1]

--- a/code/game/jobs/job_controller.dm
+++ b/code/game/jobs/job_controller.dm
@@ -481,15 +481,17 @@ var/global/datum/controller/occupations/job_master
 				H.buckled.forceMove(H.loc)
 				H.buckled.set_dir(H.dir)
 
-		// If they're head, give them the account info for their department
-		if(H.mind && job.head_position)
+		if(H.mind)
 			var/remembered_info = ""
 			var/datum/money_account/department_account = department_accounts[job.department]
 
 			if(department_account)
-				remembered_info += "<b>Your department's account number is:</b> #[department_account.account_number]<br>"
-				remembered_info += "<b>Your department's account pin is:</b> [department_account.remote_access_pin]<br>"
-				remembered_info += "<b>Your department's account funds are:</b> T[department_account.money]<br>"
+				remembered_info += "<b>Your [job.department] department account:</b><br>"
+				remembered_info += "<b>Number:</b> #[department_account.account_number]<br>"
+			// And if they're head, give them the pin and funds info for their department
+			if(job.head_position || job.title == "Quartermaster" || job.title ==  "Internal Affairs Agent")
+				remembered_info += "<b>Pin:</b> [department_account.remote_access_pin]<br>"
+				remembered_info += "<b>Funds:</b> [department_account.money]cr.<br>"
 
 			H.mind.store_memory(remembered_info)
 

--- a/code/modules/economy/Accounts.dm
+++ b/code/modules/economy/Accounts.dm
@@ -7,7 +7,7 @@
 	var/list/transaction_log = list()
 	var/suspended = 0
 	var/off_station = FALSE
-	var/security_level = 0	//0 - auto-identify from worn ID, require only account number
+	var/security_level = 1	//0 - auto-identify from worn ID, require only account number
 							//1 - require manual login / account number and pin
 							//2 - require card and manual login
 


### PR DESCRIPTION
Нашему ХоПу забыли прописать департамент. Добавил Цивильный как главный + подключил его к Сервису.
Переделал отображение аккаунта в воспоминаниях на более краткий вариант.
Повысил уровень безопасности для всех аккаунтов до требования логина и пароля.
Тайлеры превратились в кредиты.
close #3923
<details>
<summary>Чейнджлог</summary>

```yml
🆑KreeperHLC
rscadd: Теперь главы отделов (В том числе КМ и Агент Внутренних Дел) имеют в воспоминаниях коды от своего департамента.
rscadd: Обычные работники знают номер департамента, в котором они работают.
balance: Теперь для входа в любой аккаунт требуется пинкод, а не только его номер.
tweak: Переименовал Тайлеры в Кредиты.
/🆑
```

</details>

- [x] Pull Request полностью завершен, мне не нужна помощь чтобы его закончить.
- [x] Я внимательно прочитал все свои изменения и багов в них не нашел.
- [x] Я запускал сервер со своими изменениями локально и все протестировал.
- [x] Я ознакомился c [Guide to Contribute](https://github.com/ChaoticOnyx/OnyxBay/blob/dev/docs/contributing.md).
