### PR TITLE
fix(changeling): fixed a bug that allowed a changeling to resurrect after being consumed by another changeling

### DIFF
--- a/code/game/gamemodes/changeling/powers/absorb.dm
+++ b/code/game/gamemodes/changeling/powers/absorb.dm
@@ -96,6 +96,7 @@
 
 	if(T.mind?.changeling)
 		changeling.consume_changeling(T.mind.changeling)
+		T.mind.changeling.true_dead = TRUE
 
 	changeling.absorbedcount++
 	changeling.using_proboscis = FALSE


### PR DESCRIPTION
При поглощении генокрада другим генокрадом поглощаются его очки, умения, сущности которые были у цели, но сам генокрад не умирает. Данный ПР исправляет это недоразумение.

<details>
<summary>Чейнджлог</summary>

```yml
🆑Oubi
bugfix: Исправлен баг позволяющий генокраду воскреснуть после поглощения другим генокрадом.
/🆑
```

</details>

- [x] Pull Request полностью завершен, мне не нужна помощь чтобы его закончить.
- [x] Я внимательно прочитал все свои изменения и багов в них не нашел.
- [x] Я запускал сервер со своими изменениями локально и все протестировал.
- [x] Я ознакомился c [Guide to Contribute](https://github.com/ChaoticOnyx/OnyxBay/blob/dev/docs/contributing.md).
