### PR TITLE
refactoring(add_to_loadout): Add tea, coffee, etc. in character create loadout [vacuum/flask]

### DIFF
--- a/code/modules/reagents/reagent_containers/food/lunch.dm
+++ b/code/modules/reagents/reagent_containers/food/lunch.dm
@@ -90,8 +90,8 @@ var/list/lunchables_ethanol_reagents_ = list(
 // Add reagent to [vacuum]-flask no need delete reagent from lunchables_ethanol_reagents_ it's works fine
 var/list/additional_reagents = list(
 										/datum/reagent/drink/tea,
-										/datum/reagent/ethanol/coffee
-										/datum/reagent/drink/hot_coco
+										/datum/reagent/ethanol/coffee,
+										/datum/reagent/drink/hot_coco,
 										/datum/reagent/drink/milkshake
 									)
 /proc/lunchables_lunches()

--- a/code/modules/reagents/reagent_containers/food/lunch.dm
+++ b/code/modules/reagents/reagent_containers/food/lunch.dm
@@ -87,6 +87,13 @@ var/list/lunchables_ethanol_reagents_ = list(
 												/datum/reagent/ethanol/quas
 											)
 
+// Add reagent to [vacuum]-flask no need delete reagent from lunchables_ethanol_reagents_ it's works fine
+var/list/additional_reagents = list(
+										/datum/reagent/drink/tea,
+										/datum/reagent/ethanol/coffee
+										/datum/reagent/drink/hot_coco
+										/datum/reagent/drink/milkshake
+									)
 /proc/lunchables_lunches()
 	if(!(lunchables_lunches_[lunchables_lunches_[1]]))
 		lunchables_lunches_ = init_lunchable_list(lunchables_lunches_)
@@ -109,7 +116,7 @@ var/list/lunchables_ethanol_reagents_ = list(
 
 /proc/lunchables_ethanol_reagents()
 	if(!(lunchables_ethanol_reagents_[lunchables_ethanol_reagents_[1]]))
-		lunchables_ethanol_reagents_ = init_lunchable_reagent_list(lunchables_ethanol_reagents_, /datum/reagent/ethanol)
+		lunchables_ethanol_reagents_ = init_lunchable_reagent_list(lunchables_ethanol_reagents_, /datum/reagent/ethanol, additional_reagents)
 	return lunchables_ethanol_reagents_
 
 /proc/init_lunchable_list(list/lunches)
@@ -119,11 +126,20 @@ var/list/lunchables_ethanol_reagents_ = list(
 		.[initial(O.name)] = lunch
 	return sortAssoc(.)
 
-/proc/init_lunchable_reagent_list(list/banned_reagents, reagent_types)
+/proc/init_lunchable_reagent_list(list/banned_reagents, reagent_types, list/additional_reagents)
 	. = list()
 	for(var/reagent_type in subtypesof(reagent_types))
+
 		if(reagent_type in banned_reagents)
 			continue
+
 		var/datum/reagent/reagent = reagent_type
 		.[initial(reagent.name)] = reagent_type
+
+	for(var/reagent_type in additional_reagents)
+		if(!(reagent_type in .))
+
+			var/datum/reagent/reagent = reagent_type
+			.[initial(reagent.name)] = reagent_type
+
 	return sortAssoc(.)


### PR DESCRIPTION
Да, я знаю что ранее был создал ПР #6822 по данному иссую #6286. Но, в данном ПРе нету лодаута, там просто фласки/вакумки, а так-же что-то с картой, мой ПР это добавление чисто в лодаут, небольшой но полезный ПР для отыгрывающих трезневиков-язвеников. Можно считать что иссуй #6286 полностью закрыт.

Я добавил несколько безалкогольных напитков, давайте не задаваться вопросом зачем их вообще лить в флягу/вакумку, ведь есть вендоры. Я считаю что обоснованно не столько отыгрышом, сколько метагейминговым удобством использования фласков, а не вендоматов. 

<details>
<summary>Чейнджлог</summary>

-  Создал список для добавления реагентов в лодаут фласка/вакума
- Добавил базово: кофе, чай, горячий шоколад, и молочный коктейль

```yml
🆑Osumi
rscadd: Add coffee, tean, coco in character creator loadout
/🆑
```
</details>

- [x] Pull Request полностью завершен, мне не нужна помощь чтобы его закончить.
- [x] Я внимательно прочитал все свои изменения и багов в них не нашел.
- [x] Я запускал сервер со своими изменениями локально и все протестировал.
- [x] Я ознакомился c [Guide to Contribute](https://github.com/ChaoticOnyx/OnyxBay/blob/dev/docs/contributing.md).
