### PR TITLE
bugfix(silicon & airlock): harm intent fix

### DIFF
--- a/code/game/machinery/doors/airlock.dm
+++ b/code/game/machinery/doors/airlock.dm
@@ -598,6 +598,9 @@ About the new airlock wires panel:
 		return 1
 
 /obj/machinery/door/airlock/attackby(obj/item/C, mob/user)
+	if(user.a_intent == I_HURT && !isWelder(C))
+		return ..()
+
 	// Brace is considered installed on the airlock, so interacting with it is protected from electrification.
 	if(brace && (istype(C.GetIdCard(), /obj/item/card/id/) || istype(C, /obj/item/crowbar/brace_jack)))
 		return brace.attackby(C, user)

--- a/code/game/machinery/doors/braces.dm
+++ b/code/game/machinery/doors/braces.dm
@@ -5,8 +5,9 @@
 	w_class = ITEM_SIZE_NORMAL
 	icon = 'icons/obj/tools.dmi'
 	icon_state = "maintenance_jack"
-	force = 8 //It has a hammer head, should probably do some more damage. - Cirra
-	throwforce = 10
+	force = 13
+	mod_weight = 1.25
+	throwforce = 12
 
 
 

--- a/code/modules/mob/living/silicon/robot/robot.dm
+++ b/code/modules/mob/living/silicon/robot/robot.dm
@@ -551,6 +551,9 @@ var/global/list/robot_footstep_sounds = list(
 	if (istype(W, /obj/item/handcuffs)) // fuck i don't even know why isrobot() in handcuff code isn't working so this will have to do
 		return
 
+	if(user.a_intent == I_HURT)
+		return ..()
+
 	if(opened) // Are they trying to insert something?
 		for(var/V in components)
 			var/datum/robot_component/C = components[V]


### PR DESCRIPTION
Теперь при выборе harm intent можно нанести вред шлюзам и боргам. Раньше возможность нанести урон инструментами отсутствовала.
Так же повышен урон maintenance jack, он был меньше чем у его родителя, что не позволяло ему выламывать шлюзы что не есть логично судя по его назначению и древнему комменту, древнего разработчика.
Урон шлюзу сваркой намерено отключен из-за её большого force при включенном состоянии. Думаю для этого можно сделать отдельную фичу, которая позволит вырезать шлюзы.

close #8673 

<details>
<summary>Чейнджлог</summary>

```yml
🆑Oubi
bugfix: Теперь боргов и шлюзы можно бить инструментами на harm intent.
tweak: Слегка повышен урон у maintenance jack.
/🆑
```

</details>

- [x] Pull Request полностью завершен, мне не нужна помощь чтобы его закончить.
- [x] Я внимательно прочитал все свои изменения и багов в них не нашел.
- [x] Я запускал сервер со своими изменениями локально и все протестировал.
- [x] Я ознакомился c [Guide to Contribute](https://github.com/ChaoticOnyx/OnyxBay/blob/dev/docs/contributing.md).
