### PR TITLE
Мобы без сикея теперь процессятся в крио и шкафах

### DIFF
--- a/code/controllers/subsystems/processing/mobs.dm
+++ b/code/controllers/subsystems/processing/mobs.dm
@@ -16,6 +16,7 @@ PROCESSING_SUBSYSTEM_DEF(mobs)
 	if(!resumed)
 		current_run = processing.Copy()
 		player_levels.Cut()
+		player_levels += 0
 		for(var/P in GLOB.player_list)
 			var/mob/living/player = P
 			if(!istype(player) || (player.z in player_levels))

--- a/code/controllers/subsystems/processing/mobs.dm
+++ b/code/controllers/subsystems/processing/mobs.dm
@@ -21,7 +21,7 @@ PROCESSING_SUBSYSTEM_DEF(mobs)
 			var/turf/T = get_turf(player)
 			if(!istype(player) || !istype(T) || (T.z in player_levels))
 				continue
-			player_levels += player.loc.z
+			player_levels += T.z
 
 	var/mob/thing
 	for(var/i = current_run.len to 1 step -1)

--- a/code/controllers/subsystems/processing/mobs.dm
+++ b/code/controllers/subsystems/processing/mobs.dm
@@ -19,7 +19,7 @@ PROCESSING_SUBSYSTEM_DEF(mobs)
 		for(var/P in GLOB.player_list)
 			var/mob/living/player = P
 			var/turf/T = get_turf(player)
-			if(!istype(player) || (player.loc.z in player_levels))
+			if(!istype(player) || !istype(T) || (T.z in player_levels))
 				continue
 			player_levels += player.loc.z
 

--- a/code/controllers/subsystems/processing/mobs.dm
+++ b/code/controllers/subsystems/processing/mobs.dm
@@ -16,12 +16,11 @@ PROCESSING_SUBSYSTEM_DEF(mobs)
 	if(!resumed)
 		current_run = processing.Copy()
 		player_levels.Cut()
-		player_levels += 0
 		for(var/P in GLOB.player_list)
 			var/mob/living/player = P
-			if(!istype(player) || (player.z in player_levels))
+			if(!istype(player) || (player.loc.z in player_levels))
 				continue
-			player_levels += player.z
+			player_levels += player.loc.z
 
 	var/mob/thing
 	for(var/i = current_run.len to 1 step -1)
@@ -31,7 +30,7 @@ PROCESSING_SUBSYSTEM_DEF(mobs)
 			processing -= thing
 			continue
 
-		if(thing.client || (thing.z in player_levels) || thing.teleop)
+		if(thing.client || (thing.loc.z in player_levels) || thing.teleop)
 			thing.Life()
 
 		if(MC_TICK_CHECK)

--- a/code/controllers/subsystems/processing/mobs.dm
+++ b/code/controllers/subsystems/processing/mobs.dm
@@ -31,7 +31,8 @@ PROCESSING_SUBSYSTEM_DEF(mobs)
 			processing -= thing
 			continue
 
-		if(thing.client || (thing.loc.z in player_levels) || thing.teleop)
+		var/turf/T = get_turf(thing)
+		if(thing.client || (istype(T) && (T.z in player_levels)) || thing.teleop)
 			thing.Life()
 
 		if(MC_TICK_CHECK)

--- a/code/controllers/subsystems/processing/mobs.dm
+++ b/code/controllers/subsystems/processing/mobs.dm
@@ -21,7 +21,7 @@ PROCESSING_SUBSYSTEM_DEF(mobs)
 			var/turf/T = get_turf(player)
 			if(!istype(player) || !istype(T) || (T.z in player_levels))
 				continue
-			player_levels += T.z
+			player_levels |= T.z
 
 	var/mob/thing
 	for(var/i = current_run.len to 1 step -1)

--- a/code/controllers/subsystems/processing/mobs.dm
+++ b/code/controllers/subsystems/processing/mobs.dm
@@ -18,6 +18,7 @@ PROCESSING_SUBSYSTEM_DEF(mobs)
 		player_levels.Cut()
 		for(var/P in GLOB.player_list)
 			var/mob/living/player = P
+			var/turf/T = get_turf(player)
 			if(!istype(player) || (player.loc.z in player_levels))
 				continue
 			player_levels += player.loc.z


### PR DESCRIPTION
Оказалось, что у нас мобы в контейнерах уезжают на z-лвл 0, и если на нём нет игрока (в шкафу, например), то он не процессится, в том числе не меняется его температура. Теперь мобы Live(), если их loc находится на z-уровне с игроками.

close #9090

<details>
<summary>Чейнджлог</summary>

```yml
🆑
bugfix: Апатики и мобы теперь охлаждаются в крио.
/🆑
```

</details>

- [x] Pull Request полностью завершен, мне не нужна помощь чтобы его закончить.
- [x] Я внимательно прочитал все свои изменения и багов в них не нашел.
- [x] Я запускал сервер со своими изменениями локально и все протестировал.
- [x] Я ознакомился c [Guide to Contribute](https://github.com/ChaoticOnyx/OnyxBay/blob/dev/docs/contributing.md).
