### PR TITLE
tweak(callproc): now you manually enter type

### DIFF
--- a/code/modules/admin/callproc/callproc.dm
+++ b/code/modules/admin/callproc/callproc.dm
@@ -139,7 +139,11 @@
 				if(isnull(current)) return CANCEL
 
 			if("type")
-				current = input("Select type for [arguments.len+1]\th argument") as null|anything in typesof(/obj, /mob, /area, /turf)
+				var/incurrent = input("Input type for [arguments.len+1]\th argument") as text
+				current = text2path(incurrent)
+				if(!ispath(current))
+					to_chat(usr, "Your type doesn't exist - [incurrent]")
+					current = null
 				if(isnull(current)) return CANCEL
 
 			if("obj reference")


### PR DESCRIPTION
НАКОНЕЦ-ТО БЛЯТЬ!

<details>
<summary>Чейнджлог</summary>

```yml
🆑
tweak: Теперь для вызова прока нужно вводить вручную тип в поле тип, а не выбирать тип из списка, ожидая час пока список загрузится, что позволяет вводить типы в виде датумов.
/🆑
```

</details>

- [x] Pull Request полностью завершен, мне не нужна помощь чтобы его закончить.
- [x] Я внимательно прочитал все свои изменения и багов в них не нашел.
- [x] Я запускал сервер со своими изменениями локально и все протестировал.
- [x] Я ознакомился c [Guide to Contribute](https://github.com/ChaoticOnyx/OnyxBay/blob/dev/docs/contributing.md).
