### PR TITLE
Removes lack of tiny fixes

### DIFF
--- a/code/controllers/subsystems/garbage.dm
+++ b/code/controllers/subsystems/garbage.dm
@@ -17,7 +17,7 @@ SUBSYSTEM_DEF(garbage)
 	runlevels = RUNLEVELS_DEFAULT | RUNLEVEL_LOBBY
 	init_order = SS_INIT_GARBAGE
 
-	var/list/collection_timeout = list(0, 2 MINUTES, 10 SECONDS)	// deciseconds to wait before moving something up in the queue to the next level
+	var/list/collection_timeout = list(0, 30 SECONDS, 10 SECONDS)	// deciseconds to wait before moving something up in the queue to the next level
 
 	//Stat tracking
 	var/delslasttick = 0            // number of del()'s we've done this tick

--- a/code/game/objects/items/weapons/cards_ids.dm
+++ b/code/game/objects/items/weapons/cards_ids.dm
@@ -193,7 +193,7 @@ var/const/NO_EMAG_ACT = -50
 	id_card.age = 0
 	id_card.registered_name		= real_name
 	id_card.sex 				= capitalize(gender)
-	spawn(1 SECOND)
+	spawn(2 SECONDS)
 		id_card.set_id_photo(src)
 
 	if(dna)

--- a/code/modules/lighting/lighting_overlay.dm
+++ b/code/modules/lighting/lighting_overlay.dm
@@ -130,8 +130,6 @@
 	if(istype(T))
 		T.lighting_overlay = null
 
-	loc = null
-
 	. = ..()
 
 /atom/movable/lighting_overlay/forceMove()

--- a/code/modules/modular_computers/file_system/crew_record.dm
+++ b/code/modules/modular_computers/file_system/crew_record.dm
@@ -156,7 +156,7 @@ GLOBAL_LIST_INIT(department_flags_to_text, list(
 	var/datum/computer_file/crew_record/CR = new /datum/computer_file/crew_record()
 	GLOB.all_crew_records.Add(CR)
 	CR.load_from_mob(H, TRUE)
-	spawn(1 SECOND)
+	spawn(2 SECONDS)
 		CR.take_mob_photo(H)
 	return CR
 


### PR DESCRIPTION
!!! НЕ СКВОШИТЬ !!!

- Увеличена задержка перед генерацией фотографий на карточках и в рекордсах. Теперь ещё меньше шансов, что оно обосрётся при большом онлайне.
- Таймаут проверо4ек у GC уменьшен с 2 минут до 30 секунд. Если всё плохо и нужно хардделить - лишние полторы минуты уже никак не помогут, а очередь иногда получается километровая. Хуже не будет, короче.
- Ревертнут костыль с удалением оверлеев света двухлетней давности. Сейчас в нём смысл уже пропал, только к такому время от времени приводит:
![image](https://user-images.githubusercontent.com/45202681/163265306-861c8716-9ef4-4ec6-ac05-4d2a447d47a2.png)


- [x] Pull Request полностью завершен, мне не нужна помощь чтобы его закончить.
- [x] Я внимательно прочитал все свои изменения и багов в них не нашел.
- [x] Я запускал сервер со своими изменениями локально и все протестировал.
- [x] Я ознакомился c [Guide to Contribute](https://github.com/ChaoticOnyx/OnyxBay/blob/dev/docs/contributing.md).
