### PR TITLE
feat(config): add mapping section

### DIFF
--- a/baystation12.dme
+++ b/baystation12.dme
@@ -307,6 +307,7 @@
 #include "code\datums\configuration\link_section.dm"
 #include "code\datums\configuration\lobby_section.dm"
 #include "code\datums\configuration\log_section.dm"
+#include "code\datums\configuration\mapping_section.dm"
 #include "code\datums\configuration\misc_section.dm"
 #include "code\datums\configuration\movement_section.dm"
 #include "code\datums\configuration\multiaccount_section.dm"

--- a/code/datums/configuration/mapping_section.dm
+++ b/code/datums/configuration/mapping_section.dm
@@ -8,7 +8,7 @@
     CONFIG_LOAD_STR(preferable_engine, data["preferable_engine"])
     CONFIG_LOAD_STR(preferable_biodome, data["preferable_biodome"])
 
-	if(!(preferable_engine in list(MAP_ENG_RANDOM, MAP_ENG_SINGULARITY, MAP_ENG_MATTER)))
-		preferable_engine = MAP_ENG_SINGULARITY
+    if(!(preferable_engine in list(MAP_ENG_RANDOM, MAP_ENG_SINGULARITY, MAP_ENG_MATTER)))
+        preferable_engine = MAP_ENG_SINGULARITY
     if(!(preferable_biodome in list(MAP_BIO_RANDOM, MAP_BIO_FOREST, MAP_BIO_WINTER, MAP_BIO_BEACH, MAP_BIO_CONCERT)))
         preferable_biodome = MAP_BIO_FOREST

--- a/code/datums/configuration/mapping_section.dm
+++ b/code/datums/configuration/mapping_section.dm
@@ -1,0 +1,14 @@
+/datum/configuration_section/mapping
+    name = "mapping"
+
+    var/preferable_engine = MAP_ENG_SINGULARITY
+    var/preferable_biodome = MAP_BIO_FOREST
+
+/datum/configuration_section/mapping/load_data(list/data)
+    CONFIG_LOAD_STR(preferable_engine, data["preferable_engine"])
+    CONFIG_LOAD_STR(preferable_biodome, data["preferable_biodome"])
+
+	if(!(preferable_engine in list(MAP_ENG_RANDOM, MAP_ENG_SINGULARITY, MAP_ENG_MATTER)))
+		preferable_engine = MAP_ENG_SINGULARITY
+    if(!(preferable_biodome in list(MAP_BIO_RANDOM, MAP_BIO_FOREST, MAP_BIO_WINTER, MAP_BIO_BEACH, MAP_BIO_CONCERT)))
+        preferable_biodome = MAP_BIO_FOREST

--- a/code/datums/configuration/misc_section.dm
+++ b/code/datums/configuration/misc_section.dm
@@ -28,8 +28,7 @@
 	var/projectile_basketball = FALSE
 	var/fun_hydroponics = 1
 	var/forbid_singulo_following = FALSE
-	var/preferable_engine = MAP_ENG_SINGULARITY
-	var/preferable_biodome = MAP_BIO_FOREST
+
 
 /datum/configuration_section/misc/load_data(list/data)
 	CONFIG_LOAD_BOOL(ooc_allowed, data["ooc_allowed"])
@@ -59,7 +58,3 @@
 	CONFIG_LOAD_BOOL(projectile_basketball, data["projectile_basketball"])
 	CONFIG_LOAD_NUM(fun_hydroponics, data["fun_hydroponics"])
 	CONFIG_LOAD_BOOL(forbid_singulo_following, data["forbid_singulo_following"])
-	CONFIG_LOAD_STR(preferable_engine, data["preferable_engine"])
-
-	if(!(preferable_engine in list(MAP_ENG_RANDOM, MAP_ENG_SINGULARITY, MAP_ENG_MATTER)))
-		preferable_engine = MAP_ENG_SINGULARITY

--- a/code/datums/configuration/server_configuration.dm
+++ b/code/datums/configuration/server_configuration.dm
@@ -19,6 +19,7 @@ GLOBAL_REAL(config, /datum/server_configuration) = new
 	var/datum/configuration_section/revival/revival = new
 	var/datum/configuration_section/movement/movement = new
 	var/datum/configuration_section/misc/misc = new
+	var/datum/configuration_section/mapping/mapping = new
 	var/datum/configuration_section/vote/vote = new
 	var/datum/configuration_section/link/link = new
 	var/datum/configuration_section/external/external = new

--- a/code/game/map_ent/map_engine.dm
+++ b/code/game/map_ent/map_engine.dm
@@ -9,7 +9,7 @@
 	var/target_engine = ev_engine
 	
 	if(!target_engine)
-		target_engine = config.misc.preferable_engine
+		target_engine = config.mapping.preferable_engine
 	
 	if(target_engine == MAP_ENG_RANDOM)
 		target_engine = pick(MAP_ENG_SINGULARITY, MAP_ENG_MATTER)

--- a/maps/frontier/ent_biodome.dm
+++ b/maps/frontier/ent_biodome.dm
@@ -9,7 +9,7 @@
 	var/target_biodome = ev_biodome
 	
 	if(!target_biodome)
-		target_biodome = config.misc.preferable_biodome
+		target_biodome = config.mapping.preferable_biodome
 	
 	if(target_biodome == MAP_BIO_RANDOM)
 		target_biodome = pick(MAP_BIO_FOREST, MAP_BIO_BEACH, MAP_BIO_CONCERT, MAP_BIO_WINTER)


### PR DESCRIPTION
Назовем это не моим косяком с конфигами, а структурным и последовательным воркфлоу

Добавил секцию "маппинг" в конфиг для выноски туда всех штук, что связанны со спавнами на карте. Пока там лежат лишь заплатки для карт.

<details>
<summary>Чейнджлог</summary>

```yml
🆑
admin: В конфиг добавлена секция "маппинг" для настройки вещей, непосредственно связанных с картами (например - рандомизация движка).
/🆑
```

</details>


- [x] Pull Request полностью завершен, мне не нужна помощь чтобы его закончить.
- [x] Я внимательно прочитал все свои изменения и багов в них не нашел.
- [ ] Я запускал сервер со своими изменениями локально и все протестировал.
- [x] Я ознакомился c [Guide to Contribute](https://github.com/ChaoticOnyx/OnyxBay/blob/dev/docs/contributing.md).
