### PR TITLE
fix(input_alt) Makes alternative chat work as intended

### DIFF
--- a/code/modules/mob/living/carbon/human/say.dm
+++ b/code/modules/mob/living/carbon/human/say.dm
@@ -49,7 +49,7 @@
 	var/temp = client.close_saywindow(return_content = TRUE)
 
 	if(!temp)
-		temp = winget(client, "input", "text")
+		temp = winget(client, ":input", "text")
 		if(length(temp) > 4 && findtextEx(temp, "Say ", 1, 5))
 			temp = copytext(temp, 5)
 			if (text2ascii(temp, 1) == text2ascii("\""))
@@ -59,7 +59,7 @@
 				return
 		else
 			return
-		winset(client, "input", "text=\"Say \\\"\"")
+		winset(client, ":input", "text=\"Say \\\"\"")
 	temp = trim_left(temp)
 
 	if(length(temp))

--- a/code/modules/mob/typing_indicator.dm
+++ b/code/modules/mob/typing_indicator.dm
@@ -62,12 +62,12 @@ I AM TYPING!'
 
 	ASSERT(client && src == usr)
 
-	if (is_sayinput)
+	if(is_sayinput)
 		create_typing_indicator()
 		return
 
-	var/text = winget(usr, "input", "text")
-	if(findtextEx(text, "Say ", 1, 5))
+	var/text = winget(usr, ":input", "text")
+	if(findtext(text, "Say ", 1, 5))
 		create_typing_indicator()
 
 /mob/verb/remove_typing_indicator_verb()

--- a/interface/skin.dmf
+++ b/interface/skin.dmf
@@ -1174,6 +1174,8 @@ window "outputwindow"
 		is-disabled = true
 		border = sunken
 		saved-params = "command"
+		on-focus = ".add_typing_indicator"
+		on-blur = ".remove_typing_indicator"
 	elem "hotkey_toggle_alt"
 		type = BUTTON
 		pos = 560,460


### PR DESCRIPTION

Исправляет отсутствующий индикатор отправки сообщения и работу proc/forcesay при использовании альтернативного чата.

<details>
<summary>Чейнджлог</summary>

```yml
🆑
bugfix: Исправление отсутствующего индикатора отправки сообщения при использовании альтернативного чата.
/🆑
```

</details>

- [x] Pull Request полностью завершен, мне не нужна помощь чтобы его закончить.
- [x] Я внимательно прочитал все свои изменения и багов в них не нашел.
- [x] Я запускал сервер со своими изменениями локально и все протестировал.
- [x] Я ознакомился c [Guide to Contribute](https://github.com/ChaoticOnyx/OnyxBay/blob/dev/docs/contributing.md).
