### PR TITLE
fix(organs): fix limbs cutting

### DIFF
--- a/code/modules/organs/external/_external.dm
+++ b/code/modules/organs/external/_external.dm
@@ -242,53 +242,66 @@
 	switch(stage)
 		if(0)
 			if(W.sharp)
-				user.visible_message(SPAN("danger", "<b>[user]</b> cuts [src] open with [W]!"))
-				stage++
-				return
+				if(do_mob(user, src, DEFAULT_ATTACK_COOLDOWN))
+					if(children?.len)
+						var/obj/item/organ/external/external_child = pick(children)
+						status |= ORGAN_CUT_AWAY
+						children.Remove(external_child)
+						external_child.forceMove(get_turf(src))
+						external_child.SetTransform(rotation = rand(180))
+						external_child.compile_icon()
+						compile_icon()
+						user.visible_message(SPAN("danger", "<b>[user]</b> cuts [external_child] from [src] with [W]!"))
+					else
+						user.visible_message(SPAN("danger", "<b>[user]</b> cuts [src] open with [W]!"))
+						stage++
+					return
 		if(1)
 			if(istype(W))
-				user.visible_message(SPAN("danger", "<b>[user]</b> cracks [src] open like an egg with [W]!"))
-				stage++
-				return
+				if(do_mob(user, src, DEFAULT_ATTACK_COOLDOWN))
+					user.visible_message(SPAN("danger", "<b>[user]</b> cracks [src] open like an egg with [W]!"))
+					stage++
+					return
 		if(2)
 			if(W.sharp || istype(W, /obj/item/hemostat) || isWirecutter(W))
 				var/list/organs = get_contents_recursive()
-				if(organs.len)
-					var/obj/item/removing = pick(organs)
-					var/obj/item/organ/external/current_child = removing.loc
+				if(do_mob(user, src, DEFAULT_ATTACK_COOLDOWN))
+					if(organs.len)
+						var/obj/item/removing = pick(organs)
+						var/obj/item/organ/external/current_child = removing.loc
 
-					current_child.implants.Remove(removing)
-					current_child.internal_organs.Remove(removing)
+						current_child.implants.Remove(removing)
+						current_child.internal_organs.Remove(removing)
 
-					status |= ORGAN_CUT_AWAY
-					if(istype(removing, /obj/item/organ/internal/mmi_holder))
-						var/obj/item/organ/internal/mmi_holder/O = removing
-						removing = O.transfer_and_delete()
+						status |= ORGAN_CUT_AWAY
+						if(istype(removing, /obj/item/organ/internal/mmi_holder))
+							var/obj/item/organ/internal/mmi_holder/O = removing
+							removing = O.transfer_and_delete()
 
-					removing.forceMove(get_turf(src))
-					user.visible_message(SPAN_DANGER("<b>[user]</b> extracts [removing] from [src] with [W]!"))
-				else
-					if(organ_tag == BP_HEAD && W.sharp)
-						var/obj/item/organ/external/head/H = src // yeah yeah this is horrible
-						if(!H.skull_path)
-							user.visible_message(SPAN("danger", "<b>[user]</b> fishes around fruitlessly in [src] with [W]."))
-							return
-						user.visible_message(SPAN("danger", "<b>[user]</b> rips the skin off [H] with [W], revealing a skull."))
-						if(istype(H.loc, /turf))
-							new H.skull_path(H.loc)
-							gibs(H.loc)
-						else
-							new H.skull_path(user.loc)
-							gibs(user.loc)
-						H.skull_path = null // So no skulls dupe in case of lags
-						qdel(src)
+						removing.forceMove(get_turf(src))
+						user.visible_message(SPAN_DANGER("<b>[user]</b> extracts [removing] from [src] with [W]!"))
 					else
-						if(src && !QDELETED(src))
-							food_organ.appearance = food_organ_type
-							food_organ.forceMove(get_turf(loc))
-							food_organ = null
+						if(organ_tag == BP_HEAD && W.sharp)
+							var/obj/item/organ/external/head/H = src // yeah yeah this is horrible
+							if(!H.skull_path)
+								user.visible_message(SPAN("danger", "<b>[user]</b> fishes around fruitlessly in [src] with [W]."))
+								return
+							user.visible_message(SPAN("danger", "<b>[user]</b> rips the skin off [H] with [W], revealing a skull."))
+							if(istype(H.loc, /turf))
+								new H.skull_path(H.loc)
+								gibs(H.loc)
+							else
+								new H.skull_path(user.loc)
+								gibs(user.loc)
+							H.skull_path = null // So no skulls dupe in case of lags
 							qdel(src)
-						user.visible_message(SPAN_DANGER("<b>[user]</b> fishes around fruitlessly in [src] with [W]."))
+						else
+							if(src && !QDELETED(src))
+								food_organ.appearance = food_organ_type
+								food_organ.forceMove(get_turf(loc))
+								food_organ = null
+								qdel(src)
+							user.visible_message(SPAN_DANGER("<b>[user]</b> fishes around fruitlessly in [src] with [W]."))
 				return
 	..()
 
@@ -1250,7 +1263,7 @@ Note that amputating the affected organ does in fact remove the infection from t
 			// let actual implants still inside know they're no longer implanted
 			if(istype(I, /obj/item/implant))
 				var/obj/item/implant/imp_device = I
-				imp_device.removed()
+				imp_device.imp_in = null
 		else
 			implants.Remove(implant)
 			implant.forceMove(get_turf(src))


### PR DESCRIPTION
Исправлена "шинковка" конечностей имеющих дочерние конечности. При применении на живот с ногами сперва отпадет одна из ног от которой уже можно будет отпилить ступни.
Исправлено исчезновение импланта при разрезке конечностей, теперь он будет выпадать как и задумывалось изначально, т.э как внутренний орган.

Было:
![image](https://user-images.githubusercontent.com/98897017/173253137-929cece3-f5d8-421f-b483-33bea1c815e4.png)

Стало:
![image](https://user-images.githubusercontent.com/98897017/173253172-57097f02-ecc7-437a-9893-c08102699090.png)
Добавлен прогрессбар для большей информативности. Раньше их не показывало, но задержка была.

close #8626

<details>
<summary>Чейнджлог</summary>

```yml
🆑Oubi
bugfix: Исправлено исчезновение дочерних конечностей при разделке отрубленных частей тела.
bugfix: Исправлено пропадание импланта при разделке отрубленной конечности.
/🆑
```

</details>

- [x] Pull Request полностью завершен, мне не нужна помощь чтобы его закончить.
- [x] Я внимательно прочитал все свои изменения и багов в них не нашел.
- [x] Я запускал сервер со своими изменениями локально и все протестировал.
- [x] Я ознакомился c [Guide to Contribute](https://github.com/ChaoticOnyx/OnyxBay/blob/dev/docs/contributing.md).
