### PR TITLE
tweak(bullet casing): disable bullet casing throw damage

### DIFF
--- a/code/modules/projectiles/ammunition.dm
+++ b/code/modules/projectiles/ammunition.dm
@@ -6,7 +6,7 @@
 	randpixel = 10
 	obj_flags = OBJ_FLAG_CONDUCTIBLE
 	slot_flags = SLOT_BELT | SLOT_EARS
-	throwforce = 1
+	throwforce = 0
 	w_class = ITEM_SIZE_TINY
 
 	var/leaves_residue = 1


### PR DESCRIPTION
Гильзы доставляют геморой, который не должны доставлять. Расчёт мизерного урона не имеет смысл, по этому его лучше отключить вовсе. Если гильзы должны доставлять неудобства, то только так:
https://youtube.com/clip/Ugkx1UVMEFD8f_Wd_tapllylzpuQM-_Luc4s

fix #8950 

<details>
<summary>Чейнджлог</summary>

```yml
🆑Oubi
tweak: Гильзы больше не наносят урон.
/🆑
```

</details>

- [x] Pull Request полностью завершен, мне не нужна помощь чтобы его закончить.
- [x] Я внимательно прочитал все свои изменения и багов в них не нашел.
- [ ] Я запускал сервер со своими изменениями локально и все протестировал.
- [x] Я ознакомился c [Guide to Contribute](https://github.com/ChaoticOnyx/OnyxBay/blob/dev/docs/contributing.md).
