### PR TITLE
Баланс руны закипания крови культа

### DIFF
--- a/code/game/gamemodes/cult/runes.dm
+++ b/code/game/gamemodes/cult/runes.dm
@@ -853,8 +853,8 @@
 		current.Cut()
 		uses -= 1
 		if(uses <= 0)
-			user.visible_message(SPAN_WARNING("\The [src] dissipates."),
-			                     SPAN_DANGER("\The [src] suddenly dissipates. Seems like all of its power has been used up."))
+			visible_message(SPAN_WARNING("\The [src] suddenly dissipates."))
+			to_chat(user, SPAN_DANGER("Seems like all of \the [src]'s power has been used up."))
 			qdel(src)
 			return
 		sleep(40)

--- a/code/game/gamemodes/cult/runes.dm
+++ b/code/game/gamemodes/cult/runes.dm
@@ -820,6 +820,7 @@
 	cultname = "blood boil"
 	strokes = 4
 	var/is_used = FALSE
+	var/uses = 5
 
 /obj/effect/rune/blood_boil/cast(mob/living/user)
 	var/list/mob/living/cultists = get_cultists()
@@ -850,7 +851,13 @@
 					to_chat(M, "<span class='danger'>You feel searing heat inside!</span>")
 		previous = current.Copy()
 		current.Cut()
-		sleep(10)
+		uses -= 1
+		if(uses <= 0)
+			user.visible_message(SPAN_WARNING("\The [src] dissipates."),
+			                     SPAN_DANGER("\The [src] suddenly dissipates. Seems like all of its power has been used up."))
+			qdel(src)
+			return
+		sleep(40)
 	is_used = FALSE
 
 /* Tier NarNar runes */


### PR DESCRIPTION
- 1 секунда кулдауна у бладбойла -- слишком мало. Людей за 10 или даже меньше секунд кидает в крит (а чем сильнее тебя побило, тем сложнее выйти из зоны действия руны из-за замедления). Теперь кулдаун -- 4 секунды.
- Руну бладбойла теперь можно использовать только 5 раз, после чего она исчезает.

Иссуев по бладбойлу вроде нет, я не нашёл.
Рефакторинг спанов и прочего не сделал, ибо уже есть в #7903 по всему файлу (надеюсь конфликтами не насрёт).

И нет, меня не убило бладбойлом, я из гостов видел, как им выкосили человек пять-шесть, в том числе мимокрокодилов. И это не первый такой случай.

<details>
<summary>Чейнджлог</summary>

```yml
🆑TheUnknownOne
balance: Кулдаун использования руны бладбойла культа повышен до 4 секунд (была 1 секунда).
balance: Каждую руну бладбойла теперь можно использовать только 5 раз.
/🆑
```

</details>

- [x] Pull Request полностью завершен, мне не нужна помощь чтобы его закончить.
- [x] Я внимательно прочитал все свои изменения и багов в них не нашел.
- [x] Я запускал сервер со своими изменениями локально и все протестировал.
- [x] Я ознакомился c [Guide to Contribute](https://github.com/ChaoticOnyx/OnyxBay/blob/dev/docs/contributing.md).
