### PR TITLE
tweak(wizard): add restriction to use abilities and item from ethereal jaunt form

### DIFF
--- a/code/modules/mob/living/carbon/carbon_defines.dm
+++ b/code/modules/mob/living/carbon/carbon_defines.dm
@@ -43,3 +43,4 @@
 	var/stasis_value
 	var/does_not_breathe = FALSE
 	var/seeDarkness = FALSE
+	var/can_use_hands = TRUE // use only for short-term restrictions (climbing in ventilation, being in stasis, etc.)

--- a/code/modules/mob/living/carbon/human/human.dm
+++ b/code/modules/mob/living/carbon/human/human.dm
@@ -230,6 +230,8 @@
 		return 1
 	if (istype(wear_suit, /obj/item/clothing/suit/straight_jacket))
 		return 1
+	if (!can_use_hands)
+		return 1
 	return 0
 
 /mob/living/carbon/human/proc/grab_restrained()

--- a/code/modules/mob/mob_movement.dm
+++ b/code/modules/mob/mob_movement.dm
@@ -61,6 +61,8 @@
 	to_chat(usr, "<span class='warning'>This mob type cannot drop items.</span>")
 
 /mob/living/carbon/hotkey_drop()
+	if(!can_use_hands)
+		return
 	var/obj/item/I = get_active_hand()
 	if(!I)
 		to_chat(usr, SPAN("warning", "You have nothing to drop in your hand."))

--- a/code/modules/spells/spell_code.dm
+++ b/code/modules/spells/spell_code.dm
@@ -257,9 +257,8 @@
 			return FALSE
 
 	if(istype(user.loc, /obj/effect/dummy/spell_jaunt))
-		if(!istype(src, /datum/spell/targeted/ethereal_jaunt))
-			to_chat(user, SPAN_WARNING("You cannot cast spells in this form"))
-			return FALSE
+		to_chat(user, SPAN_WARNING("You cannot cast spells in this form"))
+		return FALSE
 
 	return TRUE
 

--- a/code/modules/spells/targeted/ethereal_jaunt.dm
+++ b/code/modules/spells/targeted/ethereal_jaunt.dm
@@ -16,7 +16,7 @@
 	icon_state = "wiz_jaunt"
 
 /datum/spell/targeted/ethereal_jaunt/cast(list/targets, mob/user) //magnets, so mostly hardcoded
-	for(var/mob/living/target in targets)
+	for(var/mob/living/carbon/target in targets)
 		if(HAS_TRANSFORMATION_MOVEMENT_HANDLER(target))
 			continue
 		if(target.buckled)
@@ -39,6 +39,7 @@
 				target.buckled.unbuckle_mob()
 			jaunt_disappear(animation, target)
 			target.forceMove(holder)
+			target.can_use_hands = FALSE
 			jaunt_steam(mobloc)
 			sleep(duration)
 			mobloc = holder.last_valid_turf
@@ -48,6 +49,7 @@
 			sleep(20)
 			jaunt_reappear(animation, target)
 			sleep(5)
+			target.can_use_hands = TRUE
 			if(!target.forceMove(mobloc))
 				for(var/direction in list(1,2,4,8,5,6,9,10))
 					var/turf/T = get_step(mobloc, direction)


### PR DESCRIPTION
Добавил ограничение на использование ЛЮБЫХ умений с формы джаунта. Помимо этого добавил запрет на использование предметов и их выбрасывание на хоткей во время джаунта.
Для запрета взаимодействия с предметами в `/mob/living/carbon/` была добавлена переменная `can_use_hands`, которая используется в `/mob/living/carbon/human/restrained()` и `/mob/living/carbon/hotkey_drop()`. В дальнейшем должна использоваться только для скриптовых запретов на короткое время. В дальнейшем благодаря этой переменной можно будет поправить еще несколько аналогичных багов, где нужно запретить использовать руки во время определенных действий, например для того-что бы запретить бросать гранаты из-под пола находясь в вентиляции.

Замерджить вместе с #9004
close #6377

<details>
<summary>Чейнджлог</summary>

```yml
🆑Oubi
tweak: Во время ethereal jaunt больше нельзя использовать умения и предметы.
/🆑
```

</details>

- [x] Pull Request полностью завершен, мне не нужна помощь чтобы его закончить.
- [x] Я внимательно прочитал все свои изменения и багов в них не нашел.
- [x] Я запускал сервер со своими изменениями локально и все протестировал.
- [x] Я ознакомился c [Guide to Contribute](https://github.com/ChaoticOnyx/OnyxBay/blob/dev/docs/contributing.md).
