### PR TITLE
Removes lack of advanced control over matrices

### DIFF
--- a/code/_helpers/unsorted.dm
+++ b/code/_helpers/unsorted.dm
@@ -1097,13 +1097,17 @@ GLOBAL_DATUM_INIT(dview_mob, /mob/dview, new)
 	return
 
 /proc/animate_speech_bubble(image/I, list/show_to, duration)
-	var/matrix/M = matrix()
-	M.Scale(0,0)
-	I.transform = M
+	I.SetTransform(scale = 0)
 	I.alpha = 0
 	for(var/client/C in show_to)
 		C.images += I
-	animate(I, transform = 0, alpha = 255, time = 0.5 SECONDS, easing = ELASTIC_EASING)
+	animate(
+		I,
+		transform = matrix(),
+		alpha = 255,
+		time = 0.5 SECONDS,
+		easing = ELASTIC_EASING
+	)
 	addtimer(CALLBACK(GLOBAL_PROC, /.proc/fade_out, I), duration - 0.5 SECONDS)
 
 /proc/fade_out(image/I, list/show_to)

--- a/code/_onclick/hud/action.dm
+++ b/code/_onclick/hud/action.dm
@@ -201,14 +201,12 @@
 	return "WEST[coord_col]:[coord_col_offset],NORTH[coord_row]:[coord_row_offset]"
 
 /datum/hud/proc/SetButtonCoords(obj/screen/button,number)
-	var/row = round((number-1)/AB_MAX_COLUMNS)
-	var/col = ((number - 1)%(AB_MAX_COLUMNS)) + 1
-	var/x_offset = 32*(col-1) + AB_WEST_OFFSET + 2*col
-	var/y_offset = -32*(row+1) + AB_NORTH_OFFSET
-
-	var/matrix/M = matrix()
-	M.Translate(x_offset,y_offset)
-	button.transform = M
+	var/row = round((number - 1) / AB_MAX_COLUMNS)
+	var/col = ((number - 1) % (AB_MAX_COLUMNS)) + 1
+	button.SetTransform(
+		offset_x = 32 * (col - 1) + AB_WEST_OFFSET + 2 * col,
+		offset_y = -32 * (row + 1) + AB_NORTH_OFFSET
+	)
 
 //Presets for item actions
 /datum/action/item_action

--- a/code/_onclick/hud/radial.dm
+++ b/code/_onclick/hud/radial.dm
@@ -170,11 +170,8 @@ GLOBAL_LIST_EMPTY(radial_menus)
 	var/px = round(sin(angle) * radius)
 	if(anim)
 		var/timing = anim_order * 0.5
-		var/matrix/starting = matrix()
-		starting.Scale(0.1,0.1)
-		E.transform = starting
-		var/matrix/TM = matrix()
-		animate(E,pixel_x = px,pixel_y = py, transform = TM, time = timing)
+		E.SetTransform(scale = 0.1)
+		animate(E, pixel_x = px, pixel_y = py, transform = matrix(), time = timing)
 	else
 		E.pixel_y = py
 		E.pixel_x = px

--- a/code/game/atoms.dm
+++ b/code/game/atoms.dm
@@ -29,6 +29,12 @@
 
 	var/list/climbers = list()
 
+	var/tf_scale_x  // The atom's base transform scale for width.
+	var/tf_scale_y  // The atom's base transform scale for height.
+	var/tf_rotation // The atom's base transform scale for rotation.
+	var/tf_offset_x // The atom's base transform scale for horizontal offset.
+	var/tf_offset_y // The atom's base transform scale for vertical offset.
+
 /atom/New(loc, ...)
 	CAN_BE_REDEFINED(TRUE)
 	//atom creation method that preloads variables at creation
@@ -722,3 +728,40 @@ its easier to just keep the beam vertical.
 /atom/proc/recursive_dir_set(atom/a, old_dir, new_dir)
 	if(loc != a)
 		set_dir(new_dir)
+
+// Clear the atom's tf_* variables and the current transform state.
+/atom/proc/ClearTransform()
+	tf_scale_x = null
+	tf_scale_y = null
+	tf_rotation = null
+	tf_offset_x = null
+	tf_offset_y = null
+	transform = null
+
+// Sets the atom's tf_* variables and the current transform state, also applying others if supplied.
+/atom/proc/SetTransform(
+	scale,
+	scale_x = tf_scale_x,
+	scale_y = tf_scale_y,
+	rotation = tf_rotation,
+	offset_x = tf_offset_x,
+	offset_y = tf_offset_y,
+	list/others
+)
+	if(!isnull(scale))
+		tf_scale_x = scale
+		tf_scale_y = scale
+	else
+		tf_scale_x = scale_x
+		tf_scale_y = scale_y
+	tf_rotation = rotation
+	tf_offset_x = offset_x
+	tf_offset_y = offset_y
+	transform = matrix().Update(
+		scale_x = tf_scale_x,
+		scale_y = tf_scale_y,
+		rotation = tf_rotation,
+		offset_x = tf_offset_x,
+		offset_y = tf_offset_y,
+		others = others
+	)

--- a/code/game/images.dm
+++ b/code/game/images.dm
@@ -1,3 +1,47 @@
+/image
+	var/tf_scale_x  // The image's base transform scale for width.
+	var/tf_scale_y  // The image's base transform scale for height.
+	var/tf_rotation // The image's base transform scale for rotation.
+	var/tf_offset_x // The image's base transform scale for horizontal offset.
+	var/tf_offset_y // The image's base transform scale for vertical offset.
+
 /image/Destroy()
 	..()
 	return QDEL_HINT_HARDDEL
+
+// Clear the image's tf_* variables and the current transform state.
+/image/proc/ClearTransform()
+	tf_scale_x = null
+	tf_scale_y = null
+	tf_rotation = null
+	tf_offset_x = null
+	tf_offset_y = null
+	transform = null
+
+// Sets the image's tf_* variables and the current transform state, also applying others if supplied.
+/image/proc/SetTransform(
+	scale,
+	scale_x = tf_scale_x,
+	scale_y = tf_scale_y,
+	rotation = tf_rotation,
+	offset_x = tf_offset_x,
+	offset_y = tf_offset_y,
+	list/others
+)
+	if(!isnull(scale))
+		tf_scale_x = scale
+		tf_scale_y = scale
+	else
+		tf_scale_x = scale_x
+		tf_scale_y = scale_y
+	tf_rotation = rotation
+	tf_offset_x = offset_x
+	tf_offset_y = offset_y
+	transform = matrix().Update(
+		scale_x = tf_scale_x,
+		scale_y = tf_scale_y,
+		rotation = tf_rotation,
+		offset_x = tf_offset_x,
+		offset_y = tf_offset_y,
+		others = others
+	)

--- a/code/game/machinery/kitchen/cooking_machines/cereal.dm
+++ b/code/game/machinery/kitchen/cooking_machines/cereal.dm
@@ -31,7 +31,7 @@
 	var/image/food_image = image(origin.icon, origin.icon_state)
 	food_image.color = origin.color
 	food_image.overlays += origin.overlays
-	food_image.transform *= 0.7
+	food_image.SetTransform(scale = 0.5)
 	food_image.pixel_y = 2
 	product.overlays += food_image
 	return product

--- a/code/game/machinery/vending/_vending.dm
+++ b/code/game/machinery/vending/_vending.dm
@@ -700,10 +700,10 @@
 
 /obj/machinery/vending/proc/update_standing_icon()
 	if(!anchored)
-		transform = turn(transform, -90)
+		SetTransform(rotation = -90)
 		pixel_y = -3
 	else
-		transform = turn(transform, 90)
+		ClearTransform()
 		pixel_y = initial(pixel_y)
 	update_icon()
 

--- a/code/game/objects/effects/decals/Cleanable/misc.dm
+++ b/code/game/objects/effects/decals/Cleanable/misc.dm
@@ -98,6 +98,8 @@
 	. = ..()
 	var/drytime = DRYING_TIME * (rand(20, 30) / 10) // 10 to 15 minutes
 	addtimer(CALLBACK(src, .proc/dry), drytime)
+	if(prob(75))
+		SetTransform(rotation = pick(90, 180, 270))
 
 /obj/effect/decal/cleanable/vomit/proc/dry()
 	viruses.Cut()

--- a/code/game/objects/effects/item_pickup_ghost.dm
+++ b/code/game/objects/effects/item_pickup_ghost.dm
@@ -10,4 +10,10 @@
 /obj/effect/temporary/item_pickup_ghost/proc/animate_towards(atom/target)
 	var/new_pixel_x = pixel_x + (target.x - src.x) * 32
 	var/new_pixel_y = pixel_y + (target.y - src.y) * 32
-	animate(src, pixel_x = new_pixel_x, pixel_y = new_pixel_y, transform = matrix()*0, time = lifetime)
+	animate(
+		src,
+		transform = matrix().Update(scale_x = 0, scale_y = 0),
+		pixel_x = new_pixel_x,
+		pixel_y = new_pixel_y,
+		time = lifetime
+	)

--- a/code/game/objects/items/glassjar.dm
+++ b/code/game/objects/items/glassjar.dm
@@ -92,7 +92,7 @@
 					var/image/money = image('icons/obj/items.dmi', A)
 					money.pixel_x = rand(-2, 3)
 					money.pixel_y = rand(-6, 6)
-					money.transform *= 0.6
+					money.SetTransform(scale = 0.6)
 					underlays += money
 		if(2)
 			for(var/mob/M in src)

--- a/code/game/objects/items/smokables/cigarettes.dm
+++ b/code/game/objects/items/smokables/cigarettes.dm
@@ -204,7 +204,7 @@
 		if(dynamic_icon)
 			die(nomessage = TRUE, nodestroy = TRUE)
 			if(loc == user)
-				transform = turn(transform, round(rand(0, 360), 45))
+				SetTransform(rotation = round(rand(0, 360), 45))
 				pixel_x = rand(-10, 10)
 				pixel_y = rand(-10, 10)
 				user.remove_from_mob(src) // un-equip it so the overlays can update
@@ -214,7 +214,7 @@
 
 /obj/item/clothing/mask/smokable/cigarette/attack_hand(mob/user)
 	if(ishuman(user) && dynamic_icon)
-		transform = matrix()
+		ClearTransform()
 		pixel_x = initial(pixel_x)
 		pixel_y = initial(pixel_y)
 	return ..()
@@ -253,7 +253,7 @@
 
 /obj/item/cigbutt/Initialize()
 	. = ..()
-	transform = turn(transform, round(rand(0, 360), 45))
+	SetTransform(rotation = round(rand(0, 360), 45))
 
 ////////////////
 // CIGARETTES //

--- a/code/game/objects/items/storage/storage_ui/default.dm
+++ b/code/game/objects/items/storage/storage_ui/default.dm
@@ -210,9 +210,7 @@
 
 	storage_start.overlays.Cut()
 
-	var/matrix/M = matrix()
-	M.Scale((storage_width-storage_cap_width*2+3)/32,1)
-	storage_continue.transform = M
+	storage_continue.SetTransform(scale_x = (storage_width - storage_cap_width * 2 + 3) / 32)
 
 	storage_start.screen_loc = "4:16,2:16"
 	storage_continue.screen_loc = "4:[storage_cap_width+(storage_width-storage_cap_width*2)/2+2],2:16"
@@ -225,16 +223,13 @@
 		startpoint = endpoint + 1
 		endpoint += storage_width * O.get_storage_cost()/storage.max_storage_space
 
-		var/matrix/M_start = matrix()
-		var/matrix/M_continue = matrix()
-		var/matrix/M_end = matrix()
-		M_start.Translate(startpoint,0)
-		M_continue.Scale((endpoint-startpoint-stored_cap_width*2)/32,1)
-		M_continue.Translate(startpoint+stored_cap_width+(endpoint-startpoint-stored_cap_width*2)/2 - 16,0)
-		M_end.Translate(endpoint-stored_cap_width,0)
-		stored_start.transform = M_start
-		stored_continue.transform = M_continue
-		stored_end.transform = M_end
+		stored_start.SetTransform(offset_x = startpoint)
+		stored_end.SetTransform(offset_x = endpoint - stored_cap_width)
+		stored_continue.SetTransform(
+			offset_x = startpoint + stored_cap_width + (endpoint - startpoint - stored_cap_width * 2) / 2 - 16,
+			scale_x = (endpoint - startpoint - stored_cap_width * 2) / 32
+		)
+
 		storage_start.overlays += stored_start
 		storage_start.overlays += stored_continue
 		storage_start.overlays += stored_end

--- a/code/game/objects/items/weapons/tools.dm
+++ b/code/game/objects/items/weapons/tools.dm
@@ -153,8 +153,7 @@
 	update_icon()
 
 /obj/item/screwdriver/update_icon()
-	icon_rotation = istype(loc, /obj/item/storage) ? -90 : 0
-	update_transform()
+	SetTransform(rotation = istype(loc, /obj/item/storage) ? -90 : 0)
 
 /obj/item/screwdriver/old
 	name = "old screwdriver"

--- a/code/game/objects/structures/crates_lockers/closets.dm
+++ b/code/game/objects/structures/crates_lockers/closets.dm
@@ -744,11 +744,9 @@
 	open()
 	broken = FALSE
 	locked = FALSE
-	var/matrix/M = matrix()
-	M.Turn(90)
-	cdoor.transform = M
+	cdoor.SetTransform(rotation = 90)
 	cdoor.pixel_y = -8
-	cdoor.loc = get_turf(src)
+	cdoor.forceMove(loc)
 	cdoor = null
 
 	setup = CLOSET_CAN_BE_WELDED

--- a/code/game/objects/structures/rubble.dm
+++ b/code/game/objects/structures/rubble.dm
@@ -39,9 +39,7 @@
 		I.appearance_flags = DEFAULT_APPEARANCE_FLAGS
 		I.pixel_x = rand(-16,16)
 		I.pixel_y = rand(-16,16)
-		var/matrix/M = matrix()
-		M.Turn(rand(0,360))
-		I.transform = M
+		I.SetTransform(rotation = rand(0, 360))
 		parts += I
 	overlays = parts
 

--- a/code/modules/detectivework/tools/evidencebag.dm
+++ b/code/modules/detectivework/tools/evidencebag.dm
@@ -68,7 +68,7 @@
 	I.pixel_x = 0		//then remove it so it'll stay within the evidence bag
 	I.pixel_y = 0
 	var/image/img = image(I.icon, I.icon_state, layer = FLOAT_LAYER)	//take a snapshot. (necessary to stop the underlays appearing under our inventory-HUD slots ~Carn
-	img.transform *= 0.7
+	img.SetTransform(scale = 0.7)
 	I.pixel_x = item_x		//and then return it
 	I.pixel_y = item_y
 	overlays.Add(img, "evidence")	//should look nicer for transparent stuff. not really that important, but hey.

--- a/code/modules/economy/cash.dm
+++ b/code/modules/economy/cash.dm
@@ -77,11 +77,12 @@
 
 	for(var/A in images)
 		var/image/banknote = image('icons/obj/items.dmi', A)
-		var/matrix/M = matrix()
-		M.Translate(rand(-6, 6), rand(-4, 8))
-		M.Turn(pick(-45, -27.5, 0, 0, 0, 0, 0, 0, 0, 27.5, 45))
-		banknote.transform = M
-		src.overlays += banknote
+		banknote.SetTransform(
+			rotation = pick(-45, -27.5, 0, 0, 0, 0, 0, 0, 0, 27.5, 45),
+			offset_x = rand(-6, 6),
+			offset_y = rand(-4, 8)
+		)
+		overlays += banknote
 
 	src.desc = "They are worth [worth] Credit."
 	if(worth in denominations)

--- a/code/modules/games/cards.dm
+++ b/code/modules/games/cards.dm
@@ -263,20 +263,13 @@
 		return
 
 	var/offset = Floor(20/cards.len)
-
 	var/matrix/M = matrix()
-	if(direction)
-		switch(direction)
-			if(NORTH)
-				M.Translate( 0,  0)
-			if(SOUTH)
-				M.Translate( 0,  4)
-			if(WEST)
-				M.Turn(90)
-				M.Translate( 3,  0)
-			if(EAST)
-				M.Turn(90)
-				M.Translate(-2,  0)
+	M.Update(
+		rotation = (direction & EAST|WEST) ? 90 : 0,
+		offset_x = (direction == EAST) ? -2 : (direction == WEST) ? 3 : 0,
+		offset_y = direction == SOUTH ? 4 : 0
+	)
+
 	var/i = 0
 	for(var/datum/playingcard/P in cards)
 		var/image/I = new(src.icon, (concealed ? "[P.back_icon]" : "[P.card_icon]") )
@@ -290,7 +283,7 @@
 				I.pixel_y = 8-(offset*i)
 			else
 				I.pixel_x = -7+(offset*i)
-		I.transform = M
+		I.SetTransform(others = M)
 		overlays += I
 		i++
 

--- a/code/modules/hydroponics/spreading/spreading.dm
+++ b/code/modules/hydroponics/spreading/spreading.dm
@@ -153,16 +153,10 @@
 		set_density(0)
 
 	if(!growth_type && !floor)
-		src.transform = null
-		var/matrix/M = matrix()
-		switch(dir)
-			if(WEST)
-				M.Turn(90)
-			if(NORTH)
-				M.Turn(180)
-			if(EAST)
-				M.Turn(270)
-		src.transform = M
+		SetTransform(
+			rotation = dir == WEST ? 90 : dir == NORTH ? 180 : dir == EAST ? 270 : 0,
+			offset_y = -rand(12, 14)
+		)
 
 	// Apply colour and light from seed datum.
 	if(seed.get_trait(TRAIT_BIOLUM))

--- a/code/modules/hydroponics/spreading/spreading_growth.dm
+++ b/code/modules/hydroponics/spreading/spreading_growth.dm
@@ -100,7 +100,7 @@
 		if(can_spawn_plant())
 			plant = new(T,seed)
 			plant.dir = src.dir
-			plant.transform = src.transform
+			plant.SetTransform(others = transform)
 			plant.age = seed.get_trait(TRAIT_MATURATION)-1
 			plant.update_icon()
 			if(growth_type == 0) //Vines do not become invisible.

--- a/code/modules/integrated_electronics/core/assemblies.dm
+++ b/code/modules/integrated_electronics/core/assemblies.dm
@@ -1103,7 +1103,7 @@
 		mount_assembly(T,user)
 
 /obj/item/device/electronic_assembly/pickup()
-	transform = matrix() //Reset the matrix.
+	ClearTransform()
 	..()
 
 /obj/item/device/electronic_assembly/wallmount/proc/mount_assembly(turf/on_wall, mob/user) //Yeah, this is admittedly just an abridged and kitbashed version of the wallframe attach procs.
@@ -1124,21 +1124,21 @@
 		SPAN_NOTICE("You attach [src] to the wall."),
 		SPAN_NOTICE("You hear clicking."))
 	if(user.unEquip(src,T))
-		var/matrix/M = matrix()
+		var/rotation = 0
 		switch(ndir)
 			if(NORTH)
+				rotation = 180
 				pixel_y = -32
 				pixel_x = 0
-				M.Turn(180)
 			if(SOUTH)
 				pixel_y = 21
 				pixel_x = 0
 			if(EAST)
+				rotation = 90
 				pixel_x = -27
 				pixel_y = 0
-				M.Turn(270)
 			if(WEST)
+				rotation = 270
 				pixel_x = 27
 				pixel_y = 0
-				M.Turn(90)
-		transform = M
+		SetTransform(rotation = rotation)

--- a/code/modules/lighting/lighting_planemaster.dm
+++ b/code/modules/lighting/lighting_planemaster.dm
@@ -31,10 +31,7 @@
 
 /obj/lighting_general/Initialize()
 	. = ..()
-	var/matrix/M = matrix()
-	M.Scale(world.view*2.2)
-
-	transform = M
+	SetTransform(scale = world.view * 2.2)
 
 /mob
 	var/obj/lighting_plane/l_plane

--- a/code/modules/mob/animations.dm
+++ b/code/modules/mob/animations.dm
@@ -179,7 +179,7 @@ note dizziness decrements automatically in the mob's Life() proc.
 	flick_overlay(I, viewing, 5) // 5 ticks/half a second
 
 	// Scale the icon.
-	I.transform *= 0.75
+	I.SetTransform(scale = 0.75)
 	// Set the direction of the icon animation.
 	var/direction = get_dir(src, A)
 	if(direction & NORTH)

--- a/code/modules/mob/living/carbon/hallucinations.dm
+++ b/code/modules/mob/living/carbon/hallucinations.dm
@@ -432,7 +432,7 @@
 	if(isghost(fake))
 		fake_look.invisibility = 0
 	if(fake.lying)
-		fake_look.transform = turn(fake.transform, -90)
+		fake_look.SetTransform(others = fake.transform, rotation = -90)
 	holder.client.images |= fake_look
 	log_misc("[holder.name] is hallucinating that [origin.name] is the [fake.name]")
 

--- a/code/modules/mob/living/carbon/human/update_icons.dm
+++ b/code/modules/mob/living/carbon/human/update_icons.dm
@@ -174,11 +174,11 @@ Please contact me on #coderbus IRC. ~Carn x
 			var/entry = visible_overlays[i]
 			if(istype(entry, /image))
 				var/image/overlay = entry
-				overlay.transform = M
+				overlay.SetTransform(others = M)
 				overlays_to_apply += overlay
 			else if(istype(entry, /list))
 				for(var/image/overlay in entry)
-					overlay.transform = M
+					overlay.SetTransform(others = M)
 					overlays_to_apply += overlay
 		if(species.has_floating_eyes)
 			overlays_to_apply |= species.get_eyes(src)

--- a/code/modules/mob/observer/ghost/ghost.dm
+++ b/code/modules/mob/observer/ghost/ghost.dm
@@ -586,7 +586,7 @@ This is the proc mobs get to turn into a ghost. Forked from ghostize due to comp
 	plane = pre_plane
 	layer = pre_layer
 	set_invisibility(pre_invis)
-	transform = null	//make goast stand up
+	ClearTransform()	//make goast stand up
 
 /mob/observer/ghost/verb/respawn()
 	set name = "Respawn"

--- a/code/modules/modifier/helpers.dm
+++ b/code/modules/modifier/helpers.dm
@@ -22,52 +22,56 @@
 	return hex2num(hex_to_work_on)
 
 
-/mob/living/update_transform()
-	var/matrix/M = matrix()
-	M.Scale(icon_scale)
-	M.Translate(0, 16*(icon_scale-1))
-	if(hanging)
-		M.Turn(180)
-	animate(src, transform = M, time = 10)
+/mob/living/proc/update_transform()
+	animate(
+		src,
+		transform = matrix().Update(
+			scale_x = (tf_scale_x || 1),
+			scale_y = (tf_scale_y || 1),
+			rotation = (tf_rotation || 0) + (hanging ? 180 : 0),
+			offset_x = (tf_offset_x || 0),
+			offset_y = (tf_offset_y || 0) + 16 * ((tf_scale_y || 1) - 1)
+		),
+		time = 10
+	)
 
 /mob/living/carbon/human/update_transform()
-	var/matrix/M = matrix()
 	var/anim_time = 3
+	var/rotate_deg = (tf_rotation || 0)
+	var/translate_x = 0
+	var/translate_y = 16 * ((tf_scale_y || 1) * body_height - 1)
 
 	//Due to some involuntary means, you're laying now
 	if(lying && !resting && !sleeping)
 		anim_time = 1 //Thud
 
 	if(lying && !species.prone_icon) //Only rotate them if we're not drawing a specific icon for being prone.
-		M.Scale(icon_scale, icon_scale * body_height)
-		M.Turn(90)
-		M.Translate(1,-6)
+		rotate_deg += 90
+		translate_x = 1
+		translate_y = -6
 		layer = MOB_LAYER -0.01 // Fix for a byond bug where turf entry order no longer matters
 	else if(hanging && !species.prone_icon)
-		M.Scale(icon_scale, icon_scale * body_height)
-		M.Turn(180)
-		M.Translate(0, -16 * (icon_scale * body_height - 1))
+		rotate_deg += 180
+		translate_y = -16 * ((tf_scale_y || 1) * body_height - 1)
 		layer = MOB_LAYER // Fix for a byond bug where turf entry order no longer matters
 	else
-		M.Scale(icon_scale, icon_scale * body_height)
-		M.Translate(0, 16 * (icon_scale * body_height - 1))
 		layer = MOB_LAYER // Fix for a byond bug where turf entry order no longer matters
 
-	animate(src, transform = M, time = anim_time)
+	animate(
+		src,
+		transform = matrix().Update(
+			scale_x = (tf_scale_x || 1),
+			scale_y = (tf_scale_y || 1) * body_height,
+			rotation = (tf_rotation || 0) + rotate_deg,
+			offset_x = (tf_offset_x || 0) + translate_x,
+			offset_y = (tf_offset_y || 0) + translate_y
+		),
+		time = anim_time
+	)
 
 
 /mob/living/proc/update_modifier_visuals()
 	return
-
-/atom/movable
-	var/icon_scale = 1 // Used to scale icons up or down in update_transform().
-	var/icon_rotation = 0 // Used to rotate icons in update_transform()
-
-/atom/movable/proc/update_transform()
-	var/matrix/M = matrix()
-	M.Scale(icon_scale)
-	M.Turn(icon_rotation)
-	src.transform = M
 
 /mob/proc/update_client_color()
 	if(client && client.color)

--- a/code/modules/organs/external/_external.dm
+++ b/code/modules/organs/external/_external.dm
@@ -903,12 +903,10 @@ Note that amputating the affected organ does in fact remove the infection from t
 		if(DROPLIMB_EDGE)
 			compile_icon()
 			add_blood(victim)
-			var/matrix/M = matrix()
 			if(organ_tag == BP_HEAD)
-				M.Turn(90)
+				SetTransform(rotation = 90)
 			else
-				M.Turn(rand(180))
-			src.transform = M
+				SetTransform(rotation = rand(180))
 			forceMove(victim.loc)
 			update_icon_drop(victim)
 			if(!clean) // Throw limb around.

--- a/code/modules/paperwork/photography.dm
+++ b/code/modules/paperwork/photography.dm
@@ -46,13 +46,13 @@ var/global/photo_count = 0
 	overlays.Cut()
 	var/scale = 8/(photo_size*32)
 	var/image/small_img = image(img)
-	small_img.transform *= scale
+	small_img.SetTransform(scale = scale)
 	small_img.pixel_x = -32*(photo_size-1)/2 - 3
 	small_img.pixel_y = -32*(photo_size-1)/2
 	overlays |= small_img
 
 	tiny = image(img)
-	tiny.transform *= 0.5*scale
+	small_img.SetTransform(scale = 0.5 * scale)
 	tiny.underlays += image('icons/obj/bureaucracy.dmi',"photo")
 	tiny.pixel_x = -32*(photo_size-1)/2 - 3
 	tiny.pixel_y = -32*(photo_size-1)/2 + 3

--- a/code/modules/projectiles/effects.dm
+++ b/code/modules/projectiles/effects.dm
@@ -9,10 +9,6 @@
 	light_color = "#FF00DC"
 	anchored = 1 // The reason this is here is to stop the curving of emitter shots.
 
-/obj/effect/projectile/proc/set_transform(matrix/M)
-	if(istype(M))
-		transform = M
-
 //----------------------------
 // Laser beam
 //----------------------------

--- a/code/modules/projectiles/projectile.dm
+++ b/code/modules/projectiles/projectile.dm
@@ -127,7 +127,7 @@
 //called when the projectile stops flying because it collided with something
 /obj/item/projectile/proc/on_impact(atom/A, use_impact = TRUE)
 	if(use_impact)
-		impact_effect(effect_transform)		// generate impact effect, if projectile is in the same loc as shoot start loc, that will cause bugs.
+		impact_effect()		// generate impact effect, if projectile is in the same loc as shoot start loc, that will cause bugs.
 	if(damage && damage_type == BURN)
 		var/turf/T = get_turf(A)
 		if(T)
@@ -404,10 +404,10 @@
 						return
 
 		if(first_step)
-			muzzle_effect(effect_transform)
+			muzzle_effect()
 			first_step = 0
 		else if(!bumped && kill_count > 0)
-			tracer_effect(effect_transform)
+			tracer_effect()
 		if(!hitscan)
 			sleep(step_delay)    //add delay between movement iterations if it's not a hitscan weapon
 
@@ -428,17 +428,15 @@
 		offset = rand(-radius, radius)
 
 	// plot the initial trajectory
-	trajectory = new()
+	trajectory = new
 	trajectory.setup(starting, original, pixel_x, pixel_y, angle_offset=offset)
+	effect_transform = matrix().Update(
+		scale_x = round(trajectory.return_hypotenuse() + 0.005, 0.001),
+		rotation = round(-trajectory.angle, 0.1)
+	)
+	SetTransform(rotation = -(trajectory.angle + 90))
 
-	// generate this now since all visual effects the projectile makes can use it
-	effect_transform = new()
-	effect_transform.Scale(round(trajectory.return_hypotenuse() + 0.005, 0.001) , 1) //Seems like a weird spot to truncate, but it minimizes gaps.
-	effect_transform.Turn(round(-trajectory.return_angle(), 0.1))		//no idea why this has to be inverted, but it works
-
-	transform = turn(transform, -(trajectory.return_angle() + 90)) //no idea why 90 needs to be added, but it works
-
-/obj/item/projectile/proc/muzzle_effect(matrix/T)
+/obj/item/projectile/proc/muzzle_effect()
 	if(silenced)
 		return
 
@@ -446,33 +444,33 @@
 		var/obj/effect/projectile/M = new muzzle_type(get_turf(src))
 
 		if(istype(M))
-			M.set_transform(T)
+			M.SetTransform(others = effect_transform)
 			M.pixel_x = round(location.pixel_x, 1)
 			M.pixel_y = round(location.pixel_y, 1)
 			if(!hitscan) //Bullets don't hit their target instantly, so we can't link the deletion of the muzzle flash to the bullet's Destroy()
-				QDEL_IN(M,1)
+				QDEL_IN(M, 1)
 			else
 				segments += M
 
-/obj/item/projectile/proc/tracer_effect(matrix/M)
+/obj/item/projectile/proc/tracer_effect()
 	if(ispath(tracer_type))
 		var/obj/effect/projectile/P = new tracer_type(location.loc)
 
 		if(istype(P))
-			P.set_transform(M)
+			P.SetTransform(others = effect_transform)
 			P.pixel_x = round(location.pixel_x, 1)
 			P.pixel_y = round(location.pixel_y, 1)
 			if(!hitscan)
-				QDEL_IN(M,1)
+				QDEL_IN(P, 1)
 			else
 				segments += P
 
-/obj/item/projectile/proc/impact_effect(matrix/M)
+/obj/item/projectile/proc/impact_effect()
 	if(ispath(impact_type))
 		var/obj/effect/projectile/P = new impact_type(location.loc)
 
 		if(istype(P))
-			P.set_transform(M)
+			P.SetTransform(others = effect_transform)
 			P.pixel_x = round(location.pixel_x, 1)
 			P.pixel_y = round(location.pixel_y, 1)
 			segments += P

--- a/code/modules/rcd/work_modes.dm
+++ b/code/modules/rcd/work_modes.dm
@@ -64,7 +64,7 @@
 
 	if(T.contains_dense_objects() && locate(/obj/machinery/door/airlock) in T)
 		return FALSE
-	
+
 	return TRUE
 
 /datum/rcd_work_mode/construction_airlock/_do_handle_work(obj/item/rcd/rcd, atom/target)
@@ -81,7 +81,7 @@
 
 /datum/rcd_work_mode/construction_floor/New()
 	preview = image('icons/turf/floors.dmi', "steel")
-	preview.transform *= 0.6
+	preview.SetTransform(scale = 0.6)
 
 /datum/rcd_work_mode/construction_floor/_work_message(atom/target, mob/user, obj/item/rcd/rcd)
 	user.visible_message(SPAN("notice", "\The [user] uses \a [rcd] to construct floor."), SPAN("notice", "You begin construction."))
@@ -106,7 +106,7 @@
 /datum/rcd_work_mode/construction_floor/_do_handle_work(obj/item/rcd/rcd, atom/target)
 	if(!_can_do_handle_work(rcd, target))
 		return
-	
+
 	var/turf/T = get_turf(target)
 
 	T.ChangeTurf(/turf/simulated/floor/tiled)
@@ -117,7 +117,7 @@
 
 /datum/rcd_work_mode/construction_wall/New()
 	preview = image('icons/turf/walls.dmi', "0")
-	preview.transform *= 0.6
+	preview.SetTransform(scale = 0.6)
 
 /datum/rcd_work_mode/construction_wall/_work_message(atom/target, mob/user, obj/item/rcd/rcd)
 	user.visible_message(SPAN("notice", "\The [user] uses \a [rcd] to construct wall."), SPAN("notice", "You begin construction."))
@@ -154,13 +154,13 @@
 /datum/rcd_work_mode/deconstruction/_calculate_delay(atom/target)
 	if(istype(target, /obj/machinery/door/airlock))
 		return 5 SECONDS
-	
+
 	return 2 SECONDS
 
 /datum/rcd_work_mode/deconstruction/_calculate_cost(atom/target)
 	if(istype(target, /obj/machinery/door/airlock))
 		return 10
-	
+
 	return 3
 
 /datum/rcd_work_mode/deconstruction/_work_message(atom/target, mob/user, obj/item/rcd/rcd)
@@ -169,7 +169,7 @@
 /datum/rcd_work_mode/deconstruction/_can_do_handle_work(obj/item/rcd/rcd, atom/target)
 	if(!istype(target, /obj/machinery/door/airlock) && !istype(target, /turf/simulated/wall) && !istype(target, /turf/simulated/floor))
 		return FALSE
-	
+
 	return TRUE
 
 /datum/rcd_work_mode/deconstruction/_do_handle_work(obj/item/rcd/rcd, atom/target)
@@ -181,7 +181,7 @@
 	if(istype(W) && (!W.reinf_material || rcd.can_rwall))
 		W.dismantle_wall()
 		return
-	
+
 	var/turf/simulated/floor/F = target
 	if(istype(F))
 		F.dismantle_floor()

--- a/code/modules/reagents/reagent_containers/syringes.dm
+++ b/code/modules/reagents/reagent_containers/syringes.dm
@@ -110,9 +110,7 @@
 
 /obj/item/reagent_containers/syringe/update_icon()
 	overlays.Cut()
-
-	icon_rotation = istype(loc, /obj/item/storage) ? 90 : 0
-	update_transform()
+	SetTransform(rotation = istype(loc, /obj/item/storage) ? 90 : 0)
 
 	if(mode == SYRINGE_BROKEN)
 		icon_state = "broken"

--- a/code/modules/reagents/reagent_containers/vessel/glass/_glass.dm
+++ b/code/modules/reagents/reagent_containers/vessel/glass/_glass.dm
@@ -158,10 +158,7 @@
 			var/fsy = rim_pos_data["y"] - 20
 			var/fsx = rim_pos_data[side == "left" ? "x_left" : "x_right"] - 16
 
-			var/matrix/M = matrix()
-			M.Scale(0.5)
-			M.Translate(fsx, fsy)
-			I.transform = M
+			I.SetTransform(scale = 0.5, offset_x = fsx, offset_y = fsy)
 			underlays += I
 		else
 			continue

--- a/code/modules/surgery/organs_internal.dm
+++ b/code/modules/surgery/organs_internal.dm
@@ -58,7 +58,7 @@
 		if(I && !(I.status & ORGAN_CUT_AWAY) && I.parent_organ == affected.organ_tag && !BP_IS_ROBOTIC(I))
 			var/image/img = image(icon = I.icon, icon_state = I.icon_state)
 			img.overlays = I.overlays
-			img.transform *= 1.5
+			img.SetTransform(scale = 1.5)
 			img.pixel_y = -5
 			img.pixel_x = 3
 			damaged_organs[I] = img
@@ -267,7 +267,7 @@
 		if(I && !(I.status & ORGAN_CUT_AWAY) && I.parent_organ == affected.organ_tag && !BP_IS_ROBOTIC(I))
 			var/image/img = image(icon = I.icon, icon_state = I.icon_state)
 			img.overlays = I.overlays
-			img.transform *= 1.5
+			img.SetTransform(scale = 1.5)
 			img.pixel_y = -5
 			img.pixel_x = 3
 			damaged_organs[I] = img
@@ -390,7 +390,7 @@
 		if(organ && !(organ.status & ORGAN_CUT_AWAY) && organ.parent_organ == target_zone)
 			var/image/img = image(icon = organ.icon, icon_state = organ.icon_state)
 			img.overlays = organ.overlays
-			img.transform *= 1.5
+			img.SetTransform(scale = 1.5)
 			img.pixel_y = -5
 			img.pixel_x = 3
 			attached_organs[organ] = img
@@ -466,7 +466,7 @@
 		if(I.status & ORGAN_CUT_AWAY)
 			var/image/img = image(icon = I.icon, icon_state = I.icon_state)
 			img.overlays = I.overlays
-			img.transform *= 1.5
+			img.SetTransform(scale = 1.5)
 			img.pixel_y = -5
 			img.pixel_x = 3
 			removable_organs[I] = img
@@ -648,7 +648,7 @@
 		if(I && (I.status & ORGAN_CUT_AWAY))
 			var/image/img = image(icon = I.icon, icon_state = I.icon_state)
 			img.overlays = I.overlays
-			img.transform *= 1.5
+			img.SetTransform(scale = 1.5)
 			img.pixel_y = -5
 			img.pixel_x = 3
 			attachable_organs[I] = img
@@ -738,7 +738,7 @@
 		if(I && !(I.status & ORGAN_CUT_AWAY) && I.status & ORGAN_DEAD && I.parent_organ == affected.organ_tag && !BP_IS_ROBOTIC(I))
 			var/image/img = image(icon = I.icon, icon_state = I.icon_state)
 			img.overlays = I.overlays
-			img.transform *= 1.5
+			img.SetTransform(scale = 1.5)
 			img.pixel_y = -5
 			img.pixel_x = 3
 			dead_organs[I] = img


### PR DESCRIPTION
Больше контроля над матрицами - круто. Для кода - удобно, для щитспавна - незаменимо.
Ну и фиксит некоторые штуки, связанные с матрицами - повороты вендоматов при закликивании и т.д.
![image](https://user-images.githubusercontent.com/45202681/172263119-5cdadc7a-f716-430f-9cc7-8cfc7f389e76.png)
![image](https://user-images.githubusercontent.com/45202681/172263389-75219cc0-7296-4d39-8e3b-a1c1ebb96d0c.png)
Портировано с https://github.com/Baystation12/Baystation12/pull/32067 и адаптировано под местные реалии.

```yml
🆑
admin: Добавлена возможность относительно удобно изменять матрицы любых объектов. SetTransform() и переменные tf_* в помощь.
/🆑
```

- [x] Pull Request полностью завершен, мне не нужна помощь чтобы его закончить.
- [x] Я внимательно прочитал все свои изменения и багов в них не нашел.
- [x] Я запускал сервер со своими изменениями локально и все протестировал.
- [x] Я ознакомился c [Guide to Contribute](https://github.com/ChaoticOnyx/OnyxBay/blob/dev/docs/contributing.md).
