### PR TITLE
breakout_time = 45

### DIFF
--- a/code/game/antagonist/outsider/abductor/machinery/experiment.dm
+++ b/code/game/antagonist/outsider/abductor/machinery/experiment.dm
@@ -13,7 +13,7 @@
 	var/flash = "Awaiting subject."
 	var/obj/machinery/abductor/console/console
 	var/message_cooldown = 0
-	var/breakout_time = 450
+	var/breakout_time = 45
 	var/atom/movable/occupant = null
 
 /obj/machinery/abductor/experiment/Destroy()


### PR DESCRIPTION
Время на съебывание из шкафчика заменено на 45, вместо сюрреалистичных 450.

Сделано по просьбе Ловлы в дискорде. https://discordapp.com/channels/414832443384659968/447559366237880341/971866967860469832

```yml
🆑
tweak: Теперь из экспериментальной машины абдукторов выбираемся 45 секунд, а не 450.
/🆑
```

</details>

- [x] Pull Request полностью завершен, мне не нужна помощь чтобы его закончить.
- [x] Я внимательно прочитал все свои изменения и багов в них не нашел.
- [x] Я запускал сервер со своими изменениями локально и все протестировал.
- [x] Я ознакомился c [Guide to Contribute](https://github.com/ChaoticOnyx/OnyxBay/blob/dev/docs/contributing.md).
