### PR TITLE
fix(drone): now ai control finishes after emag

### DIFF
--- a/code/modules/mob/living/silicon/robot/drone/drone.dm
+++ b/code/modules/mob/living/silicon/robot/drone/drone.dm
@@ -267,6 +267,7 @@ var/list/mob_hat_cache = list()
 	emagged = 1
 	lawupdate = 0
 	connected_ai = null
+	release_ai_control("<b>WARNING: remote system failure. Connection rejected.</b>")
 	clear_supplied_laws()
 	clear_inherent_laws()
 	QDEL_NULL(laws)


### PR DESCRIPTION
fix  #8615

<details>
<summary>Чейнджлог</summary>

```yml
🆑
bugfix: Теперь ИИ выкидывает из дрона после емага последнего.
/🆑
```

</details>

- [x] Pull Request полностью завершен, мне не нужна помощь чтобы его закончить.
- [x] Я внимательно прочитал все свои изменения и багов в них не нашел.
- [ ] Я запускал сервер со своими изменениями локально и все протестировал.
- [x] Я ознакомился c [Guide to Contribute](https://github.com/ChaoticOnyx/OnyxBay/blob/dev/docs/contributing.md).
