### PR TITLE
tweak(last words): fix name and restrict to humans and silicons

### DIFF
--- a/code/datums/elements/last_words.dm
+++ b/code/datums/elements/last_words.dm
@@ -36,7 +36,7 @@ GLOBAL_LIST_EMPTY(last_words)
 
 			data.words = L.logging[INDIVIDUAL_SAY_LOG][entry]
 			data.time_of_death = L.timeofdeath
-			data.real_name = L.real_name
+			data.real_name = L.real_name || L.name
 			data.job_title = L.job || "Unemployed"
 
 			GLOB.last_words += data

--- a/code/modules/mob/living/carbon/human/life.dm
+++ b/code/modules/mob/living/carbon/human/life.dm
@@ -43,6 +43,11 @@
 	var/blocking_hand = 0 //0 for main hand, 1 for offhand
 	var/last_block = 0
 
+/mob/living/carbon/human/Initialize()
+	. = ..()
+	
+	AddElement(/datum/element/last_words)
+
 /mob/living/carbon/human/Life()
 	set invisibility = 0
 	set background = BACKGROUND_ENABLED

--- a/code/modules/mob/living/living.dm
+++ b/code/modules/mob/living/living.dm
@@ -1,6 +1,4 @@
 /mob/living/Initialize()
-	AddElement(/datum/element/last_words)
-
 	. = ..()
 	if(stat == DEAD)
 		add_to_dead_mob_list()

--- a/code/modules/mob/living/silicon/silicon.dm
+++ b/code/modules/mob/living/silicon/silicon.dm
@@ -47,6 +47,8 @@
 	init_subsystems()
 	avaliable_huds = list("Disable", "Security", "Medical")		//("Security", "Medical", "Meson", "Science", "Night Vision", "Material", "Thermal", "X-Ray", "Flash Screen", "Disable")
 
+	AddElement(/datum/element/last_words)
+
 /mob/living/silicon/Destroy()
 	GLOB.silicon_mob_list -= src
 	QDEL_NULL(silicon_radio)


### PR DESCRIPTION
Исправил отображение имён и ограничил функционал только на /mob/living/carbon/human/ и /mob/living/silicon/

- [x] Pull Request полностью завершен, мне не нужна помощь чтобы его закончить.
- [x] Я внимательно прочитал все свои изменения и багов в них не нашел.
- [x] Я запускал сервер со своими изменениями локально и все протестировал.
- [x] Я ознакомился c [Guide to Contribute](https://github.com/ChaoticOnyx/OnyxBay/blob/dev/docs/contributing.md).
