### PR TITLE
feat(shuttles): shuttles can now be specified per map

### DIFF
--- a/code/controllers/subsystems/shuttle.dm
+++ b/code/controllers/subsystems/shuttle.dm
@@ -47,7 +47,7 @@ SUBSYSTEM_DEF(shuttle)
 
 //This is called by gameticker after all the machines and radio frequencies have been properly initialized
 /datum/controller/subsystem/shuttle/proc/initialize_shuttles()
-	for(var/shuttle_type in subtypesof(/datum/shuttle))
+	for(var/shuttle_type in GLOB.using_map.shuttle_types)
 		var/datum/shuttle/shuttle = shuttle_type
 		if((shuttle in shuttles_to_initialize) || !initial(shuttle.defer_initialisation))
 			initialise_shuttle(shuttle_type, TRUE)

--- a/maps/example/example_define.dm
+++ b/maps/example/example_define.dm
@@ -6,6 +6,10 @@
 
 	lobby_icon = 'maps/example/example_lobby.dmi'
 
+	shuttle_types = list(
+		/datum/shuttle/autodock/ferry/example
+	)
+
 	station_levels = list(1, 2, 3)
 	contact_levels = list(1, 2, 3)
 	player_levels = list(1, 2, 3)

--- a/maps/exodus/exodus_define.dm
+++ b/maps/exodus/exodus_define.dm
@@ -6,6 +6,26 @@
 
 	lobby_icon = 'maps/exodus/exodus_lobby.dmi'
 
+	shuttle_types = list(
+		/datum/shuttle/autodock/ferry/escape_pod/escape_pod1,
+		/datum/shuttle/autodock/ferry/escape_pod/escape_pod2,
+		/datum/shuttle/autodock/ferry/escape_pod/escape_pod3,
+		/datum/shuttle/autodock/ferry/escape_pod/escape_pod5,
+		/datum/shuttle/autodock/ferry/supply/drone,
+		/datum/shuttle/autodock/ferry/elevator,
+		/datum/shuttle/autodock/multi/antag/mining,
+		/datum/shuttle/autodock/ferry/research,
+		/datum/shuttle/autodock/ferry/engie,
+		/datum/shuttle/autodock/ferry/mining,
+		/datum/shuttle/autodock/multi/antag/rescue,
+		/datum/shuttle/autodock/ferry/emergency/centcom,
+		/datum/shuttle/autodock/ferry/administration,
+		/datum/shuttle/autodock/multi/antag/syndicate,
+		/datum/shuttle/autodock/multi/antag/elite_syndicate,
+		/datum/shuttle/autodock/ferry/deathsquad,
+		/datum/shuttle/autodock/multi/antag/merchant,
+		/datum/shuttle/autodock/multi/antag/skipjack,
+	)
 	load_legacy_saves = TRUE
 	station_levels = list(1, 2)
 	admin_levels = list(3)

--- a/maps/polar/polar_define.dm
+++ b/maps/polar/polar_define.dm
@@ -3,6 +3,23 @@
 	name = "Polar"
 	full_name = "Polar Colony"
 	path = "polar"
+
+	shuttle_types = list(
+		/datum/shuttle/autodock/ferry/supply/drone,
+		/datum/shuttle/autodock/ferry/elevator,
+		/datum/shuttle/autodock/multi/antag/mining,
+		/datum/shuttle/autodock/ferry/research,
+		/datum/shuttle/autodock/ferry/engie,
+		/datum/shuttle/autodock/ferry/mining,
+		/datum/shuttle/autodock/multi/antag/rescue,
+		/datum/shuttle/autodock/ferry/emergency/centcom,
+		/datum/shuttle/autodock/ferry/administration,
+		/datum/shuttle/autodock/multi/antag/syndicate,
+		/datum/shuttle/autodock/multi/antag/elite_syndicate,
+		/datum/shuttle/autodock/ferry/deathsquad,
+		/datum/shuttle/autodock/multi/antag/merchant,
+		/datum/shuttle/autodock/multi/antag/skipjack,
+	)
 	station_levels = list(1,2,3,4)
 	admin_levels = list(5)
 	contact_levels = list(1,2,3,4)

--- a/maps/~mapsystem/maps.dm
+++ b/maps/~mapsystem/maps.dm
@@ -24,6 +24,7 @@ var/const/MAP_HAS_RANK = 2		//Rank system, also togglable
 	var/full_name = "Unnamed Map"
 	var/path
 
+	var/shuttle_types = null         // Only the specified shuttles will be initialized.
 	var/list/station_levels = list() // Z-levels the station exists on
 	var/list/admin_levels = list()   // Z-levels for admin functionality (Centcom, shuttle transit, etc)
 	var/list/contact_levels = list() // Z-levels that can be contacted from the station, for eg announcements
@@ -152,6 +153,8 @@ var/const/MAP_HAS_RANK = 2		//Rank system, also togglable
 		map_levels = station_levels.Copy()
 	if(!allowed_jobs)
 		allowed_jobs = subtypesof(/datum/job)
+	if(!shuttle_types)
+		crash_with("[src] has no shuttle_types!")
 
 /datum/map/proc/setup_map()
 	if(dynamic_z_levels)


### PR DESCRIPTION
Теперь шаттлы указываются для каждой карты отдельно.

Проверял на эксодусе - карго, шахтёрка и эвакуационные шаттлы не отвалились

- [x] Pull Request полностью завершен, мне не нужна помощь чтобы его закончить.
- [x] Я внимательно прочитал все свои изменения и багов в них не нашел.
- [x] Я запускал сервер со своими изменениями локально и все протестировал.
- [x] Я ознакомился c [Guide to Contribute](https://github.com/ChaoticOnyx/OnyxBay/blob/dev/docs/contributing.md).
