### PR TITLE
fix(levels) telecomms add ztrait

### DIFF
--- a/maps/levels.dm
+++ b/maps/levels.dm
@@ -15,3 +15,6 @@
 /datum/space_level/telecomms
 	path = 'telecomms.dmm'
 	travel_chance = 15
+	traits = list(
+		ZTRAIT_STATION
+	)


### PR DESCRIPTION
Добавил телекоммам ZTRAIT_STATION, чтобы было подключение на них к НТ нет не зависимо от типа сетевой карты в устройстве.

fix #9236

<details>
<summary>Чейнджлог</summary>

```yml
🆑
bugfix: На телекоммах снова есть беспроводной НТ нет
/🆑
```

</details>

- [x] Pull Request полностью завершен, мне не нужна помощь чтобы его закончить.
- [x] Я внимательно прочитал все свои изменения и багов в них не нашел.
- [x] Я запускал сервер со своими изменениями локально и все протестировал.
- [x] Я ознакомился c [Guide to Contribute](https://github.com/ChaoticOnyx/OnyxBay/blob/dev/docs/contributing.md).
