### PR TITLE
Removes lack of pain accumulation

### DIFF
--- a/code/modules/mob/living/carbon/human/human_defense.dm
+++ b/code/modules/mob/living/carbon/human/human_defense.dm
@@ -112,16 +112,16 @@ meteor_act
 	apply_damage(reduced_power, PAIN, def_zone, 0, used_weapon)
 	damage_poise(reduced_power / 5) // So metazine-filled junkies are still prone to muscular cramps
 
-	var/reduced_tasing = max(tasing * 0.5, tasing * siemens_coeff) // Armor can provide up to 50% stun time reduction
+	var/reduced_tasing = round(max(tasing * 0.5, tasing * siemens_coeff)) // Armor can provide up to 50% stun time reduction
 	apply_effect(STUTTER, reduced_tasing)
 	apply_effect(EYE_BLUR, reduced_tasing)
 
-	if(poise <= 0 || getHalLoss() >= species.total_health)
+	if(poise <= 0 || getHalLoss() >= species.total_health || (affected && affected.pain > affected.max_pain))
 		if(prob(95)) // May gods decide your destiny
 			if(!stunned)
 				visible_message("<b>[src]</b> collapses!", SPAN("warning", "You collapse from shock!"))
-			Stun(tasing)
-			Weaken(tasing + 1) // Getting up after being tased is not instant, adding 1 tick of unstunned crawling
+			Stun(reduced_tasing)
+			Weaken(reduced_tasing + 1) // Getting up after being tased is not instant, adding 1 tick of unstunned crawling
 
 
 //////////////////////

--- a/code/modules/mob/living/carbon/human/human_defense.dm
+++ b/code/modules/mob/living/carbon/human/human_defense.dm
@@ -116,7 +116,7 @@ meteor_act
 	apply_effect(STUTTER, reduced_tasing)
 	apply_effect(EYE_BLUR, reduced_tasing)
 
-	if(poise <= 0 || getHalLoss() >= species.total_health || (affected && affected.pain > affected.max_pain))
+	if(poise <= 0 || getHalLoss() >= species.total_health || affected?.pain > species.total_health)
 		if(prob(95)) // May gods decide your destiny
 			if(!stunned)
 				visible_message("<b>[src]</b> collapses!", SPAN("warning", "You collapse from shock!"))

--- a/code/modules/organs/external/_external.dm
+++ b/code/modules/organs/external/_external.dm
@@ -27,6 +27,7 @@
 	var/last_dam = -1                  // used in healing/processing calculations.
 	var/pain = 0                       // How much the limb hurts.
 	var/full_pain = 0                  // Overall pain including damages.
+	var/max_pain = null                // Maximum pain the limb can accumulate. The actual effect's capped at max_damage.
 	var/pain_disability_threshold      // Point at which a limb becomes unusable due to pain.
 
 	// Movement delay vars.
@@ -120,6 +121,10 @@
 	if(owner)
 		replaced(owner)
 		sync_colour_to_human(owner)
+		if(isnull(max_pain))
+			max_pain = min(max_damage * 2.5, owner.species.total_health * 1.5)
+	else if(isnull(max_pain))
+		max_pain = max_damage * 1.5 // Should not ~probably~ happen
 	get_icon()
 
 	if(food_organ in implants)

--- a/code/modules/organs/external/_external_damage.dm
+++ b/code/modules/organs/external/_external_damage.dm
@@ -252,7 +252,7 @@ obj/item/organ/external/take_general_damage(amount, silent = FALSE)
 		return
 
 	if(pain)
-		pain -= owner.lying ? 3 : 1
+		pain -= (pain > max_damage ? 2.5 : 1) * (owner.lying ? 3 : 1) // Over-limit pain decreases faster.
 		pain = max(pain, 0)
 
 	var/lasting_pain = 0
@@ -261,12 +261,7 @@ obj/item/organ/external/take_general_damage(amount, silent = FALSE)
 	else if(is_dislocated())
 		lasting_pain += 5
 
-	var/tox_dam = 0
-	for(var/i in internal_organs)
-		var/obj/item/organ/internal/I = i
-		tox_dam += I.getToxLoss()
-
-	full_pain = pain + lasting_pain + min(max_damage, 0.7 * brute_dam + 0.8 * burn_dam) + 0.3 * tox_dam + 0.5 * get_genetic_damage()
+	full_pain = min(pain, max_damage) + lasting_pain + min(max_damage, 0.7 * brute_dam + 0.8 * burn_dam) + 0.5 * get_genetic_damage()
 
 /obj/item/organ/external/proc/get_pain()
 	return pain
@@ -275,7 +270,7 @@ obj/item/organ/external/take_general_damage(amount, silent = FALSE)
 	if(!can_feel_pain())
 		return 0
 	var/last_pain = pain
-	pain = clamp(pain + change, 0, max_damage)
+	pain = clamp(pain + change, 0, max_pain)
 	full_pain += pain - last_pain // Updating it without waiting for the next tick for the greater good
 
 	if(change > 0 && owner)

--- a/code/modules/organs/external/standard.dm
+++ b/code/modules/organs/external/standard.dm
@@ -137,7 +137,7 @@
 	organ_tag = BP_L_HAND
 	name = "left hand"
 	icon_name = "l_hand"
-	max_damage = 40
+	max_damage = 45
 	min_broken_damage = 20
 	w_class = ITEM_SIZE_SMALL
 	body_part = HAND_LEFT


### PR DESCRIPTION
- Теперь боль на части тела может накапливаться выше лимита в виде её максимального урона. При этом у "фактической" боли, ощущаемой персонажем, всё ещё есть этот кап. Боль выше лимита спадает быстрее.
- Тазеры теперь проверяют не только общую боль по телу, но и общую боль у части тела - отпадают случаи, когда десятый подряд выстрел по пятке не ронял космонавта, ибо её боль в лимите.
- Вырезано прибавление боли у частей тела от урона внутренних органов. Непонятно, зачем оно вообще было - каждая часть тела у человека каждый тик проходила циклом по всем внутренним органам. В итоге повреждённые глаза и почки накидывали боль на пятки. Шиза какая-то. Отдельный процессинг боли от повреждений внутренностей уже реализован отдельно, ещё и боль отдаёт только в часть тела, в которой находится повреждённый орган.
- Максимальный урон у кистей поднят с 40 до 45. Особая магия.
- Исправлено отсутствие уменьшения времени стана тазером от защиты. Формулу прописал, а в сам вызов стана пихнуть её забыл.

```yml
🆑
tweak: Немного изменена логика работы тазеров. Раньше тазеры могли не уронить космонавта при стрельбе по ноге хоть с двадцатого выстрела, так как боль упиралась в лимит. Теперь ситуация несколько иная, но стрельба по крупным частям тела всё же эффективнее.
/🆑
```

- [x] Pull Request полностью завершен, мне не нужна помощь чтобы его закончить.
- [x] Я внимательно прочитал все свои изменения и багов в них не нашел.
- [x] Я запускал сервер со своими изменениями локально и все протестировал.
- [x] Я ознакомился c [Guide to Contribute](https://github.com/ChaoticOnyx/OnyxBay/blob/dev/docs/contributing.md).
