### PR TITLE
fix(food) donuts

### DIFF
--- a/code/game/objects/random/random.dm
+++ b/code/game/objects/random/random.dm
@@ -695,7 +695,7 @@
 				/obj/item/reagent_containers/food/packaged/tastybread,
 				/obj/item/reagent_containers/food/packaged/nutribar,
 				/obj/item/reagent_containers/food/packaged/syndicake,
-				/obj/item/reagent_containers/food/donut,
+				/obj/item/reagent_containers/food/donut/normal,
 				/obj/item/reagent_containers/food/donut/cherryjelly,
 				/obj/item/reagent_containers/food/donut/jelly,
 				/obj/item/pizzabox/meat,

--- a/code/modules/reagents/reagent_containers/food/_food.dm
+++ b/code/modules/reagents/reagent_containers/food/_food.dm
@@ -68,7 +68,7 @@
 
 /obj/item/reagent_containers/food/attack(mob/M, mob/user, def_zone)
 	if(!reagents.total_volume)
-		to_chat(user, SPAN("danger", "None of [src] left!"))
+		to_chat(user, SPAN("danger", "The empty shell of [src] crumbles in your hands!"))
 		user.drop_from_inventory(src)
 		qdel(src)
 		return FALSE

--- a/code/modules/reagents/reagent_containers/food/unsorted.dm
+++ b/code/modules/reagents/reagent_containers/food/unsorted.dm
@@ -95,12 +95,9 @@
 	var/overlay_state = "box-donut1"
 	center_of_mass = "x=13;y=16"
 	nutriment_desc = list("sweetness", "donut")
+	nutriment_amt = 3
 
 /obj/item/reagent_containers/food/donut/normal
-	name = "donut"
-	desc = "Goes great with Robust Coffee."
-	icon_state = "donut1"
-	nutriment_amt = 3
 	startswith = list(/datum/reagent/nutriment/sprinkles = 1)
 	bitesize = 3
 
@@ -159,7 +156,6 @@
 	icon_state = "jdonut1"
 	filling_color = "#ed1169"
 	center_of_mass = "x=16;y=11"
-	nutriment_amt = 3
 	startswith = list(
 		/datum/reagent/nutriment/sprinkles = 1,
 		/datum/reagent/drink/juice/berry = 5)
@@ -180,7 +176,6 @@
 	icon_state = "jdonut1"
 	filling_color = "#ed1169"
 	center_of_mass = "x=16;y=11"
-	nutriment_amt = 3
 	startswith = list(
 		/datum/reagent/nutriment/sprinkles = 1,
 		/datum/reagent/metroidjelly = 5)
@@ -200,7 +195,6 @@
 	icon_state = "jdonut1"
 	filling_color = "#ed1169"
 	center_of_mass = "x=16;y=11"
-	nutriment_amt = 3
 	startswith = list(
 		/datum/reagent/nutriment/sprinkles = 1,
 		/datum/reagent/nutriment/cherryjelly = 5)


### PR DESCRIPTION
Поправил инициализацию пончиков, чтобы все по умолчанию имели 3 нутриментов.
Заменил предупреждение "Ни одного из [еда] не осталось" на "Пустая оболочка [еда] рассыпается у вас в руках". 
Старое подходило для чипсов, но чипсы превращаются в obj/item/trash и не выводят данного сообщения.
Откачать же реагенты можно из (практически) любой еды.

fix #8437 

<details>
<summary>Чейнджлог</summary>

```yml
🆑
bugfix: Небольшой фикс пончиков.
/🆑
```

</details>

- [x] Pull Request полностью завершен, мне не нужна помощь чтобы его закончить.
- [x] Я внимательно прочитал все свои изменения и багов в них не нашел.
- [x] Я запускал сервер со своими изменениями локально и все протестировал.
- [x] Я ознакомился c [Guide to Contribute](https://github.com/ChaoticOnyx/OnyxBay/blob/dev/docs/contributing.md).
