### PR TITLE
fix(materials) rglass matter

### DIFF
--- a/code/modules/materials/materials.dm
+++ b/code/modules/materials/materials.dm
@@ -597,7 +597,7 @@ var/list/name_to_material
 	resilience = 9
 	reflectance = 25
 	stack_origin_tech = list(TECH_MATERIAL = 2)
-	composite_material = list(MATERIAL_STEEL = 1875, MATERIAL_GLASS = 3750)
+	composite_material = list(MATERIAL_STEEL = 1000, MATERIAL_GLASS = 2000)
 	window_options = list("Panel" = 1, "Windoor" = 5)
 	created_window = /obj/structure/window/reinforced
 	wire_product = null


### PR DESCRIPTION
rglass no longer contains more matter than is needed to create it

Укрепленное стекло теперь содержит 1/2 листа стали и лист стекла, столько, сколько нужно для его создания. 
Из расчета, что 1 лист ресурса содержит 2000 соответствующей материи. 
(В старых расчетах был коэффициент потерь, но с ним выходит дробное число, а оно нам надо?)

fix #2204

<details>
<summary>Чейнджлог</summary>

```yml
🆑
bugfix: фикс дюпа материалов автолата
/🆑
```

</details>


- [x] Pull Request полностью завершен, мне не нужна помощь чтобы его закончить.
- [x] Я внимательно прочитал все свои изменения и багов в них не нашел.
- [x] Я запускал сервер со своими изменениями локально и все протестировал.
- [x] Я ознакомился c [Guide to Contribute](https://github.com/ChaoticOnyx/OnyxBay/blob/dev/docs/contributing.md).
