### PR TITLE
Removes ORGAN_FLAG_HEALS_OVERKILL-using organs' inability to actually heal overkill damage

### DIFF
--- a/code/modules/organs/external/_external_damage.dm
+++ b/code/modules/organs/external/_external_damage.dm
@@ -180,9 +180,9 @@ obj/item/organ/external/take_general_damage(amount, silent = FALSE)
 			break
 
 		// heal brute damage
-		if(W.damage_type == BURN && (burn_ratio < 1 || vital))
+		if(W.damage_type == BURN && (burn_ratio < 1 || vital || (limb_flags & ORGAN_FLAG_HEALS_OVERKILL)))
 			burn = W.heal_damage(burn)
-		else if(brute_ratio < 1 || vital)
+		else if(brute_ratio < 1 || vital || (limb_flags & ORGAN_FLAG_HEALS_OVERKILL))
 			brute = W.heal_damage(brute)
 
 	if(internal)

--- a/code/modules/organs/external/xenos.dm
+++ b/code/modules/organs/external/xenos.dm
@@ -136,7 +136,7 @@
 /obj/item/organ/external/groin/xeno
 	dislocated = -1
 	arterial_bleed_severity = 0
-	limb_flags = ORGAN_FLAG_CAN_AMPUTATE
+	limb_flags = ORGAN_FLAG_CAN_AMPUTATE | ORGAN_FLAG_HEALS_OVERKILL
 	max_damage = 125
 
 /obj/item/organ/external/arm/xeno


### PR DESCRIPTION
У ран была проверка на флаг, а вот у самих органов - нет. Как следствие - головы алиумов не могли вылечиваться, если у них было слишком много урона и целиком стопорили им регенерацию. 

Теперь могут. А вот иррепейрабл конечности всё ещё эффективнее пафосно от себя отрывать и отращивать новые.

- [x] Pull Request полностью завершен, мне не нужна помощь чтобы его закончить.
- [x] Я внимательно прочитал все свои изменения и багов в них не нашел.
- [x] Я запускал сервер со своими изменениями локально и все протестировал.
- [x] Я ознакомился c [Guide to Contribute](https://github.com/ChaoticOnyx/OnyxBay/blob/dev/docs/contributing.md).
