### PR TITLE
feat(virus): add zombie-virus

### DIFF
--- a/code/datums/events/virus_outbreak.dm
+++ b/code/datums/events/virus_outbreak.dm
@@ -63,6 +63,7 @@
 		/datum/ictus/fake_gbs,
 		/datum/ictus/nuclear,
 		/datum/ictus/fluspanish,
-		/datum/ictus/emp)
+		/datum/ictus/emp,
+		/datum/ictus/zombievirus)
 
 	new next_outbreak

--- a/code/modules/virus2/effects/engineering.dm
+++ b/code/modules/virus2/effects/engineering.dm
@@ -21,6 +21,26 @@
 	mob.visible_message(SPAN_WARNING("Bees fly out of [mob]'s throat when [G.he] coughs!"),
 						SPAN_DANGER("Bees fly out of your throat when you cough!"))
 
+/datum/disease2/effect/concealment
+	name = "Сoncealment syndrome"
+	stage = 1
+	badness = VIRUS_ENGINEERED
+
+/datum/disease2/effect/concealment/generate(c_data)
+	if(c_data)
+		data = c_data
+	else
+		data = pick(ALL_ANTIGENS)
+
+/datum/disease2/effect/concealment/change_parent()
+	parent_disease.antigen = list()
+
+/datum/disease2/effect/concealment/activate(mob/living/carbon/human/mob)
+	if(..())
+		return
+	var/list/antibodies_in_common = mob.antibodies & data
+	if(antibodies_in_common.len)
+		parent_disease.cure()
 
 ////////////////////////STAGE 2/////////////////////////////////
 
@@ -334,3 +354,14 @@
 	infect_virus2(mob, D, 1)
 	if(parent_disease) // what the fuck? If virus must be changed and you created a new one, THAN DELETE OLD VIRUS, BIGOTS!
 		QDEL_NULL(parent_disease)
+
+/datum/disease2/effect/zombie
+	name = "HQ41"
+	stage = 4
+	badness = VIRUS_ENGINEERED
+	oneshot = 1
+
+/datum/disease2/effect/zombie/activate(mob/living/carbon/human/mob)
+	if(..())
+		return
+	mob.zombify()

--- a/code/modules/virus2/pestilence.dm
+++ b/code/modules/virus2/pestilence.dm
@@ -595,3 +595,49 @@
 
 	if(candidate.species.name in D.affected_species)
 		infect_virus2(candidate,D,1)
+
+// ####################################################################
+// ###########################ZOMBIE VIRUS#############################
+// ####################################################################
+
+/datum/disease2/disease/zombievirus
+	infectionchance = 55
+	speed = 4
+	spreadtype = "Contact"
+	max_stage = 4
+	affected_species = list(SPECIES_HUMAN, SPECIES_TAJARA, SPECIES_SKRELL, SPECIES_DIONA, SPECIES_UNATHI)
+
+/datum/disease2/disease/zombievirus/New()
+	..()
+	antigen = list(pick(ALL_ANTIGENS))
+	var/datum/disease2/effect/concealment/E1 = new()
+	E1.stage = 1
+	E1.chance = 100
+	effects += E1
+	var/datum/disease2/effect/aggressive/E2 = new()
+	E2.stage = 2
+	E2.chance = 50
+	effects += E2
+	var/datum/disease2/effect/click/E3 = new()
+	E3.stage = 3
+	E3.chance = 35
+	effects += E3
+	var/datum/disease2/effect/zombie/E4 = new()
+	E4.stage = 4
+	E4.chance = 80
+	effects += E4
+
+/datum/ictus/zombievirus/start()
+	var/list/candidates = list()	//list of candidate keys
+	for(var/mob/living/carbon/human/G in GLOB.player_list)
+		if(G.client && G.stat != DEAD && !G.species.get_virus_immune(G))
+			candidates += G
+
+	if(!candidates.len)
+		return
+
+	var/datum/disease2/disease/zombievirus/D = new
+	var/mob/living/carbon/human/candidate = pick_n_take(candidates)
+
+	if(candidate.species.name in D.affected_species)
+		infect_virus2(candidate,D,1)


### PR DESCRIPTION
Раз уж тот ПР все равно захлебнулся в конфликтах, решил разделить его на два.

Добавлен Сoncealment syndrome, скрывающий антиген и не позволяющий получить его облучением.
Добавлен HQ41, превращающий пациента в зомби.
Добавлен зомби-вирус в ивенты.

<details>
<summary>Чейнджлог</summary>

```yml
🆑
tweak: Добавлен зомби-вирус.
/🆑
```

</details>

- [x] Pull Request полностью завершен, мне не нужна помощь чтобы его закончить.
- [x] Я внимательно прочитал все свои изменения и багов в них не нашел.
- [ ] Я запускал сервер со своими изменениями локально и все протестировал.
- [x] Я ознакомился c [Guide to Contribute](https://github.com/ChaoticOnyx/OnyxBay/blob/dev/docs/contributing.md).
