### PR TITLE
Removes tanks' inability to go brrrrrr-boom

### DIFF
--- a/code/game/objects/items/tanks/tanks.dm
+++ b/code/game/objects/items/tanks/tanks.dm
@@ -358,13 +358,16 @@ var/list/global/tank_gauge_cache = list()
 	var/datum/gas_mixture/removed = remove_air(distribute_pressure*volume_to_return/(R_IDEAL_GAS_EQUATION*air_contents.temperature))
 	if(removed)
 		removed.volume = volume_to_return
-	
+
 	set_next_think(world.time)
 
 	return removed
 
 /obj/item/tank/think()
 	//Allow for reactions
+	if(!air_contents) // Perhaps, we're already on our way out of existence right now. Or, maybe, truly hollow we are?
+		return
+
 	var/react_ret = air_contents.react() //cooking up air tanks - add plasma and oxygen, then heat above PLASMA_MINIMUM_BURN_TEMPERATURE
 	update_icon(TRUE)
 	var/status_ret = check_status()
@@ -415,7 +418,7 @@ var/list/global/tank_gauge_cache = list()
 	overlays += tank_gauge_cache[indicator]
 
 /// Handle exploding, leaking, and rupturing of the tank.
-/// Returns `TRUE` if it should to continue thinking.
+/// Returns `TRUE` if it should continue thinking.
 /obj/item/tank/proc/check_status()
 	var/pressure = air_contents.return_pressure()
 
@@ -439,8 +442,7 @@ var/list/global/tank_gauge_cache = list()
 			var/turf/simulated/T = get_turf(src)
 			if(!T)
 				return FALSE
-			if(!T.hotspot_expose(air_contents.temperature, 70, 1))
-				return FALSE
+			T.hotspot_expose(air_contents.temperature, 70, 1)
 
 			T.assume_air(air_contents)
 			explosion(


### PR DESCRIPTION
```yml
🆑
bugfix: Баллоны снова научились взрываться.
/🆑
```

- [x] Pull Request полностью завершен, мне не нужна помощь чтобы его закончить.
- [x] Я внимательно прочитал все свои изменения и багов в них не нашел.
- [x] Я запускал сервер со своими изменениями локально и все протестировал.
- [x] Я ознакомился c [Guide to Contribute](https://github.com/ChaoticOnyx/OnyxBay/blob/dev/docs/contributing.md).
