### PR TITLE
fix(handboom)

### DIFF
--- a/code/game/objects/items/weapons/handcuffs.dm
+++ b/code/game/objects/items/weapons/handcuffs.dm
@@ -257,5 +257,16 @@ var/last_chew = 0
 	if(countdown)
 		sleep(countdown_time)
 
-	explosion(get_turf(src), 0, 1, 3, 0)
+	if(istype(src.loc, /mob/living/carbon/human))
+		var/mob/living/carbon/human/H = src.loc
+		
+		if(H.get_inventory_slot(src) == slot_handcuffed)
+			var/obj/item/organ/external/l_hand = H.get_organ(BP_L_HAND)
+			var/obj/item/organ/external/r_hand = H.get_organ(BP_R_HAND)
+			if(l_hand)
+				l_hand.droplimb(0, DROPLIMB_BLUNT)
+			if(r_hand)
+				r_hand.droplimb(0, DROPLIMB_BLUNT)
+				
+	explosion(get_turf(src), -1, 1, 3, 0)
 	qdel(src)

--- a/code/modules/mob/inventory.dm
+++ b/code/modules/mob/inventory.dm
@@ -235,7 +235,7 @@ var/list/slot_equipment_priority = list( \
 	if(QDELETED(I))
 		return
 	if(force || canUnEquip(I))
-		return drop_from_inventory(I, target)
+		return drop_from_inventory(I, target) && !QDELETED(I)
 	return FALSE
 
 //Attemps to remove an object on a mob.


### PR DESCRIPTION
Взрывные наручники теперь взрывают кисти рук при срабатывании, как и должны были.

resolves #6531

<details>
<summary>Чейнджлог</summary>

```yml
🆑
bugfix: Взрывные наручники теперь корректно взрывают кисти рук.
/🆑
```

</details>

- [x] Pull Request полностью завершен, мне не нужна помощь чтобы его закончить.
- [x] Я внимательно прочитал все свои изменения и багов в них не нашел.
- [x] Я запускал сервер со своими изменениями локально и все протестировал.
- [x] Я ознакомился c [Guide to Contribute](https://github.com/ChaoticOnyx/OnyxBay/blob/dev/docs/contributing.md).
