### PR TITLE
fix(borer): fixed human's forced emotes with damaged brain

### DIFF
--- a/code/modules/mob/living/simple_animal/borer/borer.dm
+++ b/code/modules/mob/living/simple_animal/borer/borer.dm
@@ -95,7 +95,7 @@
 					host.adjustBrainLoss(0.1)
 
 				if(prob(host.getBrainLoss()/20))
-					host.say("*[pick(list("blink","blink_r","choke","aflap","drool","twitch","twitch_v","gasp"))]")
+					host.emote("[pick(list("blink","blink_r","choke","aflap","drool","twitch","twitch_v","gasp"))]")
 		else if((stat == DEAD || host.stat == DEAD) && controlling)
 			detatch()
 


### PR DESCRIPTION
fix #5924

<details>
<summary>Чейнджлог</summary>

```yml
🆑
bugfix: Пофикшены эмоуты с префиксом не по умолчанию в настройках игрока-борера, вызываемые борером у носителя с повреждённым мозгом.
/🆑
```

</details>

- [x] Pull Request полностью завершен, мне не нужна помощь чтобы его закончить.
- [x] Я внимательно прочитал все свои изменения и багов в них не нашел.
- [x] Я запускал сервер со своими изменениями локально и все протестировал.
- [x] Я ознакомился c [Guide to Contribute](https://github.com/ChaoticOnyx/OnyxBay/blob/dev/docs/contributing.md).
