### PR TITLE
Фикс колясок

### DIFF
--- a/code/game/objects/structures/stool_bed_chair_nest/wheelchair.dm
+++ b/code/game/objects/structures/stool_bed_chair_nest/wheelchair.dm
@@ -7,7 +7,7 @@
 	movement_handlers = list(
 		/datum/movement_handler/deny_stairs,
 		/datum/movement_handler/deny_multiz,
-		/datum/movement_handler/delay = list(2),
+		/datum/movement_handler/delay = list(4),
 		/datum/movement_handler/move_relay_self
 	)
 	foldable = FALSE


### PR DESCRIPTION
Коляски теперь имеют задержку перед ходом, равную четырём вместо двум, из за чего они теперь являются чем то средним между бегом и ходьбой

resolve #4633 

<details>
<summary>Чейнджлог</summary>

```yml
🆑Donaldo_TH
balance: Коляски теперь имеют скорость среднюю между бегом и ходьбой
/🆑
```

</details>



- [x] Pull Request полностью завершен, мне не нужна помощь чтобы его закончить.
- [x] Я внимательно прочитал все свои изменения и багов в них не нашел.
- [x] Я запускал сервер со своими изменениями локально и все протестировал.
- [x] Я ознакомился c [Guide to Contribute](https://github.com/ChaoticOnyx/OnyxBay/blob/dev/docs/contributing.md).
