### PR TITLE
fix(art-library): fixes image display

### DIFF
--- a/code/modules/modular_computers/file_system/programs/generic/artlibrary.dm
+++ b/code/modules/modular_computers/file_system/programs/generic/artlibrary.dm
@@ -216,9 +216,9 @@
 				if("23x19")
 					pre_icon.Crop(6, 26, 28, 8)
 				if("23x23")
-					pre_icon.Crop(6, 27, 27, 5)
+					pre_icon.Crop(6, 27, 28, 5)
 				if("24x24")
-					pre_icon.Crop(5, 27, 27, 4)
+					pre_icon.Crop(5, 27, 28, 4)
 			art_icon = icon2base64(pre_icon)
 			icon_cache[query.item[3]] = art_icon
 			current_art = list(


### PR DESCRIPTION
Картинки теперь правильно отображаются в превью

close #8467

<details>
<summary>Чейнджлог</summary>

```yml
🆑
bugfix: Превью в art-library теперь корректно отображается
/🆑
```

</details>

- [x] Pull Request полностью завершен, мне не нужна помощь чтобы его закончить.
- [x] Я внимательно прочитал все свои изменения и багов в них не нашел.
- [x] Я запускал сервер со своими изменениями локально и все протестировал.
- [ ] Я ознакомился c [Guide to Contribute](https://github.com/ChaoticOnyx/OnyxBay/blob/dev/docs/contributing.md).
