### PR TITLE
fix(metroid): fixed metroid following

### DIFF
--- a/code/modules/mob/living/carbon/xenobiological/death.dm
+++ b/code/modules/mob/living/carbon/xenobiological/death.dm
@@ -2,6 +2,10 @@
 
 	if(stat == DEAD) return
 
+	if(Leader)
+		Leader = null
+		walk_to(src, 0)
+
 	if(!gibbed && is_adult)
 		var/mob/living/carbon/metroid/M = new /mob/living/carbon/metroid(loc, colour)
 		M.rabid = 1

--- a/code/modules/mob/living/carbon/xenobiological/metroid_AI.dm
+++ b/code/modules/mob/living/carbon/xenobiological/metroid_AI.dm
@@ -254,9 +254,11 @@
 					if (Leader == who)
 						to_say = "Yes... I'll stay..."
 						Leader = null
+						walk_to(src, 0)
 					else
 						if (Friends[who] > Friends[Leader])
 							Leader = null
+							walk_to(src, 0)
 							to_say = "Yes... I'll stop..."
 						else
 							to_say = "No... I'll keep following..."


### PR DESCRIPTION
Метроиды больше не преследуют своего мастера после команд "стоп" и смерти самого метроида.

close #8550

<details>
<summary>Чейнджлог</summary>

```yml
🆑
bugfix: Метроиды больше не преследуют лидера после своей смерти и приказа к остановке.
/🆑
```

</details>


- [x] Pull Request полностью завершен, мне не нужна помощь чтобы его закончить.
- [x] Я внимательно прочитал все свои изменения и багов в них не нашел.
- [x] Я запускал сервер со своими изменениями локально и все протестировал.
- [x] Я ознакомился c [Guide to Contribute](https://github.com/ChaoticOnyx/OnyxBay/blob/dev/docs/contributing.md).
