### PR TITLE
feat(rotate-screen): purge 7 year old feature

### DIFF
--- a/code/modules/client/movement.dm
+++ b/code/modules/client/movement.dm
@@ -2,14 +2,3 @@
 /client/New()
 	..()
 	dir = NORTH
-
-/client/verb/spinleft()
-	set name = "Spin View CCW"
-	set category = "OOC"
-	dir = turn(dir, 90)
-
-/client/verb/spinright()
-	set name = "Spin View CW"
-	set category = "OOC"
-	dir = turn(dir, -90)
-

--- a/code/modules/virus2/effects/mild.dm
+++ b/code/modules/virus2/effects/mild.dm
@@ -148,12 +148,7 @@
 	if(..())
 		return
 	to_chat(mob, DISORIENTATION_EFFECT_WARNING)
-	if(mob.client)
-		var/client/C = mob.client
-		if(prob(50))
-			C.dir = turn(C.dir, 90)
-		else
-			C.dir = turn(C.dir, -90)
+	mob.confused += (rand(1,4) + 2)
 
 
 /datum/disease2/effect/fridge

--- a/code/modules/virus2/effects/mild.dm
+++ b/code/modules/virus2/effects/mild.dm
@@ -148,7 +148,8 @@
 	if(..())
 		return
 	to_chat(mob, DISORIENTATION_EFFECT_WARNING)
-	mob.confused += (rand(1,4) + 2)
+	mob.eye_blurry = max(mob.eye_blurry, 10)
+
 
 
 /datum/disease2/effect/fridge


### PR DESCRIPTION
Я не знаю, с какой целью мы держим этот огрызок кода, который ломает половину спрайтов у клиента.

fix #4717
fix #8630
<details>
<summary>Чейнджлог</summary>

```yml
🆑
rscdel: Убрана возможность повернуть экран в OOC вкладке.
tweak: Симптом Дизориентации теперь не поворачивает экран, а накладывает дизориентацию как у флешки.
/🆑
```

</details>

- [x] Pull Request полностью завершен, мне не нужна помощь чтобы его закончить.
- [x] Я внимательно прочитал все свои изменения и багов в них не нашел.
- [ ] Я запускал сервер со своими изменениями локально и все протестировал.
- [x] Я ознакомился c [Guide to Contribute](https://github.com/ChaoticOnyx/OnyxBay/blob/dev/docs/contributing.md).
