### PR TITLE
Removes bad qdels, forceMoving qdel'd atoms out of nullspace and stuff

### DIFF
--- a/code/_helpers/global_lists.dm
+++ b/code/_helpers/global_lists.dm
@@ -228,10 +228,9 @@ var/global/list/string_slot_flags = list(
 	//Manuals
 	paths = typesof(/obj/item/book/wiki) - /obj/item/book/wiki - /obj/item/book/wiki/template
 	for(var/booktype in paths)
-		var/obj/item/book/wiki/manual = new booktype
+		var/obj/item/book/wiki/manual = new booktype(null, null, null, null, TRUE)
 		if(manual.topic)
 			GLOB.premade_manuals[manual.topic] = booktype
-		qdel(manual)
 
 	paths = typesof(/datum/body_build)
 	for(var/T in paths)

--- a/code/controllers/subsystems/garbage.dm
+++ b/code/controllers/subsystems/garbage.dm
@@ -1,3 +1,14 @@
+//Check if an /atom/movable that has been Destroyed has been correctly placed into nullspace and if not, throws a runtime and moves it to nullspace
+#define GC_CHECK_AM_NULLSPACE(D, hint) \
+	if(istype(D, /atom/movable)) {\
+		var/atom/movable/AM = D; \
+		if(AM.loc != null) {\
+			crash_with("QDEL("+hint+"): "+AM.name+" was supposed to be in nullspace but isn't \
+						(LOCATION= "+AM.loc.name+" ("+AM.loc.x+","+AM.loc.y+","+AM.loc.z+") )! Destroy didn't do its job!"); \
+			AM.forceMove(null); \
+		} \
+	}
+
 SUBSYSTEM_DEF(garbage)
 	name = "Garbage"
 	priority = SS_PRIORITY_GARBAGE
@@ -323,6 +334,7 @@ SUBSYSTEM_DEF(garbage)
 			return
 		switch(hint)
 			if (QDEL_HINT_QUEUE)		//qdel should queue the object for deletion.
+				GC_CHECK_AM_NULLSPACE(D, "QDEL_HINT_QUEUE")
 				SSgarbage.PreQueue(D)
 			if (QDEL_HINT_IWILLGC)
 				D.gc_destroyed = world.time
@@ -345,6 +357,7 @@ SUBSYSTEM_DEF(garbage)
 
 				SSgarbage.PreQueue(D)
 			if (QDEL_HINT_HARDDEL)		//qdel should assume this object won't gc, and queue a hard delete using a hard reference to save time from the locate()
+				GC_CHECK_AM_NULLSPACE(D, "QDEL_HINT_HARDDEL")
 				SSgarbage.HardQueue(D)
 			if (QDEL_HINT_HARDDEL_NOW)	//qdel should assume this object won't gc, and hard del it post haste.
 				SSgarbage.HardDelete(D)

--- a/code/datums/components/sentry.dm
+++ b/code/datums/components/sentry.dm
@@ -61,7 +61,7 @@
 			else
 				_register_not_visible_turf(T)
 				turfs_not_in_view_range += T
-		
+
 		if(A in cached_view)
 			view += A
 
@@ -69,21 +69,28 @@
 	register_signal(T, SIGNAL_ENTERED, .proc/_on_turf_entered)
 	register_signal(T, SIGNAL_EXITED, .proc/_on_turf_exited)
 	register_signal(T, SIGNAL_TURF_CHANGED, .proc/_turf_changed)
+	register_signal(T, SIGNAL_OPACITY_SET, .proc/_turf_opacity_set)
 
 /datum/component/sentry_view/proc/_register_not_visible_turf(turf/T)
 	register_signal(T, SIGNAL_TURF_CHANGED, .proc/_turf_changed)
+	register_signal(T, SIGNAL_OPACITY_SET, .proc/_turf_opacity_set)
 
 /datum/component/sentry_view/proc/_unregister_visible_turf(turf/T)
 	unregister_signal(T, SIGNAL_ENTERED)
 	unregister_signal(T, SIGNAL_EXITED)
 	unregister_signal(T, SIGNAL_TURF_CHANGED)
+	unregister_signal(T, SIGNAL_OPACITY_SET)
 
 /datum/component/sentry_view/proc/_unregister_not_visible_turf(turf/T)
 	unregister_signal(T, SIGNAL_TURF_CHANGED)
+	unregister_signal(T, SIGNAL_OPACITY_SET)
 
 /datum/component/sentry_view/proc/_turf_changed(turf/T, old_density, density, old_opacity, opacity)
 	if(old_opacity != opacity)
 		_recalculate_turfs()
+
+/datum/component/sentry_view/proc/_turf_opacity_set()
+	_recalculate_turfs()
 
 /datum/component/sentry_view/proc/_on_turf_entered(turf/new_turf, atom/enterer, turf/old_turf)
 	if(!(old_turf in turfs_in_view_range))

--- a/code/game/atoms_movable.dm
+++ b/code/game/atoms_movable.dm
@@ -19,6 +19,11 @@
 	var/pull_sound = null
 
 /atom/movable/Destroy()
+	if(!(atom_flags & ATOM_FLAG_INITIALIZED))
+		crash_with("Was deleted before initalization")
+
+	walk(src, 0) // Because we might have called walk_to, we must stop the walk loop or BYOND keeps an internal reference to us forever.
+
 	for(var/A in src)
 		qdel(A)
 
@@ -60,6 +65,8 @@
 	return
 
 /atom/movable/proc/forceMove(atom/destination)
+	if((gc_destroyed && gc_destroyed != GC_CURRENTLY_BEING_QDELETED) && !isnull(destination))
+		CRASH("Attempted to forceMove a QDELETED [src] out of nullspace!")
 	if(loc == destination)
 		return 0
 	var/is_origin_turf = isturf(loc)

--- a/code/game/objects/effects/chem/chemsmoke.dm
+++ b/code/game/objects/effects/chem/chemsmoke.dm
@@ -34,7 +34,6 @@
 		walk_to(src, destination)
 
 /obj/effect/effect/smoke/chem/Destroy()
-	walk(src, 0) // Because we might have called walk_to, we must stop the walk loop or BYOND keeps an internal reference to us forever.
 	set_opacity(0)
 	// TODO - fadeOut() sleeps.  Sleeping in /Destroy is Bad, this needs to be fixed.
 	fadeOut()

--- a/code/game/objects/effects/spiders.dm
+++ b/code/game/objects/effects/spiders.dm
@@ -153,7 +153,6 @@
 	if(dormant)
 		unregister_signal(src, SIGNAL_MOVED)
 	STOP_PROCESSING(SSobj, src)
-	walk(src, 0) // Because we might have called walk_to, we must stop the walk loop or BYOND keeps an internal reference to us forever.
 	. = ..()
 
 /obj/effect/spider/spiderling/attackby(obj/item/W, mob/user)

--- a/code/game/objects/items/grenades/flashbang.dm
+++ b/code/game/objects/items/grenades/flashbang.dm
@@ -91,10 +91,6 @@
 			to_chat(M, SPAN("danger", "Your ears start to ring!"))
 	M.update_icons()
 
-/obj/item/grenade/flashbang/Destroy()
-	walk(src, 0) // Because we might have called walk_away, we must stop the walk loop or BYOND keeps an internal reference to us forever.
-	return ..()
-
 /obj/item/grenade/flashbang/instant/Initialize()
 	. = ..()
 	name = "arcane energy"

--- a/code/game/turfs/simulated.dm
+++ b/code/game/turfs/simulated.dm
@@ -18,7 +18,7 @@
 /turf/simulated/post_change()
 	..()
 	var/turf/T = GetAbove(src)
-	if(istype(T,/turf/space) || (density && istype(T,/turf/simulated/open)))
+	if(istype(T,/turf/space) || (density && istype(T, /turf/simulated/open)))
 		var/new_turf_type = density ? (istype(T.loc, /area/space) ? /turf/simulated/floor/plating/airless : /turf/simulated/floor/plating) : /turf/simulated/open
 		T.ChangeTurf(new_turf_type)
 
@@ -55,10 +55,6 @@
 	if(istype(loc, /area/chapel))
 		holy = TRUE
 	levelupdate()
-
-/turf/simulated/Destroy()
-	deltimer(timer_id)
-	return ..()
 
 /turf/simulated/proc/AddTracks(typepath,bloodDNA,comingdir,goingdir,bloodcolor=COLOR_BLOOD_HUMAN)
 	var/obj/effect/decal/cleanable/blood/tracks/tracks = locate(typepath) in src

--- a/code/game/turfs/simulated/walls.dm
+++ b/code/game/turfs/simulated/walls.dm
@@ -39,12 +39,6 @@
 	update_material()
 	hitsound = material.hitsound
 
-/turf/simulated/wall/Destroy()
-	dismantle_wall(null,null,1)
-	
-	// At this point `src` is a new instance, the old one was destroyed in `dismantle_wall`.
-	return QDEL_HINT_LETMELIVE
-
 // Walls always hide the stuff below them.
 /turf/simulated/wall/levelupdate()
 	for(var/obj/O in src)

--- a/code/game/turfs/turf.dm
+++ b/code/game/turfs/turf.dm
@@ -31,6 +31,8 @@
 
 	var/movement_delay
 
+	var/changing_turf
+
 /turf/Initialize(mapload, ...)
 	. = ..()
 	if(dynamic_lighting)
@@ -41,6 +43,10 @@
 	RecalculateOpacity()
 
 /turf/Destroy()
+	if(!changing_turf)
+		crash_with("Improper turf qdel. Do not qdel turfs directly.")
+
+	changing_turf = FALSE
 	remove_cleanables()
 	..()
 	return QDEL_HINT_IWILLGC

--- a/code/game/turfs/turf_changing.dm
+++ b/code/game/turfs/turf_changing.dm
@@ -1,7 +1,9 @@
 /turf/proc/ReplaceWithLattice()
-	src.ChangeTurf(get_base_turf_by_area(src))
-	spawn()
-		new /obj/structure/lattice( locate(src.x, src.y, src.z) )
+	var base_turf = get_base_turf_by_area(src)
+	if(type != base_turf)
+		ChangeTurf(get_base_turf_by_area(src))
+	if(!locate(/obj/structure/lattice) in src)
+		new /obj/structure/lattice(src)
 
 // Removes all signs of lattice on the pos of the turf -Donkieyo
 /turf/proc/RemoveLattice()
@@ -35,6 +37,7 @@
 
 //	log_debug("Replacing [src.type] with [N]")
 
+	changing_turf = TRUE
 
 	if(connections) connections.erase_all()
 
@@ -54,11 +57,18 @@
 		A.forceMove(null)
 
 	var/old_opaque_counter = opaque_counter
-	var/old_lookups = comp_lookup.Copy()
-	var/old_components = datum_components.Copy()
-	var/old_signals = signal_procs.Copy()
 
-	var/turf/simulated/W = new N( locate(src.x, src.y, src.z) )
+	var/old_lookups = comp_lookup?.Copy()
+	var/old_components = datum_components?.Copy()
+	var/old_signals = signal_procs?.Copy()
+	comp_lookup?.Cut()
+	datum_components?.Cut()
+	signal_procs?.Cut()
+
+	// Run the Destroy() chain.
+	qdel(src)
+
+	var/turf/simulated/W = new N(src)
 
 	comp_lookup = old_lookups
 	datum_components = old_components
@@ -103,6 +113,9 @@
 				lighting_build_overlay()
 			else
 				lighting_clear_overlay()
+
+	for(var/turf/T in RANGE_TURFS(1, src))
+		T.update_icon()
 
 	SEND_SIGNAL(src, SIGNAL_TURF_CHANGED, src, old_density, density, old_opacity, opacity)
 

--- a/code/modules/admin/verbs/SDQL_2/SDQL_2.dm
+++ b/code/modules/admin/verbs/SDQL_2/SDQL_2.dm
@@ -91,7 +91,11 @@
 
 				if("delete")
 					for(var/datum/d in objs)
-						qdel(d)
+						if(isturf(d))
+							var/turf/T = d
+							T.ChangeTurf(world.turf)
+						else
+							qdel(d)
 						CHECK_TICK
 
 				if("select")

--- a/code/modules/admin/verbs/randomverbs.dm
+++ b/code/modules/admin/verbs/randomverbs.dm
@@ -579,7 +579,11 @@ Ccomp's first proc.
 		log_admin("[key_name(usr)] deleted [O] at ([O.x],[O.y],[O.z])")
 		message_admins("[key_name_admin(usr)] deleted [O] at ([O.x],[O.y],[O.z])", 1)
 		feedback_add_details("admin_verb","DEL") //If you are copy-pasting this, ensure the 2nd parameter is unique to the new proc!
-		qdel(O)
+		if(isturf(O))
+			var/turf/T = O
+			T.ChangeTurf(world.turf)
+		else
+			qdel(O)
 
 /client/proc/cmd_admin_list_open_jobs()
 	set category = "Admin"

--- a/code/modules/library/lib_items.dm
+++ b/code/modules/library/lib_items.dm
@@ -299,7 +299,7 @@
 	var/style = WIKI_MINI
 	var/censored = 1
 
-/obj/item/book/wiki/Initialize(mapload, ntopic, ncensored, nstyle)
+/obj/item/book/wiki/Initialize(mapload, ntopic, ncensored, nstyle, temporary = FALSE)
 	if(ntopic)
 		topic = ntopic
 	if(!isnull(ncensored))
@@ -311,6 +311,9 @@
 	if(title)
 		SetName(title)
 	dat = wiki_request(topic, style, censored, src)
+	if(temporary) // I hate myself for doing this
+		atom_flags |= ATOM_FLAG_INITIALIZED
+		return INITIALIZE_HINT_QDEL
 	. = ..(mapload)
 
 /obj/item/book/wiki/Topic(href, href_list[])

--- a/code/modules/lighting/lighting_overlay.dm
+++ b/code/modules/lighting/lighting_overlay.dm
@@ -135,6 +135,8 @@
 	. = ..()
 
 /atom/movable/lighting_overlay/forceMove()
+	if(QDELING(src))
+		return ..()
 	return 0 //should never move
 
 /atom/movable/lighting_overlay/Move()

--- a/code/modules/paperwork/clipboard.dm
+++ b/code/modules/paperwork/clipboard.dm
@@ -12,7 +12,8 @@
 	slot_flags = SLOT_BELT
 	matter = list(MATERIAL_STEEL = 70)
 
-/obj/item/clipboard/New()
+/obj/item/clipboard/Initialize()
+	. = ..()
 	update_icon()
 
 /obj/item/clipboard/MouseDrop(obj/over_object as obj) //Quick clipboard fix. -Agouri

--- a/code/modules/reagents/reagent_containers/glass/bottle.dm
+++ b/code/modules/reagents/reagent_containers/glass/bottle.dm
@@ -22,6 +22,7 @@
 	var/default_name = "bottle"
 	var/default_desc = "A regular glass bottle."
 	var/starting_label = null
+	var/has_label = FALSE
 
 /obj/item/reagent_containers/glass/bottle/small
 	name = "small bottle"
@@ -84,10 +85,12 @@
 	update_icon()
 
 /obj/item/reagent_containers/glass/bottle/post_attach_label()
+	has_label = TRUE
 	update_icon()
 
 /obj/item/reagent_containers/glass/bottle/post_remove_label()
 	..()
+	has_label = FALSE
 	desc = default_desc
 	update_icon()
 
@@ -112,7 +115,7 @@
 
 	overlays += image(icon, src, "over_[icon_state]")
 
-	if(length(get_components(/datum/component/label)))
+	if(has_label)
 		overlays += image(icon, src, "label_[icon_state]")
 
 	if(!is_open_container())

--- a/code/modules/shield_generators/shield.dm
+++ b/code/modules/shield_generators/shield.dm
@@ -43,8 +43,8 @@
 
 // Prevents shuttles, singularities and pretty much everything else from moving the field segments away.
 // The only thing that is allowed to move us is the Destroy() proc.
-/obj/effect/shield/forceMove(newloc, qdeled = 0)
-	if(qdeled)
+/obj/effect/shield/forceMove()
+	if(QDELING(src))
 		return ..()
 	return 0
 


### PR DESCRIPTION
- ФорсМув больше не может вытягивать удалённые атомы из нуллспейса. Возможно, исправляет появление "призрачных" мобов на лестницах. 
- Исправлены проблемы с удалением турфов. Никогда, **никогда** не пытайтесь напрямую куделить турфы. **Никогда**.
![image](https://user-images.githubusercontent.com/45202681/162813470-7778166d-db19-4cde-8411-949239e5742a.png)
- Чутка больше надёжности для GC.
- Исправлено обновление иконок у бутылок.
- Турели теперь обновляют обзор не только при обновлении турфов в зоне действия, но и при обновлении opacity у чего-либо внутри. Самое заметное - открытие дверей.

```yml
🆑
bugfix: Исправлены некоторые ошибки с удалением и обновлением тайлов.
bugfix: Возможно, исправлено появление "фантомных" мобов на лестницах.
bugfix: Немного доработано поведение турелей. Самое заметное - теперь они могут видеть цели через открытые двери.
/🆑
```

- [x] Pull Request полностью завершен, мне не нужна помощь чтобы его закончить.
- [x] Я внимательно прочитал все свои изменения и багов в них не нашел.
- [x] Я запускал сервер со своими изменениями локально и все протестировал.
- [x] Я ознакомился c [Guide to Contribute](https://github.com/ChaoticOnyx/OnyxBay/blob/dev/docs/contributing.md).
