### PR TITLE
fix(xenomorphes): fixed deletion of facehuggers after leap

### DIFF
--- a/code/modules/mob/living/simple_animal/hostile/facehugger.dm
+++ b/code/modules/mob/living/simple_animal/hostile/facehugger.dm
@@ -23,8 +23,8 @@
 	mob_size = MOB_MINISCULE
 	can_escape = 1
 	pass_flags = PASS_FLAG_TABLE
-	melee_damage_lower = 5
-	melee_damage_upper = 7.5
+	melee_damage_lower = 2.5
+	melee_damage_upper = 5
 
 	min_gas = null
 	max_gas = null

--- a/code/modules/mob/living/simple_animal/hostile/hostile.dm
+++ b/code/modules/mob/living/simple_animal/hostile/hostile.dm
@@ -123,7 +123,7 @@
 		else
 			stance = HOSTILE_STANCE_ATTACKING
 			Goto(target_mob, move_to_delay, minimum_distance)
-	if(target_mob.loc != null && get_dist(src, target_mob.loc) <= vision_range)//We can't see our target, but he's in our vision range still
+	if(target_mob?.loc != null && get_dist(src, target_mob.loc) <= vision_range)//We can't see our target, but he's in our vision range still
 		Goto(target_mob, move_to_delay, minimum_distance)
 
 /mob/living/simple_animal/hostile/proc/Goto(target_mob, delay, minimum_distance)
@@ -258,6 +258,7 @@
 		MoveToTarget()
 
 /mob/living/simple_animal/hostile/proc/OpenFire(target_mob)
+	ranged_cooldown = ranged_cooldown_cap
 
 	var/target = target_mob
 	visible_message("\red <b>[src]</b> [ranged_message] at [target]!")
@@ -279,7 +280,6 @@
 		Shoot(target, src.loc, src)
 		if(casingtype)
 			new casingtype
-	ranged_cooldown = ranged_cooldown_cap
 	return
 
 /mob/living/simple_animal/hostile/proc/Shoot(target, start, user, bullet = 0)

--- a/code/modules/projectiles/projectile/special.dm
+++ b/code/modules/projectiles/projectile/special.dm
@@ -242,8 +242,11 @@
 	icon = 'icons/mob/alien.dmi'
 	icon_state = "facehugger_thrown"
 	embed = 0 // nope nope nope nope nope
+	damage = 5
 	damage_type = PAIN
 	pass_flags = PASS_FLAG_TABLE
+	kill_count = 12
+
 	var/mob/living/simple_animal/hostile/facehugger/holder = null
 
 /obj/item/projectile/facehugger_proj/Bump(atom/A, forced = FALSE)
@@ -296,8 +299,21 @@
 	holder.MoveToTarget() // Calling these two to make sure the facehugger will try to keep distance upon missing
 	holder = null
 
-
 	set_density(0)
 	set_invisibility(101)
 	qdel(src)
 	return TRUE
+
+/obj/item/projectile/facehugger_proj/on_impact(atom/A, use_impact = TRUE)
+	Bump(A)
+
+/obj/item/projectile/facehugger_proj/Destroy()
+	if(kill_count)
+		QDEL_NULL(holder)
+	else
+		var/turf/T = get_turf(loc)
+		if(T)
+			holder.forceMove(T)
+			holder = null
+
+	return ..()


### PR DESCRIPTION
Вроде пофиксил пропажу лицехватов при неудачных прыжках на космонавтиков.
Также подрегулировал им kill_count, теперь они не будут при промахе лететь через пол станции, а только чуть больше чем расстояние прыжка.
По результатам совещания в дискорде убавил им урон(Тоби не против).

Ещё они почему-то нифига от людей не отбегают(а должны!), но я уже устал.

fix #7520

<details>
<summary>Чейнджлог</summary>

```yml
🆑
bugfix: Лицехваты больше не исчезают при неудачных прыжках.
/🆑
```

</details>

- [x] Pull Request полностью завершен, мне не нужна помощь чтобы его закончить.
- [x] Я внимательно прочитал все свои изменения и багов в них не нашел.
- [x] Я запускал сервер со своими изменениями локально и все протестировал.
- [x] Я ознакомился c [Guide to Contribute](https://github.com/ChaoticOnyx/OnyxBay/blob/dev/docs/contributing.md).
