### PR TITLE
fix(borer): added check of head into leave_host()

### DIFF
--- a/code/modules/mob/living/simple_animal/borer/borer_powers.dm
+++ b/code/modules/mob/living/simple_animal/borer/borer_powers.dm
@@ -389,8 +389,7 @@ list(\
 
 	var/mob/living/carbon/human/H = host
 	var/obj/item/organ/external/head = H.get_organ(BP_HEAD)
-	if(head)
-		head.implants -= src
+	head?.implants -= src
 
 	src.loc = get_turf(host)
 

--- a/code/modules/mob/living/simple_animal/borer/borer_powers.dm
+++ b/code/modules/mob/living/simple_animal/borer/borer_powers.dm
@@ -389,7 +389,8 @@ list(\
 
 	var/mob/living/carbon/human/H = host
 	var/obj/item/organ/external/head = H.get_organ(BP_HEAD)
-	head.implants -= src
+	if(head)
+		head.implants -= src
 
 	src.loc = get_turf(host)
 


### PR DESCRIPTION
fix #7766

Всё ещё остаётся проблема со смертью, но это часть общей проблемы, что всем остальным прокам не известно, что в человеке сидит не основной разум.

<details>
<summary>Чейнджлог</summary>

```yml
🆑
bugfix: Теперь борер не ломается после отрубания/отпиливания/чего-то ещё головы его носителя.
/🆑
```

</details>

- [x] Pull Request полностью завершен, мне не нужна помощь чтобы его закончить.
- [x] Я внимательно прочитал все свои изменения и багов в них не нашел.
- [x] Я запускал сервер со своими изменениями локально и все протестировал.
- [x] Я ознакомился c [Guide to Contribute](https://github.com/ChaoticOnyx/OnyxBay/blob/dev/docs/contributing.md).
