### PR TITLE
Removes unwanted radiation behavior making carbon/aliens die instantly upon spawning

### DIFF
--- a/code/modules/mob/living/carbon/alien/life.dm
+++ b/code/modules/mob/living/carbon/alien/life.dm
@@ -26,7 +26,7 @@
 		health = maxHealth
 		set_stat(CONSCIOUS)
 	else
-		health = maxHealth - getOxyLoss() - getToxLoss() - getFireLoss() - getBruteLoss() - getCloneLoss() - getHalLoss()
+		health = maxHealth - getOxyLoss() - getToxLoss() - getFireLoss() - getBruteLoss() - getCloneLoss()
 		if(health <= 0)
 			death()
 			return 0
@@ -36,10 +36,10 @@
 // Currently both Dionaea and larvae like to eat radiation, so I'm defining the
 // rad absorbtion here. This will need to be changed if other baby aliens are added.
 /mob/living/carbon/alien/handle_mutations_and_radiation()
-	if(!radiation)
+	if(radiation <= SAFE_RADIATION_DOSE)
 		return
 	var/rads = radiation / (0.05 SIEVERT)
-	radiation -= rads
+	radiation = max(SPACE_RADIATION, radiation - rads)
 	nutrition += rads
 	heal_overall_damage(rads, rads)
 	adjustOxyLoss(-rads)
@@ -94,7 +94,8 @@
 	update_sight()
 	if(healths)
 		if(stat != 2)
-			switch(health)
+			var/health_ratio = health / maxHealth * 100
+			switch(health_ratio)
 				if(100 to INFINITY)
 					healths.icon_state = "health0"
 				if(80 to 100)


### PR DESCRIPTION
![toktok](https://user-images.githubusercontent.com/45202681/190145655-57adfba3-bbfd-4e95-8f8f-b13213c8e64a.gif)
- Грудоломы и дионы больше не дохнут от радиации сразу после спавна.
- Грудоломы и дионы больше не воспринимают halLoss aka боль как реальный дамаг, отжирающий ХП.
- У грудоломов теперь правильно отображается иконка здоровья на ХУДе.

```yml
🆑
bugfix: Исправлена ошибка, из-за которой грудоломы и дионы умирали от кринжа через пару секунд после спавна.
bugfix: У грудоломов теперь правильно отображается иконка здоровья на ХУДе.
/🆑
```

- [x] Pull Request полностью завершен, мне не нужна помощь чтобы его закончить.
- [x] Я внимательно прочитал все свои изменения и багов в них не нашел.
- [x] Я запускал сервер со своими изменениями локально и все протестировал.
- [x] Я ознакомился c [Guide to Contribute](https://github.com/ChaoticOnyx/OnyxBay/blob/dev/docs/contributing.md).
