### PR TITLE
Removes taser SMGs supremacy

### DIFF
--- a/code/modules/projectiles/guns/energy/stun.dm
+++ b/code/modules/projectiles/guns/energy/stun.dm
@@ -268,7 +268,7 @@
 	icon_state = "taser_smg"
 	wielded_item_state = FALSE
 	projectile_type = /obj/item/projectile/energy/electrode/small
-	max_shots = 15
+	max_shots = 12
 	accuracy = 0
 	one_hand_penalty = 1
 	fire_delay = 3


### PR DESCRIPTION
В данный момент ПП уверенно вырывают очко у своих братьев. Боезапаса у пистолета и винтовки хватает чтобы уронить максимум трёх человек. У ПП - хватает на пятерых, либо четверых если попадания с перерывами. Теперь - 4/3, ближе к собратьям по тиру.

```yml
🆑
balance: Запас выстрелов у тазеров-ПП уменьшен с 15 до 12.
/🆑
```

- [x] Pull Request полностью завершен, мне не нужна помощь чтобы его закончить.
- [x] Я внимательно прочитал все свои изменения и багов в них не нашел.
- [x] Я запускал сервер со своими изменениями локально и все протестировал.
- [x] Я ознакомился c [Guide to Contribute](https://github.com/ChaoticOnyx/OnyxBay/blob/dev/docs/contributing.md).
