### PR TITLE
fix(holder): fixed incorrect simple mob placing in holder

### DIFF
--- a/code/modules/mob/holder.dm
+++ b/code/modules/mob/holder.dm
@@ -15,36 +15,23 @@ var/list/holder_mob_icon_cache = list()
 		)
 	pixel_y = 8
 
-	var/mob/held_mob = null
-
-	var/last_holder
-
-/obj/item/holder/New(loc, mob_to_hold)
-	..(loc)
-	ASSERT(mob_to_hold)
-	held_mob = mob_to_hold
-	register_signal(mob_to_hold, SIGNAL_QDELETING, /obj/item/holder/proc/onMobQdeleting)
+/obj/item/holder/New()
+	..()
 	START_PROCESSING(SSobj, src)
 
 /obj/item/holder/proc/destroy_all()
-	QDEL_NULL(held_mob)
-	qdel(src)
-
-/obj/item/holder/proc/onMobQdeleting()
-	ASSERT(held_mob)
-	unregister_signal(held_mob, SIGNAL_QDELETING)
-	held_mob = null
+	for(var/atom/movable/AM in src)
+		qdel(AM)
 	qdel(src)
 
 /obj/item/holder/Destroy()
-	if(held_mob)
-		unregister_signal(held_mob, SIGNAL_QDELETING)
-		held_mob.forceMove(get_turf(src))
-		held_mob = null
-	last_holder = null
 	if(ismob(loc))
 		var/mob/M = loc
 		M.drop_from_inventory(src, get_turf(M))
+	for(var/thing in src)
+		var/mob/M = thing
+		M.dropInto(loc)
+		M.reset_view()
 	STOP_PROCESSING(SSobj, src)
 	return ..()
 
@@ -57,7 +44,7 @@ var/list/holder_mob_icon_cache = list()
 		check_condition()
 
 /obj/item/holder/proc/check_condition()
-	if(isturf(loc) || !held_mob)
+	if(isturf(loc) || !(contents.len))
 		qdel(src)
 
 /obj/item/holder/onDropInto(atom/movable/AM)
@@ -66,15 +53,20 @@ var/list/holder_mob_icon_cache = list()
 	return ..()
 
 /obj/item/holder/GetIdCard()
-	return held_mob.GetIdCard()
+	for(var/mob/M in contents)
+		var/obj/item/I = M.GetIdCard()
+		if(I)
+			return I
+	return null
 
 /obj/item/holder/GetAccess()
 	var/obj/item/I = GetIdCard()
 	return I ? I.GetAccess() : ..()
 
 /obj/item/holder/attack_self()
-	held_mob.show_inv(usr)
-	usr.show_inventory?.open()
+	for(var/mob/M in contents)
+		M.show_inv(usr)
+		usr.show_inventory?.open()
 
 /obj/item/holder/attack(mob/target, mob/user)
 	// Devour on click on self with holder
@@ -86,21 +78,23 @@ var/list/holder_mob_icon_cache = list()
 		if(blocked)
 			to_chat(user, SPAN_WARNING("\The [blocked] is in the way!"))
 			return 1
-		M.devour(held_mob)
-		qdel(src)
+		for(var/mob/victim in src.contents)
+			M.devour(victim)
+
+		check_condition()
 
 	..()
 
-/obj/item/holder/proc/sync()
+/obj/item/holder/proc/sync(mob/living/M)
 	dir = 2
 	overlays.Cut()
-	icon = held_mob.icon
-	icon_state = held_mob.icon_state
-	item_state = held_mob.item_state
-	color = held_mob.color
-	name = held_mob.name
-	desc = held_mob.desc
-	overlays |= held_mob.overlays
+	icon = M.icon
+	icon_state = M.icon_state
+	item_state = M.item_state
+	color = M.color
+	name = M.name
+	desc = M.desc
+	overlays |= M.overlays
 
 	update_held_icon()
 
@@ -136,9 +130,9 @@ var/list/holder_mob_icon_cache = list()
 	origin_tech = list(TECH_BIO = 2)
 	slot_flags = SLOT_HOLSTER
 
-/obj/item/holder/attackby(obj/item/W, mob/user)
-	held_mob.attackby(W, user)
-	sync()
+/obj/item/holder/attackby(obj/item/W as obj, mob/user as mob)
+	for(var/mob/M in src.contents)
+		M.attackby(W,user)
 
 //Mob procs and vars for scooping up
 /mob/living/var/holder_type
@@ -163,12 +157,11 @@ var/list/holder_mob_icon_cache = list()
 			to_chat(grabber, SPAN("warning", "You can't scoop up \the [src] because of [G.assailant]'s grab!"))
 			return
 
-	var/obj/item/holder/H = new holder_type(get_turf(src), src)
+	var/obj/item/holder/H = new holder_type(get_turf(src))
 
 	if(self_grab)
 		if(!grabber.equip_to_slot_if_possible(H, slot_back, del_on_fail = FALSE, disable_warning = TRUE))
 			to_chat(src, SPAN("warning", "You can't climb onto [grabber]!"))
-			qdel(H)
 			return
 
 		to_chat(grabber, SPAN("notice", "\The [src] clambers onto you!"))
@@ -176,7 +169,6 @@ var/list/holder_mob_icon_cache = list()
 	else
 		if(!grabber.put_in_hands(H))
 			to_chat(grabber, SPAN("warning", "Your hands are full!"))
-			qdel(H)
 			return
 
 		to_chat(grabber, SPAN("notice", "You scoop up \the [src]!"))
@@ -186,7 +178,6 @@ var/list/holder_mob_icon_cache = list()
 		qdel(G) // All the checks have been done above, it's safe to murder one (or even two, who knows) of grabber's grab objects
 
 	forceMove(H)
-
 	if(isanimal(src))
 		var/mob/living/simple_animal/SA = src
 		SA.panic_target = null
@@ -194,8 +185,7 @@ var/list/holder_mob_icon_cache = list()
 		SA.turns_since_scan = 5
 
 	grabber.status_flags |= PASSEMOTES
-	H.sync()
-
+	H.sync(src)
 	return H
 
 /mob/living/MouseDrop(mob/living/carbon/human/over_object)
@@ -217,9 +207,9 @@ var/list/holder_mob_icon_cache = list()
 	slot_flags = SLOT_BACK
 	w_class = ITEM_SIZE_LARGE
 
-/obj/item/holder/human/sync()
+/obj/item/holder/human/sync(mob/living/M)
 	// Generate appropriate on-mob icons.
-	var/mob/living/carbon/human/owner = held_mob
+	var/mob/living/carbon/human/owner = M
 	if(istype(owner) && owner.species)
 
 		var/skin_colour = rgb(owner.r_skin, owner.g_skin, owner.b_skin)
@@ -248,4 +238,4 @@ var/list/holder_mob_icon_cache = list()
 			item_icons[cache_entry] = holder_mob_icon_cache[cache_key]
 
 	// Handle the rest of sync().
-	..()
+	..(M)

--- a/code/modules/mob/living/simple_animal/hostile/facehugger.dm
+++ b/code/modules/mob/living/simple_animal/hostile/facehugger.dm
@@ -23,8 +23,8 @@
 	mob_size = MOB_MINISCULE
 	can_escape = 1
 	pass_flags = PASS_FLAG_TABLE
-	melee_damage_lower = 2.5
-	melee_damage_upper = 5
+	melee_damage_lower = 5
+	melee_damage_upper = 7.5
 
 	min_gas = null
 	max_gas = null
@@ -97,9 +97,8 @@
 	var/obj/item/r_ear = H.get_equipped_item(slot_r_ear)
 	r_ear?.knocked_out(H, dist = 0)
 
-	var/obj/item/holder/facehugger/holder = new(get_turf(src), src)
+	var/obj/item/holder/facehugger/holder = new()
 	forceMove(holder)
-
 	if(!silent)
 		H.visible_message(SPAN("warning", "\The [src] latches itself onto [H]'s face!"))
 	holder.sync(src)
@@ -166,24 +165,28 @@
 /obj/item/holder/facehugger
 	origin_tech = list(TECH_BIO = 4)
 	slot_flags = SLOT_MASK | SLOT_HOLSTER
+	throw_speed = 4
 	icon_state = "facehugger"
 	item_state = "facehugger"
 	var/wasted = FALSE
 
 /obj/item/holder/facehugger/proc/kill_holder()
-	var/mob/living/simple_animal/hostile/facehugger/F = held_mob
-	F.death()
-	sync()
-	wasted = TRUE
+	var/mob/living/simple_animal/hostile/facehugger/F = contents[1]
+	if(F)
+		F.death()
+		sync(F)
+		wasted = TRUE
 
-/obj/item/holder/facehugger/sync()
+/obj/item/holder/facehugger/sync(mob/living/M)
 	..()
-	var/mob/living/simple_animal/hostile/facehugger/F = held_mob
+	if(!istype(M, /mob/living/simple_animal/hostile/facehugger))
+		return
+	var/mob/living/simple_animal/hostile/facehugger/F = M
 	if(F.stat)
 		wasted = TRUE
 
 /obj/item/holder/facehugger/attack(mob/target, mob/user)
-	var/mob/living/simple_animal/hostile/facehugger/F = held_mob
+	var/mob/living/simple_animal/hostile/facehugger/F = contents[1]
 	if(user && !F.stat && istype(target, /mob/living/carbon/human))
 		var/mob/living/carbon/human/H = target
 		if(!do_mob(user, H, 20))
@@ -192,14 +195,6 @@
 		if(F.facefuck(H, TRUE, TRUE))
 			H.visible_message(SPAN("warning", "[user] latches \the [F] onto [H]'s face!"))
 		return
-	..()
-
-/obj/item/holder/facehugger/equipped(mob/user, slot)
-	if(slot != slot_wear_mask)
-		return ..()
-	var/mob/living/simple_animal/hostile/facehugger/F = held_mob
-	user.drop_from_inventory(src)
-	F.facefuck(user, TRUE, TRUE)
 	..()
 
 

--- a/code/modules/mob/living/simple_animal/hostile/voxslug.dm
+++ b/code/modules/mob/living/simple_animal/hostile/voxslug.dm
@@ -55,10 +55,10 @@ Small, little HP, poisonous.
 
 /mob/living/simple_animal/hostile/voxslug/proc/attach(mob/living/carbon/human/H)
 	var/obj/item/organ/external/chest = H.organs_by_name["chest"]
-	var/obj/item/holder/voxslug/holder = new(get_turf(src), src)
+	var/obj/item/holder/voxslug/holder = new(get_turf(src))
 	src.forceMove(holder)
-	chest.embed(holder, 0, "\The [src] latches itself onto \the [H]!")
-	holder.sync()
+	chest.embed(holder,0,"\The [src] latches itself onto \the [H]!")
+	holder.sync(src)
 
 /mob/living/simple_animal/hostile/voxslug/AttackingTarget()
 	. = ..()
@@ -78,14 +78,14 @@ Small, little HP, poisonous.
 			R.add_reagent(/datum/reagent/cryptobiolin, 0.5)
 
 /obj/item/holder/voxslug/attack(mob/target, mob/user)
-	var/mob/living/simple_animal/hostile/voxslug/V = held_mob
+	var/mob/living/simple_animal/hostile/voxslug/V = contents[1]
 	if(!V.stat && istype(target, /mob/living/carbon/human))
 		var/mob/living/carbon/human/H = target
 		if(!do_mob(user, H, 30))
 			return
 		user.drop_from_inventory(src)
-		qdel(src)
 		V.attach(H)
+		qdel(src)
 		return
 	..()
 


### PR DESCRIPTION
По факту это обычный реверт рефакторинга холдеров, но с сохранением фикса дион. Рефакторить это всё самому и исправлять старые баги и синтаксические ошибки старого кода я и не собирался. Фикс ручного надевания лицехватов в ПР не входит, да и смысла в нём нет, ибо лицехват одевается ударом по мобу.
На локалке всё проверял, галочку не просто так поставил, всё работает как и должно работать, т.э. холдеры симплмобов не дюпаются, фейсфакеры фейсфачат, а мелкие вредители снова могут выступать в качестве пищи.

Частичный реверт #7673
Открыть #6036, но баг не баг и играть не мешает, ибо есть альтернатива.
Открыть #5448
Фикс иссуя #8491 не пострадал
fix #8993
fix #9198
fix #9039

<details>
<summary>Чейнджлог</summary>

```yml
🆑Oubi
bugfix: Лицехваты снова работают.
bugfix: Мелких симплмобов снова можно есть.
/🆑
```

</details>

- [x] Pull Request полностью завершен, мне не нужна помощь чтобы его закончить.
- [x] Я внимательно прочитал все свои изменения и багов в них не нашел.
- [x] Я запускал сервер со своими изменениями локально и все протестировал.
- [x] Я ознакомился c [Guide to Contribute](https://github.com/ChaoticOnyx/OnyxBay/blob/dev/docs/contributing.md).
