### PR TITLE
fix(atoms_movable): fixed lack of proper acceleration when throwing

### DIFF
--- a/code/game/atoms_movable.dm
+++ b/code/game/atoms_movable.dm
@@ -177,7 +177,7 @@
 	speed = round(speed)
 	var/impact_speed = speed
 	if(launched_mult)
-		impact_speed /= launched_mult
+		impact_speed *= launched_mult
 		pre_launched()
 	var/area/a = get_area(loc)
 

--- a/code/modules/projectiles/guns/launcher/syringe_gun.dm
+++ b/code/modules/projectiles/guns/launcher/syringe_gun.dm
@@ -63,7 +63,7 @@
 	if(syringe)
 		//check speed to see if we hit hard enough to trigger the rapid injection
 		//incidentally, this means syringe_cartridges can be used with the pneumatic launcher
-		if(speed >= 10 && isliving(hit_atom))
+		if(speed >= 7 && isliving(hit_atom))
 			var/mob/living/L = hit_atom
 			//unfortuately we don't know where the dart will actually hit, since that's done by the parent.
 			if(L.can_inject(null, ran_zone()) && syringe.reagents)
@@ -93,7 +93,7 @@
 	fire_sound = 'sound/weapons/empty.ogg'
 	fire_sound_text = "a metallic thunk"
 	screen_shake = 0
-	release_force = 2
+	release_force = 10
 	throw_distance = 10
 
 	var/list/darts = list()


### PR DESCRIPTION
Пофикшено ускорение при броске с лаунчеров. Всякие пневмопушки и шприцеметы теперь работают как и работали раньше, до введения анимаций при броске, при этом **АНИМАЦИЯ НЕ ПОЛОМАЛАСЬ**. Помимо этого пофиксил трейторский скрытый дротикомёт, который не втыкал содержимое дротика.
Многозарядный трейторский шприцемёт остался не тронутым, это будет в другом ПР-е.

fix #8963 

<details>
<summary>Чейнджлог</summary>

```yml
🆑Oubi
bugfix: Починена скорость метания снарядов с лаунчеров. Дротики вводят содержимое, а остальные снаряды корректно ускоряются при стрельбе с пневмопушки.
bugfix: Трейторский "Disguised Syringe Gun" теперь так же нормально вводит содержимое дротика.
/🆑
```

</details>

- [x] Pull Request полностью завершен, мне не нужна помощь чтобы его закончить.
- [x] Я внимательно прочитал все свои изменения и багов в них не нашел.
- [x] Я запускал сервер со своими изменениями локально и все протестировал.
- [x] Я ознакомился c [Guide to Contribute](https://github.com/ChaoticOnyx/OnyxBay/blob/dev/docs/contributing.md).
