### PR TITLE
feat(death_alarm): adds notification of neural lace presence

### DIFF
--- a/code/game/objects/items/implants/implants/death_alarm.dm
+++ b/code/game/objects/items/implants/implants/death_alarm.dm
@@ -45,7 +45,12 @@
 	if(!cause || !location)
 		death_message = "A message from [name] has been received. [mobname] has died-zzzzt in-in-in..."
 	else
-		death_message = "A message from [name] has been received. [mobname] has died in [location]!"
+		var/additional_info = " The neural lace signature not found in the body."
+		var/mob/living/carbon/human/H = imp_in
+		var/obj/item/organ/internal/stack/S = H?.internal_organs_by_name[BP_STACK]
+		if(istype(S))
+			additional_info = " The neural lace signature found in the body."
+		death_message = "A message from [name] has been received. [mobname] has died in [location]![additional_info]"
 	set_next_think(0)
 
 	for(var/channel in list("Security", "Medical", "Command"))


### PR DESCRIPTION
У кодера опять забыли взять нитку, чтобы оживить.

<details>
<summary>Чейнджлог</summary>

```yml
🆑
rscadd: Теперь имплант оповещения о смерти будет уведомлять есть ли нитка в теле или нет.
/🆑
```

</details>

- [x] Pull Request полностью завершен, мне не нужна помощь чтобы его закончить.
- [x] Я внимательно прочитал все свои изменения и багов в них не нашел.
- [ ] Я запускал сервер со своими изменениями локально и все протестировал.
- [x] Я ознакомился c [Guide to Contribute](https://github.com/ChaoticOnyx/OnyxBay/blob/dev/docs/contributing.md).
