### PR TITLE
feat(viruses): Comprehensive rework spread disease

### DIFF
--- a/code/game/objects/effects/decals/Cleanable/humans.dm
+++ b/code/game/objects/effects/decals/Cleanable/humans.dm
@@ -258,7 +258,6 @@ var/global/list/image/splatter_cache=list()
 	var/drytime = DRYING_TIME * (rand(20, 30) / 10) // 10 to 15 minutes
 	if(dry_timer_id)
 		deltimer(dry_timer_id)
-		dry_timer_id = null
 	if(overlays.len <= 20) // We don't want to scare kids with a snotty monster.
 		var/image/mucus_overlay = image(icon = 'icons/effects/blood.dmi', icon_state = "mucus", pixel_x = rand(-8, 8), pixel_y = rand(-8, 8))
 		mucus_overlay.layer = FLOAT_LAYER

--- a/code/game/objects/effects/decals/Cleanable/humans.dm
+++ b/code/game/objects/effects/decals/Cleanable/humans.dm
@@ -234,17 +234,14 @@ var/global/list/image/splatter_cache=list()
 	density = 0
 	anchored = 1
 	icon = 'icons/effects/blood.dmi'
-	icon_state = "mucus"
 
 	var/list/datum/disease2/disease/virus2 = list()
 	var/dried = FALSE
+	var/dry_timer_id
 
 /obj/effect/decal/cleanable/mucus/Initialize()
 	. = ..()
-	pixel_x = rand(-8, 8)
-	pixel_y = rand(-8, 8)
-	var/drytime = DRYING_TIME * (rand(20, 30) / 10) // 10 to 15 minutes
-	addtimer(CALLBACK(src, .proc/dry), drytime) // Let's not keep these fuckers infectious forever 'kay?
+	update_stats()
 
 /obj/effect/decal/cleanable/mucus/Destroy()
 	virus2 = null
@@ -253,6 +250,19 @@ var/global/list/image/splatter_cache=list()
 /obj/effect/decal/cleanable/mucus/proc/dry()
 	name = "dried mucus"
 	desc = "Disguisting nonetheless."
-	icon_state = "mucus_dry"
 	dried = TRUE
 	virus2.Cut()
+	color = "#2c991a"
+
+/obj/effect/decal/cleanable/mucus/proc/update_stats(list/viruses = list())
+	var/drytime = DRYING_TIME * (rand(20, 30) / 10) // 10 to 15 minutes
+	if(dry_timer_id)
+		deltimer(dry_timer_id)
+		dry_timer_id = null
+	if(overlays.len <= 20) // We don't want to scare kids with a snotty monster.
+		var/image/mucus_overlay = image(icon = 'icons/effects/blood.dmi', icon_state = "mucus", pixel_x = rand(-8, 8), pixel_y = rand(-8, 8))
+		mucus_overlay.layer = FLOAT_LAYER
+		mucus_overlay.transform = turn(src.transform, rand(0, 359))
+		overlays += mucus_overlay
+	dry_timer_id = addtimer(CALLBACK(src, .proc/dry), drytime, TIMER_STOPPABLE)
+	virus2 |= viruses

--- a/code/modules/virus2/effects/mild.dm
+++ b/code/modules/virus2/effects/mild.dm
@@ -24,15 +24,43 @@
 /datum/disease2/effect/sneeze/activate(mob/living/carbon/human/mob)
 	if(..())
 		return
+	if(mob.stat)
+		return
 	if(prob(30))
 		to_chat(mob, SNEEZE_EFFECT_WARNING)
 	spawn(5)
 		mob.emote("sneeze")
-		for(var/mob/living/carbon/human/M in get_step(mob, mob.dir))
+		if(!mob.check_mouth_coverage())
+			var/turf/x1y1
+			var/turf/x2y2
+			switch(mob.dir)
+				if(NORTH)
+					x1y1 = locate(mob.x - 1, mob.y, mob.z)
+					x2y2 = locate(mob.x + 1, mob.y + 3, mob.z)
+				if(SOUTH)
+					x1y1 = locate(mob.x + 1, mob.y, mob.z)
+					x2y2 = locate(mob.x - 1, mob.y - 3, mob.z)
+				if(EAST)
+					x1y1 = locate(mob.x, mob.y + 1, mob.z)
+					x2y2 = locate(mob.x + 3, mob.y - 1, mob.z)
+				if(WEST)
+					x1y1 = locate(mob.x, mob.y - 1, mob.z)
+					x2y2 = locate(mob.x - 3, mob.y + 1, mob.z)
+			for(var/turf/T in block(x1y1, x2y2))
+				for(var/mob/living/carbon/human/M in T)
+					mob.spread_disease_to(M)
+			if(prob(50))
+				return
+			var/obj/effect/decal/cleanable/mucus/M = locate(/obj/effect/decal/cleanable/mucus, get_turf(mob))
+			if(M && !M.dried)
+				M = locate(/obj/effect/decal/cleanable/mucus, get_turf(mob))
+				M.update_stats(virus_copylist(mob.virus2))
+			else
+				M = new(get_turf(mob))
+		if(!mob.can_spread_disease())
+			return
+		for(var/mob/living/carbon/human/M in oview(1, mob))
 			mob.spread_disease_to(M)
-		if(prob(50) && !mob.wear_mask)
-			var/obj/effect/decal/cleanable/mucus/M = new(get_turf(mob))
-			M.virus2 = virus_copylist(mob.virus2)
 
 
 /datum/disease2/effect/gunck
@@ -180,10 +208,16 @@
 /datum/disease2/effect/cough/activate(mob/living/carbon/human/mob)
 	if(..())
 		return
-	mob.emote("cough")
-	if(mob.wear_mask)
+	if(mob.stat)
 		return
-	for(var/mob/living/carbon/human/M in oview(2, mob))
+	mob.emote("cough")
+	if(!mob.check_mouth_coverage())
+		for(var/mob/living/carbon/human/M in oview(2, mob))
+			mob.spread_disease_to(M)
+		return
+	if(!mob.can_spread_disease())
+		return
+	for(var/mob/living/carbon/human/M in oview(1, mob))
 		mob.spread_disease_to(M)
 
 

--- a/code/modules/virus2/effects/mild.dm
+++ b/code/modules/virus2/effects/mild.dm
@@ -57,6 +57,7 @@
 				M.update_stats(virus_copylist(mob.virus2))
 			else
 				M = new(get_turf(mob))
+			return
 		if(!mob.can_spread_disease())
 			return
 		for(var/mob/living/carbon/human/M in oview(1, mob))

--- a/code/modules/virus2/helpers.dm
+++ b/code/modules/virus2/helpers.dm
@@ -122,6 +122,14 @@
 /proc/dprob(p)
 	return(prob(sqrt(p)) && prob(sqrt(p)))
 
+//Checks if the equipment that covers the mouth has bioprotection
+/mob/living/carbon/human/proc/can_spread_disease()
+	for(var/obj/item/clothing/gear in list(head, wear_mask))
+		if(istype(gear) && (gear.body_parts_covered & FACE))
+			if(gear.armor["bio"] > 0)
+				return FALSE
+	return TRUE
+
 /mob/living/carbon/proc/spread_disease_to(mob/living/carbon/victim, vector = "Airborne")
 	if (src == victim)
 		return "retardation"


### PR DESCRIPTION
В ПР-е убраны множественные старые баги, которые делали симптомы кашля и чихания не предсказуемыми для игроков, а изменена сам алгоритм заражения других через чих/кашель. Помимо этого затронут дроп соплей, он более оптимизированным и случайным (теперь рандомится и направление спрайта сопли). Перед началом этого ПР-а я уйму времени поиграл на вирусологе что бы понять всю ущербность чихов, которые не способны заражать быстро в людных местах и рассчитаны лишь на дроп соплей, по которым пройдет лишь невнимательный игрок.

О соплях. **Сопли теперь основаны на оверлее** и при попытке создания новой сопли не высохшей старой - создаться оверлей поверх уже существующей, а так же обновится таймер высыхания и добавятся вирусы с новой сопли. Это позволяет не захламлять мир отдельно живущими соплями, где каждая имеет свой личный таймер высыхания и датум с вирусом.

![image](https://user-images.githubusercontent.com/98897017/186713106-51201501-39c9-42b8-80b7-6800ae14dcd7.png)
О кашле. Раньше кашель имел лишь одну проверку на наличие маски, от результата которой зависело заразятся ли окружающие. Такая грубая проверка позволяла быть не заразным со спущенной маской/сигаретой/конфетой и даже при использовании шлемов биозащиты и других (при условии что маска при этом не одета). А кашлюны в отключке, так это вообще отдельная тема.
Теперь же мобы без сознания не кашляют и имеют полноценную проверку перед тем как попытаются распространить заразу. **Перед кашлем учитывается закрыт ли рот у инфицированного и имеет ли этот предмет биологическую защиту.** В случае если рот не прикрыт, то кашель, как и раньше, заражает всех в радиусе 2-х клеток (красная рамка). Если рот прикрыт чем-либо что не имеет биологической защиты (балаклава, бандана и т.п.), то кашель так-же заразит окружающих в радиусе 1-й клетки (голубая рамка). Если рот прикрыт предметом имеющий биологическую защиту (стерильные маски, противогазы, шлема ригов и т.д.), то никакого заражения окружающих не будет.

О чихах. К моему удивлению чихание вообще не имело проверки на наличие какой-либо защиты на лице, в любом случае заражался моб стоящий перед лицом инфицированного. Единственное что могло сделать чихание, так это положить сервер, что бы хоть кто-то в лагах наступил на соплю. По сравнению с кашлем бесполезный симптом если бы не сопли, которые время от времени всё же стреляют.
В этом ПР-е сопли реализованы аналогично как и кашель, но если кашель при отсутствии любой защиты заражает всех в радиусе 2-х клеток, то чихание заражает область 3x4 по направлению взгляда (оранжевая рамка).

Для ревьюверов:
`code/game/objects/effects/decals/Cleanable/humans.dm` - убрал иконстейты для того что бы подружить это всё с оверлеями (в идеале заменить стейт на прозрачный, а не null, буду рад если кто-то предложит правку с нужным стейтом), перенёс код инита в свой метод, который теперь отвечает за первое и последующее построение соплей. Высыхание реализовал через смену цвета, ибо с оверлеями после добавления взаимодействовать нет возможности (да и не надо).

`code/modules/virus2/helpers.dm` - добавил хелпер для проверки bio армора у предметов закрывающих рот.

`code/modules/virus2/effects/mild.dm` - обоим симптомам добавлены доп. проверки на закрытость лица, наличие биозащиты, состояние моба (что бы спящий не мог срать заразой). В эффект чиха добавил алгоритм возвращающий прямоугольную область перед игроком с использованием block().

fix #9244

<details>
<summary>Чейнджлог</summary>

```yml
🆑Oubi
tweak: Переработано распространение вирусов через кашель и чихание. Подробнее в ПР-е на GitHub
/🆑
```

</details>

- [x] Pull Request полностью завершен, мне не нужна помощь чтобы его закончить.
- [x] Я внимательно прочитал все свои изменения и багов в них не нашел.
- [x] Я запускал сервер со своими изменениями локально и все протестировал.
- [x] Я ознакомился c [Guide to Contribute](https://github.com/ChaoticOnyx/OnyxBay/blob/dev/docs/contributing.md).
