### PR TITLE
fix(drone_items): safety pin decompiler

### DIFF
--- a/code/modules/mob/living/silicon/robot/drone/drone_items.dm
+++ b/code/modules/mob/living/silicon/robot/drone/drone_items.dm
@@ -589,6 +589,9 @@
 		else if(istype(W,/obj/item/reagent_containers/food/grown))
 			if(wood)
 				wood.add_charge(4000)
+		else if(istype(W,/obj/item/safety_pin))
+			if(metal)
+				metal.add_charge(1000)
 		else if(istype(W,/obj/item/pipe))
 			// This allows drones and engiborgs to clear pipe assemblies from floors.
 		else


### PR DESCRIPTION
Чека от гранаты может быть разобрана модулем matter_decompiler (дрона или борга).
Получаем столько же сколько и с гильзы, 1 лист стали.

fix #9324
<details>
<summary>Чейнджлог</summary>

```yml
🆑
bugfix: Чеку от гранаты теперь можно декомпилировать
/🆑
```

</details>

- [x] Pull Request полностью завершен, мне не нужна помощь чтобы его закончить.
- [x] Я внимательно прочитал все свои изменения и багов в них не нашел.
- [x] Я запускал сервер со своими изменениями локально и все протестировал.
- [x] Я ознакомился c [Guide to Contribute](https://github.com/ChaoticOnyx/OnyxBay/blob/dev/docs/contributing.md).
