### PR TITLE
fix(doors): purge retarded timers and issues caused by them

### DIFF
--- a/code/game/machinery/doors/airlock.dm
+++ b/code/game/machinery/doors/airlock.dm
@@ -147,13 +147,13 @@ About the new airlock wires panel:
 /obj/machinery/door/airlock/proc/loseMainPower()
 	main_power_lost_until = mainPowerCablesCut() ? -1 : SecondsToTicks(60)
 	if(main_power_lost_until > 0)
-		addtimer(CALLBACK(src, .proc/regainMainPower), main_power_lost_until)
+		set_next_think_ctx("regain_main_power", world.time + main_power_lost_until)
 
 
 	// If backup power is permanently disabled then activate in 10 seconds if possible, otherwise it's already enabled or a timer is already running
 	if(backup_power_lost_until == -1 && !backupPowerCablesCut())
 		backup_power_lost_until = SecondsToTicks(10)
-		addtimer(CALLBACK(src, .proc/regainBackupPower), backup_power_lost_until)
+		set_next_think_ctx("regain_backup_power", world.time + backup_power_lost_until)
 	// Disable electricity if required
 	if(electrified_until && isAllPowerLoss())
 		electrify(0)
@@ -163,7 +163,7 @@ About the new airlock wires panel:
 /obj/machinery/door/airlock/proc/loseBackupPower()
 	backup_power_lost_until = backupPowerCablesCut() ? -1 : SecondsToTicks(60)
 	if(backup_power_lost_until > 0)
-		addtimer(CALLBACK(src, .proc/regainBackupPower), backup_power_lost_until)
+		set_next_think_ctx("regain_backup_power", world.time + backup_power_lost_until)
 	// Disable electricity if required
 	if(electrified_until && isAllPowerLoss())
 		electrify(0)
@@ -207,7 +207,7 @@ About the new airlock wires panel:
 		message = "The door is now electrified [duration == -1 ? "permanently" : "for [duration] second\s"]."
 		electrified_until = duration == -1 ? -1 : SecondsToTicks(duration)
 		if(electrified_until > 0)
-			addtimer(CALLBACK(src, .proc/electrify), electrified_until)
+			set_next_think_ctx("electrify", world.time + electrified_until)
 		. = 1
 
 	if(feedback && message)
@@ -799,7 +799,7 @@ About the new airlock wires panel:
 /obj/machinery/door/airlock/close(forced = 0)
 	var/wait = normalspeed ? 150 : 5
 	if(!can_close(forced))
-		addtimer(CALLBACK(src, .proc/close), wait, TIMER_UNIQUE|TIMER_OVERRIDE)
+		set_next_think_ctx("close", world.time + wait)
 		return 0
 
 	if(safe)
@@ -807,11 +807,11 @@ About the new airlock wires panel:
 			for(var/atom/movable/AM in T)
 				if(AM.blocks_airlock())
 					if(autoclose && tryingToLock)
-						addtimer(CALLBACK(src, .proc/close), 30 SECONDS)
+						set_next_think_ctx("close", world.time + (30 SECONDS))
 					if(world.time > next_beep_at)
 						playsound(src.loc, close_failure_blocked, 30, 0, -3)
 						next_beep_at = world.time + SecondsToTicks(10)
-					addtimer(CALLBACK(src, .proc/close), wait, TIMER_UNIQUE|TIMER_OVERRIDE)
+					set_next_think_ctx("close", world.time + wait)
 					return
 
 	for(var/turf/T in locs)
@@ -865,6 +865,11 @@ About the new airlock wires panel:
 
 /obj/machinery/door/airlock/New(newloc, obj/structure/door_assembly/assembly = null)
 	..()
+
+	add_think_ctx("regain_main_power", CALLBACK(src, .proc/regainMainPower), 0)
+	add_think_ctx("regain_backup_power", CALLBACK(src, .proc/regainBackupPower), 0)
+	add_think_ctx("electrify", CALLBACK(src, .proc/electrify), 0)
+	add_think_ctx("close", CALLBACK(src, .proc/close), 0)
 
 	//if assembly is given, create the new door from the assembly
 	if (assembly && istype(assembly))


### PR DESCRIPTION
<details>
<summary>Чейнджлог</summary>

```yml
🆑
bugfix: Фикс мгновенного восстановления энергии у дверей при взломе через мультитул.
/🆑
```

</details>

- [x] Pull Request полностью завершен, мне не нужна помощь чтобы его закончить.
- [x] Я внимательно прочитал все свои изменения и багов в них не нашел.
- [x] Я запускал сервер со своими изменениями локально и все протестировал.
- [x] Я ознакомился c [Guide to Contribute](https://github.com/ChaoticOnyx/OnyxBay/blob/dev/docs/contributing.md).
