### PR TITLE
fix(throwing): throw airlocks correctly

### DIFF
--- a/code/game/atoms_movable.dm
+++ b/code/game/atoms_movable.dm
@@ -235,7 +235,8 @@
 		var/atom/previous = src.loc
 		src.loc = null
 		if (Move(previous))
-			Move(step)
+			if (!QDELETED(src))
+				Move(step)
 		hit_check(impact_speed)
 		dist_travelled++
 		dist_since_sleep += tiles_per_tick


### PR DESCRIPTION
Теперь бросок не дюпает шлюзы. 

Причина была в некорректной обработке удаления шлюза после броска.

close #9119

<details>
<summary>Чейнджлог</summary>

```yml
🆑
bugfix: Ментал фокус мага больше не дюпает шлюзы
/🆑
```

</details>

- [x] Pull Request полностью завершен, мне не нужна помощь чтобы его закончить.
- [x] Я внимательно прочитал все свои изменения и багов в них не нашел.
- [x] Я запускал сервер со своими изменениями локально и все протестировал.
- [x] Я ознакомился c [Guide to Contribute](https://github.com/ChaoticOnyx/OnyxBay/blob/dev/docs/contributing.md).
