### PR TITLE
bugfix(drone_buckle)

### DIFF
--- a/code/game/objects/buckling.dm
+++ b/code/game/objects/buckling.dm
@@ -75,7 +75,7 @@
 	if(istype(M, /mob/living/carbon/metroid))
 		to_chat(user, SPAN("warning", "\The [M] is too squishy to buckle in."))
 		return 0
-	if(istype(M, /mob/living/silicon && ! /mob/living/silicon/robot/drone))
+	if(issilicon(M) && !is_drone(M))
 		to_chat(user, SPAN("warning", "\The [M] is too heavy to buckle in."))
 		return 0
 

--- a/code/game/objects/buckling.dm
+++ b/code/game/objects/buckling.dm
@@ -75,7 +75,7 @@
 	if(istype(M, /mob/living/carbon/metroid))
 		to_chat(user, SPAN("warning", "\The [M] is too squishy to buckle in."))
 		return 0
-	if(istype(M, /mob/living/silicon))
+	if(istype(M, /mob/living/silicon && ! /mob/living/silicon/robot/drone))
 		to_chat(user, SPAN("warning", "\The [M] is too heavy to buckle in."))
 		return 0
 


### PR DESCRIPTION
Так как мы можем посадить дрона на голову или взять в руки, значит мы можем пристегнуть его к стулу. Раньше писало, что дрон слишком тяжелый для того, чтобы его забаклить.

close #8397

```yml
🆑
bugfix: Теперь maintenance drone может быть посажен на стульчик.
/🆑
```

</details>

- [x] Pull Request полностью завершен, мне не нужна помощь чтобы его закончить.
- [x] Я внимательно прочитал все свои изменения и багов в них не нашел.
- [x] Я запускал сервер со своими изменениями локально и все протестировал.
- [x] Я ознакомился c [Guide to Contribute](https://github.com/ChaoticOnyx/OnyxBay/blob/dev/docs/contributing.md).
