### PR TITLE
Арморостореррное

### DIFF
--- a/code/modules/clothing/suits/armor.dm
+++ b/code/modules/clothing/suits/armor.dm
@@ -12,7 +12,9 @@
 		/obj/item/handcuffs,
 		/obj/item/gun/magnetic,
 		/obj/item/grenade,
-		/obj/item/gun/launcher/grenade
+		/obj/item/gun/launcher/grenade,
+		/obj/item/clothing/head/helmet,
+		/obj/item/clothing/mask/gas
 		)
 	body_parts_covered = UPPER_TORSO|LOWER_TORSO
 	item_flags = ITEM_FLAG_THICKMATERIAL


### PR DESCRIPTION
В броники теперь можно класть шлем и противогаз.
<details>
<summary>Чейнджлог</summary>

```yml
🆑KreeperHLC
tweak: В бронежилеты теперь можно класть шлемы и противогазы.
/🆑
```

</details>

- [x] Pull Request полностью завершен, мне не нужна помощь чтобы его закончить.
- [x] Я внимательно прочитал все свои изменения и багов в них не нашел.
- [ ] Я запускал сервер со своими изменениями локально и все протестировал.
- [x] Я ознакомился c [Guide to Contribute](https://github.com/ChaoticOnyx/OnyxBay/blob/dev/docs/contributing.md).
