### PR TITLE
fix(wizard): fixed custom messages output when upgrading mage skills

### DIFF
--- a/code/modules/spells/spellbook.dm
+++ b/code/modules/spells/spellbook.dm
@@ -121,6 +121,7 @@ var/list/artefact_feedback = list(
 /obj/item/spellbook/proc/upgrade_spell(mob/user, datum/spell/path, upgrade_type)
 	var/datum/wizard/W = user.mind.wizard
 	var/datum/spell/spell_to_upgrade = null
+	var/upgrade_message
 
 
 	ASSERT(path in subtypesof(/datum/spell))
@@ -144,11 +145,13 @@ var/list/artefact_feedback = list(
 	W.spend(1)
 	switch(upgrade_type)
 		if(SP_POWER)
-			ASSERT(spell_to_upgrade.empower_spell())
-			to_chat(user, "You empower [spell_to_upgrade]!")
+			upgrade_message = spell_to_upgrade.empower_spell()
+			ASSERT(upgrade_message)
+			to_chat(user, (upgrade_message || "You empower [spell_to_upgrade]!"))
 		if(SP_SPEED)
+			upgrade_message = spell_to_upgrade.empower_spell()
 			ASSERT(spell_to_upgrade.quicken_spell())
-			to_chat(user, "You quicken [spell_to_upgrade]!")
+			to_chat(user, (upgrade_message || "You quicken [spell_to_upgrade]!"))
 		else
 			CRASH("Unknown upgrade type [upgrade_type]")
 

--- a/code/modules/spells/spellbook.dm
+++ b/code/modules/spells/spellbook.dm
@@ -121,8 +121,6 @@ var/list/artefact_feedback = list(
 /obj/item/spellbook/proc/upgrade_spell(mob/user, datum/spell/path, upgrade_type)
 	var/datum/wizard/W = user.mind.wizard
 	var/datum/spell/spell_to_upgrade = null
-	var/upgrade_message
-
 
 	ASSERT(path in subtypesof(/datum/spell))
 
@@ -142,15 +140,15 @@ var/list/artefact_feedback = list(
 		to_chat(user, SPAN("warning", "You don't have enough points to upgrade the spell!"))
 		return
 
+
 	W.spend(1)
+	var/upgrade_message
 	switch(upgrade_type)
 		if(SP_POWER)
 			upgrade_message = spell_to_upgrade.empower_spell()
-			ASSERT(upgrade_message)
 			to_chat(user, (upgrade_message || "You empower [spell_to_upgrade]!"))
 		if(SP_SPEED)
-			upgrade_message = spell_to_upgrade.empower_spell()
-			ASSERT(spell_to_upgrade.quicken_spell())
+			upgrade_message = spell_to_upgrade.quicken_spell()
 			to_chat(user, (upgrade_message || "You quicken [spell_to_upgrade]!"))
 		else
 			CRASH("Unknown upgrade type [upgrade_type]")


### PR DESCRIPTION
Починил вывод кастомных сообщений при апгрейдей умений. Это было сломано еще с момента перехода на новый дизайн спелбука.
![image](https://user-images.githubusercontent.com/98897017/181915566-2c56f3ca-7222-4616-bfe6-f44ef0d91dba.png)

<details>
<summary>Чейнджлог</summary>

```yml
🆑Oubi
bugfix: Исправлен вывод сообщений апгрейда умений мага.
```

</details>

- [x] Pull Request полностью завершен, мне не нужна помощь чтобы его закончить.
- [x] Я внимательно прочитал все свои изменения и багов в них не нашел.
- [x] Я запускал сервер со своими изменениями локально и все протестировал.
- [x] Я ознакомился c [Guide to Contribute](https://github.com/ChaoticOnyx/OnyxBay/blob/dev/docs/contributing.md).
