### PR TITLE
fix(viruses): Fixed removal of the virus when the effect is mutated

### DIFF
--- a/code/modules/virus2/disease2.dm
+++ b/code/modules/virus2/disease2.dm
@@ -178,7 +178,8 @@ LEGACY_RECORD_STRUCTURE(virus_records, virus_record)
 	var/datum/disease2/effect/new_effect = get_mutated_effect(mutating_effect)
 	if(!new_effect)
 		return 0
-	mutating_effect.deactivate()
+	if(infected)
+		mutating_effect.deactivate(infected)
 	effects -= mutating_effect
 	effects += new_effect
 	update_disease()
@@ -192,9 +193,9 @@ LEGACY_RECORD_STRUCTURE(virus_records, virus_record)
 	for(var/datum/disease2/effect/D in effects)
 		if(D != E)
 			exclude += D.type
-
 	var/effect_stage = E.stage
-	E.deactivate()
+	if(infected)
+		E.deactivate(infected)
 	effects -= E
 	qdel(E)
 


### PR DESCRIPTION
Исправлено удаление вируса при мутации одного из эффектов (как в образце, так и в хумане). До этого, при удалении старого эффекта, сборщик мусора подхватывал и сам вирус. Добавлена проверка на носителя перед `deactivate()` что бы он не вызывался там где не был никогда активирован. В этой же проверке идет обNULLение `parent_disease`, для того что-бы сборщик мусора не подхватил лишнего. На локалке всё работает отлично, старый эффект удаляется, новый добавляется, таймер для мусоросборщика не появляется, в теории ничего сломаться не должно.
На момент написания этого ПР-а, багу исполнилось 14 месяцев и 15 дней.

fix #8500 

<details>
<summary>Чейнджлог</summary>

```yml
🆑Oubi
bugfix: Исправлен критический баг, удаляющий вирус после мутации.
/🆑
```

</details>

- [x] Pull Request полностью завершен, мне не нужна помощь чтобы его закончить.
- [x] Я внимательно прочитал все свои изменения и багов в них не нашел.
- [x] Я запускал сервер со своими изменениями локально и все протестировал.
- [x] Я ознакомился c [Guide to Contribute](https://github.com/ChaoticOnyx/OnyxBay/blob/dev/docs/contributing.md).
