### PR TITLE
Removes some of the mobholders' bugs

### DIFF
--- a/code/modules/mob/living/carbon/human/human.dm
+++ b/code/modules/mob/living/carbon/human/human.dm
@@ -235,7 +235,9 @@
 /mob/living/carbon/human/var/temperature_resistance = T0C+75
 
 /mob/living/carbon/human/show_inv(mob/user)
-	if(user.incapacitated() || !user.Adjacent(src))
+	if(user.incapacitated())
+		return
+	if(!(user.Adjacent(src) || (istype(loc, /obj/item/holder) && loc.loc == user)))
 		return
 	if(!user.IsAdvancedToolUser(TRUE))
 		show_inv_reduced(user)
@@ -296,7 +298,9 @@
 
 // Used when the user is not an advanced tool user (i.e. xenomorph)
 /mob/living/carbon/human/proc/show_inv_reduced(mob/user) // aka show_inv_to_a_moron
-	if(user.incapacitated() || !user.Adjacent(src))
+	if(user.incapacitated())
+		return
+	if(!(user.Adjacent(src) || (istype(loc, /obj/item/holder) && loc.loc == user)))
 		return
 	var/dat = "<B><HR><FONT size=3>[name]</FONT></B><BR><HR>"
 	var/firstline = TRUE

--- a/code/modules/projectiles/guns/launcher/pneumatic.dm
+++ b/code/modules/projectiles/guns/launcher/pneumatic.dm
@@ -70,6 +70,8 @@
 		tank = W
 		user.visible_message("[user] jams [W] into [src]'s valve and twists it closed.","You jam [W] into [src]'s valve and twist it closed.")
 		update_icon()
+	else if(istype(W, /obj/item/holder))
+		to_chat(user, SPAN("warning", "[W] doesn't seem to fit inside."))
 	else if(istype(W) && item_storage.can_be_inserted(W, user))
 		item_storage.handle_item_insertion(W)
 

--- a/code/modules/recycling/disposal.dm
+++ b/code/modules/recycling/disposal.dm
@@ -114,7 +114,7 @@
 							 "You stuff [H] into \the [src].")
 		for(var/atom/movable/AM in H)
 			AM.forceMove(src)
-		user.drop_from_inventory(H)
+		qdel(H)
 		playsound(src, SFX_DISPOSAL, 75, 0)
 		update_icon()
 		return


### PR DESCRIPTION
Я не понял, на кой хрен холдеры вообще заставляли своих мобов слушать повороты держащего.
- Обезьян больше нельзя заставить поворачиваться магической магией.
- Обезьянам на ручках снова можно открывать инвентарь селфкликом. Хз, в какой момент это вообще отвалилось.
- Мобхолдеры больше не пихаются в пневмопушку. Когда-нибудь надо будет зарефакторить саму пневмопушку, но пока что это лучше, чем дюпающиеся холдеры.

```yml
🆑
bugfix: Исправлены некоторые проблемы с поднятыми на руки мобами.
/🆑
```

- [x] Pull Request полностью завершен, мне не нужна помощь чтобы его закончить.
- [x] Я внимательно прочитал все свои изменения и багов в них не нашел.
- [x] Я запускал сервер со своими изменениями локально и все протестировал.
- [x] Я ознакомился c [Guide to Contribute](https://github.com/ChaoticOnyx/OnyxBay/blob/dev/docs/contributing.md).
