### PR TITLE
feat(loadout): adds kneepad color options

### DIFF
--- a/code/modules/client/preference_setup/loadout/lists/security.dm
+++ b/code/modules/client/preference_setup/loadout/lists/security.dm
@@ -35,6 +35,7 @@
 /datum/gear/security/kneepads
 	display_name = "kneepads"
 	path = /obj/item/clothing/accessory/kneepads
+	flags = GEAR_HAS_COLOR_SELECTION
 	allowed_roles = ARMED_ROLES
 	cost = 2
 


### PR DESCRIPTION
Я не знаю, какой гений додумался добавить белые наколенники как маску, но не додумался сделать их перекрашиваемыми, чтобы ты мог носить серые-тёмные наколенники со своей формой.

![image](https://user-images.githubusercontent.com/41485301/175044680-d2d2c0ff-02c7-4f0c-ad66-b979b8679fff.png)
![image](https://user-images.githubusercontent.com/41485301/175044708-ac1fafc6-bc2c-4498-8f74-69559d3747e5.png)


<details>
<summary>Чейнджлог</summary>

```yml
🆑
tweak: Наколенники в лоадауте теперь перекрашиваются.
/🆑
```

</details>

- [x] Pull Request полностью завершен, мне не нужна помощь чтобы его закончить.
- [x] Я внимательно прочитал все свои изменения и багов в них не нашел.
- [ ] Я запускал сервер со своими изменениями локально и все протестировал.
- [ ] Я ознакомился c [Guide to Contribute](https://github.com/ChaoticOnyx/OnyxBay/blob/dev/docs/contributing.md).
