### PR TITLE
Removes absence of Aloe icon and wrong beer bottle item state

### DIFF
--- a/code/modules/reagents/Chemistry-Reagents/ethanol.dm
+++ b/code/modules/reagents/Chemistry-Reagents/ethanol.dm
@@ -465,7 +465,7 @@
 	strength = 15
 
 	glass_required = "wine"
-	glass_icon_state = "alloe"
+	glass_icon_state = "aloe"
 	glass_name = "Aloe"
 	glass_desc = "Very, very, very good."
 

--- a/code/modules/reagents/reagent_containers/vessel/presets/bottle.dm
+++ b/code/modules/reagents/reagent_containers/vessel/presets/bottle.dm
@@ -249,6 +249,7 @@
 	name = "Space Beer"
 	desc = "Contains only water, malt and hops."
 	icon_state = "beer"
+	item_state = "beer"
 	center_of_mass = "x=16;y=12"
 	startswith = list(/datum/reagent/ethanol/beer = 45)
 


### PR DESCRIPTION
- Два года оно было alloe вместо aloe. Качество
- У пива отлетел итем стейт, печаль.

- [x] Pull Request полностью завершен, мне не нужна помощь чтобы его закончить.
- [x] Я внимательно прочитал все свои изменения и багов в них не нашел.
- [x] Я запускал сервер со своими изменениями локально и все протестировал.
- [x] Я ознакомился c [Guide to Contribute](https://github.com/ChaoticOnyx/OnyxBay/blob/dev/docs/contributing.md).
