### PR TITLE
fix(map): sunset SM engine wires fix

### DIFF
--- a/maps/sunset/sunset-3.dmm
+++ b/maps/sunset/sunset-3.dmm
@@ -1123,7 +1123,7 @@
 "vE" = (/obj/structure/table/reinforced,/turf/simulated/floor/trim/carpet/orange,/area/engineering/engine_monitoring)
 "vF" = (/obj/item/modular_computer/console/preset/engineering,/turf/simulated/floor/trim/carpet/orange,/area/engineering/engine_monitoring)
 "vG" = (/obj/structure/bed/chair/office/light{dir = 4},/obj/machinery/atmospherics/unary/vent_pump/on{dir = 1},/obj/effect/landmark/start/crew/ce,/turf/simulated/floor/trim/carpet/orange,/area/engineering/engine_monitoring)
-"vH" = (/obj/structure/railing{dir = 8; tag = "icon-railing0 (WEST)"},/obj/structure/cable/yellow{d1 = 32; icon_state = "32-1"},/turf/simulated/open,/area/engineering/engine_monitoring)
+"vH" = (/obj/structure/railing{dir = 8; tag = "icon-railing0 (WEST)"},/obj/structure/cable/yellow{d1 = 32; d2 = 4; icon_state = "32-4"; step_x = 0; step_y = 0},/turf/simulated/open,/area/engineering/engine_monitoring)
 "vI" = (/obj/structure/plasticflaps/mining{opacity = 1},/obj/effect/floor_decal/industrial/hatch/yellow,/obj/structure/cable/yellow{d1 = 4; d2 = 8; icon_state = "4-8"},/turf/simulated/floor/plating,/area/engineering/engine_monitoring)
 "vJ" = (/obj/structure/cable/yellow{d1 = 4; d2 = 8; icon_state = "4-8"},/obj/machinery/atmospherics/pipe/simple/hidden/supply{dir = 6},/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{dir = 6},/obj/structure/catwalk,/turf/simulated/floor/plating,/area/engineering/engine_room)
 "vK" = (/obj/structure/cable/yellow{d1 = 4; d2 = 8; icon_state = "4-8"},/obj/machinery/atmospherics/pipe/simple/hidden/supply{dir = 4},/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{dir = 4},/obj/structure/catwalk,/turf/simulated/floor/plating,/area/engineering/engine_room)


### PR DESCRIPTION
Фикс проводов переходящих на следующий уровень от двигателя СМ.
Теперь провода на Cансете идущие от двигателя на уровень выше лежат нормально и передают электричество.


<details>
<summary>Чейнджлог</summary>

```yml
🆑
bugfix: Теперь провода на Сансете ведущие от двигателя СМ лежат нормально и передают электричество на уровень выше.
/🆑
```

</details>

![вввв](https://user-images.githubusercontent.com/114770504/193421977-7760fb11-e9c8-46a1-afee-65ccff72578b.png)


- [x] Pull Request полностью завершен, мне не нужна помощь чтобы его закончить.
- [x] Я внимательно прочитал все свои изменения и багов в них не нашел.
- [x] Я запускал сервер со своими изменениями локально и все протестировал.
- [x] Я ознакомился c [Guide to Contribute](https://github.com/ChaoticOnyx/OnyxBay/blob/dev/docs/contributing.md).
