### PR TITLE
fix(plane_master) removes window frame overlays' plane assignment

### DIFF
--- a/code/game/objects/structures/window_frame.dm
+++ b/code/game/objects/structures/window_frame.dm
@@ -348,20 +348,17 @@
 
 		for(var/i = 1 to 4)
 			var/image/I = image(icon, "[inner_pane.icon_base][connections[i]]", dir = 1<<(i-1))
-			I.plane = DEFAULT_PLANE
 			I.layer = WINDOW_INNER_LAYER
 			overlays += I
 
 		if(inner_pane.tinted)
 			new_opacity = TRUE
 			var/image/I = image(icon, "winframe_tint")
-			I.plane = DEFAULT_PLANE
 			I.layer = WINDOW_INNER_LAYER
 			overlays += I
 
 		if(inner_pane.damage_state)
 			var/image/I = image(icon, "winframe_damage[inner_pane.damage_state]")
-			I.plane = DEFAULT_PLANE
 			I.layer = WINDOW_INNER_LAYER
 			overlays += I
 
@@ -382,20 +379,17 @@
 
 		for(var/i = 1 to 4)
 			var/image/I = image(icon, "[outer_pane.icon_base][connections[i]]", dir = 1<<(i-1))
-			I.plane = DEFAULT_PLANE
 			I.layer = WINDOW_OUTER_LAYER
 			overlays += I
 
 		if(outer_pane.tinted)
 			new_opacity = TRUE
 			var/image/I = image(icon, "winframe_tint")
-			I.plane = DEFAULT_PLANE
 			I.layer = WINDOW_OUTER_LAYER
 			overlays += I
 
 		if(outer_pane.damage_state)
 			var/image/I = image(icon, "winframe_damage[outer_pane.damage_state]")
-			I.plane = DEFAULT_PLANE
 			I.layer = WINDOW_OUTER_LAYER
 			overlays += I
 
@@ -412,7 +406,6 @@
 
 		for(var/i = 1 to 4)
 			var/image/I = image(icon, "[icon_border][connections[i]]", dir = 1<<(i-1))
-			I.plane = DEFAULT_PLANE
 			I.layer = WINDOW_BORDER_LAYER
 			overlays += I
 


### PR DESCRIPTION
Убирает (совершенно бесполезное) присвоение плейна оверлеям окошек, из-за которых те неадекватно отображались на опенспейсах.

До
![before](https://user-images.githubusercontent.com/107106680/175318090-845f4e59-f21b-4e04-b9ef-5c2c936342f4.png)
После
![after](https://user-images.githubusercontent.com/107106680/175318132-431c58d7-cf6a-4774-99ea-4669d6df16cd.png)

<details>
<summary>Чейнджлог</summary>

```yml
🆑
bugfix: Оконные рамы и окна теперь отображаются корректно при взгляде с верхнего z-уровня.
/🆑
```

</details>

- [x] Pull Request полностью завершен, мне не нужна помощь чтобы его закончить.
- [x] Я внимательно прочитал все свои изменения и багов в них не нашел.
- [x] Я запускал сервер со своими изменениями локально и все протестировал.
- [x] Я ознакомился c [Guide to Contribute](https://github.com/ChaoticOnyx/OnyxBay/blob/dev/docs/contributing.md).
