### PR TITLE
Святая вода поджигает вампира

### DIFF
--- a/code/game/gamemodes/vampire/vampire_helpers.dm
+++ b/code/game/gamemodes/vampire/vampire_helpers.dm
@@ -265,14 +265,15 @@
 		if(prob(20))
 			to_chat(src, "You feel like you`re burning!")
 
-	if(src.get_ingested_reagents().has_reagent(/datum/reagent/water/holywater/))
-		src.adjust_fire_stacks(0.2)
-		src.IgniteMob()
-		src.vomit()
-		if(prob(20))
-			for (var/mob/V in viewers(src))
-				V.show_message(SPAN_WARNING("[src]'s skin sizzles and burns."), 1)
-		src.get_ingested_reagents().remove_reagent(/datum/reagent/water/holywater/, 5)
+	if (!(mind.vampire.status & VAMP_ISTHRALL))
+		if(src.reagents.has_reagent(/datum/reagent/water/holywater/) || src.get_ingested_reagents().has_reagent(/datum/reagent/water/holywater/))
+			src.adjust_fire_stacks(0.2)
+			src.IgniteMob()
+			if(prob(20))
+				for (var/mob/V in viewers(src))
+					V.show_message(SPAN_WARNING("[src]'s skin sizzles and burns."), 1)
+			src.reagents.remove_reagent(/datum/reagent/water/holywater/, 3)
+			src.get_ingested_reagents().remove_reagent(/datum/reagent/water/holywater/, 3)
 
 	if (mind.vampire.blood_usable < 10)
 		mind.vampire.frenzy += 2

--- a/code/game/gamemodes/vampire/vampire_helpers.dm
+++ b/code/game/gamemodes/vampire/vampire_helpers.dm
@@ -33,7 +33,7 @@
 			if(!P.blood_cost)
 				mind.vampire.add_power(mind, P, 0)
 		else if(P.is_active && P.verbpath)
-			verbs += P.verbpath	
+			verbs += P.verbpath
 	return TRUE
 
 /mob/living/carbon/human/proc/replace_vampiric_organs()
@@ -261,9 +261,18 @@
 /mob/living/carbon/human/proc/handle_vampire()
 	// Apply frenzy while in the holy location.
 	if (get_area(loc)?.holy)
-		mind.vampire.frenzy += 3		
+		mind.vampire.frenzy += 3
 		if(prob(20))
 			to_chat(src, "You feel like you`re burning!")
+
+	if(src.get_ingested_reagents().has_reagent(/datum/reagent/water/holywater/))
+		src.adjust_fire_stacks(0.2)
+		src.IgniteMob()
+		src.vomit()
+		if(prob(20))
+			for (var/mob/V in viewers(src))
+				V.show_message(SPAN_WARNING("[src]'s skin sizzles and burns."), 1)
+		src.get_ingested_reagents().remove_reagent(/datum/reagent/water/holywater/, 5)
 
 	if (mind.vampire.blood_usable < 10)
 		mind.vampire.frenzy += 2

--- a/code/game/gamemodes/vampire/vampire_helpers.dm
+++ b/code/game/gamemodes/vampire/vampire_helpers.dm
@@ -265,15 +265,15 @@
 		if(prob(20))
 			to_chat(src, "You feel like you`re burning!")
 
-	if (!(mind.vampire.status & VAMP_ISTHRALL))
-		if(src.reagents.has_reagent(/datum/reagent/water/holywater/) || src.get_ingested_reagents().has_reagent(/datum/reagent/water/holywater/))
+	if(!(mind.vampire.status & VAMP_ISTHRALL))
+		if(src.reagents.has_reagent(/datum/reagent/water/holywater) || src.get_ingested_reagents().has_reagent(/datum/reagent/water/holywater))
 			src.adjust_fire_stacks(0.2)
 			src.IgniteMob()
 			if(prob(20))
 				for (var/mob/V in viewers(src))
 					V.show_message(SPAN_WARNING("[src]'s skin sizzles and burns."), 1)
-			src.reagents.remove_reagent(/datum/reagent/water/holywater/, 3)
-			src.get_ingested_reagents().remove_reagent(/datum/reagent/water/holywater/, 3)
+			src.reagents.remove_reagent(/datum/reagent/water/holywater, 3)
+			src.get_ingested_reagents().remove_reagent(/datum/reagent/water/holywater, 3)
 
 	if (mind.vampire.blood_usable < 10)
 		mind.vampire.frenzy += 2

--- a/code/modules/reagents/Chemistry-Reagents/other.dm
+++ b/code/modules/reagents/Chemistry-Reagents/other.dm
@@ -196,7 +196,7 @@
 	if(istype(L))
 		if(ishuman(L))
 			if(L.mind && L.mind.vampire)
-				L.adjust_fire_stacks(amount / 30)
+				L.adjust_fire_stacks(amount / 15)
 				L.IgniteMob()
 				if(prob(20))
 					for (var/mob/V in viewers(L))

--- a/code/modules/reagents/Chemistry-Reagents/other.dm
+++ b/code/modules/reagents/Chemistry-Reagents/other.dm
@@ -192,13 +192,16 @@
 				var/obj/effect/spider/spiderling/S = new /obj/effect/spider/spiderling(M.loc)
 				M.visible_message(SPAN_WARNING("\The [M] coughs up \the [S]!</span>"))
 
-		if(M.mind && M.mind.vampire)
-			M.adjustFireLoss(6)
-			M.adjust_fire_stacks(1)
-			M.IgniteMob()
-			if(prob(20))
-				for (var/mob/V in viewers(src))
-					V.show_message(SPAN_WARNING("[M]'s skin sizzles and burns."), 1)
+/datum/reagent/water/holywater/touch_mob(mob/living/L, amount)
+	if(istype(L))
+		if(ishuman(L))
+			if(L.mind && L.mind.vampire)
+				L.adjust_fire_stacks(amount / 30)
+				L.IgniteMob()
+				if(prob(20))
+					for (var/mob/V in viewers(L))
+						V.show_message(SPAN_WARNING("[L]'s skin sizzles and burns."), 1)
+
 /datum/reagent/water/holywater/touch_turf(turf/T)
 	if(volume >= 5)
 		T.holy = TRUE

--- a/code/modules/reagents/Chemistry-Reagents/other.dm
+++ b/code/modules/reagents/Chemistry-Reagents/other.dm
@@ -193,14 +193,13 @@
 				M.visible_message(SPAN_WARNING("\The [M] coughs up \the [S]!</span>"))
 
 /datum/reagent/water/holywater/touch_mob(mob/living/L, amount)
-	if(istype(L))
-		if(ishuman(L))
-			if(L.mind && L.mind.vampire)
-				L.adjust_fire_stacks(amount / 15)
-				L.IgniteMob()
-				if(prob(20))
-					for (var/mob/V in viewers(L))
-						V.show_message(SPAN_WARNING("[L]'s skin sizzles and burns."), 1)
+	if(!ishuman(L))
+		return
+	if(!L.mind)
+		return
+	if(L.mind.vampire && !(L.mind.vampire.status & VAMP_ISTHRALL))
+		L.adjust_fire_stacks(amount / 15)
+		L.IgniteMob()
 
 /datum/reagent/water/holywater/touch_turf(turf/T)
 	if(volume >= 5)


### PR DESCRIPTION
Святая вода теперь поджигает вампира при обливании, при поглощении внутрь и при вкалывании шприцом.

Оно было и раньше, но я это сломал. Теперь починил. Ещё добавил поджигание при обливании и вкалывании шприцом.

Траллы не горят от святой воды.

<details>
<summary>Чейнджлог</summary>

```yml
🆑
bugfix: Вампир горит от выпитой святой воды.
tweak: Вампир горит при обливании святой водой.
tweak: Вампир горит при вкалывании святой воды.
tweak: Траллы вампира не горят от святой воды.
/🆑
```

</details>

- [x] Pull Request полностью завершен, мне не нужна помощь чтобы его закончить.
- [x] Я внимательно прочитал все свои изменения и багов в них не нашел.
- [x] Я запускал сервер со своими изменениями локально и все протестировал.
- [x] Я ознакомился c [Guide to Contribute](https://github.com/ChaoticOnyx/OnyxBay/blob/dev/docs/contributing.md).
