### PR TITLE
Поправил защиту от гипноза очками СБ и солнечными

### DIFF
--- a/code/game/gamemodes/vampire/vampire_powers.dm
+++ b/code/game/gamemodes/vampire/vampire_powers.dm
@@ -224,7 +224,7 @@
 	for (var/mob/living/carbon/human/H in view(3))
 		if (H == src)
 			continue
-		if(H.eyecheck() > FLASH_PROTECTION_MODERATE)
+		if(H.eyecheck() > FLASH_PROTECTION_NONE)
 			continue
 		victims += H
 	if (!victims.len)


### PR DESCRIPTION
Теперь Гипноз вампира не проходит через солнцезащитные очки, в том числе и СБшников.

close #7554

<details>
<summary>Чейнджлог</summary>

```yml
🆑
bugfix: Гипноз вампира не работает через солнцезащитные очки
/🆑
```

</details>


- [x] Pull Request полностью завершен, мне не нужна помощь чтобы его закончить.
- [x] Я внимательно прочитал все свои изменения и багов в них не нашел.
- [x] Я запускал сервер со своими изменениями локально и все протестировал.
- [x] Я ознакомился c [Guide to Contribute](https://github.com/ChaoticOnyx/OnyxBay/blob/dev/docs/contributing.md).
