### PR TITLE
fix(holodeck): fix landmarks copying

### DIFF
--- a/code/_helpers/unsorted.dm
+++ b/code/_helpers/unsorted.dm
@@ -693,7 +693,7 @@ Turf and target are seperate in case you want to teleport some distance from a t
 	var/y_pos = null
 	var/z_pos = null
 
-/area/proc/copy_contents_to(area/A , platingRequired = 0 )
+/area/proc/copy_contents_to(area/A, platingRequired = FALSE, ignore_unsimulated = TRUE )
 	//Takes: Area. Optional: If it should copy to areas that don't have plating
 	//Returns: Nothing.
 	//Notes: Attempts to move the contents of one area to another area.
@@ -772,7 +772,10 @@ Turf and target are seperate in case you want to teleport some distance from a t
 
 					for(var/obj/O in T)
 
-						if(!istype(O,/obj) || !O.simulated)
+						if(!istype(O,/obj))
+							continue
+
+						if(ignore_unsimulated && !O.simulated)
 							continue
 
 						objs += O
@@ -787,7 +790,13 @@ Turf and target are seperate in case you want to teleport some distance from a t
 
 					for(var/mob/M in T)
 
-						if(!istype(M,/mob) || !M.simulated) continue // If we need to check for more mobs, I'll add a variable
+						// If we need to check for more mobs, I'll add a variable
+						if(!istype(M,/mob))
+							continue
+
+						if(ignore_unsimulated && !M.simulated)
+							continue
+
 						mobs += M
 
 					for(var/mob/M in mobs)

--- a/code/modules/holodeck/HolodeckControl.dm
+++ b/code/modules/holodeck/HolodeckControl.dm
@@ -287,7 +287,7 @@
 	for(var/obj/effect/decal/cleanable/blood/B in linkedholodeck)
 		qdel(B)
 
-	holographic_objs = A.copy_contents_to(linkedholodeck , 1)
+	holographic_objs = A.copy_contents_to(linkedholodeck, TRUE, FALSE)
 	for(var/obj/holo_obj in holographic_objs)
 		holo_obj.alpha *= 0.8 //give holodeck objs a slight transparency
 


### PR DESCRIPTION
Ландмарки имеют `simulated = 0`

![image](https://user-images.githubusercontent.com/55196698/171682295-e9fc3af7-0ee9-485b-aedd-9abc8b2ba715.png)

fix #1514

<details>
<summary>Чейнджлог</summary>

```yml
🆑
bugfix: Спавн животных через голодек емагом теперь работает.
/🆑
```

</details>

- [x] Pull Request полностью завершен, мне не нужна помощь чтобы его закончить.
- [x] Я внимательно прочитал все свои изменения и багов в них не нашел.
- [x] Я запускал сервер со своими изменениями локально и все протестировал.
- [x] Я ознакомился c [Guide to Contribute](https://github.com/ChaoticOnyx/OnyxBay/blob/dev/docs/contributing.md).
