### PR TITLE
Removes starlight whiteness

### DIFF
--- a/code/game/turfs/space/space.dm
+++ b/code/game/turfs/space/space.dm
@@ -52,7 +52,7 @@
 	if(!config.misc.starlight)
 		return
 	if(locate(/turf/simulated) in orange(src,1))
-		set_light(min(0.1*config.misc.starlight, 1), 1, 2.5)
+		set_light(min(0.1*config.misc.starlight, 1), 1, 2.5, l_color = "#96dcff")
 	else
 		set_light(0)
 

--- a/code/game/turfs/space/space.dm
+++ b/code/game/turfs/space/space.dm
@@ -52,7 +52,7 @@
 	if(!config.misc.starlight)
 		return
 	if(locate(/turf/simulated) in orange(src,1))
-		set_light(min(0.1*config.misc.starlight, 1), 1, 2.5, l_color = "#96dcff")
+		set_light(min(0.1*config.misc.starlight, 1), 1, 2.5, 1.5, "#74dcff")
 	else
 		set_light(0)
 


### PR DESCRIPTION
Перекрашиваем старлайт из белого в синеватый, в цвет космоса.
![starlight1](https://user-images.githubusercontent.com/45202681/196291037-fc6b47b2-476e-4fb0-9eb0-e02f5d51634b.png)
![starlight2](https://user-images.githubusercontent.com/45202681/196291048-4a589378-b747-4694-a75e-500940e40d42.png)
![image](https://user-images.githubusercontent.com/45202681/196296854-1c464cb0-d336-48bb-a7e3-d03bd27296c5.png)


- [x] Pull Request полностью завершен, мне не нужна помощь чтобы его закончить.
- [x] Я внимательно прочитал все свои изменения и багов в них не нашел.
- [x] Я запускал сервер со своими изменениями локально и все протестировал.
- [x] Я ознакомился c [Guide to Contribute](https://github.com/ChaoticOnyx/OnyxBay/blob/dev/docs/contributing.md).
