### PR TITLE
rscadd(random_law_selection) 

### DIFF
--- a/maps/~mapsystem/maps.dm
+++ b/maps/~mapsystem/maps.dm
@@ -144,6 +144,24 @@ var/const/MAP_HAS_RANK = 2		//Rank system, also togglable
 		allowed_jobs = subtypesof(/datum/job)
 	if(!shuttle_types)
 		crash_with("[src] has no shuttle_types!")
+	default_law_type = choose_laws()
+
+/datum/map/proc/choose_laws() //maybe le costil, it will choose one from "list" below with specific chance
+	var/random = rand(0,100)
+	if(random >= 0 && random <= 15)
+		return /datum/ai_laws/asimov
+	else if(random > 15 && random <= 20)
+		return /datum/ai_laws/nanotrasen_aggressive
+	else if(random > 20 && random <= 30)
+		return /datum/ai_laws/robocop
+	else if(random > 30 && random <= 40)
+		return /datum/ai_laws/tyrant
+	else if(random > 40 && random <= 50)
+		return /datum/ai_laws/paladin
+	else if(random > 50 && random <= 60)
+		return /datum/ai_laws/corporate
+	else
+		return /datum/ai_laws/nanotrasen
 
 /datum/map/proc/level_has_trait(z, trait)
 	return map_levels[z].has_trait(trait)


### PR DESCRIPTION
Давным-давно, был создан иссуй (прикреплен ниже), в котором описывалось создание рандомизатора для законов кремниевых. Теперь при заходе игрока - будет определенный шанс на выбор закона.

Asimov - 15%
NT - 40%
NT_agressive - 5%
Robocop - 10%
Tyrant - 10%
Paladin - 10%
Corporate - 10%

Собственно, данный ПР закончен, но я более чем уверен что понадобится обсудить все добавленные в список законы + их редактирование, готов все сделать как будет нужно.

close #1944

<details>
<summary>Чейнджлог</summary>

```yml
🆑
rscadd: Теперь борги/ИИ при заходе имеют шанс получить другой набор законов, вместо стандартных.
/🆑
```

</details>


- [x] Pull Request полностью завершен, мне не нужна помощь чтобы его закончить.
- [x] Я внимательно прочитал все свои изменения и багов в них не нашел.
- [x] Я запускал сервер со своими изменениями локально и все протестировал.
- [x] Я ознакомился c [Guide to Contribute](https://github.com/ChaoticOnyx/OnyxBay/blob/dev/docs/contributing.md).
