### PR TITLE
tweak(mod_list): add option to remove nulls

### DIFF
--- a/code/modules/admin/verbs/modifyvariables.dm
+++ b/code/modules/admin/verbs/modifyvariables.dm
@@ -115,6 +115,11 @@
 		if(confirm != "Continue")
 			return
 
+	var/clear_null_confirm = alert(src, "The list you're trying to edit may contain null vars, do you want to delete null vars?", "Null Deletion", "Yes", "No")
+	if(clear_null_confirm == "Yes")
+		while(null in L)
+			L -= null
+
 	var/assoc = 0
 	if(L.len > 0)
 		var/a = L[1]

--- a/code/modules/admin/verbs/modifyvariables.dm
+++ b/code/modules/admin/verbs/modifyvariables.dm
@@ -133,6 +133,12 @@
 	if(!assoc)
 		names = sortList(L)
 
+	if(clear_null_confirm && assoc)
+		if(alert(src, "The assoc list you're trying to edit may contain null vars in values, do you want to delete null vars in values?", "Null Deletion", "Yes", "No") == "Yes")
+			for(var/key in L)
+				if(L[key] == null)
+					L -= key
+
 	var/variable
 	var/assoc_key
 	if(assoc)


### PR DESCRIPTION
Кодеры древности (или настоящего) не смогли в безопасный код и из-за этого падает сервер?

Вы видите, что в списке находиться nullы и код попадает на них?

Теперь Вы можете избавиться от нуллов!

<details>
<summary>Чейнджлог</summary>

```yml
🆑
admin: Добавлена возможность удалить nullы из списка.
/🆑
```

</details>

- [x] Pull Request полностью завершен, мне не нужна помощь чтобы его закончить.
- [x] Я внимательно прочитал все свои изменения и багов в них не нашел.
- [ ] Я запускал сервер со своими изменениями локально и все протестировал.
- [x] Я ознакомился c [Guide to Contribute](https://github.com/ChaoticOnyx/OnyxBay/blob/dev/docs/contributing.md).
