### PR TITLE
fix(reagents): fixed initially opened beakers, added lid check to grinder

### DIFF
--- a/code/modules/reagents/Chemistry-Machinery.dm
+++ b/code/modules/reagents/Chemistry-Machinery.dm
@@ -383,7 +383,7 @@
 		/obj/item/stock_parts/console_screen,
 	)
 	var/inuse = 0
-	var/obj/item/reagent_containers/beaker
+	var/obj/item/reagent_containers/vessel/beaker/beaker
 	var/limit = 10
 	var/list/holdingitems = list()
 
@@ -568,7 +568,12 @@
 		return
 
 	// Sanity check.
-	if (!beaker || (beaker && beaker.reagents.total_volume >= beaker.reagents.maximum_volume))
+	if(!beaker || beaker.reagents.total_volume >= beaker.reagents.maximum_volume)
+		return
+
+	if(!(beaker.atom_flags & ATOM_FLAG_OPEN_CONTAINER))
+		audible_message(SPAN("warning", "<b>The [src]</b> states, \"The beaker is closed, reagent processing is impossible.\""))
+		playsound(src.loc, 'sound/signals/error28.ogg', 50, 1)
 		return
 
 	playsound(src.loc, 'sound/machines/blender.ogg', 50, 1)

--- a/code/modules/reagents/reagent_containers/vessel/_lid.dm
+++ b/code/modules/reagents/reagent_containers/vessel/_lid.dm
@@ -31,8 +31,8 @@
 			owner.atom_flags |= ATOM_FLAG_OPEN_CONTAINER
 			owner.verbs |= /obj/item/reagent_containers/vessel/verb/drink_whole
 		if(LID_CLOSED, LID_SEALED)
-			owner.atom_flags ^= ATOM_FLAG_OPEN_CONTAINER
-			owner.verbs ^= /obj/item/reagent_containers/vessel/verb/drink_whole
+			owner.atom_flags &= ~ATOM_FLAG_OPEN_CONTAINER
+			owner.verbs -= /obj/item/reagent_containers/vessel/verb/drink_whole
 
 /datum/vessel_lid/proc/toggle(mob/user)
 	return
@@ -62,11 +62,11 @@
 			owner.verbs |= /obj/item/reagent_containers/vessel/verb/drink_whole
 			return TRUE
 		if(LID_OPEN)
-			owner.atom_flags ^= ATOM_FLAG_OPEN_CONTAINER
+			owner.atom_flags &= ~ATOM_FLAG_OPEN_CONTAINER
 			state = LID_CLOSED
 			if(user)
 				to_chat(usr, SPAN("notice", "You put the [name] on \the [owner]."))
-			owner.verbs ^= /obj/item/reagent_containers/vessel/verb/drink_whole
+			owner.verbs -= /obj/item/reagent_containers/vessel/verb/drink_whole
 			return TRUE
 	return FALSE
 
@@ -86,11 +86,11 @@
 			owner.verbs |= /obj/item/reagent_containers/vessel/verb/drink_whole
 			return TRUE
 		if(LID_OPEN)
-			owner.atom_flags ^= ATOM_FLAG_OPEN_CONTAINER
+			owner.atom_flags &= ~ATOM_FLAG_OPEN_CONTAINER
 			state = LID_CLOSED
 			if(user)
 				to_chat(usr, SPAN("notice", "You push the [name] into \the [owner]."))
-			owner.verbs ^= /obj/item/reagent_containers/vessel/verb/drink_whole
+			owner.verbs -= /obj/item/reagent_containers/vessel/verb/drink_whole
 			return TRUE
 	return FALSE
 
@@ -182,11 +182,11 @@
 			owner.verbs |= /obj/item/reagent_containers/vessel/verb/drink_whole
 			return TRUE
 		if(LID_OPEN)
-			owner.atom_flags ^= ATOM_FLAG_OPEN_CONTAINER
+			owner.atom_flags &= ~ATOM_FLAG_OPEN_CONTAINER
 			state = LID_CLOSED
 			if(user)
 				to_chat(usr, SPAN("notice", "You put \the [name] on \the [owner]."))
-			owner.verbs ^= /obj/item/reagent_containers/vessel/verb/drink_whole
+			owner.verbs -= /obj/item/reagent_containers/vessel/verb/drink_whole
 			return TRUE
 	return FALSE
 
@@ -214,11 +214,11 @@
 			return TRUE
 		if(LID_OPEN)
 			playsound(owner.loc, 'sound/effects/flask_lid1.ogg', rand(10, 30), 1)
-			owner.atom_flags ^= ATOM_FLAG_OPEN_CONTAINER
+			owner.atom_flags &= ~ATOM_FLAG_OPEN_CONTAINER
 			state = LID_CLOSED
 			if(user)
 				to_chat(usr, SPAN("notice", "You close \the [owner]."))
-			owner.verbs ^= /obj/item/reagent_containers/vessel/verb/drink_whole
+			owner.verbs -= /obj/item/reagent_containers/vessel/verb/drink_whole
 			return TRUE
 	return FALSE
 

--- a/code/modules/reagents/reagent_containers/vessel/beaker.dm
+++ b/code/modules/reagents/reagent_containers/vessel/beaker.dm
@@ -31,7 +31,7 @@
 	volume = 120
 	amount_per_transfer_from_this = 10
 	possible_transfer_amounts = "5;10;15;25;30;60;120"
-	atom_flags = ATOM_FLAG_OPEN_CONTAINER
+	override_lid_state = LID_OPEN
 
 /obj/item/reagent_containers/vessel/beaker/large/get_storage_cost()
 	return ..() * 1.5
@@ -53,7 +53,8 @@
 	brittle = FALSE
 	volume = 60
 	amount_per_transfer_from_this = 10
-	atom_flags = ATOM_FLAG_OPEN_CONTAINER | ATOM_FLAG_NO_REACT
+	atom_flags = ATOM_FLAG_NO_REACT
+	override_lid_state = LID_OPEN
 	effect_flags = EFFECT_FLAG_RAD_SHIELDED
 
 /obj/item/reagent_containers/vessel/beaker/bluespace
@@ -70,7 +71,7 @@
 	volume = 300
 	amount_per_transfer_from_this = 10
 	possible_transfer_amounts = "5;10;15;25;30;60;120;150;200;250;300"
-	atom_flags = ATOM_FLAG_OPEN_CONTAINER
+	override_lid_state = LID_OPEN
 
 /obj/item/reagent_containers/vessel/beaker/vial
 	name = "vial"
@@ -86,5 +87,5 @@
 	w_class = ITEM_SIZE_TINY //half the volume of a bottle, half the size
 	amount_per_transfer_from_this = 10
 	possible_transfer_amounts = "5;10;15;30"
-	atom_flags = ATOM_FLAG_OPEN_CONTAINER
+	override_lid_state = LID_OPEN
 	lid_type = /datum/vessel_lid/cork


### PR DESCRIPTION
fixed #9052

Помимо чейнджлога пофиксил возможные проблемы с крышкой, так как `^=` переключает флаг.
Вместо флага атома сделал перезапись состояния крышки, а то она всё равно его переделает.

<details>
<summary>Чейнджлог</summary>

```yml
🆑
bugfix: Гриндер теперь проверяет что бикер открыт.
/🆑
```

</details>

- [x] Pull Request полностью завершен, мне не нужна помощь чтобы его закончить.
- [x] Я внимательно прочитал все свои изменения и багов в них не нашел.
- [x] Я запускал сервер со своими изменениями локально и все протестировал.
- [x] Я ознакомился c [Guide to Contribute](https://github.com/ChaoticOnyx/OnyxBay/blob/dev/docs/contributing.md).
