### PR TITLE
fix(facehugger): fix pregnancy  from a dead facehugger

### DIFF
--- a/code/modules/mob/living/simple_animal/hostile/facehugger.dm
+++ b/code/modules/mob/living/simple_animal/hostile/facehugger.dm
@@ -68,6 +68,7 @@
 	if(.)
 		if(is_sterile)
 			icon_state = "facehugger_impregnated"
+		is_sterile = TRUE
 
 /mob/living/simple_animal/hostile/facehugger/get_scooped(mob/living/carbon/grabber, self_grab)
 	if(grabber.faction != "xenomorph" && !is_sterile && !stat)

--- a/code/modules/mob/living/simple_animal/hostile/facehugger.dm
+++ b/code/modules/mob/living/simple_animal/hostile/facehugger.dm
@@ -68,7 +68,6 @@
 	if(.)
 		if(is_sterile)
 			icon_state = "facehugger_impregnated"
-		is_sterile = TRUE
 
 /mob/living/simple_animal/hostile/facehugger/get_scooped(mob/living/carbon/grabber, self_grab)
 	if(grabber.faction != "xenomorph" && !is_sterile && !stat)
@@ -159,7 +158,7 @@
 	if(H.isSynthetic())
 		return FALSE
 
-	return H.species?.xenomorph_type && !is_sterile && (forced || !H.internal_organs_by_name[BP_HIVE])
+	return H.species?.xenomorph_type && !stat && !is_sterile && (forced || !H.internal_organs_by_name[BP_HIVE])
 
 
 /mob/living/simple_animal/hostile/facehugger/AttackingTarget()


### PR DESCRIPTION
Фикс, что мертвые лицехваты могут оплодотворять людей.

close #9605

<details>
<summary>Чейнджлог</summary>

```yml
🆑
bugfix: Мёртвые лицехваты больше не могут заражать людей.
/🆑
```

</details>


- [x] Pull Request полностью завершен, мне не нужна помощь чтобы его закончить.
- [x] Я внимательно прочитал все свои изменения и багов в них не нашел.
- [x] Я запускал сервер со своими изменениями локально и все протестировал.
- [x] Я ознакомился c [Guide to Contribute](https://github.com/ChaoticOnyx/OnyxBay/blob/dev/docs/contributing.md).
