### PR TITLE
Removes inability to cancel fake update announcement

### DIFF
--- a/code/datums/uplink/categories/services.dm
+++ b/code/datums/uplink/categories/services.dm
@@ -186,7 +186,7 @@
 	state = CURRENTLY_ACTIVE
 	var/input = sanitize(input(user, "Please enter anything you want. Anything. Serious.", "What?", "") as message|null, extra = 0)
 	if(!input)
-		state = CURRENTLY_ACTIVE
+		state = AWAITING_ACTIVATION
 		return
 	var/customname = sanitizeSafe(input(user, "Pick a title for the report.", "Title") as text|null)
 	if(!customname)

--- a/code/datums/uplink/categories/services.dm
+++ b/code/datums/uplink/categories/services.dm
@@ -185,9 +185,10 @@
 	log_and_message_admins("has activated the service '[service_label]'", user)
 	state = CURRENTLY_ACTIVE
 	var/input = sanitize(input(user, "Please enter anything you want. Anything. Serious.", "What?", "") as message|null, extra = 0)
-	var/customname = sanitizeSafe(input(user, "Pick a title for the report.", "Title") as text|null)
 	if(!input)
+		state = CURRENTLY_ACTIVE
 		return
+	var/customname = sanitizeSafe(input(user, "Pick a title for the report.", "Title") as text|null)
 	if(!customname)
 		customname = "[command_name()] Update"
 


### PR DESCRIPTION
```yml
🆑
bugfix: Теперь кнопка отмены у трейторского Fake Update Announcement работает, не сжигая сам девайс.
/🆑
```

- [x] Pull Request полностью завершен, мне не нужна помощь чтобы его закончить.
- [x] Я внимательно прочитал все свои изменения и багов в них не нашел.
- [ ] Я запускал сервер со своими изменениями локально и все протестировал.
- [x] Я ознакомился c [Guide to Contribute](https://github.com/ChaoticOnyx/OnyxBay/blob/dev/docs/contributing.md).
