### PR TITLE
Removes absence of combat stats in the Examination tab

### DIFF
--- a/baystation12.dme
+++ b/baystation12.dme
@@ -1652,6 +1652,7 @@
 #include "code\modules\examine\descriptions\atmospherics.dm"
 #include "code\modules\examine\descriptions\drink_containers.dm"
 #include "code\modules\examine\descriptions\engineering.dm"
+#include "code\modules\examine\descriptions\items.dm"
 #include "code\modules\examine\descriptions\machinery.dm"
 #include "code\modules\examine\descriptions\medical.dm"
 #include "code\modules\examine\descriptions\mobs.dm"

--- a/code/modules/examine/descriptions/items.dm
+++ b/code/modules/examine/descriptions/items.dm
@@ -1,0 +1,50 @@
+
+/obj/item/get_description_combat()
+	. = ""
+
+	if(force)
+		. = "Weight: "
+		switch(mod_weight)
+			if(0 to 0.4)
+				. += "Very light"
+			if(0.4 to 0.8)
+				. += "Light"
+			if(0.8 to 1.25)
+				. += "Moderate"
+			if(1.25 to 1.65)
+				. += "Heavy"
+			else
+				. += "Very heavy"
+
+		. += "\nReach: "
+		switch(mod_reach)
+			if(0 to 0.4)
+				. += "Very short"
+			if(0.4 to 0.8)
+				. += "Short"
+			if(0.8 to 1.25)
+				. += "Average"
+			if(1.25 to 1.65)
+				. += "Long"
+			else
+				. += "Very heavy"
+
+		. += "\nConvenience: "
+		switch(mod_handy)
+			if(0 to 0.4)
+				. += "Unhandy"
+			if(0.4 to 0.8)
+				. += "Not that handy"
+			if(0.8 to 1.25)
+				. += "Handy"
+			if(1.25 to 1.65)
+				. += "Really handy"
+			else
+				. += "Outstandingly handy"
+
+		. += "\nAttack Cooldown: [round((attack_cooldown + DEFAULT_WEAPON_COOLDOWN * (mod_weight / mod_handy)) * mod_speed * 0.1, 0.1)]s"
+		. += "\nParry Window: [round(mod_handy * 12 * 0.1, 0.1)]s"
+	if(mod_shield >= 2.0)
+		. += "\nIt may block or reflect projectiles really well."
+	else if(mod_shield >= 1.3)
+		. += "\nIt may block projectiles."

--- a/code/modules/examine/descriptions/items.dm
+++ b/code/modules/examine/descriptions/items.dm
@@ -27,7 +27,7 @@
 			if(1.25 to 1.65)
 				. += "Long"
 			else
-				. += "Very heavy"
+				. += "Very long"
 
 		. += "\nConvenience: "
 		switch(mod_handy)

--- a/code/modules/examine/examine.dm
+++ b/code/modules/examine/examine.dm
@@ -27,6 +27,9 @@
 		return description_antag
 	return
 
+/atom/proc/get_description_combat()
+	return
+
 /mob/living/get_description_fluff()
 	if(flavor_text) //Get flavor text for the green text.
 		return flavor_text
@@ -44,6 +47,7 @@
 	description_holders["info"] = A.get_description_info()
 	description_holders["fluff"] = A.get_description_fluff()
 	description_holders["antag"] = (update_antag_info)? A.get_description_antag() : ""
+	description_holders["combat"] = A.get_description_combat()
 
 	description_holders["name"] = "[A.name]"
 	description_holders["icon"] = "\icon[A]"
@@ -54,6 +58,8 @@
 	if(client && statpanel("Examine"))
 		stat(null,"[client.description_holders["icon"]]    <font size='5'>[client.description_holders["name"]]</font>") //The name, written in big letters.
 		stat(null,"[client.description_holders["desc"]]") //the default examine text.
+		if(client.description_holders["combat"])
+			stat(null,"<b>[client.description_holders["combat"]]</b>") //Colorless, combat stats.
 		if(client.description_holders["info"])
 			stat(null,"<font color='#084b8a'><b>[client.description_holders["info"]]</b></font>") //Blue, informative text.
 		if(client.description_holders["fluff"])

--- a/code/modules/paperwork/pen.dm
+++ b/code/modules/paperwork/pen.dm
@@ -205,7 +205,7 @@
 	mod_weight = 0.5
 	mod_reach = 0.4
 	mod_handy = 1.25
-	force = 25 // Half an esword's force
+	force = 0
 	armor_penetration = 35
 	sharp = TRUE
 	edge = TRUE
@@ -214,6 +214,7 @@
 	hitsound = 'sound/effects/fighting/energy1.ogg'
 	attack_verb = list("attacked", "slashed", "stabbed", "sliced", "torn", "ripped", "diced", "cut")
 	check_armour = "laser"
+	var/active_force = 25.0 // Half an esword's force
 	var/active_max_bright = 0.17
 	var/active_outer_range = 1.65
 	var/brightness_color = "#ff5959"
@@ -243,6 +244,7 @@
 	slot_flags |= SLOT_DENYPOCKET
 	name = "energy dagger"
 	desc = "Bureaucracy has never ever been so deadly."
+	force = active_force
 	throwforce = 45
 	throw_speed = 1
 	icon_state = "edagger1"
@@ -256,6 +258,7 @@
 	slot_flags = initial(slot_flags)
 	name = initial(name)
 	desc = initial(desc)
+	force = initial(force)
 	throwforce = initial(throwforce)
 	throw_speed = initial(throw_speed)
 	icon_state = initial(icon_state)


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/45202681/163761787-f5d701ff-0896-415e-92e8-8bf3b52621b7.png)
 _на скрине кулдаун и окно домножены на десять, не обращайте внимание_

```yml
🆑
rscadd: Во вкладке Examine теперь указываются боевые характеристики предмета (если его вообще можно использовать в качестве оружия) - вес, длина, удобство, кулдаун и окно парирования.
/🆑
```

- [x] Pull Request полностью завершен, мне не нужна помощь чтобы его закончить.
- [x] Я внимательно прочитал все свои изменения и багов в них не нашел.
- [x] Я запускал сервер со своими изменениями локально и все протестировал.
- [x] Я ознакомился c [Guide to Contribute](https://github.com/ChaoticOnyx/OnyxBay/blob/dev/docs/contributing.md).
