### PR TITLE
Removes lack of antag indicators' past glory

### DIFF
--- a/code/game/antagonist/antagonist_factions.dm
+++ b/code/game/antagonist/antagonist_factions.dm
@@ -21,18 +21,22 @@
 	if(!faction.faction_verb || !faction.faction_descriptor || !faction.faction_verb)
 		return
 
+	if(faction.is_antagonist(player))
+		to_chat(src, SPAN("notice", "\The [player.current] is already \a [faction.faction_role_text]!"))
+		return
+
 	if(!faction.can_become_antag(player, 1) || player_is_antag(player))
 		to_chat(src, SPAN_WARNING("\The [player.current] cannot be \a [faction.faction_role_text]!"))
 		return
 
 	if(world.time < player.rev_cooldown)
-		to_chat(src, SPAN_DANGER("You must wait five seconds between attempts."))
+		to_chat(src, SPAN_DANGER("You must wait ten seconds between attempts."))
 		return
 
 	to_chat(src, SPAN_DANGER("You are attempting to convert \the [player.current]..."))
 	log_and_message_admins("attempted to convert [player.current] to the [faction.faction_role_text] faction.")
 
-	player.rev_cooldown = world.time + 100
+	player.rev_cooldown = world.time + 10 SECONDS
 	if (!faction.is_antagonist(player))
 		var/choice = alert(player.current, "Asked by [src]: Do you want to join the [faction.faction_descriptor]?","Join the [faction.faction_descriptor]?","No!","Yes!")
 		if(!(player.current in able_mobs_in_oview(src)))

--- a/code/game/antagonist/antagonist_update.dm
+++ b/code/game/antagonist/antagonist_update.dm
@@ -31,7 +31,7 @@
 	if(!antag_indicator || !other.current || !recipient.current)
 		return
 	var/indicator = (faction_indicator && (other in faction_members)) ? faction_indicator : antag_indicator
-	return image('icons/mob/hud.dmi', loc = other.current, icon_state = indicator, layer = LIGHTING_LAYER+0.1)
+	return image('icons/mob/hud.dmi', loc = other.current, icon_state = indicator, layer = ABOVE_HUMAN_LAYER)
 
 /datum/antagonist/proc/update_all_icons()
 	if(!antag_indicator)

--- a/code/game/antagonist/station/revolutionary.dm
+++ b/code/game/antagonist/station/revolutionary.dm
@@ -25,7 +25,7 @@ GLOBAL_DATUM_INIT(revs, /datum/antagonist/revolutionary, new)
 	faction_verb = /mob/living/proc/convert_to_rev
 	faction_welcome = "Help the cause overturn the ruling class. Do not harm your fellow freedom fighters."
 	faction_indicator = "hudrevolutionary"
-	faction_invisible = 1
+	faction_invisible = FALSE
 	faction = "revolutionary"
 
 	blacklisted_jobs = list(/datum/job/ai, /datum/job/cyborg)


### PR DESCRIPTION
```yml
🆑
bugfix: Революционеры снова корректно видят индикаторы друг над другом.
bugfix: Индикаторы антагонистов теперь отображаются поверх персонажа, а не перекрываются любыми объектами.
/🆑
```

- [x] Pull Request полностью завершен, мне не нужна помощь чтобы его закончить.
- [x] Я внимательно прочитал все свои изменения и багов в них не нашел.
- [x] Я запускал сервер со своими изменениями локально и все протестировал.
- [x] Я ознакомился c [Guide to Contribute](https://github.com/ChaoticOnyx/OnyxBay/blob/dev/docs/contributing.md).
