### PR TITLE
tweak(pistol): reduced shaking when firing a silenced holdout pistol

### DIFF
--- a/code/modules/projectiles/gun.dm
+++ b/code/modules/projectiles/gun.dm
@@ -62,6 +62,7 @@
 	var/fire_anim = null
 	var/screen_shake = 0 //shouldn't be greater than 2 unless zoomed
 	var/silenced = 0
+	var/silenced_coeff = 0 //shaking reduction coefficient in the presence of a silencer. 1 - no shaking, 0.5 - half off screen_shake, 0 - default shaking
 	var/accuracy = 0   //accuracy is measured in tiles. +1 accuracy means that everything is effectively one tile closer for the purpose of miss chance, -1 means the opposite. launchers are not supported, at the moment.
 	var/scoped_accuracy = null
 	var/list/burst_accuracy = list(0) //allows for different accuracies for each shot in a burst. Applied on top of accuracy
@@ -285,7 +286,7 @@
 
 	if(screen_shake)
 		spawn()
-			shake_camera(user, screen_shake+1, screen_shake)
+			shake_camera(user, screen_shake+1, screen_shake - screen_shake * silenced_coeff * silenced)
 
 	if(combustion)
 		var/turf/curloc = get_turf(src)

--- a/code/modules/projectiles/guns/projectile/pistol.dm
+++ b/code/modules/projectiles/guns/projectile/pistol.dm
@@ -206,6 +206,7 @@
 	w_class = ITEM_SIZE_SMALL
 	caliber = "9mm"
 	silenced = 0
+	silenced_coeff = 0.8
 	fire_delay = 1
 	fire_sound = 'sound/effects/weapons/gun/fire_9mm2.ogg'
 	mod_weight = 0.65
@@ -231,7 +232,6 @@
 			w_class = initial(w_class)
 			fire_sound = 'sound/effects/weapons/gun/fire_9mm2.ogg'
 			update_icon()
-			screen_shake = initial(screen_shake)
 			return
 	..()
 
@@ -242,12 +242,11 @@
 			return
 		user.drop_item()
 		to_chat(user, "<span class='notice'>You screw [I] onto [src].</span>")
-		silenced = I	//dodgy?
+		silenced = 1
 		w_class = ITEM_SIZE_NORMAL
 		I.forceMove(src)		//put the silencer into the gun
 		update_icon()
 		fire_sound = SFX_SILENT_FIRE
-		screen_shake = 0.2
 		return
 	..()
 

--- a/code/modules/projectiles/guns/projectile/pistol.dm
+++ b/code/modules/projectiles/guns/projectile/pistol.dm
@@ -231,6 +231,7 @@
 			w_class = initial(w_class)
 			fire_sound = 'sound/effects/weapons/gun/fire_9mm2.ogg'
 			update_icon()
+			screen_shake = initial(screen_shake)
 			return
 	..()
 
@@ -246,6 +247,7 @@
 		I.forceMove(src)		//put the silencer into the gun
 		update_icon()
 		fire_sound = SFX_SILENT_FIRE
+		screen_shake = 0.2
 		return
 	..()
 


### PR DESCRIPTION
Убираем ебейшую тряску (как обрез) на 9мм пистолете с глушителем, тем самым повышая его популярность.
Помимо этого оружию добавил множитель глушения тряски при наличии глушителя, что бы этот эффект можно было настроить на всём оружии которое будет иметь глушитель.

<details>
<summary>Чейнджлог</summary>

```yml
🆑Oubi
tweak: Уменьшена тряска камеры при выстреле с трейторского 9mm пистолета с глушителем.
/🆑
```

</details>

- [x] Pull Request полностью завершен, мне не нужна помощь чтобы его закончить.
- [x] Я внимательно прочитал все свои изменения и багов в них не нашел.
- [x] Я запускал сервер со своими изменениями локально и все протестировал.
- [x] Я ознакомился c [Guide to Contribute](https://github.com/ChaoticOnyx/OnyxBay/blob/dev/docs/contributing.md).
