### PR TITLE
Tweak(portable_hard_drive) Changed name from data crystal to flash drive

### DIFF
--- a/code/modules/modular_computers/hardware/portable_hard_drive.dm
+++ b/code/modules/modular_computers/hardware/portable_hard_drive.dm
@@ -1,7 +1,7 @@
 // These are basically USB data sticks and may be used to transfer files between devices
 /obj/item/computer_hardware/hard_drive/portable/
-	name = "basic data crystal"
-	desc = "Small crystal with imprinted photonic circuits that can be used to store data. Its capacity is 16 GQ."
+	name = "basic flash drive"
+	desc = "Small flash drive with imprinted photonic circuits that can be used to store data. Its capacity is 16 GQ."
 	power_usage = 10
 	icon_state = "flashdrive_basic"
 	hardware_size = 1
@@ -9,8 +9,8 @@
 	origin_tech = list(TECH_DATA = 1)
 
 /obj/item/computer_hardware/hard_drive/portable/advanced
-	name = "advanced data crystal"
-	desc = "Small crystal with imprinted high-density photonic circuits that can be used to store data. Its capacity is 64 GQ."
+	name = "advanced flash drive"
+	desc = "Small flash drive with imprinted high-density photonic circuits that can be used to store data. Its capacity is 64 GQ."
 	power_usage = 20
 	icon_state = "flashdrive_advanced"
 	hardware_size = 1
@@ -18,8 +18,8 @@
 	origin_tech = list(TECH_DATA = 2)
 
 /obj/item/computer_hardware/hard_drive/portable/super
-	name = "super data crystal"
-	desc = "Small crystal with imprinted ultra-density photonic circuits that can be used to store data. Its capacity is 256 GQ."
+	name = "super flash drive"
+	desc = "Small flash drive with imprinted ultra-density photonic circuits that can be used to store data. Its capacity is 256 GQ."
 	power_usage = 40
 	icon_state = "flashdrive_super"
 	hardware_size = 1


### PR DESCRIPTION
Замена с дата кристаллов на флеш накопители, как и должно быть по логике.

<details>
<summary>Чейнджлог</summary>

```yml
🆑Einstein1088
tweak: Замена названия переносных дисков с дата кристаллов на флеш драйверы.
/🆑
```

</details>


- [x] Pull Request полностью завершен, мне не нужна помощь чтобы его закончить.
- [x] Я внимательно прочитал все свои изменения и багов в них не нашел.
- [x] Я запускал сервер со своими изменениями локально и все протестировал.
- [x] Я ознакомился c [Guide to Contribute](https://github.com/ChaoticOnyx/OnyxBay/blob/dev/docs/contributing.md).
