### PR TITLE
fix(living): fixed going beyond the maxHealth limit

### DIFF
--- a/code/modules/mob/living/living.dm
+++ b/code/modules/mob/living/living.dm
@@ -261,7 +261,7 @@
 /mob/living/proc/adjustBruteLoss(amount)
 	if(status_flags & GODMODE)
 		return 0
-	health = min(maxHealth, max(health-amount, 0))
+	health = Clamp(health-amount, 0, maxHealth)
 
 /mob/living/proc/getOxyLoss()
 	return 0

--- a/code/modules/mob/living/living.dm
+++ b/code/modules/mob/living/living.dm
@@ -261,7 +261,7 @@
 /mob/living/proc/adjustBruteLoss(amount)
 	if(status_flags & GODMODE)
 		return 0
-	health = max(health-amount, 0)
+	health = min(maxHealth, max(health-amount, 0))
 
 /mob/living/proc/getOxyLoss()
 	return 0


### PR DESCRIPTION
Исправлен выход за пределы maxHealth. Ранее багом можно было восстанавливать здоровье симплмобам (а может и не только им) до бесконечности игнорируя maxHealth

<details>
<summary>Чейнджлог</summary>

```yml
🆑Oubi
bugfix: Исправлен баг, позволяющий лечить симплмобов выше лимита максимального здоровья.
/🆑
```

</details>

- [x] Pull Request полностью завершен, мне не нужна помощь чтобы его закончить.
- [x] Я внимательно прочитал все свои изменения и багов в них не нашел.
- [x] Я запускал сервер со своими изменениями локально и все протестировал.
- [x] Я ознакомился c [Guide to Contribute](https://github.com/ChaoticOnyx/OnyxBay/blob/dev/docs/contributing.md).
