### PR TITLE
fix(cult): now shadow correctly dies

### DIFF
--- a/code/modules/mob/living/simple_animal/constructs/soulstone.dm
+++ b/code/modules/mob/living/simple_animal/constructs/soulstone.dm
@@ -25,10 +25,30 @@
 /obj/item/device/soulstone/New()
 	..()
 	shade = new /mob/living/simple_animal/shade(src)
+	register_signal(shade, SIGNAL_QDELETING, /obj/item/device/soulstone/proc/onShadeDeath)
 
 /obj/item/device/soulstone/Destroy()
+	unregister_signal(shade, SIGNAL_QDELETING)
 	QDEL_NULL(shade)
 	return ..()
+
+/obj/item/device/soulstone/proc/onShadeDeath()
+	unregister_signal(shade, SIGNAL_QDELETING)
+
+	if(ishuman(loc))
+		var/mob/living/carbon/human/H = loc
+		if(iscultist(H))
+			H.show_message(SPAN("warning", "You feel that the soul stone lost link with its shade and lacks power..."))
+		else
+			H.show_message(SPAN("warning", "You feel that a strange wave went throught you..."))
+	else if(isturf(loc))
+		visible_message(SPAN("warning", "\The [src] emits powerful flare!"))
+
+	set_full(SOULSTONE_EMPTY)
+
+	shade = new /mob/living/simple_animal/shade(src)
+	register_signal(shade, SIGNAL_QDELETING, /obj/item/device/soulstone/proc/onShadeDeath)
+
 
 /obj/item/device/soulstone/_examine_text(mob/user)
 	. = ..()
@@ -51,29 +71,33 @@
 /obj/item/device/soulstone/attackby(obj/item/I, mob/user)
 	..()
 	if(is_evil && istype(I, /obj/item/nullrod))
-		to_chat(user, "<span class='notice'>You cleanse \the [src] of taint, purging its shackles to its creator..</span>")
+		to_chat(user, SPAN("notice", "You cleanse \the [src] of taint, purging its shackles to its creator..."))
 		is_evil = 0
 		return
 	if(I.force > 10)
 		if(!smashing)
-			to_chat(user, "<span class='notice'>\The [src] looks fragile. Are you sure you want to smash it? If so, hit it again.</span>")
+			to_chat(user, SPAN("notice", "\The [src] looks fragile. Are you sure you want to smash it? If so, hit it again."))
 			smashing = 1
 			spawn(20)
 				smashing = 0
 			return
-		user.visible_message("<span class='warning'>\The [user] hits \the [src] with \the [I], and it breaks.[shade.client ? " You hear a terrible scream!" : ""]</span>", "<span class='warning'>You hit \the [src] with \the [I], and it breaks.[shade.client ? " You hear a terrible scream!" : ""]</span>", shade.client ? "You hear a scream." : null)
+		user.visible_message(
+		  SPAN("warning", "\The [user] hits \the [src] with \the [I], and it breaks.[shade.client ? " You hear a terrible scream!" : ""]"),
+		  SPAN("warning", "You hit \the [src] with \the [I], and it breaks.[shade.client ? " You hear a terrible scream!" : ""]"),
+		  shade.client ? SPAN("warning", "You hear a terrible scream.") : null
+		)
 		set_full(SOULSTONE_CRACKED)
 
 /obj/item/device/soulstone/attack(mob/living/simple_animal/M, mob/user)
 	if(M == shade)
-		to_chat(user, "<span class='notice'>You recapture \the [M].</span>")
+		to_chat(user, SPAN("notice", "You recapture \the [M]."))
 		M.forceMove(src)
 		return
 	if(full == SOULSTONE_ESSENCE)
-		to_chat(user, "<span class='notice'>\The [src] is already full.</span>")
+		to_chat(user, SPAN("notice", "\The [src] is already full."))
 		return
 	if(M.stat != DEAD && !M.is_asystole())
-		to_chat(user, "<span class='notice'>Kill or maim the victim first.</span>")
+		to_chat(user, SPAN("notice", "Kill or maim the victim first."))
 		return
 	for(var/obj/item/I in M)
 		M.drop_from_inventory(I)
@@ -82,22 +106,22 @@
 
 /obj/item/device/soulstone/attack_self(mob/user)
 	if(full != SOULSTONE_ESSENCE) // No essence - no shade
-		to_chat(user, "<span class='notice'>This [src] has no life essence.</span>")
+		to_chat(user, SPAN("notice", "This [src] has no life essence."))
 		return
 
 	if(!shade.key) // No key = hasn't been used
-		to_chat(user, "<span class='notice'>You cut your finger and let the blood drip on \the [src].</span>")
+		to_chat(user, SPAN("notice", "You cut your finger and let the blood drip on \the [src]."))
 		user.pay_for_rune(1)
 		var/datum/ghosttrap/cult/shade/S = get_ghost_trap("soul stone")
 		S.request_player(shade, "The soul stone shade summon ritual has been performed. ")
 	else if(!shade.client) // Has a key but no client - shade logged out
-		to_chat(user, "<span class='notice'>\The [shade] in \the [src] is dormant.</span>")
+		to_chat(user, SPAN("notice", "\The [shade] in \the [src] is dormant."))
 		return
 	else if(shade.loc == src)
 		var/choice = alert("Would you like to invoke the spirit within?",,"Yes","No")
 		if(choice == "Yes")
 			shade.forceMove(get_turf(src))
-			to_chat(user, "<span class='notice'>You summon \the [shade].</span>")
+			to_chat(user, SPAN("notice", "You summon \the [shade]."))
 		if(choice == "No")
 			return
 

--- a/code/modules/mob/living/simple_animal/shade.dm
+++ b/code/modules/mob/living/simple_animal/shade.dm
@@ -37,12 +37,12 @@
 	OnDeathInLife()
 
 /mob/living/simple_animal/shade/proc/OnDeathInLife()
-	if(stat == 2)
-		new /obj/item/ectoplasm (src.loc)
+	if(stat == DEAD)
+		new /obj/item/ectoplasm(loc)
 		for(var/mob/M in viewers(src, null))
 			if((M.client && !( M.blinded )))
-				M.show_message("<span class='warning'>[src] lets out a contented sigh as their form unwinds.</span>")
-				ghostize()
+				M.show_message(SPAN("warning", "[src] lets out a contented sigh as their form unwinds."))
+		ghostize()
 		qdel(src)
 		return
 


### PR DESCRIPTION
По следам ~полосатого слона~ ПР-а https://github.com/ChaoticOnyx/OnyxBay/pull/8853.

fix #7009

<details>
<summary>Чейнджлог</summary>

```yml
🆑
bugfix: Смерть тени из камня души теперь приводит к удалению эссенции в камне, а новая тень призывается нормально.
/🆑
```

</details>

- [x] Pull Request полностью завершен, мне не нужна помощь чтобы его закончить.
- [x] Я внимательно прочитал все свои изменения и багов в них не нашел.
- [x] Я запускал сервер со своими изменениями локально и все протестировал.
- [x] Я ознакомился c [Guide to Contribute](https://github.com/ChaoticOnyx/OnyxBay/blob/dev/docs/contributing.md).
