### PR TITLE
Багфикс абилок вампира в наручниках

### DIFF
--- a/code/game/gamemodes/vampire/vampire_powers.dm
+++ b/code/game/gamemodes/vampire/vampire_powers.dm
@@ -700,7 +700,7 @@
 	if (!(vampire.status & VAMP_FULLPOWER))
 		to_chat(src, SPAN_NOTICE("You begin peering into [T]'s mind, looking for a way to gain control."))
 
-		if (!do_mob(src, T, 50,incapacitation_flags=INCAPACITATION_DISABLED))//Can dominate while being buckled
+		if (!do_mob(src, T, 50, incapacitation_flags = INCAPACITATION_DISABLED))//Can dominate while being buckled
 			to_chat(src, SPAN_WARNING("Your concentration is broken!"))
 			return
 

--- a/code/game/gamemodes/vampire/vampire_powers.dm
+++ b/code/game/gamemodes/vampire/vampire_powers.dm
@@ -238,7 +238,7 @@
 
 	to_chat(src, SPAN_NOTICE("You begin peering into [T.name]'s mind, looking for a way to render them useless."))
 
-	if (do_mob(src, T, 50))
+	if (do_mob(src, T, 50,0,0,1,INCAPACITATION_DISABLED)) // Can hypnose while being buckled
 		to_chat(src, SPAN_DANGER("You dominate [T.name]'s mind and render them temporarily powerless to resist"))
 		to_chat(T, SPAN_DANGER("You are captivated by [src.name]'s gaze, and find yourself unable to move or even speak."))
 		T.Weaken(25)
@@ -570,7 +570,7 @@
 
 	log_and_message_admins("activated blood heal.")
 
-	while (do_after(src, 20, 0))
+	while (do_after(src, 20, 0,1,1,INCAPACITATION_DISABLED))// Can heal while being buckled
 		if (!(vampire.status & VAMP_HEALING))
 			to_chat(src, SPAN_WARNING("Your concentration is broken! You are no longer regenerating!"))
 			break
@@ -700,7 +700,7 @@
 	if (!(vampire.status & VAMP_FULLPOWER))
 		to_chat(src, SPAN_NOTICE("You begin peering into [T]'s mind, looking for a way to gain control."))
 
-		if (!do_mob(src, T, 50))
+		if (!do_mob(src, T, 50,0,0,1,INCAPACITATION_DISABLED))//Can dominate while being buckled
 			to_chat(src, SPAN_WARNING("Your concentration is broken!"))
 			return
 

--- a/code/game/gamemodes/vampire/vampire_powers.dm
+++ b/code/game/gamemodes/vampire/vampire_powers.dm
@@ -238,7 +238,7 @@
 
 	to_chat(src, SPAN_NOTICE("You begin peering into [T.name]'s mind, looking for a way to render them useless."))
 
-	if (do_mob(src, T, 50, incapacitation_flags = INCAPACITATION_DISABLED)) // Can hypnose while being buckled
+	if (do_mob(src, T, 50, incapacitation_flags = INCAPACITATION_DISABLED))
 		to_chat(src, SPAN_DANGER("You dominate [T.name]'s mind and render them temporarily powerless to resist"))
 		to_chat(T, SPAN_DANGER("You are captivated by [src.name]'s gaze, and find yourself unable to move or even speak."))
 		T.Weaken(25)
@@ -570,7 +570,7 @@
 
 	log_and_message_admins("activated blood heal.")
 
-	while (do_after(src, 20, 0, incapacitation_flags = INCAPACITATION_DISABLED))// Can heal while being buckled
+	while (do_after(src, 20, 0, incapacitation_flags = INCAPACITATION_DISABLED))
 		if (!(vampire.status & VAMP_HEALING))
 			to_chat(src, SPAN_WARNING("Your concentration is broken! You are no longer regenerating!"))
 			break
@@ -700,7 +700,7 @@
 	if (!(vampire.status & VAMP_FULLPOWER))
 		to_chat(src, SPAN_NOTICE("You begin peering into [T]'s mind, looking for a way to gain control."))
 
-		if (!do_mob(src, T, 50, incapacitation_flags = INCAPACITATION_DISABLED))//Can dominate while being buckled
+		if (!do_mob(src, T, 50, incapacitation_flags = INCAPACITATION_DISABLED))
 			to_chat(src, SPAN_WARNING("Your concentration is broken!"))
 			return
 

--- a/code/game/gamemodes/vampire/vampire_powers.dm
+++ b/code/game/gamemodes/vampire/vampire_powers.dm
@@ -238,7 +238,7 @@
 
 	to_chat(src, SPAN_NOTICE("You begin peering into [T.name]'s mind, looking for a way to render them useless."))
 
-	if (do_mob(src, T, 50,0,0,1,INCAPACITATION_DISABLED)) // Can hypnose while being buckled
+	if (do_mob(src, T, 50))
 		to_chat(src, SPAN_DANGER("You dominate [T.name]'s mind and render them temporarily powerless to resist"))
 		to_chat(T, SPAN_DANGER("You are captivated by [src.name]'s gaze, and find yourself unable to move or even speak."))
 		T.Weaken(25)
@@ -570,7 +570,7 @@
 
 	log_and_message_admins("activated blood heal.")
 
-	while (do_after(src, 20, 0,1,1,INCAPACITATION_DISABLED))// Can heal while being buckled
+	while (do_after(src, 20, 0))
 		if (!(vampire.status & VAMP_HEALING))
 			to_chat(src, SPAN_WARNING("Your concentration is broken! You are no longer regenerating!"))
 			break
@@ -700,7 +700,7 @@
 	if (!(vampire.status & VAMP_FULLPOWER))
 		to_chat(src, SPAN_NOTICE("You begin peering into [T]'s mind, looking for a way to gain control."))
 
-		if (!do_mob(src, T, 50,0,0,1,INCAPACITATION_DISABLED))//Can dominate while being buckled
+		if (!do_mob(src, T, 50))
 			to_chat(src, SPAN_WARNING("Your concentration is broken!"))
 			return
 

--- a/code/game/gamemodes/vampire/vampire_powers.dm
+++ b/code/game/gamemodes/vampire/vampire_powers.dm
@@ -238,7 +238,7 @@
 
 	to_chat(src, SPAN_NOTICE("You begin peering into [T.name]'s mind, looking for a way to render them useless."))
 
-	if (do_mob(src, T, 50))
+	if (do_mob(src, T, 50,incapacitation_flags=INCAPACITATION_DISABLED)) // Can hypnose while being buckled
 		to_chat(src, SPAN_DANGER("You dominate [T.name]'s mind and render them temporarily powerless to resist"))
 		to_chat(T, SPAN_DANGER("You are captivated by [src.name]'s gaze, and find yourself unable to move or even speak."))
 		T.Weaken(25)
@@ -570,7 +570,7 @@
 
 	log_and_message_admins("activated blood heal.")
 
-	while (do_after(src, 20, 0))
+	while (do_after(src, 20, 0,incapacitation_flags=INCAPACITATION_DISABLED))// Can heal while being buckled
 		if (!(vampire.status & VAMP_HEALING))
 			to_chat(src, SPAN_WARNING("Your concentration is broken! You are no longer regenerating!"))
 			break
@@ -700,7 +700,7 @@
 	if (!(vampire.status & VAMP_FULLPOWER))
 		to_chat(src, SPAN_NOTICE("You begin peering into [T]'s mind, looking for a way to gain control."))
 
-		if (!do_mob(src, T, 50))
+		if (!do_mob(src, T, 50,incapacitation_flags=INCAPACITATION_DISABLED))//Can dominate while being buckled
 			to_chat(src, SPAN_WARNING("Your concentration is broken!"))
 			return
 

--- a/code/game/gamemodes/vampire/vampire_powers.dm
+++ b/code/game/gamemodes/vampire/vampire_powers.dm
@@ -238,7 +238,7 @@
 
 	to_chat(src, SPAN_NOTICE("You begin peering into [T.name]'s mind, looking for a way to render them useless."))
 
-	if (do_mob(src, T, 50,incapacitation_flags=INCAPACITATION_DISABLED)) // Can hypnose while being buckled
+	if (do_mob(src, T, 50, incapacitation_flags = INCAPACITATION_DISABLED)) // Can hypnose while being buckled
 		to_chat(src, SPAN_DANGER("You dominate [T.name]'s mind and render them temporarily powerless to resist"))
 		to_chat(T, SPAN_DANGER("You are captivated by [src.name]'s gaze, and find yourself unable to move or even speak."))
 		T.Weaken(25)

--- a/code/game/gamemodes/vampire/vampire_powers.dm
+++ b/code/game/gamemodes/vampire/vampire_powers.dm
@@ -570,7 +570,7 @@
 
 	log_and_message_admins("activated blood heal.")
 
-	while (do_after(src, 20, 0,incapacitation_flags=INCAPACITATION_DISABLED))// Can heal while being buckled
+	while (do_after(src, 20, 0, incapacitation_flags = INCAPACITATION_DISABLED))// Can heal while being buckled
 		if (!(vampire.status & VAMP_HEALING))
 			to_chat(src, SPAN_WARNING("Your concentration is broken! You are no longer regenerating!"))
 			break


### PR DESCRIPTION
Теперь вампиры могут гипнотизировать, доминировать и использовать лечение будучи связанными.
close #7288

<details>
<summary>Чейнджлог</summary>

```yml
🆑
bugfix: Вампиры могут использовать реген, гипноз и доминейт связанными
/🆑
```

</details>

- [x] Pull Request полностью завершен, мне не нужна помощь чтобы его закончить.
- [x] Я внимательно прочитал все свои изменения и багов в них не нашел.
- [x] Я запускал сервер со своими изменениями локально и все протестировал.
- [x] Я ознакомился c [Guide to Contribute](https://github.com/ChaoticOnyx/OnyxBay/blob/dev/docs/contributing.md).
