### PR TITLE
Removes roundstart starving fatties and bursting slims

### DIFF
--- a/code/modules/client/preferences.dm
+++ b/code/modules/client/preferences.dm
@@ -377,7 +377,7 @@
 	character.religion = religion
 
 	if(!character.isSynthetic())
-		character.nutrition = rand(140,360)
+		character.nutrition = rand(140, 360) * character.body_build.stomach_capacity
 
 	return
 


### PR DESCRIPTION
```yml
🆑
bugfix: Худые космонавты больше не будут появляться с критическим перееданием.
/🆑
```

- [x] Pull Request полностью завершен, мне не нужна помощь чтобы его закончить.
- [x] Я внимательно прочитал все свои изменения и багов в них не нашел.
- [ ] Я запускал сервер со своими изменениями локально и все протестировал.
- [x] Я ознакомился c [Guide to Contribute](https://github.com/ChaoticOnyx/OnyxBay/blob/dev/docs/contributing.md).
