### PR TITLE
fix(ghosts): fix character setup

### DIFF
--- a/code/modules/mob/new_player/new_player.dm
+++ b/code/modules/mob/new_player/new_player.dm
@@ -159,7 +159,6 @@
 			if(mannequin)
 				client.prefs.dress_preview_mob(mannequin)
 				observer.set_appearance(mannequin)
-				qdel(mannequin)
 
 			if(client.prefs.be_random_name)
 				client.prefs.real_name = random_name(client.prefs.gender)


### PR DESCRIPTION
Убрал удаление манекена, ибо он удаляется только при нажатии кнопки обсёрва из лобби. Учитывая что в других случаях он остаётся + мы можем заходить в чарактер сетап даже в игре, удаление манекена тут теряет смысл.

<details>
<summary>Чейнджлог</summary>

```yml
🆑KreeperHLC
bugfix: У гостов больше не ломается чарактер сетап.
/🆑
```

</details>

- [x] Pull Request полностью завершен, мне не нужна помощь чтобы его закончить.
- [x] Я внимательно прочитал все свои изменения и багов в них не нашел.
- [ ] Я запускал сервер со своими изменениями локально и все протестировал.
- [x] Я ознакомился c [Guide to Contribute](https://github.com/ChaoticOnyx/OnyxBay/blob/dev/docs/contributing.md).
