### PR TITLE
fix(singularity): loc replaced with get_turf() in bag of holding

### DIFF
--- a/code/game/objects/items/storage/backpack.dm
+++ b/code/game/objects/items/storage/backpack.dm
@@ -72,7 +72,7 @@
 		investigate_log("has become a singularity. Caused by [user.key]", "singulo")
 		to_chat(usr, "\red The Bluespace interfaces of the two devices catastrophically malfunction!")
 		qdel(W)
-		new /obj/singularity(src.loc, 300)
+		new /obj/singularity(get_turf(src), 300)
 		log_and_message_admins("detonated a bag of holding", user, src.loc)
 		qdel(src)
 		return


### PR DESCRIPTION
Дети - цветы жизни!
Даже если это singularity.childs
fix #9372

Не особо тестил, просто убедился что присутствует на обоих уровнях Исхода при БоХ-в-БоХ в руках.

<details>
<summary>Чейнджлог</summary>

```yml
🆑
bugfix: Теперь БоХ-в-БоХ порождает многоуровневую сингулярность.
/🆑
```

</details>

После символа 🆑 на той же строке можно написать никнейм, который будет отображён в чейнджлогах вместо никнейма автора ПРа.

- [x] Pull Request полностью завершен, мне не нужна помощь чтобы его закончить.
- [x] Я внимательно прочитал все свои изменения и багов в них не нашел.
- [x] Я запускал сервер со своими изменениями локально и все протестировал.
- [x] Я ознакомился c [Guide to Contribute](https://github.com/ChaoticOnyx/OnyxBay/blob/dev/docs/contributing.md).
