### PR TITLE
Removes accordionish height changing when laying down

### DIFF
--- a/code/_helpers/global_access.dm
+++ b/code/_helpers/global_access.dm
@@ -233,6 +233,8 @@
 			return global.blackbox;
 		if("blocked")
 			return global.blocked;
+		if("body_heights")
+			return global.body_heights;
 		if("bomb_set")
 			return global.bomb_set;
 		if("cable_list")
@@ -1128,6 +1130,8 @@
 			global.blackbox=newval;
 		if("blocked")
 			global.blocked=newval;
+		if("body_heights")
+			global.body_heights=newval;
 		if("bomb_set")
 			global.bomb_set=newval;
 		if("cable_list")
@@ -1912,6 +1916,7 @@
 	"basic_robolimb",
 	"blackbox",
 	"blocked",
+	"body_heights",
 	"bomb_set",
 	"cable_list",
 	"cached_space",

--- a/code/_helpers/global_lists.dm
+++ b/code/_helpers/global_lists.dm
@@ -56,6 +56,8 @@ GLOBAL_DATUM_INIT(underwear, /datum/category_collection/underwear, new())
 
 GLOBAL_LIST_EMPTY(bb_clothing_icon_states) //stores /datum/body_build's icon_state lists
 
+var/global/list/body_heights = list(HUMAN_HEIGHT_TINY, HUMAN_HEIGHT_SMALL, HUMAN_HEIGHT_NORMAL, HUMAN_HEIGHT_LARGE, HUMAN_HEIGHT_HUGE)
+
 var/global/list/exclude_jobs = list(/datum/job/ai,/datum/job/cyborg)
 
 // Visual nets

--- a/code/game/dna/dna2.dm
+++ b/code/game/dna/dna2.dm
@@ -33,7 +33,8 @@
 #define DNA_UI_GENDER      14
 #define DNA_UI_BEARD_STYLE 15
 #define DNA_UI_HAIR_STYLE  16
-#define DNA_UI_LENGTH      16 // Update this when you add something, or you WILL break shit.
+#define DNA_UI_BODY_HEIGHT 17
+#define DNA_UI_LENGTH      17 // Update this when you add something, or you WILL break shit.
 
 #define DNA_SE_LENGTH 27
 // For later:
@@ -82,6 +83,7 @@ var/global/list/datum/dna/gene/dna_genes[0]
 	var/species = SPECIES_HUMAN
 	var/s_base = ""
 	var/list/body_markings = list()
+	var/body_height = HUMAN_HEIGHT_NORMAL
 
 // Make a copy of this strand.
 // USE THIS WHEN COPYING STUFF OR YOU'LL GET CORRUPTION!
@@ -94,6 +96,7 @@ var/global/list/datum/dna/gene/dna_genes[0]
 	new_dna.species=species
 	new_dna.body_markings=body_markings.Copy()
 	new_dna.s_base=s_base
+	new_dna.body_height=body_height
 	for(var/b=1;b<=DNA_SE_LENGTH;b++)
 		new_dna.SE[b]=SE[b]
 		if(b<=DNA_UI_LENGTH)
@@ -157,6 +160,7 @@ var/global/list/datum/dna/gene/dna_genes[0]
 
 	body_markings.Cut()
 	s_base = character.s_base
+	body_height = character.body_height
 	for(var/obj/item/organ/external/E in character.organs)
 		E.s_base = s_base
 		if(E.markings.len)

--- a/code/game/dna/dna2_helpers.dm
+++ b/code/game/dna/dna2_helpers.dm
@@ -166,6 +166,7 @@
 
 		H.body_build = H.species.get_body_build(H.gender, dna.body_build)
 		H.fix_body_build()
+		H.body_height = dna.body_height
 
 		//Body markings
 		for(var/tag in dna.body_markings)

--- a/code/modules/client/preference_setup/general/03_body.dm
+++ b/code/modules/client/preference_setup/general/03_body.dm
@@ -105,7 +105,7 @@ var/global/list/valid_bloodtypes = list("A+", "A-", "B+", "B-", "AB+", "AB-", "O
 	pref.b_type			= sanitize_text(pref.b_type, initial(pref.b_type))
 	pref.has_cortical_stack = sanitize_bool(pref.has_cortical_stack, initial(pref.has_cortical_stack))
 
-	if(!pref.body_height || !(pref.body_height in list(HUMAN_HEIGHT_TINY, HUMAN_HEIGHT_SMALL, HUMAN_HEIGHT_NORMAL, HUMAN_HEIGHT_LARGE, HUMAN_HEIGHT_HUGE)))
+	if(!pref.body_height || !(pref.body_height in body_heights))
 		pref.body_height = HUMAN_HEIGHT_NORMAL
 
 	var/datum/species/mob_species = all_species[pref.species]

--- a/code/modules/mob/new_player/preferences_setup.dm
+++ b/code/modules/mob/new_player/preferences_setup.dm
@@ -12,7 +12,7 @@
 			if (gender in build.genders)
 				available_body_builds += build
 		body = pick(available_body_builds).name
-		body_height = pick(HUMAN_HEIGHT_TINY, HUMAN_HEIGHT_SMALL, HUMAN_HEIGHT_NORMAL, HUMAN_HEIGHT_LARGE, HUMAN_HEIGHT_HUGE)
+		body_height = pick(body_heights)
 
 		h_style = random_hair_style(gender, species)
 		f_style = random_facial_hair_style(gender, species)

--- a/code/modules/modifier/helpers.dm
+++ b/code/modules/modifier/helpers.dm
@@ -39,13 +39,13 @@
 		anim_time = 1 //Thud
 
 	if(lying && !species.prone_icon) //Only rotate them if we're not drawing a specific icon for being prone.
-		M.Turn(90)
 		M.Scale(icon_scale, icon_scale * body_height)
+		M.Turn(90)
 		M.Translate(1,-6)
 		layer = MOB_LAYER -0.01 // Fix for a byond bug where turf entry order no longer matters
 	else if(hanging && !species.prone_icon)
-		M.Turn(180)
 		M.Scale(icon_scale, icon_scale * body_height)
+		M.Turn(180)
 		M.Translate(0, -16 * (icon_scale * body_height - 1))
 		layer = MOB_LAYER // Fix for a byond bug where turf entry order no longer matters
 	else


### PR DESCRIPTION
- Генокрады копируют рост жертвы при трансформации;
- Рост правильно отображается у лежащих людей;
- Мыло из превью характер сетупа не фиксится в лоб, его надо основательно переписывать. Спасибо Люммоксу, что не осилил впилить appearance_flagи для iconов.

- [x] Pull Request полностью завершен, мне не нужна помощь чтобы его закончить.
- [x] Я внимательно прочитал все свои изменения и багов в них не нашел.
- [x] Я запускал сервер со своими изменениями локально и все протестировал.
- [x] Я ознакомился c [Guide to Contribute](https://github.com/ChaoticOnyx/OnyxBay/blob/dev/docs/contributing.md).
