### PR TITLE
Removes the Old Wormholes Event, long live the New Wormholes Event

### DIFF
--- a/code/datums/events/wormholes.dm
+++ b/code/datums/events/wormholes.dm
@@ -6,9 +6,10 @@
 	mtth = 4 HOURS
 
 	var/list/pick_turfs = list()
-	var/list/wormholes = list()
-	var/shift_frequency = 3
-	var/number_of_wormholes = 400
+	var/shift_frequency = 5 SECONDS // How often wormhole batches should spawn
+	var/number_of_wormholes = 400 // Overall number of wormholes spawned, might randomize a bit
+	var/total_duration = 90 SECONDS // Total duration of the wormholes event, 90 sec on average
+	var/end_time = 0
 
 /datum/event/wormholes/New()
 	. = ..()
@@ -28,38 +29,36 @@
 	. = max(1 HOUR, .)
 
 /datum/event/wormholes/on_fire()
+	set waitfor = FALSE
+
 	SSevents.evars["wormholes_running"] = TRUE
-	var/list/areas = area_repository.get_areas_by_z_level()
-	for(var/i in areas)
-		var/area/A = areas[i]
-		for(var/turf/simulated/floor/T in A)
-			if(isAdminLevel(T.z))
-				continue
+	var/list/affecting_z = GLOB.using_map.get_levels_with_trait(ZTRAIT_STATION)
+
+	for(var/z in affecting_z)
+		for(var/turf/simulated/floor/T in block(locate(1, 1, z), locate(world.maxx, world.maxy, z)))
 			if(turf_contains_dense_objects(T))
 				continue
 			pick_turfs.Add(weakref(T))
 
-	for(var/i in 1 to number_of_wormholes)
+	total_duration = rand(60, 180) SECONDS
+	end_time = world.time + total_duration
+
+	set_next_think_ctx("announce", world.time + (rand(0, 5) SECONDS))
+	set_next_think_ctx("end", end_time)
+	set_next_think(world.time)
+
+/datum/event/wormholes/think()
+	for(var/i in 1 to round(number_of_wormholes / (total_duration / shift_frequency)))
 		var/turf/enter = safepick(pick_turfs)?.resolve()
 		var/turf/exit = safepick(pick_turfs)?.resolve()
 		if(!istype(enter) || !istype(exit))
 			continue
 		pick_turfs -= weakref(enter)
 		pick_turfs -= weakref(exit)
+		create_wormhole(enter, exit)
 
-		wormholes.Add(create_wormhole(enter, exit))
-
-	set_next_think_ctx("announce", world.time + (rand(0, 5) SECONDS))
-	set_next_think_ctx("end", world.time + (rand(1, 3) MINUTES))
-	set_next_think(world.time)
-
-/datum/event/wormholes/think()
-	for(var/obj/effect/portal/wormhole/O in wormholes)
-		var/turf/T = safepick(pick_turfs)?.resolve()
-		if(T)
-			O.forceMove(T)
-
-	set_next_think(world.time + 3 SECONDS)
+	if(world.time < end_time)
+		set_next_think(world.time + shift_frequency)
 
 /datum/event/wormholes/proc/announce()
 	GLOB.using_map.space_time_anomaly_detected_annoncement()
@@ -67,7 +66,7 @@
 /datum/event/wormholes/proc/end()
 	SSevents.evars["wormholes_running"] = FALSE
 	set_next_think(0)
-	QDEL_NULL_LIST(wormholes)
+	pick_turfs.Cut()
 
 /proc/create_wormhole(turf/enter, turf/exit)
 	if(!enter || !exit)

--- a/code/game/objects/effects/wormhole.dm
+++ b/code/game/objects/effects/wormhole.dm
@@ -9,6 +9,7 @@ GLOBAL_LIST_EMPTY(all_wormholes)
 /obj/effect/portal/wormhole/Initialize()
 	. = ..()
 	GLOB.all_wormholes += src
+	QDEL_IN(src, rand(10 SECONDS, 180 SECONDS))
 
 /obj/effect/portal/wormhole/Destroy()
 	GLOB.all_wormholes -= src


### PR DESCRIPTION
Переписан ивент с червоточинами (wormholes). 
Раньше все червоточины появлялись одновременно, после чего каждые несколько секунд рандомно перемещались, в конце ивента все червоточины плюс-минус одновременно исчезали.
Теперь червоточины появляются равномерными пачками раз в пять секунд. Ивент длится от 60 до 180 секунд. Общее количество червоточин - 400. Каждая червоточина существует от 10 до 180 секунд. 

Из приятного - ивент больше не укладывает сервер на лопатки на несколько секунд. И не пытается после этого добить его на протяжении трёх минут.
Из балансного - количество червоточин в единицу времени уменьшилось. Количество достигает пика к середине ивента, после чего постепенно уменьшается.

```yml
🆑
tweak: Изменён ивент с червоточинами. Теперь они появляются не все сразу, а волнами. И не отправляют сервер в повидло на десять секунд.
/🆑
```

- [x] Pull Request полностью завершен, мне не нужна помощь чтобы его закончить.
- [x] Я внимательно прочитал все свои изменения и багов в них не нашел.
- [x] Я запускал сервер со своими изменениями локально и все протестировал.
- [x] Я ознакомился c [Guide to Contribute](https://github.com/ChaoticOnyx/OnyxBay/blob/dev/docs/contributing.md).
