### PR TITLE
tweak(firedoor): Fixing minor firedoor bugs and removing annoying alert when clicking it

### DIFF
--- a/code/game/area/areas.dm
+++ b/code/game/area/areas.dm
@@ -105,7 +105,7 @@
 	if(!all_doors)
 		return
 	for(var/obj/machinery/door/firedoor/E in all_doors)
-		addtimer(CALLBACK(E,/obj/machinery/door/proc/close), 0)
+		INVOKE_ASYNC(E, /obj/machinery/door/proc/close)
 
 /area/proc/air_doors_open()
 	if(!air_doors_activated)
@@ -114,11 +114,10 @@
 	if(!all_doors)
 		return
 	for(var/obj/machinery/door/firedoor/E in all_doors)
-		spawn(0)
-			if(!E.density || (E.stat & (BROKEN|NOPOWER)))
-				continue
-			if(E.can_safely_open())
-				E.open()
+		if(!E.density || (E.stat & (BROKEN|NOPOWER)))
+			continue
+		if(E.can_safely_open())
+			INVOKE_ASYNC(E, /obj/machinery/door/proc/open)
 
 
 /area/proc/fire_alert()
@@ -131,7 +130,7 @@
 	if(!all_doors)
 		return
 	for(var/obj/machinery/door/firedoor/D in all_doors)
-		addtimer(CALLBACK(D,/obj/machinery/door/proc/close), 0)
+		INVOKE_ASYNC(D, /obj/machinery/door/proc/close)
 
 /area/proc/fire_reset()
 	if (!fire)
@@ -143,7 +142,7 @@
 	if(!all_doors)
 		return
 	for(var/obj/machinery/door/firedoor/D in all_doors)
-		addtimer(CALLBACK(D,/obj/machinery/door/proc/close), 0)
+		INVOKE_ASYNC(D, /obj/machinery/door/proc/open)
 
 /area/proc/readyalert()
 	if(!eject)
@@ -171,7 +170,7 @@
 	mouse_opacity = 0
 	update_icon()
 	for(var/obj/machinery/door/firedoor/D in src)
-		addtimer(CALLBACK(D,/obj/machinery/door/proc/close), 0)
+		INVOKE_ASYNC(D, /obj/machinery/door/proc/close)
 
 /area/update_icon()
 	if ((eject || party) && (!requires_power||power_environ))//If it doesn't require power, can still activate this proc.

--- a/code/game/area/areas.dm
+++ b/code/game/area/areas.dm
@@ -105,8 +105,7 @@
 	if(!all_doors)
 		return
 	for(var/obj/machinery/door/firedoor/E in all_doors)
-		spawn(0)
-			E.close()
+		addtimer(CALLBACK(E,/obj/machinery/door/proc/close), 0)
 
 /area/proc/air_doors_open()
 	if(!air_doors_activated)
@@ -132,8 +131,7 @@
 	if(!all_doors)
 		return
 	for(var/obj/machinery/door/firedoor/D in all_doors)
-		spawn(0)
-			D.close()
+		addtimer(CALLBACK(D,/obj/machinery/door/proc/close), 0)
 
 /area/proc/fire_reset()
 	if (!fire)
@@ -145,8 +143,7 @@
 	if(!all_doors)
 		return
 	for(var/obj/machinery/door/firedoor/D in all_doors)
-		spawn(0)
-			D.open()
+		addtimer(CALLBACK(D,/obj/machinery/door/proc/close), 0)
 
 /area/proc/readyalert()
 	if(!eject)
@@ -174,8 +171,7 @@
 	mouse_opacity = 0
 	update_icon()
 	for(var/obj/machinery/door/firedoor/D in src)
-		spawn(0)
-			D.open()
+		addtimer(CALLBACK(D,/obj/machinery/door/proc/close), 0)
 
 /area/update_icon()
 	if ((eject || party) && (!requires_power||power_environ))//If it doesn't require power, can still activate this proc.

--- a/code/game/area/areas.dm
+++ b/code/game/area/areas.dm
@@ -170,7 +170,7 @@
 	mouse_opacity = 0
 	update_icon()
 	for(var/obj/machinery/door/firedoor/D in src)
-		INVOKE_ASYNC(D, /obj/machinery/door/proc/close)
+		INVOKE_ASYNC(D, /obj/machinery/door/proc/open)
 
 /area/update_icon()
 	if ((eject || party) && (!requires_power||power_environ))//If it doesn't require power, can still activate this proc.

--- a/code/game/area/areas.dm
+++ b/code/game/area/areas.dm
@@ -115,9 +115,9 @@
 	if(!all_doors)
 		return
 	for(var/obj/machinery/door/firedoor/E in all_doors)
-		if(!E.density || (E.stat & (BROKEN|NOPOWER)))
-			continue
 		spawn(0)
+			if(!E.density || (E.stat & (BROKEN|NOPOWER)))
+				continue
 			if(E.can_safely_open())
 				E.open()
 
@@ -132,7 +132,7 @@
 	if(!all_doors)
 		return
 	for(var/obj/machinery/door/firedoor/D in all_doors)
-		spawn()
+		spawn(0)
 			D.close()
 
 /area/proc/fire_reset()

--- a/code/game/area/areas.dm
+++ b/code/game/area/areas.dm
@@ -99,64 +99,54 @@
 	return 0
 
 /area/proc/air_doors_close()
-	if(!air_doors_activated)
-		air_doors_activated = 1
-		if(!all_doors)
-			return
-		for(var/obj/machinery/door/firedoor/E in all_doors)
-			if(!E.blocked)
-				if(E.operating)
-					E.nextstate = FIREDOOR_CLOSED
-				else if(!E.density)
-					spawn(0)
-						E.close()
+	if(air_doors_activated)
+		return
+	air_doors_activated = 1
+	if(!all_doors)
+		return
+	for(var/obj/machinery/door/firedoor/E in all_doors)
+		spawn(0)
+			E.close()
 
 /area/proc/air_doors_open()
-	if(air_doors_activated)
-		air_doors_activated = 0
-		if(!all_doors)
-			return
-		for(var/obj/machinery/door/firedoor/E in all_doors)
-			if(!E.blocked)
-				if(E.operating)
-					E.nextstate = FIREDOOR_OPEN
-				else if(E.density)
-					spawn(0)
-						if(E.can_safely_open())
-							E.open()
+	if(!air_doors_activated)
+		return
+	air_doors_activated = 0
+	if(!all_doors)
+		return
+	for(var/obj/machinery/door/firedoor/E in all_doors)
+		if(!E.density || (E.stat & (BROKEN|NOPOWER)))
+			continue
+		spawn(0)
+			if(E.can_safely_open())
+				E.open()
 
 
 /area/proc/fire_alert()
-	if(!fire)
-		fire = TRUE	//used for firedoor checks
-		update_icon()
-		mouse_opacity = 0
-		set_lighting_mode(LIGHTMODE_ALARM, TRUE)
-		if(!all_doors)
-			return
-		for(var/obj/machinery/door/firedoor/D in all_doors)
-			if(!D.blocked)
-				if(D.operating)
-					D.nextstate = FIREDOOR_CLOSED
-				else if(!D.density)
-					spawn()
-						D.close()
+	if(fire)
+		return
+	fire = TRUE	//used for firedoor checks
+	update_icon()
+	mouse_opacity = 0
+	set_lighting_mode(LIGHTMODE_ALARM, TRUE)
+	if(!all_doors)
+		return
+	for(var/obj/machinery/door/firedoor/D in all_doors)
+		spawn()
+			D.close()
 
 /area/proc/fire_reset()
-	if (fire)
-		fire = FALSE	//used for firedoor checks
-		update_icon()
-		mouse_opacity = 0
-		set_lighting_mode(LIGHTMODE_ALARM, FALSE)
-		if(!all_doors)
-			return
-		for(var/obj/machinery/door/firedoor/D in all_doors)
-			if(!D.blocked)
-				if(D.operating)
-					D.nextstate = FIREDOOR_OPEN
-				else if(D.density)
-					spawn(0)
-					D.open()
+	if (!fire)
+		return
+	fire = FALSE	//used for firedoor checks
+	update_icon()
+	mouse_opacity = 0
+	set_lighting_mode(LIGHTMODE_ALARM, FALSE)
+	if(!all_doors)
+		return
+	for(var/obj/machinery/door/firedoor/D in all_doors)
+		spawn(0)
+			D.open()
 
 /area/proc/readyalert()
 	if(!eject)
@@ -171,25 +161,21 @@
 	return
 
 /area/proc/partyalert()
-	if (!( party ))
-		party = 1
-		update_icon()
-		mouse_opacity = 0
-	return
+	if (party)
+		return
+	party = 1
+	update_icon()
+	mouse_opacity = 0
 
 /area/proc/partyreset()
-	if (party)
-		party = 0
-		mouse_opacity = 0
-		update_icon()
-		for(var/obj/machinery/door/firedoor/D in src)
-			if(!D.blocked)
-				if(D.operating)
-					D.nextstate = FIREDOOR_OPEN
-				else if(D.density)
-					spawn(0)
-					D.open()
-	return
+	if (!party)
+		return
+	party = 0
+	mouse_opacity = 0
+	update_icon()
+	for(var/obj/machinery/door/firedoor/D in src)
+		spawn(0)
+			D.open()
 
 /area/update_icon()
 	if ((eject || party) && (!requires_power||power_environ))//If it doesn't require power, can still activate this proc.

--- a/code/game/machinery/doors/door.dm
+++ b/code/game/machinery/doors/door.dm
@@ -143,7 +143,7 @@
 	return !density
 
 
-/obj/machinery/door/proc/bumpopen(mob/user as mob)
+/obj/machinery/door/proc/bumpopen(mob/user)
 	if(operating)	return
 	if(user.last_airflow > world.time - vsc.airflow_delay) //Fakkit
 		return
@@ -186,18 +186,18 @@
 	take_damage(tforce)
 	return
 
-/obj/machinery/door/attack_ai(mob/user as mob)
+/obj/machinery/door/attack_ai(mob/user)
 	return src.attack_hand(user)
 
-/obj/machinery/door/attack_hand(mob/user as mob)
+/obj/machinery/door/attack_hand(mob/user)
 	return src.attackby(user, user)
 
-/obj/machinery/door/attack_tk(mob/user as mob)
+/obj/machinery/door/attack_tk(mob/user)
 	if(requiresID() && !allowed(null))
 		return
 	..()
 
-/obj/machinery/door/attackby(obj/item/I as obj, mob/user as mob)
+/obj/machinery/door/attackby(obj/item/I, mob/user)
 	src.add_fingerprint(user, 0, I)
 
 	if(istype(I, /obj/item/stack/material) && I.get_material_name() == src.get_material_name())

--- a/code/game/machinery/doors/door.dm
+++ b/code/game/machinery/doors/door.dm
@@ -86,15 +86,15 @@
 	update_nearby_tiles()
 	. = ..()
 
-/obj/machinery/door/proc/can_open()
+/obj/machinery/door/proc/can_open(forced = 0)
 	if(!density || operating)
-		return 0
-	return 1
+		return FALSE
+	return TRUE
 
-/obj/machinery/door/proc/can_close()
+/obj/machinery/door/proc/can_close(forced = 0)
 	if(density || operating)
-		return 0
-	return 1
+		return FALSE
+	return TRUE
 
 /obj/machinery/door/Bumped(atom/AM)
 	if(p_open || operating) return
@@ -381,7 +381,7 @@
 /obj/machinery/door/proc/open(forced = FALSE)
 	var/wait = normalspeed ? 150 : 5
 	if(!can_open(forced))
-		return
+		return FALSE
 	operating = TRUE
 
 	do_animate("opening")
@@ -413,7 +413,7 @@
 		if(autoclose)
 			tryingToLock = TRUE
 			addtimer(CALLBACK(src, .proc/close), wait, TIMER_UNIQUE|TIMER_OVERRIDE)
-		return
+		return FALSE
 	operating = TRUE
 
 	do_animate("closing")
@@ -437,7 +437,7 @@
 	var/obj/fire/fire = locate() in loc
 	if(fire)
 		qdel(fire)
-	return
+	return TRUE
 
 /obj/machinery/door/proc/requiresID()
 	return 1

--- a/code/game/machinery/doors/firedoor.dm
+++ b/code/game/machinery/doors/firedoor.dm
@@ -168,14 +168,12 @@
 			// Accountability!
 			users_to_open |= user.name
 			needs_to_close = !issilicon(user)
-		spawn()
-			open()
+		INVOKE_ASYNC(src, /obj/machinery/door/proc/open)
 	else
-		spawn()
-			close()
+		INVOKE_ASYNC(src, /obj/machinery/door/proc/close)
 
 	if(needs_to_close)
-		addtimer(CALLBACK(src, .proc/close), 50, TIMER_UNIQUE|TIMER_OVERRIDE)
+		addtimer(CALLBACK(src, /obj/machinery/door/proc/close), 50, TIMER_UNIQUE|TIMER_OVERRIDE)
 
 /obj/machinery/door/firedoor/attack_generic(mob/user, damage)
 	if(stat & (BROKEN|NOPOWER))
@@ -262,12 +260,10 @@
 								 "You force \the [ blocked ? "welded" : "" ] [src] [density ? "open" : "closed"] with \the [C]!",\
 								 "You hear metal strain and groan, and a door [density ? "opening" : "closing"].")
 		if(density)
-			spawn()
-				open(TRUE)
-				addtimer(CALLBACK(src, .proc/close), 150, TIMER_UNIQUE|TIMER_OVERRIDE)
+			INVOKE_ASYNC(src, /obj/machinery/door/proc/open, TRUE)
+			addtimer(CALLBACK(src, /obj/machinery/door/proc/close), 150, TIMER_UNIQUE|TIMER_OVERRIDE)
 		else
-			spawn()
-				close()
+			INVOKE_ASYNC(src, /obj/machinery/door/proc/close)
 		return
 
 	return ..()

--- a/code/game/machinery/doors/firedoor.dm
+++ b/code/game/machinery/doors/firedoor.dm
@@ -124,7 +124,7 @@
 			attack_hand(M)
 	return 0
 
-/obj/machinery/door/firedoor/attack_hand(mob/user as mob)
+/obj/machinery/door/firedoor/attack_hand(mob/user)
 	add_fingerprint(user)
 	if(operating)
 		return//Already doing something.
@@ -193,7 +193,7 @@
 		return
 	..()
 
-/obj/machinery/door/firedoor/attackby(obj/item/C as obj, mob/user as mob)
+/obj/machinery/door/firedoor/attackby(obj/item/C, mob/user)
 	add_fingerprint(user, 0, C)
 	if(operating)
 		return//Already doing something.
@@ -469,7 +469,7 @@
 		else
 			return 1
 
-	CheckExit(atom/movable/mover as mob|obj, turf/target as turf)
+	CheckExit(atom/movable/mover, turf/target)
 		if(istype(mover) && mover.pass_flags & PASS_FLAG_GLASS)
 			return 1
 		if(get_dir(loc, target) == dir)


### PR DESCRIPTION
- Убран надоедливый алёрт, возникающий при нажатии по аварийной двери и более не несущий в себе никакой цели, кроме как отвлечь игрока от игры.
- Аварийные двери более не закрываются, если приварить их в открытом состоянии

<details>
<summary>Чейнджлог</summary>

```yml
🆑
tweak: Аварийные двери больше не вызывают надоедливое окно при нажатии по ним.
bugfix: Аварийные двери, заваренные в открытом положении, теперь не могут быть закрыты.
/🆑
```

</details>

- [x] Pull Request полностью завершен, мне не нужна помощь чтобы его закончить.
- [x] Я внимательно прочитал все свои изменения и багов в них не нашел.
- [x] Я запускал сервер со своими изменениями локально и все протестировал.
- [x] Я ознакомился c [Guide to Contribute](https://github.com/ChaoticOnyx/OnyxBay/blob/dev/docs/contributing.md).
