### PR TITLE
Removes lack of xenomorphs balance and more

### DIFF
--- a/code/modules/mob/living/carbon/human/human.dm
+++ b/code/modules/mob/living/carbon/human/human.dm
@@ -1682,7 +1682,7 @@
 
 //Point at which you dun breathe no more. Separate from asystole crit, which is heart-related.
 /mob/living/carbon/human/nervous_system_failure()
-	return getBrainLoss() >= maxHealth * 0.4 // > than 80 brain dmg - ur rekt
+	return getBrainLoss() >= maxHealth * 0.8 // > than 80 brain dmg - ur rekt
 
 /mob/living/carbon/human/verb/useblock()
 	set name = "Block"

--- a/code/modules/mob/living/carbon/human/human_damage.dm
+++ b/code/modules/mob/living/carbon/human/human_damage.dm
@@ -6,7 +6,7 @@
 		set_stat(CONSCIOUS)
 		return
 
-	health = maxHealth - (getBrainLoss() * 2) // Since brains' get 50% of maxHealth as their HP
+	health = maxHealth - getBrainLoss()
 
 	//TODO: fix husking
 	if(((maxHealth - getFireLoss()) < config.health_threshold_dead) && stat == DEAD)
@@ -193,7 +193,7 @@
 	else
 		var/obj/item/organ/internal/lungs/breathe_organ = internal_organs_by_name[species.breathing_organ]
 		if(!breathe_organ)
-			return maxHealth/2
+			return maxHealth
 		return breathe_organ.get_oxygen_deprivation()
 
 /mob/living/carbon/human/setOxyLoss(amount)
@@ -304,9 +304,9 @@
 	if(!species || !dam_type) return FALSE
 
 	if(dam_type == BRUTE)
-		return(getBruteLoss() < species.total_health / 2)
+		return(getBruteLoss() < species.total_health)
 	else if(dam_type == BURN)
-		return(getFireLoss() < species.total_health / 2)
+		return(getFireLoss() < species.total_health)
 	return FALSE
 
 ////////////////////////////////////////////

--- a/code/modules/mob/living/carbon/human/human_defense.dm
+++ b/code/modules/mob/living/carbon/human/human_defense.dm
@@ -47,8 +47,8 @@ meteor_act
 	var/internal_damage_prob = 70 + max(penetrating_damage, -30) // The minimal chance to deal internal damage is 40%, armor is more about blocking damage itself
 
 	var/overkill_value = 1
-	if(organ.damage >= organ.max_damage * 1.5) // Overkill stuff; if our bodypart is a pile of shredded meat then it doesn't protect organs well
-		overkill_value *= 3
+	if(organ.damage > organ.max_damage) // Overkill stuff; if our bodypart is a pile of shredded meat then it doesn't protect organs well
+		overkill_value *= organ.damage / organ.max_damage * 2
 
 	if(organ.internal_organs.len && prob(internal_damage_prob * overkill_value))
 		var/damage_amt = (P.damage * P.penetration_modifier) * blocked_mult(blocked / 1.5) //So we don't factor in armor_penetration as additional damage

--- a/code/modules/mob/living/carbon/human/human_movement.dm
+++ b/code/modules/mob/living/carbon/human/human_movement.dm
@@ -35,8 +35,8 @@
 
 	. += blocking * 1.5
 
-	var/health_deficiency = (maxHealth - health)
-	if(health_deficiency >= 40)
+	var/health_deficiency_percent = 100 - (health / maxHealth) * 100
+	if(health_deficiency_percent >= 40)
 		. += (health_deficiency / 25)
 
 	var/shock = get_shock()

--- a/code/modules/mob/living/carbon/human/human_movement.dm
+++ b/code/modules/mob/living/carbon/human/human_movement.dm
@@ -37,7 +37,7 @@
 
 	var/health_deficiency_percent = 100 - (health / maxHealth) * 100
 	if(health_deficiency_percent >= 40)
-		. += (health_deficiency / 25)
+		. += (health_deficiency_percent / 25)
 
 	var/shock = get_shock()
 	if(shock >= 10)

--- a/code/modules/mob/living/carbon/human/life.dm
+++ b/code/modules/mob/living/carbon/human/life.dm
@@ -593,7 +593,7 @@
 		if(hallucination_power)
 			handle_hallucinations()
 
-		if(get_shock() >= species.total_health)
+		if(get_shock() >= species.total_health * 2)
 			if(!stat)
 				to_chat(src, "<span class='warning'>[species.halloss_message_self]</span>")
 				src.visible_message("<B>[src]</B> [species.halloss_message]")
@@ -699,20 +699,21 @@
 		return
 
 	if(stat != DEAD)
-		if(stat == UNCONSCIOUS && health < maxHealth/2)
+		if(stat == UNCONSCIOUS && health < maxHealth * 0.25)
 			//Critical damage passage overlay
 			var/severity = 0
-			switch(health - maxHealth/2)
-				if(-20 to -10)       severity = 1
-				if(-30 to -20)       severity = 2
-				if(-40 to -30)       severity = 3
-				if(-50 to -40)       severity = 4
-				if(-60 to -50)       severity = 5
-				if(-70 to -60)       severity = 6
-				if(-80 to -70)       severity = 7
-				if(-90 to -80)       severity = 8
-				if(-95 to -90)       severity = 9
-				if(-INFINITY to -95) severity = 10
+			var/health_deficiency_percent = 100 - (health / maxHealth) * 100
+			switch(health_deficiency_percent)
+				if(75.0 to 77.5)       severity = 1
+				if(77.5 to 80.0)       severity = 2
+				if(80.0 to 82.5)       severity = 3
+				if(82.5 to 85.0)       severity = 4
+				if(85.0 to 87.5)       severity = 5
+				if(87.5 to 90.0)       severity = 6
+				if(90.0 to 92.5)       severity = 7
+				if(92.5 to 95.0)       severity = 8
+				if(95.0 to 97.5)       severity = 9
+				if(97.5 to INFINITY)   severity = 10
 			overlay_fullscreen("crit", /obj/screen/fullscreen/crit, severity)
 		else
 			clear_fullscreen("crit")
@@ -768,7 +769,7 @@
 				var/trauma_val = 0 // Used in calculating softcrit/hardcrit indicators.
 				var/canfeelpain = can_feel_pain()
 				if(canfeelpain)
-					trauma_val = max(shock_stage,get_shock())/(species.total_health-100)
+					trauma_val = max(shock_stage, get_shock()) / species.total_health
 				// Collect and apply the images all at once to avoid appearance churn.
 				var/list/health_images = list()
 				for(var/obj/item/organ/external/E in organs)

--- a/code/modules/mob/living/carbon/human/species/species.dm
+++ b/code/modules/mob/living/carbon/human/species/species.dm
@@ -75,7 +75,7 @@
 	var/additional_langs                      // Any other languages the species always gets.
 
 	// Combat vars.
-	var/total_health = 200                   // Point at which the mob will enter crit.
+	var/total_health = 100                   // Point at which the mob will enter crit.
 	var/list/unarmed_types = list(           // Possible unarmed attacks that the mob will use in combat,
 		/datum/unarmed_attack,
 		/datum/unarmed_attack/bite

--- a/code/modules/mob/living/carbon/human/species/station/monkey.dm
+++ b/code/modules/mob/living/carbon/human/species/station/monkey.dm
@@ -29,7 +29,7 @@
 	meat_type = /obj/item/reagent_containers/food/snacks/meat/monkey
 
 	rarity_value = 0.1
-	total_health = 150
+	total_health = 75
 	brute_mod = 1.5
 	burn_mod = 1.5
 

--- a/code/modules/mob/living/carbon/human/species/station/prometheans.dm
+++ b/code/modules/mob/living/carbon/human/species/station/prometheans.dm
@@ -34,7 +34,7 @@ var/datum/species/shapeshifter/promethean/prometheans
 	brute_mod =           0.5
 	burn_mod =            2
 	oxy_mod =             0
-	total_health =        240
+	total_health =        120
 	siemens_coefficient = -1
 	rarity_value =        5
 	limbs_are_nonsolid =  TRUE

--- a/code/modules/mob/living/carbon/human/species/xenomorphs/alien_species.dm
+++ b/code/modules/mob/living/carbon/human/species/xenomorphs/alien_species.dm
@@ -201,12 +201,12 @@
 	caste_name = "drone"
 	weeds_plasma_rate = 15
 	slowdown = 0
-	total_health = 150
+	total_health = 100
 	tail = "xenos_drone_tail"
 	rarity_value = 5
 	strength = STR_MEDIUM
 	brute_mod = 0.85
-	burn_mod  = 1.75
+	burn_mod  = 1.6
 	generic_attack_mod = 3.5
 
 	icobase = 'icons/mob/human_races/xenos/r_xenos_drone.dmi'
@@ -259,11 +259,11 @@
 	weeds_plasma_rate = 5
 	caste_name = "hunter"
 	slowdown = -0.5
-	total_health = 200
+	total_health = 125
 	tail = "xenos_hunter_tail"
 	strength = STR_HIGH
 	brute_mod = 0.75
-	burn_mod  = 1.65
+	burn_mod  = 1.5
 	generic_attack_mod = 4.5
 
 	icobase = 'icons/mob/human_races/xenos/r_xenos_hunter.dmi'
@@ -304,12 +304,12 @@
 	weeds_plasma_rate = 10
 	caste_name = "sentinel"
 	slowdown = 0
-	total_health = 200
+	total_health = 150
 	weeds_heal_rate = 15
 	tail = "xenos_sentinel_tail"
 	strength = STR_VHIGH
 	brute_mod = 0.65
-	burn_mod  = 1.55
+	burn_mod  = 1.4
 
 	icobase = 'icons/mob/human_races/xenos/r_xenos_sentinel.dmi'
 	deform =  'icons/mob/human_races/xenos/r_xenos_sentinel.dmi'
@@ -341,7 +341,7 @@
 	name = SPECIES_XENO_SENTINEL_PRIMAL
 	caste_name = "primal sentinel"
 	weeds_heal_rate = 20
-	burn_mod  = 1.4
+	burn_mod  = 1.3
 	icobase = 'icons/mob/human_races/xenos/r_xenos_sentinel_primal.dmi'
 	deform =  'icons/mob/human_races/xenos/r_xenos_sentinel_primal.dmi'
 	tail = "xenos_sentinel_primal_tail"
@@ -349,7 +349,7 @@
 /datum/species/xenos/queen
 
 	name = SPECIES_XENO_QUEEN
-	total_health = 250
+	total_health = 200
 	weeds_heal_rate = 20
 	weeds_plasma_rate = 20
 	caste_name = "queen"
@@ -358,7 +358,7 @@
 	rarity_value = 10
 	strength = STR_VHIGH
 	brute_mod = 0.5
-	burn_mod  = 1.25
+	burn_mod  = 1.2
 	icon_scale = 1.3
 	generic_attack_mod = 4.5
 

--- a/code/modules/mob/living/carbon/xenobiological/powers.dm
+++ b/code/modules/mob/living/carbon/xenobiological/powers.dm
@@ -30,7 +30,7 @@
 		if(H.species.species_flags & (SPECIES_FLAG_NO_POISON|SPECIES_FLAG_NO_SCAN))
 			//they can't take clone or tox damage, then for the most part they aren't affected by being fed on - and presumably feeding on them would not affect the metroid either
 			return "This subject does not have an edible life energy..."
-	if (istype(M, /mob/living/carbon) && M.getCloneLoss() >= M.maxHealth * 1.5 || istype(M, /mob/living/simple_animal) && M.stat == DEAD)
+	if (istype(M, /mob/living/carbon) && M.getCloneLoss() >= M.maxHealth * 3 || istype(M, /mob/living/simple_animal) && M.stat == DEAD)
 		return "This subject does not have an edible life energy..."
 	for(var/mob/living/carbon/metroid/met in view())
 		if(met.Victim == M && met != src)

--- a/code/modules/organs/blood.dm
+++ b/code/modules/organs/blood.dm
@@ -310,7 +310,7 @@
 	if(!blood_carries_oxygen())
 		blood_volume = 100
 
-	var/blood_volume_mod = max(0, 1 - getOxyLoss()/(maxHealth/2))
+	var/blood_volume_mod = max(0, 1 - getOxyLoss() / maxHealth)
 	var/oxygenated_mult = 0
 	if(chem_effects[CE_OXYGENATED] == 1) // Dexalin.
 		oxygenated_mult = 0.5

--- a/code/modules/organs/external/xenos.dm
+++ b/code/modules/organs/external/xenos.dm
@@ -58,6 +58,7 @@
 	parent_organ = BP_CHEST
 	icon_state = "xgibmid2"
 	organ_tag = BP_HIVE
+	relative_size = 15
 
 /obj/item/organ/internal/xenos/resinspinner
 	name = "resin spinner"
@@ -65,6 +66,7 @@
 	icon_state = "xgibmid2"
 	organ_tag = BP_RESIN
 	associated_power = /mob/living/carbon/human/proc/resin
+	relative_size = 20
 
 /obj/item/organ/internal/xenos/ganglion
 	name = "spinal ganglion"
@@ -73,13 +75,14 @@
 	parent_organ = BP_CHEST
 	icon_state = "weed_extract" // For now it looks... acceptable
 	organ_tag = BP_GANGLION
-	vital = 1
+	vital = TRUE
+	relative_size = 30
 
 /obj/item/organ/internal/xenos/ganglion/New(mob/living/carbon/holder)
 	..()
 	max_damage = 100
 	if(species)
-		max_damage = species.total_health*1.5
+		max_damage = species.total_health
 	min_bruised_damage = max_damage*0.25
 	min_broken_damage = max_damage*0.75
 
@@ -129,7 +132,7 @@
 	dislocated = -1
 	arterial_bleed_severity = 0
 	limb_flags = ORGAN_FLAG_HEALS_OVERKILL
-	max_damage = 175
+	max_damage = 150
 
 /obj/item/organ/external/groin/xeno
 	dislocated = -1

--- a/code/modules/organs/external/xenos.dm
+++ b/code/modules/organs/external/xenos.dm
@@ -121,7 +121,7 @@
 	dislocated = -1
 	arterial_bleed_severity = 0
 	limb_flags = ORGAN_FLAG_HEALS_OVERKILL
-	max_damage = 100
+	max_damage = 125
 	skull_path = null // The head itself is a skull. Exoskeleton, eh?
 
 /obj/item/organ/external/head/xeno/disfigure(type)

--- a/code/modules/organs/internal/brain.dm
+++ b/code/modules/organs/internal/brain.dm
@@ -50,7 +50,7 @@
 	..()
 	max_damage = 100
 	if(species)
-		max_damage = species.total_health/2
+		max_damage = species.total_health
 	min_bruised_damage = max_damage*0.25
 	min_broken_damage = max_damage*0.75
 

--- a/code/modules/organs/internal/lungs.dm
+++ b/code/modules/organs/internal/lungs.dm
@@ -29,12 +29,12 @@
 
 /obj/item/organ/internal/lungs/proc/remove_oxygen_deprivation(amount)
 	var/last_suffocation = oxygen_deprivation
-	oxygen_deprivation = min(species.total_health,max(0,oxygen_deprivation - amount))
+	oxygen_deprivation = clamp(oxygen_deprivation - amount, 0, species.total_health)
 	return -(oxygen_deprivation - last_suffocation)
 
 /obj/item/organ/internal/lungs/proc/add_oxygen_deprivation(amount)
 	var/last_suffocation = oxygen_deprivation
-	oxygen_deprivation = min(species.total_health,max(0,oxygen_deprivation + amount))
+	oxygen_deprivation = clamp(oxygen_deprivation + amount, 0, species.total_health)
 	return (oxygen_deprivation - last_suffocation)
 
 // Returns a percentage value for use by GetOxyloss().


### PR DESCRIPTION
Очередной выпуск вашего любимого аниме.

- Порезал всем расам total_health вдвое. Ибо в нашем цирке практически везде, где оно использовалось, оно делилось на два (хп мозга = тотал_хелс/2 и т.д.). Подкорректировал и порефакторил расчёты везде, где использовалось.
- Изменена система оверкилл-урона по органам.
-- Раньше: если урон на части тела превышает максимальный на 150%, то шанс и урон по органам увеличивались в 3 раза.
-- Теперь: если урон на части тела превышает максимальный, то шанс и урон увеличиваются в 2 раза. Чем больше превышение - тем выше множитель (150% - х3, 200% - х4 и т.д.).
- Слегка уменьшен максимальный урон туловища и увеличен максимальный урон у головы ксеноморфов.
- Немного увеличено ХП мозга у ксеноморфов.
- Немного снижен модификатор бёрн-урона у ксеноморфов.
- Значительно снижено ХП ганглия у ксеноморфов; также у него увеличен размер и, как следствие, шанс на получение урона.

Как результат, все гуманоиды теперь будут быстрее ловить урон по органам, если на части тела высокий урон.
Ксеноморфы теперь менее рандомны. ХП головы с мозгом и резист к лазерам увеличены, но это компенсируется новой системой оверкилл-урона. Выстрелы в грудь теперь куда более летальны для них, чем раньше и неизбежно приведут к смерти. При этом пара-тройка случайных попаданий всё так же не представляет для них практически никакой угрозы, как и раньше. Количество переживающих 500 урона хантеров снижено.

```yml
🆑
tweak: Немного доработана система получения органами урона от выстрелов. Теперь при превышении максимального урона у части тела урон и шанс нанесения урона не домножаются на фиксированное значение, а продолжают расти в зависимости от превышения. 
tweak: Изменены характеристики ксеноморфов. Максимальный урон у ганглия значительно снижен, а размер - увеличен, максимальный урон у груди понижен; как следствие - выстрелы по груди теперь гораздо более опасны. Максимальный урон головы с мозгом и устойчивость к лазерам слегка повышены чтобы скомпенсировать пункт выше.
/🆑
```

- [x] Pull Request полностью завершен, мне не нужна помощь чтобы его закончить.
- [x] Я внимательно прочитал все свои изменения и багов в них не нашел.
- [x] Я запускал сервер со своими изменениями локально и все протестировал.
- [x] Я ознакомился c [Guide to Contribute](https://github.com/ChaoticOnyx/OnyxBay/blob/dev/docs/contributing.md).
