### PR TITLE
fix(SMES): now SMES can be disassembled

### DIFF
--- a/code/datums/browser.dm
+++ b/code/datums/browser.dm
@@ -11,7 +11,7 @@
 	var/title_image
 	var/head_elements
 	var/body_elements
-	var/head_content = ""  #ebun
+	var/head_content = ""
 	var/content = ""
 	var/title_buttons = ""
 

--- a/code/datums/browser.dm
+++ b/code/datums/browser.dm
@@ -11,7 +11,7 @@
 	var/title_image
 	var/head_elements
 	var/body_elements
-	var/head_content = ""  #еболик
+	var/head_content = ""  #ebun
 	var/content = ""
 	var/title_buttons = ""
 

--- a/code/datums/browser.dm
+++ b/code/datums/browser.dm
@@ -11,7 +11,7 @@
 	var/title_image
 	var/head_elements
 	var/body_elements
-	var/head_content = ""
+	var/head_content = ""  #еболик
 	var/content = ""
 	var/title_buttons = ""
 

--- a/code/game/machinery/constructable_frame.dm
+++ b/code/game/machinery/constructable_frame.dm
@@ -188,7 +188,3 @@
 		LAZYADD(new_machine.component_parts, circuit)
 		new_machine.RefreshParts()
 		qdel(src)
-
-#undef STAGE_CABLE
-#undef STAGE_CIRCUIT
-#undef STAGE_COMPONENTS

--- a/code/modules/power/smes_construction.dm
+++ b/code/modules/power/smes_construction.dm
@@ -375,7 +375,7 @@
 
 				to_chat(usr, "<span class='warning'>You have disassembled the SMES cell!</span>")
 				var/obj/machinery/constructable_frame/machine_frame/M = new /obj/machinery/constructable_frame/machine_frame(src.loc)
-				M.state = 2
+				M.state = 1
 				M.icon_state = "box_1"
 				for(var/obj/I in component_parts)
 					I.forceMove(src.loc)

--- a/code/modules/power/smes_construction.dm
+++ b/code/modules/power/smes_construction.dm
@@ -375,7 +375,7 @@
 
 				to_chat(usr, "<span class='warning'>You have disassembled the SMES cell!</span>")
 				var/obj/machinery/constructable_frame/machine_frame/M = new /obj/machinery/constructable_frame/machine_frame(src.loc)
-				M.state = STAGE_CIRCUIT
+				M.state = 1
 				M.icon_state = "box_1"
 				for(var/obj/I in component_parts)
 					I.forceMove(src.loc)

--- a/code/modules/power/smes_construction.dm
+++ b/code/modules/power/smes_construction.dm
@@ -375,7 +375,7 @@
 
 				to_chat(usr, "<span class='warning'>You have disassembled the SMES cell!</span>")
 				var/obj/machinery/constructable_frame/machine_frame/M = new /obj/machinery/constructable_frame/machine_frame(src.loc)
-				M.state = 1
+				M.state = STAGE_CIRCUIT
 				M.icon_state = "box_1"
 				for(var/obj/I in component_parts)
 					I.forceMove(src.loc)

--- a/code/modules/power/smes_construction.dm
+++ b/code/modules/power/smes_construction.dm
@@ -375,7 +375,7 @@
 
 				to_chat(usr, "<span class='warning'>You have disassembled the SMES cell!</span>")
 				var/obj/machinery/constructable_frame/machine_frame/M = new /obj/machinery/constructable_frame/machine_frame(src.loc)
-				M.state = 1
+				M.state = 2
 				M.icon_state = "box_1"
 				for(var/obj/I in component_parts)
 					I.forceMove(src.loc)


### PR DESCRIPTION
Причина отказа разборки СМЕСА крылась в неправильно написанном стейте при снятии платы ломиком.

P.S коммиты ДО [fix(smes):destraction](https://github.com/ChaoticOnyx/OnyxBay/pull/9848/commits/ef1db180c698bfa49c1741e4e631d49525c2b4d6) не имеют изменений.


Fix #9845

<details>
<summary>Чейнджлог</summary>

```yml
🆑
Bugfix: СМЕС теперь можно разобрать.
/🆑
```

</details>

- [x] Pull Request полностью завершен, мне не нужна помощь чтобы его закончить.
- [x] Я внимательно прочитал все свои изменения и багов в них не нашел.
- [x] Я запускал сервер со своими изменениями локально и все протестировал.
- [x] Я ознакомился c [Guide to Contribute](https://github.com/ChaoticOnyx/OnyxBay/blob/dev/docs/contributing.md).
