### PR TITLE
tweak(ooc verb): add verb info storyteller in OOC

### DIFF
--- a/code/game/verbs/ooc.dm
+++ b/code/game/verbs/ooc.dm
@@ -49,3 +49,10 @@
 		winset(src, null, "reset=true")
 		update_chat_position()
 		nuke_chat()
+
+/client/verb/info_storyteller()
+	set name = "Storyteller info"
+	set category = "OOC"
+
+	to_chat(src, "<b>Current Storyteller:</b> [SSstoryteller.character.name] - [SSstoryteller.character.desc]")
+


### PR DESCRIPTION
Добавлен верб в OOC, который позволяет узнать текущего сторитейлера.

<details>
<summary>Чейнджлог</summary>

```yml
🆑
tweak: Во вкладку ООС добавлен верб, позволяющий узнать текущего сторитейлера.
/🆑
```

</details>

- [x] Pull Request полностью завершен, мне не нужна помощь чтобы его закончить.
- [x] Я внимательно прочитал все свои изменения и багов в них не нашел.
- [x] Я запускал сервер со своими изменениями локально и все протестировал.
- [x] Я ознакомился c [Guide to Contribute](https://github.com/ChaoticOnyx/OnyxBay/blob/dev/docs/contributing.md).
