### PR TITLE
fix(maploader): didn't delete objects when map was uploaded via adminverb

### DIFF
--- a/code/modules/maps/map_template.dm
+++ b/code/modules/maps/map_template.dm
@@ -113,7 +113,7 @@
 	var/list/atoms_to_initialise = list()
 
 	for (var/mappath in mappaths)
-		var/datum/map_load_metadata/M = maploader.load_map(file(mappath), T.x, T.y, T.z, cropMap=TRUE, clear_contents= template_flags & TEMPLATE_FLAG_CLEAR_CONTENTS)
+		var/datum/map_load_metadata/M = maploader.load_map(file(mappath), T.x, T.y, T.z, cropMap=TRUE, clear_contents= clear_contents)
 		if (M)
 			atoms_to_initialise += M.atoms_to_initialise
 		else


### PR DESCRIPTION
Исправил неверную передачу аргументов в функциях накладывания карты, из-за чего не удалялись объекты, когда должны были.

В админпанели есть кнопка для загрузки карты на сервер и накладывания этой самой карты поверх текущей. При размещении карты всплывает вопрос о необходимости удаления всех предметов из зоны, на которую будет наложена новая карта. При выборе "да" до этого предметы оставались, теперь их удаляет.

- [x] Pull Request полностью завершен, мне не нужна помощь чтобы его закончить.
- [x] Я внимательно прочитал все свои изменения и багов в них не нашел.
- [x] Я запускал сервер со своими изменениями локально и все протестировал.
- [x] Я ознакомился c [Guide to Contribute](https://github.com/ChaoticOnyx/OnyxBay/blob/dev/docs/contributing.md).
