### PR TITLE
Теперь все сообщения в ie8(for Linux) окрашиваются

### DIFF
--- a/code/stylesheet.dm
+++ b/code/stylesheet.dm
@@ -84,7 +84,7 @@ h1.alert, h2.alert		{color: #000080;}
 .disarm					{color: #990000;}
 .passive				{color: #660000;}
 
-.danger					{color: #ff0000; font-weight: bold;hivemind}
+.danger					{color: #ff0000; font-weight: bold;}
 .warning				{color: #ff0000; font-style: italic;}
 .boldannounce			{color: #ff0000; font-weight: bold;}
 .rose					{color: #ff5050;}


### PR DESCRIPTION
Я пофиксил это.

*Крик души*

<details>
<summary>Чейнджлог</summary>

```yml
🆑
bugfix: Игроки на Линуксе с ie8 теперь снова видят цветастый чатик.
/🆑
```

</details>

- [x] Pull Request полностью завершен, мне не нужна помощь чтобы его закончить.
- [x] Я внимательно прочитал все свои изменения и багов в них не нашел.
- [x] Я запускал сервер со своими изменениями локально и все протестировал.
- [x] Я ознакомился c [Guide to Contribute](https://github.com/ChaoticOnyx/OnyxBay/blob/dev/docs/contributing.md).
