### PR TITLE
fix(traitor): now voice changer works inside rig

### DIFF
--- a/code/modules/mob/living/carbon/human/say.dm
+++ b/code/modules/mob/living/carbon/human/say.dm
@@ -96,13 +96,14 @@
 		var/obj/item/rig/rig = back
 		if(rig.speech?.voice_holder?.active && rig.speech.voice_holder.voice)
 			voice_sub = rig.speech.voice_holder.voice
-	else
+	if(!voice_sub)
 		for(var/obj/item/gear in list(wear_mask,wear_suit,head))
 			if(!gear)
 				continue
 			var/obj/item/voice_changer/changer = locate() in gear
-			if(changer && changer.active && changer.voice)
+			if(changer?.active)
 				voice_sub = changer.voice
+				break
 	if(voice_sub)
 		return voice_sub
 	if(mind?.changeling?.mimicing)


### PR DESCRIPTION
fix #4530

<details>
<summary>Чейнджлог</summary>

```yml
🆑
bugfix: Теперь voice changer тритора работает и внутри РИГа. Но если РИГ имеет свой голосовой синтезатор и тот включён - то у него более высокий приоритет.
/🆑
```

</details>

- [x] Pull Request полностью завершен, мне не нужна помощь чтобы его закончить.
- [x] Я внимательно прочитал все свои изменения и багов в них не нашел.
- [ ] Я запускал сервер со своими изменениями локально и все протестировал.
- [x] Я ознакомился c [Guide to Contribute](https://github.com/ChaoticOnyx/OnyxBay/blob/dev/docs/contributing.md).
