### PR TITLE
Торгашное

### DIFF
--- a/code/datums/trading/trade.dm
+++ b/code/datums/trading/trade.dm
@@ -95,7 +95,6 @@
 			possible -= subtypesof(type)
 		if(status & TRADER_BLACKLIST_ALL)
 			possible -= typesof(type)
-			possible -= subtypesof(type)
 
 	if(possible.len)
 		var/picked = pick(possible)

--- a/code/datums/trading/trade.dm
+++ b/code/datums/trading/trade.dm
@@ -93,6 +93,9 @@
 			possible -= type
 		if(status & TRADER_BLACKLIST_SUB)
 			possible -= subtypesof(type)
+		if(status & TRADER_BLACKLIST_ALL)
+			possible -= type
+			possible -= subtypesof(type)
 
 	if(possible.len)
 		var/picked = pick(possible)

--- a/code/datums/trading/trade.dm
+++ b/code/datums/trading/trade.dm
@@ -94,7 +94,7 @@
 		if(status & TRADER_BLACKLIST_SUB)
 			possible -= subtypesof(type)
 		if(status & TRADER_BLACKLIST_ALL)
-			possible -= type
+			possible -= typesof(type)
 			possible -= subtypesof(type)
 
 	if(possible.len)


### PR DESCRIPTION
Теперь Торгаши действительно не продают все предметы и их подтипы с этим флагом.
<details>
<summary>Чейнджлог</summary>

```yml
🆑KreeperHLC
bugfix: Торгашам теперь не могут выпасть предметы, которые в коде были отмечены флагом TRADER_BLACKLIST_ALL.
/🆑
```

</details>

- [x] Pull Request полностью завершен, мне не нужна помощь чтобы его закончить.
- [x] Я внимательно прочитал все свои изменения и багов в них не нашел.
- [ ] Я запускал сервер со своими изменениями локально и все протестировал.
- [x] Я ознакомился c [Guide to Contribute](https://github.com/ChaoticOnyx/OnyxBay/blob/dev/docs/contributing.md).
