### PR TITLE
Removes nudes from ID cards and Crew Records

### DIFF
--- a/code/game/objects/items/weapons/cards_ids.dm
+++ b/code/game/objects/items/weapons/cards_ids.dm
@@ -193,7 +193,8 @@ var/const/NO_EMAG_ACT = -50
 	id_card.age = 0
 	id_card.registered_name		= real_name
 	id_card.sex 				= capitalize(gender)
-	id_card.set_id_photo(src)
+	spawn(1 SECOND)
+		id_card.set_id_photo(src)
 
 	if(dna)
 		id_card.blood_type		= dna.b_type

--- a/code/modules/modular_computers/file_system/crew_record.dm
+++ b/code/modules/modular_computers/file_system/crew_record.dm
@@ -71,15 +71,6 @@ GLOBAL_LIST_INIT(department_flags_to_text, list(
 	GLOB.all_crew_records.Remove(src)
 
 /datum/computer_file/crew_record/proc/load_from_mob(mob/living/carbon/human/H, automatic = FALSE)
-	if(istype(H))
-		photo_front = getFlatIcon(H, SOUTH, always_use_defdir = 1)
-		photo_side = getFlatIcon(H, WEST, always_use_defdir = 1)
-	else
-		var/mob/living/carbon/human/dummy = new()
-		photo_front = getFlatIcon(dummy, SOUTH, always_use_defdir = 1)
-		photo_side = getFlatIcon(dummy, WEST, always_use_defdir = 1)
-		qdel(dummy)
-
 	// Generic record
 	set_name(H ? H.real_name : "Unset")
 	set_job(H ? GetAssignment(H) : "Unset")
@@ -135,6 +126,14 @@ GLOBAL_LIST_INIT(department_flags_to_text, list(
 	// Antag record
 	set_antagRecord((H && H.exploit_record && !jobban_isbanned(H, "Records") ? H.exploit_record : ""))
 
+/datum/computer_file/crew_record/proc/take_mob_photo(mob/living/carbon/human/H)
+	if(istype(H))
+		photo_front = getFlatIcon(H, SOUTH, always_use_defdir = 1)
+		photo_side = getFlatIcon(H, WEST, always_use_defdir = 1)
+	else
+		photo_front = icon('icons/mob/human_races/r_human.dmi', "preview_m", SOUTH)
+		photo_side = icon('icons/mob/human_races/r_human.dmi', "preview_m", WEST)
+
 // Returns independent copy of this file.
 /datum/computer_file/crew_record/clone(rename = 0)
 	var/datum/computer_file/crew_record/temp = ..()
@@ -157,6 +156,8 @@ GLOBAL_LIST_INIT(department_flags_to_text, list(
 	var/datum/computer_file/crew_record/CR = new /datum/computer_file/crew_record()
 	GLOB.all_crew_records.Add(CR)
 	CR.load_from_mob(H, TRUE)
+	spawn(1 SECOND)
+		CR.take_mob_photo(H)
 	return CR
 
 // Gets crew records filtered by set of positions


### PR DESCRIPTION
```yml
🆑
bugfix: Космонавты на фотографиях с ID-карточек и Crew Records больше не голые. Нюдесы от трапов придётся получать другими путями.
/🆑
```

- [x] Pull Request полностью завершен, мне не нужна помощь чтобы его закончить.
- [x] Я внимательно прочитал все свои изменения и багов в них не нашел.
- [x] Я запускал сервер со своими изменениями локально и все протестировал.
- [x] Я ознакомился c [Guide to Contribute](https://github.com/ChaoticOnyx/OnyxBay/blob/dev/docs/contributing.md).
