### PR TITLE
Added ability to toggle off spawn of some antags at ST

### DIFF
--- a/baystation12.dme
+++ b/baystation12.dme
@@ -312,6 +312,7 @@
 #include "code\datums\configuration\multiaccount_section.dm"
 #include "code\datums\configuration\revival_section.dm"
 #include "code\datums\configuration\server_configuration.dm"
+#include "code\datums\configuration\storyteller_antags_section.dm"
 #include "code\datums\configuration\vote_section.dm"
 #include "code\datums\elements\_element.dm"
 #include "code\datums\elements\connect_loc.dm"

--- a/code/datums/configuration/server_configuration.dm
+++ b/code/datums/configuration/server_configuration.dm
@@ -25,6 +25,7 @@ GLOBAL_REAL(config, /datum/server_configuration) = new
 	var/datum/configuration_section/external/external = new
 	var/datum/configuration_section/error/error = new
 	var/datum/configuration_section/donations/donations = new
+	var/datum/configuration_section/storyteller_antags/storyteller_antags = new
 
 	/// Raw data. Stored here to avoid passing data between procs constantly
 	var/list/raw_data = list()

--- a/code/datums/configuration/storyteller_antags_section.dm
+++ b/code/datums/configuration/storyteller_antags_section.dm
@@ -1,0 +1,19 @@
+/datum/configuration_section/storyteller_antags
+	name = "storyteller_antags"
+
+	var/spawn_abductors = TRUE
+	var/spawn_vampire = TRUE
+	var/spawn_traitor = TRUE
+	var/spawn_borer = TRUE
+	var/spawn_changeling = TRUE
+	var/spawn_ninja = TRUE
+	var/spawn_wizard = TRUE
+
+/datum/configuration_section/storyteller_antags/load_data(list/data)
+	CONFIG_LOAD_BOOL(spawn_abductors, data["spawn_abductors"])
+	CONFIG_LOAD_BOOL(spawn_vampire, data["spawn_vampire"])
+	CONFIG_LOAD_BOOL(spawn_traitor, data["spawn_traitor"])
+	CONFIG_LOAD_BOOL(spawn_borer, data["spawn_borer"])
+	CONFIG_LOAD_BOOL(spawn_changeling, data["spawn_changeling"])
+	CONFIG_LOAD_BOOL(spawn_ninja, data["spawn_ninja"])
+	CONFIG_LOAD_BOOL(spawn_wizard, data["spawn_wizard"])

--- a/code/game/storyteller/storyteller.dm
+++ b/code/game/storyteller/storyteller.dm
@@ -170,7 +170,9 @@ SUBSYSTEM_DEF(storyteller)
 /datum/controller/subsystem/storyteller/proc/run_trigger(type)
 	ASSERT(type in __triggers)
 	var/storyteller_trigger/trigger = __triggers[type]
-	return trigger.invoke()
+	if(trigger.can_be_invoked())
+		return trigger.invoke()
+	return FALSE
 
 /datum/controller/subsystem/storyteller/proc/get_tick()
 	return __storyteller_tick

--- a/code/game/storyteller/triggers/spawn_antagonists_triggers.dm
+++ b/code/game/storyteller/triggers/spawn_antagonists_triggers.dm
@@ -1,9 +1,10 @@
 /storyteller_trigger/spawn_antagonist
 	name = "Spawn Unknown Antagonist"
 	var/antagonist_id
+	var/is_toggled = FALSE
 
 /storyteller_trigger/spawn_antagonist/can_be_invoked()
-	return !!antagonist_id
+	return !!antagonist_id && is_toggled
 
 /storyteller_trigger/spawn_antagonist/invoke()
 	ASSERT(antagonist_id)
@@ -15,27 +16,34 @@
 /storyteller_trigger/spawn_antagonist/traitor/New()
 	name = "Spawn Traitor"
 	antagonist_id = MODE_TRAITOR
+	is_toggled = config.storyteller_antags.spawn_traitor
 
 /storyteller_trigger/spawn_antagonist/changeling/New()
 	name = "Spawn Changeling"
 	antagonist_id = MODE_CHANGELING
+	is_toggled = config.storyteller_antags.spawn_changeling
 
 /storyteller_trigger/spawn_antagonist/vampire/New()
 	name = "Spawn Vampire"
 	antagonist_id = MODE_VAMPIRE
+	is_toggled = config.storyteller_antags.spawn_vampire
 
 /storyteller_trigger/spawn_antagonist/wizard/New()
 	name = "Spawn Wizard"
 	antagonist_id = MODE_WIZARD
+	is_toggled = config.storyteller_antags.spawn_wizard
 
 /storyteller_trigger/spawn_antagonist/ninja/New()
 	name = "Spawn Ninja"
 	antagonist_id = MODE_NINJA
+	is_toggled = config.storyteller_antags.spawn_ninja
 
 /storyteller_trigger/spawn_antagonist/borer/New()
 	name = "Spawn Borer"
 	antagonist_id = MODE_BORER
+	is_toggled = config.storyteller_antags.spawn_borer
 
 /storyteller_trigger/spawn_antagonist/abductor/New()
 	name = "Spawn Abductor"
 	antagonist_id = MODE_ABDUCTOR
+	is_toggled = config.storyteller_antags.spawn_abductors

--- a/config/example/config.toml
+++ b/config/example/config.toml
@@ -652,4 +652,10 @@ silence_time = 6000
 msg_delay = 50
 
 [storyteller_antags]
-enable_abductors = true
+spawn_abductors = true
+spawn_vampire = true
+spawn_traitor = true
+spawn_borer = true
+spawn_changeling = true
+spawn_ninja = true
+spawn_wizard = true

--- a/config/example/config.toml
+++ b/config/example/config.toml
@@ -650,3 +650,6 @@ silence_time = 6000
 
 ## How long to wait between messaging admins about occurrences of a unique error.
 msg_delay = 50
+
+[storyteller_antags]
+enable_abductors = true


### PR DESCRIPTION
Ну уже два Лида ЕОСа говорят что им не нужны абдукторы, а выпилить с билда не разрешают овнеры, следовательно нужна кнопка их отключения, сделал на быструю руку, нихуя не тестил.

<details>
<summary>Чейнджлог</summary>

```yml
🆑
admin: Добавлена возможность отключать спавн некоторых антагов у сторителера.
/🆑
```

</details>

- [ ] Pull Request полностью завершен, мне не нужна помощь чтобы его закончить.
- [ ] Я внимательно прочитал все свои изменения и багов в них не нашел.
- [ ] Я запускал сервер со своими изменениями локально и все протестировал.
- [x] Я ознакомился c [Guide to Contribute](https://github.com/ChaoticOnyx/OnyxBay/blob/dev/docs/contributing.md).
