### PR TITLE
fix(metroids): fix metroid extracts and potion

### DIFF
--- a/code/modules/mob/living/carbon/xenobiological/items.dm
+++ b/code/modules/mob/living/carbon/xenobiological/items.dm
@@ -274,7 +274,7 @@
 	icon = 'icons/obj/chemical.dmi'
 	icon_state = "potred"
 
-/obj/item/metroid_stabilizer/attack(mob/living/carbon/metroid/M as mob, mob/user as mob)
+/obj/item/metroid_mutation/attack(mob/living/carbon/metroid/M as mob, mob/user as mob)
 	if(!istype(M, /mob/living/carbon/metroid))//If target is not a metroid.
 		to_chat(user, "<span class='warning'> The mutation potion only works on metroids!</span>")
 		return ..()

--- a/code/modules/mob/living/carbon/xenobiological/items.dm
+++ b/code/modules/mob/living/carbon/xenobiological/items.dm
@@ -274,7 +274,7 @@
 	icon = 'icons/obj/chemical.dmi'
 	icon_state = "potred"
 
-/obj/item/metroid_mutation/attack(mob/living/carbon/metroid/M as mob, mob/user as mob)
+/obj/item/metroid_mutation/attack(mob/living/carbon/metroid/M, mob/user)
 	if(!istype(M, /mob/living/carbon/metroid))//If target is not a metroid.
 		to_chat(user, "<span class='warning'> The mutation potion only works on metroids!</span>")
 		return ..()

--- a/code/modules/reagents/Chemistry-Recipes.dm
+++ b/code/modules/reagents/Chemistry-Recipes.dm
@@ -993,11 +993,11 @@
 							)
 
 /datum/chemical_reaction/metroid/n_crit/on_reaction(datum/reagents/holder)
+	..()
 	for(var/i = 1, i <= 3, i++)
 		var/mob/living/simple_animal/hostile/asteroid/type = pick(possible_mobs)
 		new type(get_turf(holder.my_atom))
 		type.faction = "neutral"
-	..()
 
 /datum/chemical_reaction/metroid/d_crit
 	name = "Metroid Dangerous Crit"

--- a/code/modules/reagents/Chemistry-Recipes.dm
+++ b/code/modules/reagents/Chemistry-Recipes.dm
@@ -1229,10 +1229,9 @@
 	result_amount = 1
 	required = /obj/item/metroid_extract/pink
 
-/datum/chemical_reaction/metroid/ppotion/on_reaction(datum/reagents/holder)
+/datum/chemical_reaction/metroid/docility/on_reaction(datum/reagents/holder)
 	..()
-	var/obj/item/metroidpotion/P = new /obj/item/metroidpotion
-	P.loc = get_turf(holder.my_atom)
+	new /obj/item/metroidpotion(get_turf(holder.my_atom))
 
 //Black
 /datum/chemical_reaction/metroid/mutate2


### PR DESCRIPTION
Исправил зелье стабилизации и мутации
Золотой экстракт + кровь больше нельзя бесконечно повторять
Розовое зелье теперь выпадает после реакции

close #8207 
close #9425 
close #9427 

<details>
<summary>Чейнджлог</summary>

```yml
🆑
bugfix: Зелье мутации метроидов теперь работает.
bugfix: Золотой экстракт больше не может бесконечно рожать мобов.
bugfix: Розовое зелье снова можно получить.
/🆑
```

</details>

- [x] Pull Request полностью завершен, мне не нужна помощь чтобы его закончить.
- [x] Я внимательно прочитал все свои изменения и багов в них не нашел.
- [x] Я запускал сервер со своими изменениями локально и все протестировал.
- [x] Я ознакомился c [Guide to Contribute](https://github.com/ChaoticOnyx/OnyxBay/blob/dev/docs/contributing.md).
