### PR TITLE
Трейдномулботовое

### DIFF
--- a/code/datums/trading/goods.dm
+++ b/code/datums/trading/goods.dm
@@ -272,11 +272,12 @@ Sells devices, odds and ends, and medical stuff
 	possible_origins = list("AI for the Straight Guy", "Mechanical Buddies", "Bot Chop Shop", "Omni Consumer Projects")
 	possible_trading_items = list(/obj/item/device/bot_kit							= TRADER_THIS_TYPE,
 								/obj/item/device/paicard							= TRADER_THIS_TYPE,
-								/obj/item/aicard								= TRADER_THIS_TYPE,
+								/obj/item/aicard						    		= TRADER_THIS_TYPE,
 								/mob/living/bot										= TRADER_SUBTYPES_ONLY,
+								/mob/living/bot/mulebot                             = TRADER_BLACKLIST,
 								/obj/item/organ/internal/posibrain					= TRADER_THIS_TYPE,
 								/obj/item/robot_parts								= TRADER_SUBTYPES_ONLY,
-								/obj/item/stock_parts/manipulator			= TRADER_THIS_TYPE
+								/obj/item/stock_parts/manipulator			        = TRADER_THIS_TYPE
 								)
 	speech = list("hail_generic" = "Welcome to ORIGIN! Let me walk you through our fine robotic selection!",
 				"hail_silicon"   = "Welcome to ORIGIN! Let- oh, you're a synth! Well, your money is good anyway. Welcome, welcome!",


### PR DESCRIPTION
Мулбота больше нельзя купить.
close #1191
<details>
<summary>Чейнджлог</summary>

```yml
🆑KreeperHLC
bugfix: Мулбота больше нельзя купить у Торговцев.
/🆑
```

</details>

- [x] Pull Request полностью завершен, мне не нужна помощь чтобы его закончить.
- [x] Я внимательно прочитал все свои изменения и багов в них не нашел.
- [ ] Я запускал сервер со своими изменениями локально и все протестировал.
- [x] Я ознакомился c [Guide to Contribute](https://github.com/ChaoticOnyx/OnyxBay/blob/dev/docs/contributing.md).
