### PR TITLE
Removes my will to live

### DIFF
--- a/code/game/machinery/cryopod.dm
+++ b/code/game/machinery/cryopod.dm
@@ -337,21 +337,22 @@
 
 //Lifted from Unity stasis.dm and refactored. ~Zuhayr
 /obj/machinery/cryopod/Process()
-	if(occupant)
-		if(applies_stasis && iscarbon(occupant))
-			var/mob/living/carbon/C = occupant
-			C.SetStasis(3)
+	if(QDELETED(occupant))
+		return
+	if(applies_stasis && iscarbon(occupant))
+		var/mob/living/carbon/C = occupant
+		C.SetStasis(3)
 
-		//Allow a ten minute gap between entering the pod and actually despawning.
-		if(world.time - time_entered < time_till_despawn)
-			return
+	//Allow a ten minute gap between entering the pod and actually despawning.
+	if(world.time - time_entered < time_till_despawn)
+		return
 
-		if(!occupant.client && occupant.stat<2) //Occupant is living and has no client.
-			if(!control_computer)
-				if(!find_control_computer(urgent=1))
-					return
+	if(!occupant.client && occupant.stat<2) //Occupant is living and has no client.
+		if(!control_computer)
+			if(!find_control_computer(urgent=1))
+				return
 
-			despawn_occupant()
+		despawn_occupant()
 
 // This function can not be undone; do not call this unless you are sure
 // Also make sure there is a valid control computer

--- a/code/game/turfs/simulated/footsteps.dm
+++ b/code/game/turfs/simulated/footsteps.dm
@@ -182,6 +182,12 @@
 		return
 
 	for(var/mob/M in GLOB.player_list)
+		if(M == src)
+			continue
+
+		if(istype(M, /mob/new_player))
+			continue
+
 		// This IS NOT a permanent solution, but I've spent too much time trying to track down
 		// the way a mob can get nullspace'd BEFORE getting removed from the player_list.
 		// Testing it on a local machine is totally pointless.
@@ -189,12 +195,6 @@
 		if(!M.loc)
 			crash_with("[M] was in nullspace trying to receive [src]'s distant footstep sound!")
 			return
-
-		if(M == src)
-			continue
-
-		if(istype(M, /mob/new_player))
-			continue
 
 		if(M.loc.z != src.loc.z || !istype(get_area(M), /area/maintenance))
 			continue


### PR DESCRIPTION
- Проверка на нулл в плеер_листе у футстепов смещена вниз чтобы не цеплять нью_плееров, а то в ней смысл пропадает.
- Добавлена проверка на куделнутых оккупантов в криоподах, ибо они между процессами иногда не успевают нормально удаляться.

- [x] Pull Request полностью завершен, мне не нужна помощь чтобы его закончить.
- [x] Я внимательно прочитал все свои изменения и багов в них не нашел.
- [x] Я запускал сервер со своими изменениями локально и все протестировал.
- [x] Я ознакомился c [Guide to Contribute](https://github.com/ChaoticOnyx/OnyxBay/blob/dev/docs/contributing.md).
