### PR TITLE
Remove magical disappearance of the clown mask under the welding mask

### DIFF
--- a/code/modules/clothing/head/misc_special.dm
+++ b/code/modules/clothing/head/misc_special.dm
@@ -22,7 +22,7 @@
 	matter = list(MATERIAL_STEEL = 3000, MATERIAL_GLASS = 1000)
 	var/up = 0
 	armor = list(melee = 45, bullet = 45, laser = 55, energy = 20, bomb = 20, bio = 0)
-	flags_inv = (HIDEMASK|HIDEEARS|HIDEEYES|HIDEFACE)
+	flags_inv = (HIDEEARS|HIDEEYES|HIDEFACE)
 	body_parts_covered = HEAD|FACE|EYES
 	action_button_name = "Flip Welding Mask"
 	siemens_coefficient = 0.9
@@ -73,7 +73,7 @@
 		if(src.up)
 			src.up = !src.up
 			body_parts_covered |= (EYES|FACE)
-			flags_inv |= (HIDEMASK|HIDEEARS|HIDEEYES|HIDEFACE)
+			flags_inv |= (HIDEEARS|HIDEEYES|HIDEFACE)
 			flash_protection = initial(flash_protection)
 			tint = initial(tint)
 			icon_state = "[cover ? "[cover.icon_state]welding" : base_state]"
@@ -85,7 +85,7 @@
 			body_parts_covered &= ~(EYES|FACE)
 			flash_protection = FLASH_PROTECTION_NONE
 			tint = TINT_NONE
-			flags_inv &= ~(HIDEMASK|HIDEEARS|HIDEEYES|HIDEFACE)
+			flags_inv &= ~(HIDEEARS|HIDEEYES|HIDEFACE)
 			icon_state = "[cover ? "[cover.icon_state]welding" : base_state]up"
 			item_state = "[cover ? "[cover.icon_state]welding" : base_state]up"
 			to_chat(usr, "You push the [src] up out of your face.")


### PR DESCRIPTION
Убрал флаг сокрытия маски у сварочной маски. 
Теперь маска клоуна под сварочной маской не исчезает безвозвратно

<details>
<summary>Чейнджлог</summary>

```yml
🆑
fix: Маска клоуна теперь не исчезает при поднятии сварочной маски
/🆑
```

</details>

- [ ] Pull Request полностью завершен, мне не нужна помощь чтобы его закончить.
- [ ] Я внимательно прочитал все свои изменения и багов в них не нашел.
- [ ] Я запускал сервер со своими изменениями локально и все протестировал.
- [ ] Я ознакомился c [Guide to Contribute](https://github.com/ChaoticOnyx/OnyxBay/blob/dev/docs/contributing.md).
