### PR TITLE
Removes some odd lighting behavior

### DIFF
--- a/code/__defines/lighting.dm
+++ b/code/__defines/lighting.dm
@@ -3,7 +3,7 @@
 	GLOB.dview_mob.see_invisible = invis_flags; \
 	for(type in view(range, GLOB.dview_mob))
 
-#define END_FOR_DVIEW dview_mob.loc = null
+#define END_FOR_DVIEW GLOB.dview_mob.loc = null
 
 #define LIGHTING_ICON 'icons/effects/lighting_overlay.dmi' // icon used for lighting shading effects
 #define LIGHTING_ICON_STATE_DARK "dark" // Change between "soft_dark" and "dark" to swap soft darkvision

--- a/code/modules/lighting/lighting_atom.dm
+++ b/code/modules/lighting/lighting_atom.dm
@@ -45,10 +45,13 @@
 /atom/proc/update_light()
 	set waitfor = FALSE
 
-	if(!light_max_bright || !light_outer_range)
+	if(!light_max_bright || !light_outer_range || light_max_bright > 1)
 		if(light)
 			light.destroy()
 			light = null
+		if(light_max_bright > 1)
+			light_max_bright = 1
+			CRASH("Attempted to call update_light() on atom [src] \ref[src] with a light_max_bright value greater than one")
 	else
 		if(!istype(loc, /atom/movable))
 			. = src

--- a/code/modules/lighting/lighting_source.dm
+++ b/code/modules/lighting/lighting_source.dm
@@ -69,10 +69,10 @@
 	total_lighting_sources--
 	destroyed = TRUE
 	force_update()
-	if(source_atom && source_atom.light_sources)
+	if(source_atom?.light_sources)
 		source_atom.light_sources -= src
 
-	if(top_atom && top_atom.light_sources)
+	if(top_atom?.light_sources)
 		top_atom.light_sources    -= src
 
 // Call it dirty, I don't care.

--- a/code/modules/mob/living/living_defense.dm
+++ b/code/modules/mob/living/living_defense.dm
@@ -302,14 +302,14 @@
 /mob/living/proc/IgniteMob()
 	if(fire_stacks > 0 && !on_fire)
 		on_fire = 1
-		set_light(0.6, 0.1, light_outer_range + 3)
+		set_light(0.6, 0.1, 4, l_color = COLOR_ORANGE)
 		update_fire()
 
 /mob/living/proc/ExtinguishMob()
 	if(on_fire)
 		on_fire = 0
 		fire_stacks = 0
-		set_light(max(0, light_outer_range - 3))
+		set_light(0)
 		update_fire()
 
 /mob/living/proc/update_fire()

--- a/code/modules/mob/living/simple_animal/constructs/constructs.dm
+++ b/code/modules/mob/living/simple_animal/constructs/constructs.dm
@@ -273,7 +273,7 @@
 	eye_glow.plane = EFFECTS_ABOVE_LIGHTING_PLANE
 	eye_glow.layer = EYE_GLOW_LAYER
 	overlays += eye_glow
-	set_light(-10, 0.1, 3, l_color = "#ffffff")
+	set_light(-2, 0.1, 1.5, l_color = "#ffffff")
 
 ////////////////HUD//////////////////////
 


### PR DESCRIPTION
- Поправлен антисвет у конструктов культа. Выглядит всё ещё всрато, но хотя бы не уводит половину экрана в полную тьму. Надо будет посмотреть, какого хера любые значения ниже -1 полностью гасят любой свет. Но не сегодня.
- Должны исправиться смешные баги света при поджигании и тушении хуманов.
- Проверочка на light_max_bright > 1, ибо из-за этого пересвеченные тайлы могут проваливаться в темноту. Хуже не будет.

- [x] Pull Request полностью завершен, мне не нужна помощь чтобы его закончить.
- [x] Я внимательно прочитал все свои изменения и багов в них не нашел.
- [x] Я запускал сервер со своими изменениями локально и все протестировал.
- [x] Я ознакомился c [Guide to Contribute](https://github.com/ChaoticOnyx/OnyxBay/blob/dev/docs/contributing.md).
