### PR TITLE
tweak(wizard): added restriction on using skills during ethereal jaunt

### DIFF
--- a/code/modules/spells/spell_code.dm
+++ b/code/modules/spells/spell_code.dm
@@ -256,6 +256,11 @@
 		if(!user.wearing_wiz_garb())
 			return FALSE
 
+	if(istype(user.loc, /obj/effect/dummy/spell_jaunt))
+		if(!istype(src, /datum/spell/targeted/ethereal_jaunt))
+			to_chat(user, SPAN_WARNING("You cannot cast spells in this form"))
+			return FALSE
+
 	return TRUE
 
 /datum/spell/proc/check_charge(skipcharge, mob/user)


### PR DESCRIPTION
Из джаунта теперь можно юзать только джаунт (нужно для макс. прокачки). Другие умения естественно запрещены.

fix #6375
#6377

<details>
<summary>Чейнджлог</summary>

```yml
🆑Oubi
tweak: Находясь магом в Ethereal jaunt-е больше нельзя использовать другие умения.
/🆑
```

</details>

- [x] Pull Request полностью завершен, мне не нужна помощь чтобы его закончить.
- [x] Я внимательно прочитал все свои изменения и багов в них не нашел.
- [x] Я запускал сервер со своими изменениями локально и все протестировал.
- [x] Я ознакомился c [Guide to Contribute](https://github.com/ChaoticOnyx/OnyxBay/blob/dev/docs/contributing.md).
