### PR TITLE
Фиксим прохождение пуль сквозь вещи, on_impact кейс

### DIFF
--- a/code/modules/projectiles/projectile.dm
+++ b/code/modules/projectiles/projectile.dm
@@ -357,13 +357,16 @@
 		bumped = 0 //reset bumped variable!
 		return 0
 
-	//stop flying
-	on_impact(A)
-
+	// Effectively cease existing
 	set_density(0)
 	set_invisibility(101)
 
-	qdel(src)
+	spawn
+		// on_impact might take a long time
+		//   so we defer its execution
+		on_impact(A)
+		qdel(src)
+
 	return 1
 
 /obj/item/projectile/ex_act()
@@ -404,6 +407,11 @@
 		before_move()
 		previous = loc
 		Move(location.return_turf())
+
+		if (!src.density)
+			// We are unable to hit anything anymore
+			//   so don't bother moving further
+			break
 
 		if(!bumped && (!isturf(original) || impact_on_original))
 			if(loc == get_turf(original))


### PR DESCRIPTION
У некоторых снарядов (например ионных пуль или взрывных) их действие вызывает анимации или другие отложенные функции, что заставляет Bump не возвращать ничего, приводя к прохождению пуль сквозь вещи.
У ионок это заметно было на дверях -- если они открывали дверь, то они и пролетали сквозь неё же и все препятствия на пути в этой двери.
Поэтому мы откладываем выполнение on_impact у снарядов и заставляем их сразу же останавливаться при попадании.

fix #8695
Решение неполное -- рикошеты ещё один источник прохождений сквозь стены.

<details>
<summary>Чейнджлог</summary>

```yml
🆑EditorRUS
bugfix: Прохождение снарядов сквозь препятствия, часть первая
/🆑
```

</details>

- [X] Pull Request полностью завершен, мне не нужна помощь чтобы его закончить.
- [X] Я внимательно прочитал все свои изменения и багов в них не нашел.
- [X] Я запускал сервер со своими изменениями локально и все протестировал.
- [X] Я ознакомился c [Guide to Contribute](https://github.com/ChaoticOnyx/OnyxBay/blob/dev/docs/contributing.md).
