### PR TITLE
Фикс продвинутого мультитула и контейнеров

### DIFF
--- a/code/game/objects/items/weapons/combotools.dm
+++ b/code/game/objects/items/weapons/combotools.dm
@@ -26,10 +26,13 @@
 	return
 
 /obj/item/combotool/resolve_attackby(atom/a, mob/user, click_params)
-	if(istype(a, /obj/item/storage))
+	if(istype(a, /obj/item/storage) && user.a_intent != I_DISARM)
 		a.attackby(src, user)
 		return
-	if(istype(a, /obj/structure/table) && user.a_intent == I_DISARM)
+	if(istype(a, /obj/structure/table))
+		a.attackby(src, user)
+		return
+	if(istype(a, /obj/structure/closet) && user.a_intent != I_DISARM)
 		a.attackby(src, user)
 		return
 	a.attackby(tool_u, user)

--- a/code/game/objects/items/weapons/combotools.dm
+++ b/code/game/objects/items/weapons/combotools.dm
@@ -29,7 +29,7 @@
 	if(istype(a, /obj/item/storage) && user.a_intent != I_DISARM)
 		a.attackby(src, user)
 		return
-	if(istype(a, /obj/structure/table))
+	if(istype(a, /obj/structure/table) && user.a_intent == I_DISARM)
 		a.attackby(src, user)
 		return
 	if(istype(a, /obj/structure/closet) && user.a_intent != I_DISARM)


### PR DESCRIPTION
Теперь можно положить мультитул на стол в любом режиме, положить его в шкаф в любом режиме, кроме режима безоруживания (при нём, шкаф начинается откручиваться). Если положить его в рюкзак при синем режиме, в рюкзак кладётся отсоединённый модуль мультитула.

<details>
<summary>Чейнджлог</summary>

```yml
🆑
tweak: Исправление поведения комбитула с контейнерами
/🆑
```

</details>

close #5773 

- [x] Pull Request полностью завершен, мне не нужна помощь чтобы его закончить.
- [x] Я внимательно прочитал все свои изменения и багов в них не нашел.
- [x] Я запускал сервер со своими изменениями локально и все протестировал.
- [x] Я ознакомился c [Guide to Contribute](https://github.com/ChaoticOnyx/OnyxBay/blob/dev/docs/contributing.md).
