### PR TITLE
Removes negative radiation poisoning values caused by drugs

### DIFF
--- a/code/modules/reagents/Chemistry-Reagents/ethanol.dm
+++ b/code/modules/reagents/Chemistry-Reagents/ethanol.dm
@@ -338,8 +338,7 @@
 
 /datum/reagent/ethanol/vodka/affect_ingest(mob/living/carbon/M, alien, removed)
 	..()
-
-	M.radiation -= (0.009 SIEVERT) * removed
+	M.radiation = max(SPACE_RADIATION, M.radiation - ((0.009 SIEVERT) * removed))
 
 /datum/reagent/ethanol/vodka/premium
 	name = "Premium Vodka"
@@ -380,7 +379,7 @@
 
 /datum/reagent/ethanol/wine/affect_ingest(mob/living/carbon/M, alien, removed)
 	..()
-	M.radiation -= (0.005 SIEVERT) * removed
+	M.radiation = max(SPACE_RADIATION, M.radiation - ((0.005 SIEVERT) * removed))
 
 /datum/reagent/ethanol/wine/premium
 	name = "White Wine"

--- a/code/modules/reagents/Chemistry-Reagents/medicine.dm
+++ b/code/modules/reagents/Chemistry-Reagents/medicine.dm
@@ -425,7 +425,7 @@
 	flags = IGNORE_MOB_SIZE
 
 /datum/reagent/hyronalin/affect_blood(mob/living/carbon/M, alien, removed)
-	M.radiation -= (0.01 SIEVERT) * removed
+	M.radiation = max(SPACE_RADIATION, M.radiation - ((0.01 SIEVERT) * removed))
 
 /datum/reagent/arithrazine
 	name = "Arithrazine"
@@ -438,7 +438,7 @@
 	flags = IGNORE_MOB_SIZE
 
 /datum/reagent/arithrazine/affect_blood(mob/living/carbon/M, alien, removed)
-	M.radiation -= (0.1 SIEVERT) * removed
+	M.radiation = max(SPACE_RADIATION, M.radiation - ((0.1 SIEVERT) * removed))
 	M.adjustToxLoss(-10 * removed)
 	if(prob(60))
 		if(ishuman(M))


### PR DESCRIPTION
```yml
🆑
bugfix: Аритразин, гироналин, водка и красное вино больше не уводят радиацию в отрицательные значения.
/🆑
```

- [x] Pull Request полностью завершен, мне не нужна помощь чтобы его закончить.
- [x] Я внимательно прочитал все свои изменения и багов в них не нашел.
- [x] Я запускал сервер со своими изменениями локально и все протестировал.
- [x] Я ознакомился c [Guide to Contribute](https://github.com/ChaoticOnyx/OnyxBay/blob/dev/docs/contributing.md).
