### PR TITLE
Removes even more weird CMO's cats

### DIFF
--- a/code/game/atoms_movable.dm
+++ b/code/game/atoms_movable.dm
@@ -76,7 +76,8 @@
 
 /atom/movable/proc/forceMove(atom/destination)
 	if((gc_destroyed && gc_destroyed != GC_CURRENTLY_BEING_QDELETED) && !isnull(destination))
-		CRASH("Attempted to forceMove a QDELETED [src] out of nullspace!")
+		util_crash_with("Attempted to forceMove a QDELETED [src] out of nullspace! Destination: [destination].")
+		return 0
 	if(loc == destination)
 		return 0
 	var/is_origin_turf = isturf(loc)

--- a/code/game/gamemodes/traitor/contracts.dm
+++ b/code/game/gamemodes/traitor/contracts.dm
@@ -366,8 +366,10 @@ GLOBAL_LIST_INIT(syndicate_factions, list(
 	var/current_samples = 0
 	for(var/obj/item/reagent_containers/C in contents)
 		var/list/data = C.reagents?.get_data(/datum/reagent/blood)
+		if(!length(data))
+			continue
 		var/datum/species/spec = all_species[data["species"]]
-		if(!data || (data["blood_DNA"] in samples) || (spec?.species_flags & SPECIES_FLAG_NO_ANTAG_TARGET))
+		if((data["blood_DNA"] in samples) || (spec?.species_flags & SPECIES_FLAG_NO_ANTAG_TARGET))
 			continue
 		if(add_checked)
 			samples += data["blood_DNA"]

--- a/code/game/machinery/doors/simple.dm
+++ b/code/game/machinery/doors/simple.dm
@@ -255,7 +255,7 @@
 	add_fingerprint(user, 0, I)
 	if(user.a_intent == I_HURT)
 		user.setClickCooldown(DEFAULT_ATTACK_COOLDOWN)
-		if(I.damtype == BRUTE || I.damtype == BURN)
+		if(istype(I) && (I.damtype == BRUTE || I.damtype == BURN))
 			user.do_attack_animation(src)
 			if(I.force < min_force)
 				user.visible_message(SPAN("danger", "\The [user] hits \the [src] with \the [I] with no visible effect."))

--- a/code/game/machinery/oxygen_pump.dm
+++ b/code/game/machinery/oxygen_pump.dm
@@ -33,13 +33,11 @@
 		breather.internal = null
 		if(breather.internals)
 			breather.internals.icon_state = "internal0"
-	if(tank)
-		qdel(tank)
+	QDEL_NULL(tank)
 	if(breather)
 		breather.drop(contained, force = TRUE)
 		visible_message("<span class='notice'>The mask rapidly retracts just before \the [src] is destroyed!</span>")
-	qdel(contained)
-	contained = null
+	QDEL_NULL(contained)
 	breather = null
 	return ..()
 

--- a/code/game/objects/effects/effect_system.dm
+++ b/code/game/objects/effects/effect_system.dm
@@ -27,6 +27,8 @@ would spawn and follow the beaker, even if it is carried or thrown.
 	setup = 1
 
 /datum/effect/effect/system/proc/attach(atom/atom)
+	if(holder)
+		unregister_signal(holder, SIGNAL_QDELETING)
 	holder = atom
 	register_signal(holder, SIGNAL_QDELETING, /datum/effect/effect/system/proc/onHolderDeleted)
 

--- a/code/game/objects/items/devices/radio/radio.dm
+++ b/code/game/objects/items/devices/radio/radio.dm
@@ -335,10 +335,10 @@
   /* ###### Radio headsets can only broadcast through subspace ###### */
 	if(subspace_transmission)
 		// No one can hear our screams in an area with the unstable bluespace.
-		if(GLOB.using_map.level_has_trait(loc.z, ZTRAIT_BLUESPACE_EXIT))
+		if(GLOB.using_map.level_has_trait(position.z, ZTRAIT_BLUESPACE_EXIT))
 			return
 		// The bluespace is less unstable so we can transmit something.
-		else if(GLOB.using_map.level_has_trait(loc.z, ZTRAIT_BLUESPACE_CONVERGENCE))
+		else if(GLOB.using_map.level_has_trait(position.z, ZTRAIT_BLUESPACE_CONVERGENCE))
 			message = stars(message)
 
 		// First, we want to generate a new radio signal

--- a/code/modules/economy/cash.dm
+++ b/code/modules/economy/cash.dm
@@ -37,8 +37,8 @@
 		bundle.update_icon()
 		if(ishuman(user))
 			var/mob/living/carbon/human/h_user = user
-			h_user.drop(src)
-			h_user.drop(bundle)
+			if(buldle.loc == h_user)
+				h_user.drop(bundle)
 			h_user.pick_or_drop(bundle)
 		to_chat(user, "<span class='notice'>You add [src.worth] credits worth of money to the bundles.<br>It holds [bundle.worth] credits now.</span>")
 		qdel(src)

--- a/code/modules/economy/cash.dm
+++ b/code/modules/economy/cash.dm
@@ -37,7 +37,7 @@
 		bundle.update_icon()
 		if(ishuman(user))
 			var/mob/living/carbon/human/h_user = user
-			if(buldle.loc == h_user)
+			if(bundle.loc == h_user)
 				h_user.drop(bundle)
 			h_user.pick_or_drop(bundle)
 		to_chat(user, "<span class='notice'>You add [src.worth] credits worth of money to the bundles.<br>It holds [bundle.worth] credits now.</span>")

--- a/code/modules/mob/inventory.dm
+++ b/code/modules/mob/inventory.dm
@@ -159,7 +159,8 @@ var/list/slot_equipment_priority = list( \
 // Please ONLY use it on "external" items, *with their loc != src*, or our ballsack will instantly fall off. You've been warned.
 // Otherwise it's pretty much safe and preferable over calling put_in_hands and whatever movement separately.
 /mob/proc/pick_or_drop(obj/item/W, atom/A = null)
-	if(!W)
+	if(QDELETED(W))
+		util_crash_with("Called [src]'s ([type]) proc/pick_or_drop(W = [W], A = [A]), passing qdeleted W as an argment, what the fuck.")
 		return FALSE
 	if(put_in_hands(W))
 		return TRUE
@@ -190,7 +191,7 @@ var/list/slot_equipment_priority = list( \
 
 	if(I.loc != src)
 		util_crash_with("Called [src]'s ([type]) proc/drop(I = [I], target = [target], force = [force]) while the item isn't located inside the mob.") // This may save us someday.
-		return FALSE
+		// return FALSE // Gonna uncomment this after resolving some weird bugs. Multiple runtime errors wreck stack tracing and do more harm than good. ~Toby
 
 	if(!(force || can_unequip(I)))
 		return FALSE

--- a/code/modules/power/singularity/collector.dm
+++ b/code/modules/power/singularity/collector.dm
@@ -134,7 +134,10 @@ var/global/list/rad_collectors = list()
 	if (distance <= 3 && !(stat & BROKEN))
 		. += "\nSensor readings:"
 		. += "\nPower rate: [fmt_siunit(last_power, "W/s", 3)]"
-		. += "\nTank temperature: [P.air_contents.temperature]K"
+		if(P?.air_contents)
+			. += "\nTank temperature: [P.air_contents.temperature]K"
+		else
+			. += "\nTank temperature: N/A"
 		. += "\nEntropy drift: [last_temp_dif] K/s"
 
 /obj/machinery/power/rad_collector/ex_act(severity)

--- a/code/modules/projectiles/gun.dm
+++ b/code/modules/projectiles/gun.dm
@@ -422,7 +422,7 @@
 		else
 			to_chat(user, "<span class = 'notice'>Ow...</span>")
 			user.apply_effect(110,PAIN,0)
-		qdel(in_chamber)
+		QDEL_NULL(in_chamber)
 		mouthshoot = 0
 		return
 	else
@@ -485,7 +485,7 @@
 			else
 				to_chat(user, SPAN_NOTICE("Ow..."))
 				target.apply_effect(110, PAIN, 0)
-			qdel(in_chamber)
+			QDEL_NULL(in_chamber)
 			weapon_in_mouth = FALSE
 			return
 		else

--- a/code/modules/projectiles/projectile.dm
+++ b/code/modules/projectiles/projectile.dm
@@ -347,7 +347,7 @@
 	//the bullet passes through a dense object!
 	if(passthrough)
 		//move ourselves onto A so we can continue on our way.
-		if(A)
+		if(A && !QDELETED(src))
 			if(istype(A, /turf))
 				loc = A
 			else

--- a/code/modules/recycling/disposal.dm
+++ b/code/modules/recycling/disposal.dm
@@ -137,9 +137,10 @@
 				admin_attack_log(usr, GM, "Placed the victim into \the [src].", "Was placed into \the [src] by the attacker.", "stuffed \the [src] with")
 		return
 
-	if(!user.drop(I, src))
+	if(I.loc == user && !user.drop(I))
 		to_chat(user, "You can't place that into \the [src].")
 		return
+	I.forceMove(src)
 
 	if(I.loc != src)
 		return

--- a/code/modules/vehicles/vehicle.dm
+++ b/code/modules/vehicles/vehicle.dm
@@ -344,6 +344,8 @@
 		return 0
 
 	load.forceMove(dest)
+	if(!load) // Strange stuff's happened before.
+		return 0
 	load.set_dir(get_dir(loc, dest))
 	load.anchored = 0		//we can only load non-anchored items, so it makes sense to set this to false
 	if(ismob(load)) //atoms should probably have their own procs to define how their pixel shifts and layer can be manipulated, someday


### PR DESCRIPTION
- drop() больше не прерывается при попытке уронить что-то, что не находится на персонаже. Но всё ещё отчитывается об этом. Практически всё, что с этим связано, уже было исправлено, но остались некоторые совсем странные вещи. Во-первых, два раунда подряд у людей застревали в руках лампочки, ибо на них ссылался слот руки, но они были где-то в другом месте. Во-вторых, иногда вызывается какой-то странный дроп хуманов. Оба кейса я так и не смог отследить, будем дальше посмотреть. Прерывание процесса и последующие сотни рантаймов особо в этом деле не помогают.
- pick_or_drop() теперь проверяет не только отсутствие предмета, но и его нахождение в очереди GC. И выдаёт рантайм. Чую, найду что-нибудь интересное.

Ну и ещё больше фиксов рантаймов.

- [x] Pull Request полностью завершен, мне не нужна помощь чтобы его закончить.
- [x] Я внимательно прочитал все свои изменения и багов в них не нашел.
- [x] Я запускал сервер со своими изменениями локально и все протестировал.
- [x] Я ознакомился c [Guide to Contribute](https://github.com/ChaoticOnyx/OnyxBay/blob/dev/docs/contributing.md).
