### PR TITLE
fix(ntnrc_client): channel deletion fix

### DIFF
--- a/code/modules/modular_computers/NTNet/NTNRC/conversation.dm
+++ b/code/modules/modular_computers/NTNet/NTNRC/conversation.dm
@@ -15,6 +15,10 @@ var/global/ntnrc_uid = 0
 		ntnet_global.chat_channels.Add(src)
 	..()
 
+/datum/Destroy()
+	ntnet_global.chat_channels.Remove(src)
+	..()
+
 /datum/ntnet_conversation/proc/add_message(message, username)
 	message = "[stationtime2text()] [username]: [message]"
 	messages.Add(message)

--- a/code/modules/modular_computers/NTNet/NTNRC/conversation.dm
+++ b/code/modules/modular_computers/NTNet/NTNRC/conversation.dm
@@ -15,9 +15,9 @@ var/global/ntnrc_uid = 0
 		ntnet_global.chat_channels.Add(src)
 	..()
 
-/datum/Destroy()
+/datum/ntnet_conversation/Destroy()
 	ntnet_global.chat_channels.Remove(src)
-	..()
+	return ..()
 
 /datum/ntnet_conversation/proc/add_message(message, username)
 	message = "[stationtime2text()] [username]: [message]"

--- a/code/modules/modular_computers/file_system/programs/generic/ntnrc_client.dm
+++ b/code/modules/modular_computers/file_system/programs/generic/ntnrc_client.dm
@@ -142,7 +142,7 @@
 	if(href_list["PRG_deletechannel"])
 		. = 1
 		if(channel && ((channel.operator == src) || netadmin_mode))
-			del(channel)
+			qdel(channel)
 			channel = null
 	if(href_list["PRG_setpassword"])
 		. = 1

--- a/code/modules/modular_computers/file_system/programs/generic/ntnrc_client.dm
+++ b/code/modules/modular_computers/file_system/programs/generic/ntnrc_client.dm
@@ -142,7 +142,7 @@
 	if(href_list["PRG_deletechannel"])
 		. = 1
 		if(channel && ((channel.operator == src) || netadmin_mode))
-			qdel(channel)
+			del(channel)
 			channel = null
 	if(href_list["PRG_setpassword"])
 		. = 1


### PR DESCRIPTION
close #2208

<summary>Чейнджлог</summary>

```yml
🆑
bugfix: Теперь в чат-клиенте NT можно удалять каналы
/🆑
```

- [x] Pull Request полностью завершен, мне не нужна помощь чтобы его закончить.
- [x] Я внимательно прочитал все свои изменения и багов в них не нашел.
- [x] Я запускал сервер со своими изменениями локально и все протестировал.
- [x] Я ознакомился c [Guide to Contribute](https://github.com/ChaoticOnyx/OnyxBay/blob/dev/docs/contributing.md).
