### PR TITLE
fix(admin): fix Invisimin

### DIFF
--- a/code/modules/admin/admin_verbs.dm
+++ b/code/modules/admin/admin_verbs.dm
@@ -466,7 +466,10 @@ var/list/admin_verbs_mentor = list(
 	set desc = "Toggles ghost-like invisibility (Don't abuse this)"
 	if(holder && mob)
 		if(mob.invisibility == INVISIBILITY_OBSERVER)
-			mob.set_invisibility(initial(mob.invisibility))
+			if(isghost(mob))
+				mob.set_invisibility(0)
+			else
+				mob.set_invisibility(initial(mob.invisibility))
 			to_chat(mob, SPAN_DANGER("Invisimin off. Invisibility reset."))
 			mob.alpha = max(mob.alpha + 100, 255)
 		else


### PR DESCRIPTION
Пофиксил прикол с гостами. Неприятно что ради них ИФ вставить пришлось, но вдруг там есть случаи когда Визибилити будут переключать у моба, отличного от INVISIBILITY_OBSERVER и 0.
fix #3385
<details>
<summary>Чейнджлог</summary>

```yml
🆑KreeperHLC
admin: Педальная кнопка Invisimin теперь адекватно работает с гостами.
/🆑
```

</details>

- [x] Pull Request полностью завершен, мне не нужна помощь чтобы его закончить.
- [x] Я внимательно прочитал все свои изменения и багов в них не нашел.
- [ ] Я запускал сервер со своими изменениями локально и все протестировал.
- [x] Я ознакомился c [Guide to Contribute](https://github.com/ChaoticOnyx/OnyxBay/blob/dev/docs/contributing.md).
