### PR TITLE
feat(rig_launcher): Now with adjustable timer

### DIFF
--- a/code/modules/clothing/spacesuits/rig/modules/combat.dm
+++ b/code/modules/clothing/spacesuits/rig/modules/combat.dm
@@ -103,7 +103,6 @@
 
 	charge.charges--
 	var/obj/item/grenade/new_grenade = new charge.product_type(get_turf(H))
-	H.visible_message(SPAN("danger","[H] launches \a [new_grenade]!"))
 	new_grenade.safety_pin = null
 
 	if(new_grenade.detonator)
@@ -117,6 +116,7 @@
 
 	new_grenade.activate(H)
 	new_grenade.throw_at(target, fire_distance, fire_force)
+	H.visible_message(SPAN("danger","[H] launches \a [new_grenade]!"))
 
 /obj/item/rig_module/grenade_launcher/cleaner
 	name = "mounted cleaning grenade launcher"

--- a/code/modules/clothing/spacesuits/rig/modules/combat.dm
+++ b/code/modules/clothing/spacesuits/rig/modules/combat.dm
@@ -111,7 +111,7 @@
 			var/obj/item/device/assembly/timer/timer = det.a_left
 			timer.time = timings[timing_selected].timing
 		if(istimer(det.a_right))
-			var/obj/item/device/assembly/timer/timer = det.a_left
+			var/obj/item/device/assembly/timer/timer = det.a_right
 			timer.time = timings[timing_selected].timing
 
 	new_grenade.activate(H)

--- a/code/modules/clothing/spacesuits/rig/modules/combat.dm
+++ b/code/modules/clothing/spacesuits/rig/modules/combat.dm
@@ -47,6 +47,11 @@
 		list("smoke bomb",  "smoke bomb",  /obj/item/grenade/smokebomb,  3),
 		list("EMP grenade", "EMP grenade", /obj/item/grenade/empgrenade, 3),
 		)
+	timings = list(
+		list("2 seconds", "short",  2),
+		list("3 seconds", "medium", 3),
+		list("5 seconds", "long",	5),
+		)
 
 /obj/item/rig_module/grenade_launcher/accepts_item(obj/item/input_device, mob/living/user)
 
@@ -84,7 +89,7 @@
 	var/mob/living/carbon/human/H = holder.wearer
 
 	if(!charge_selected)
-		to_chat(H, "<span class='danger'>You have not selected a grenade type.</span>")
+		to_chat(H, SPAN("danger","You have not selected a grenade type."))
 		return 0
 
 	var/datum/rig_charge/charge = charges[charge_selected]
@@ -93,14 +98,23 @@
 		return 0
 
 	if(charge.charges <= 0)
-		to_chat(H, "<span class='danger'>Insufficient grenades!</span>")
+		to_chat(H, SPAN("danger","Insufficient grenades!"))
 		return 0
 
 	charge.charges--
 	var/obj/item/grenade/new_grenade = new charge.product_type(get_turf(H))
-	H.visible_message("<span class='danger'>[H] launches \a [new_grenade]!</span>")
+	H.visible_message(SPAN("danger","[H] launches \a [new_grenade]!"))
 	new_grenade.safety_pin = null
-	new_grenade.det_time = 10
+
+	if(new_grenade.detonator)
+		var/obj/item/device/assembly_holder/det = new_grenade.detonator
+		if(istimer(det.a_left))
+			var/obj/item/device/assembly/timer/timer = det.a_left
+			timer.time = timings[timing_selected].timing
+		if(istimer(det.a_right))
+			var/obj/item/device/assembly/timer/timer = det.a_left
+			timer.time = timings[timing_selected].timing
+
 	new_grenade.activate(H)
 	new_grenade.throw_at(target, fire_distance, fire_force)
 

--- a/code/modules/clothing/spacesuits/rig/modules/modules.dm
+++ b/code/modules/clothing/spacesuits/rig/modules/modules.dm
@@ -8,6 +8,11 @@
 	var/product_type = "undefined"
 	var/charges = 0
 
+/datum/rig_timing
+	var/full_name = "undefined"
+	var/short_name = "undef"
+	var/timing = 0
+
 /obj/item/rig_module
 	name = "powersuit upgrade"
 	desc = "It looks pretty sciency."
@@ -39,6 +44,9 @@
 
 	var/list/charges                    // Associative list of charge types and remaining numbers.
 	var/charge_selected                 // Currently selected option used for charge dispensing.
+
+	var/list/timings 					// Associative list of timings.
+	var/timing_selected					// Timing options for grenade launchers (in seconds).
 
 	// Icons.
 	var/suit_overlay
@@ -129,11 +137,26 @@
 
 		charges = processed_charges
 
+	if(timings && timings.len)
+		var/list/processed_timings = list()
+		for(var/list/timing in timings)
+			var/datum/rig_timing/timing_dat = new
+
+			timing_dat.full_name 	= timing[1]
+			timing_dat.short_name	= timing[2]
+			timing_dat.timing 		= timing[3]
+
+			if(!timing_selected) timing_selected = timing_dat.short_name
+			processed_timings[timing_dat.short_name] = timing_dat
+
+		timings = processed_timings
+
 	stat_modules += new /stat_rig_module/activate(src)
 	stat_modules += new /stat_rig_module/deactivate(src)
 	stat_modules += new /stat_rig_module/engage(src)
 	stat_modules += new /stat_rig_module/select(src)
 	stat_modules += new /stat_rig_module/charge(src)
+	stat_modules += new /stat_rig_module/timing(src)
 
 /obj/item/rig_module/Destroy()
 	deactivate()
@@ -340,5 +363,26 @@
 	if(module.charges && module.charges.len)
 		var/datum/rig_charge/charge = module.charges[module.charge_selected]
 		name = "[charge.display_name] ([charge.charges]C) - Change"
+		return 1
+	return 0
+
+/stat_rig_module/timing/New()
+	..()
+	name = "Change Timing"
+	module_mode = "select_timing"
+
+/stat_rig_module/timing/AddHref(list/href_list)
+	var/timing_index = module.timings.Find(module.timing_selected)
+	if(!timing_index)
+		timing_index = 0
+	else
+		timing_index = timing_index == module.timings.len ? 1 : timing_index+1
+
+	href_list["timing"] = module.timings[timing_index]
+
+/stat_rig_module/timing/CanUse()
+	if(module.timings && module.timings.len)
+		var/datum/rig_timing/timing = module.timings[module.timing_selected]
+		name = "Current grenade timing is: [timing.full_name] - Change"
 		return 1
 	return 0

--- a/code/modules/clothing/spacesuits/rig/modules/modules.dm
+++ b/code/modules/clothing/spacesuits/rig/modules/modules.dm
@@ -384,5 +384,5 @@
 	if(module.timings?.len)
 		var/datum/rig_timing/timing = module.timings[module.timing_selected]
 		name = "Current grenade timing is: [timing.full_name] - Change"
-		return 1
-	return 0
+		return TRUE
+	return FALSE

--- a/code/modules/clothing/spacesuits/rig/modules/modules.dm
+++ b/code/modules/clothing/spacesuits/rig/modules/modules.dm
@@ -137,7 +137,7 @@
 
 		charges = processed_charges
 
-	if(timings && timings.len)
+	if(timings?.len)
 		var/list/processed_timings = list()
 		for(var/list/timing in timings)
 			var/datum/rig_timing/timing_dat = new
@@ -381,7 +381,7 @@
 	href_list["timing"] = module.timings[timing_index]
 
 /stat_rig_module/timing/CanUse()
-	if(module.timings && module.timings.len)
+	if(module.timings?.len)
 		var/datum/rig_timing/timing = module.timings[module.timing_selected]
 		name = "Current grenade timing is: [timing.full_name] - Change"
 		return 1

--- a/code/modules/clothing/spacesuits/rig/rig.dm
+++ b/code/modules/clothing/spacesuits/rig/rig.dm
@@ -641,6 +641,8 @@
 					selected_module = module
 				if("select_charge_type")
 					module.charge_selected = href_list["charge_type"]
+				if("select_timing")
+					module.timing_selected = href_list["timing"]
 		return 1
 	if(href_list["toggle_ai_control"])
 		ai_override_enabled = !ai_override_enabled


### PR DESCRIPTION
Кажется, пятисекундные гранаты в риге это не так смешно. Теперь можно выбрать тайминг из трех пресетов (2, 3, 5 секунд).

close #8748
<details>
<summary>Чейнджлог</summary>

```yml
🆑
rscadd: В гранатометы РИГов добавлена возможность настраивать таймер гранаты.
/🆑
```

</details>

- [x] Pull Request полностью завершен, мне не нужна помощь чтобы его закончить.
- [x] Я внимательно прочитал все свои изменения и багов в них не нашел.
- [x] Я запускал сервер со своими изменениями локально и все протестировал.
- [x] Я ознакомился c [Guide to Contribute](https://github.com/ChaoticOnyx/OnyxBay/blob/dev/docs/contributing.md).
