### PR TITLE
tweak(ticker): add as-soon-as-possible launch option

### DIFF
--- a/code/controllers/subsystems/ticker.dm
+++ b/code/controllers/subsystems/ticker.dm
@@ -19,6 +19,7 @@ SUBSYSTEM_DEF(ticker)
 	var/end_game_state = END_GAME_NOT_OVER
 	var/delay_end = 0               //Can be set true to postpone restart.
 	var/delay_notified = 0          //Spam prevention.
+	var/auto_start = FALSE			// If TRUE it will start round as soon as game initialized
 
 	var/force_end = FALSE
 
@@ -51,7 +52,8 @@ SUBSYSTEM_DEF(ticker)
 /datum/controller/subsystem/ticker/proc/pregame_tick()
 	if(round_progressing && last_fire)
 		pregame_timeleft -= world.time - last_fire
-	if(pregame_timeleft <= 0)
+	if(pregame_timeleft <= 0 || auto_start)
+		pregame_timeleft = 0
 		Master.SetRunLevel(RUNLEVEL_SETUP)
 		return
 

--- a/code/modules/admin/admin.dm
+++ b/code/modules/admin/admin.dm
@@ -848,7 +848,8 @@ var/global/floorIsLava = 0
 	set name="Start Now"
 	if(GAME_STATE < RUNLEVEL_LOBBY)
 		SSticker.auto_start = !SSticker.auto_start
-		alert("Unable to start the game as it is not set up. [SSticker.auto_start ? "It will automatically start as soon as possible" : "It will run in normal mode (with a timer)."]")
+		alert("Unable to start the game as it is not set up. [SSticker.auto_start ? "It will automatically start game as soon as possible" : "It will start game in normal mode (with a timer)."]")
+		message_admins(SPAN("info", "[key_name(src)] set the server start round configuration to [SSticker.auto_start ? "automatically start game as soon as possible" : "start game in normal mode (with a timer)."]"))
 		return 0
 	if(SSticker.start_now())
 		log_admin("[key_name(usr)] has started the game.")

--- a/code/modules/admin/admin.dm
+++ b/code/modules/admin/admin.dm
@@ -849,7 +849,7 @@ var/global/floorIsLava = 0
 	if(GAME_STATE < RUNLEVEL_LOBBY)
 		SSticker.auto_start = !SSticker.auto_start
 		message_admins(SPAN("info", "[key_name(src)] set the server start round configuration to [SSticker.auto_start ? "automatically start game as soon as possible" : "start game in normal mode (with a timer)."]"))
-		alert("Unable to start the game as it is not set up. [SSticker.auto_start ? "It will automatically start game as soon as possible" : "It will start game in normal mode (with a timer)."]")
+		to_chat(owner, SPAN_NOTICE("Unable to start the game as it is not set up. [SSticker.auto_start ? "It will automatically start game as soon as possible" : "It will start game in normal mode (with a timer)."]"))
 		return 0
 	if(SSticker.start_now())
 		log_admin("[key_name(usr)] has started the game.")

--- a/code/modules/admin/admin.dm
+++ b/code/modules/admin/admin.dm
@@ -848,8 +848,8 @@ var/global/floorIsLava = 0
 	set name="Start Now"
 	if(GAME_STATE < RUNLEVEL_LOBBY)
 		SSticker.auto_start = !SSticker.auto_start
-		alert("Unable to start the game as it is not set up. [SSticker.auto_start ? "It will automatically start game as soon as possible" : "It will start game in normal mode (with a timer)."]")
 		message_admins(SPAN("info", "[key_name(src)] set the server start round configuration to [SSticker.auto_start ? "automatically start game as soon as possible" : "start game in normal mode (with a timer)."]"))
+		alert("Unable to start the game as it is not set up. [SSticker.auto_start ? "It will automatically start game as soon as possible" : "It will start game in normal mode (with a timer)."]")
 		return 0
 	if(SSticker.start_now())
 		log_admin("[key_name(usr)] has started the game.")

--- a/code/modules/admin/admin.dm
+++ b/code/modules/admin/admin.dm
@@ -847,7 +847,8 @@ var/global/floorIsLava = 0
 	set desc="Start the round RIGHT NOW"
 	set name="Start Now"
 	if(GAME_STATE < RUNLEVEL_LOBBY)
-		alert("Unable to start the game as it is not set up.")
+		SSticker.auto_start = !SSticker.auto_start
+		alert("Unable to start the game as it is not set up. [SSticker.auto_start ? "It will automatically start as soon as possible" : "It will run in normal mode (with a timer)."]")
 		return 0
 	if(SSticker.start_now())
 		log_admin("[key_name(usr)] has started the game.")


### PR DESCRIPTION
Добавил в верб Start Now возможность запустить раунд сразу же после инициализации.

close #8317 

<details>
<summary>Чейнджлог</summary>

```yml
🆑
admin: Добавлена возможность запустить игру сразу после инициализации, для активации нажмите на Start Now во время инициализации.
/🆑
```

</details>

- [x] Pull Request полностью завершен, мне не нужна помощь чтобы его закончить.
- [x] Я внимательно прочитал все свои изменения и багов в них не нашел.
- [x] Я запускал сервер со своими изменениями локально и все протестировал.
- [x] Я ознакомился c [Guide to Contribute](https://github.com/ChaoticOnyx/OnyxBay/blob/dev/docs/contributing.md).
