### PR TITLE
fix(flame): now you selfignites faster (x2)

### DIFF
--- a/code/modules/mob/living/living_defense.dm
+++ b/code/modules/mob/living/living_defense.dm
@@ -342,7 +342,7 @@
 	//once our fire_burn_temperature has reached the temperature of the fire that's giving fire_stacks, stop adding them.
 	//allow fire_stacks to go up to 4 for fires cooler than 700 K, since are being immersed in flame after all.
 	if(fire_stacks <= 4 || fire_burn_temperature() < temperature)
-		adjust_fire_stacks(2)
+		adjust_fire_stacks(4)
 	IgniteMob()
 
 /mob/living/proc/get_cold_protection()


### PR DESCRIPTION
Ускорение самовоспламнения в 2 раза по иссую #2680, урон от огня не тронут, но теперь мобы загораются практически сразу, разве что у него не супер реакция. Воспламенение не многовенное, но довольно быстрое, это обоснованно тем что игрок должен иметь возможность "убежать" от огня, пускай эта возможность и стремится к нулю.

<details>
<summary>Чейнджлог</summary>

- Увеличение adjust_fire_stacks до 4 (с 2)
- 
```yml
🆑 Osumi
bugfix: увеличена скорость самовоспламенения (х2)
/🆑
```

</details>

- [x] Pull Request полностью завершен, мне не нужна помощь чтобы его закончить.
- [x] Я внимательно прочитал все свои изменения и багов в них не нашел.
- [x] Я запускал сервер со своими изменениями локально и все протестировал.
- [x] Я ознакомился c [Guide to Contribute](https://github.com/ChaoticOnyx/OnyxBay/blob/dev/docs/contributing.md).