### PR TITLE
Examine fixes

### DIFF
--- a/code/_helpers/lists.dm
+++ b/code/_helpers/lists.dm
@@ -10,12 +10,20 @@
  */
 
 //Returns a list in plain english as a string
-/proc/english_list(list/input, nothing_text = "nothing", and_text = " and ", comma_text = ", ", final_comma_text = "" )
+/proc/english_list(list/input, nothing_text = "nothing", and_text = " and ", comma_text = ", ", final_comma_text = "")
 	switch(input.len)
 		if(0) return nothing_text
 		if(1) return "[input[1]]"
 		if(2) return "[input[1]][and_text][input[2]]"
 		else  return "[jointext(input, comma_text, 1, -1)][final_comma_text][and_text][input[input.len]]"
+
+/proc/items_english_list(list/input, nothing_text = "nothing", and_text = " and ", comma_text = ", ", final_comma_text = "")
+	var/out = list()
+
+	for(var/atom/I in input)
+		out += SPAN("info", I.name)
+
+	return english_list(out, nothing_text, and_text, comma_text, final_comma_text)
 
 //Returns list element or null. Should prevent "index out of bounds" error.
 /proc/listgetindex(list/list,index)

--- a/code/game/atoms.dm
+++ b/code/game/atoms.dm
@@ -294,7 +294,7 @@ its easier to just keep the beam vertical.
 
 	var/content = "<div class='Examine'>"
 	
-	content += _examine_text(args)
+	content += _examine_text(arglist(args))
 	content += "</div>"
 
 	return content

--- a/code/game/objects/structures/crates_lockers/closets.dm
+++ b/code/game/objects/structures/crates_lockers/closets.dm
@@ -141,6 +141,12 @@
 		else
 			. += "\nIt is full."
 
+	if(isghost(user) && user.client?.inquisitive_ghost)
+		if(src.opened)
+			return
+		
+		. += "\nIt contains: [items_english_list(contents)]."
+
 /obj/structure/closet/CanPass(atom/movable/mover, turf/target)
 	if(wall_mounted)
 		return TRUE
@@ -514,12 +520,6 @@
 	src.add_fingerprint(user)
 	if(!src.toggle())
 		to_chat(usr, SPAN_NOTICE("It won't budge!"))
-
-/obj/structure/closet/attack_ghost(mob/ghost)
-	if(ghost.client && ghost.client.inquisitive_ghost)
-		ghost.examinate(src)
-		if (!src.opened)
-			to_chat(ghost, "It contains: [english_list(contents)].")
 
 /obj/structure/closet/verb/verb_toggleopen()
 	set src in oview(1)

--- a/code/modules/power/lighting.dm
+++ b/code/modules/power/lighting.dm
@@ -350,13 +350,13 @@
 	var/fitting = get_fitting_name()
 	switch(get_status())
 		if(LIGHT_OK)
-			. += "\n[desc] It is turned [on? "on" : "off"]."
+			. += "\nIt is turned [on? "on" : "off"]."
 		if(LIGHT_EMPTY)
-			. += "\n[desc] The [fitting] has been removed."
+			. += "\nThe [fitting] has been removed."
 		if(LIGHT_BURNED)
-			. += "\n[desc] The [fitting] is burnt out."
+			. += "\nThe [fitting] is burnt out."
 		if(LIGHT_BROKEN)
-			. += "\n[desc] The [fitting] has been smashed."
+			. += "\nThe [fitting] has been smashed."
 
 /obj/machinery/light/proc/get_fitting_name()
 	var/obj/item/light/L = light_type


### PR DESCRIPTION
fix #7997

У гостов нормально отображается содержимое локеров.
У лампочек убрано дублирование описания.

<details>
<summary>Чейнджлог</summary>

```yml
🆑
bugfix: Небольшие исправления `Examine`.
/🆑
```

</details>

- [x] Pull Request полностью завершен, мне не нужна помощь чтобы его закончить.
- [x] Я внимательно прочитал все свои изменения и багов в них не нашел.
- [x] Я запускал сервер со своими изменениями локально и все протестировал.
- [x] Я ознакомился c [Guide to Contribute](https://github.com/ChaoticOnyx/OnyxBay/blob/dev/docs/contributing.md).
