### PR TITLE
tweak(client): kick out outdated users from server

### DIFF
--- a/code/datums/configuration/general_section.dm
+++ b/code/datums/configuration/general_section.dm
@@ -38,7 +38,7 @@
 	if(ticklag)
 		fps = 10 / ticklag
 
-	CONFIG_LOAD_NUM(client_fps, data["clien_tfps"])
+	CONFIG_LOAD_NUM(client_fps, data["client_fps"])
 
 	if(fps <= 0)
 		fps = initial(fps)

--- a/code/datums/configuration/general_section.dm
+++ b/code/datums/configuration/general_section.dm
@@ -18,6 +18,9 @@
 	var/second_topic_limit = null
 	var/wait_for_sigusr1 = FALSE
 
+	var/client_min_major_version = 514
+	var/client_min_minor_version = 1572
+
 /datum/configuration_section/general/load_data(list/data)
 	CONFIG_LOAD_STR(server_name, data["server_name"])
 	CONFIG_LOAD_STR(subserver_name, data["subserver_name"])
@@ -28,6 +31,9 @@
 	CONFIG_LOAD_NUM(player_limit, data["player_limit"])
 	CONFIG_LOAD_NUM(hard_player_limit, data["hard_player_limit"])
 	CONFIG_LOAD_NUM(ticklag, data["ticklag"])
+
+	CONFIG_LOAD_NUM(server_port, data["client_min_major_version"])
+	CONFIG_LOAD_NUM(server_port, data["client_min_minor_version"])
 
 	if(ticklag)
 		fps = 10 / ticklag

--- a/code/datums/configuration/general_section.dm
+++ b/code/datums/configuration/general_section.dm
@@ -32,8 +32,8 @@
 	CONFIG_LOAD_NUM(hard_player_limit, data["hard_player_limit"])
 	CONFIG_LOAD_NUM(ticklag, data["ticklag"])
 
-	CONFIG_LOAD_NUM(server_port, data["client_min_major_version"])
-	CONFIG_LOAD_NUM(server_port, data["client_min_minor_version"])
+	CONFIG_LOAD_NUM(client_min_major_version, data["client_min_major_version"])
+	CONFIG_LOAD_NUM(client_min_minor_version, data["client_min_minor_version"])
 
 	if(ticklag)
 		fps = 10 / ticklag

--- a/code/modules/client/client_procs.dm
+++ b/code/modules/client/client_procs.dm
@@ -214,8 +214,9 @@
 
 	if(byond_version < config.general.client_min_major_version || byond_build < config.general.client_min_minor_version)
 		to_chat(src, "<b><center><font size='5' color='red'>Your <font color='blue'>BYOND</font> version is too out of date!</font><br>\
-		<font size='3'>Please update it to [config.general.client_min_major_version].[byond_build < config.general.client_min_minor_version].</font></center>")
-		qdel(src)
+		<font size='3'>Please update it to [config.general.client_min_major_version].[config.general.client_min_minor_version].</font></center>")
+		spawn(1)
+			qdel(src)
 		return
 
 	GLOB.using_map.map_info(src)

--- a/code/modules/client/client_procs.dm
+++ b/code/modules/client/client_procs.dm
@@ -2,7 +2,6 @@
 	//SECURITY//
 	////////////
 #define UPLOAD_LIMIT		10485760	//Restricts client uploads to the server to 10MB //Boosted this thing. What's the worst that can happen?
-#define MIN_CLIENT_VERSION	513
 
 #define LIMITER_SIZE	5
 #define CURRENT_SECOND	1
@@ -213,9 +212,9 @@
 
 	. = ..()	// calls mob.Login()
 
-	if(byond_version < MIN_CLIENT_VERSION)
+	if(byond_version < config.general.client_min_major_version || byond_build < config.general.client_min_minor_version)
 		to_chat(src, "<b><center><font size='5' color='red'>Your <font color='blue'>BYOND</font> version is too out of date!</font><br>\
-		<font size='3'>Please update it to [MIN_CLIENT_VERSION].</font></center>")
+		<font size='3'>Please update it to [config.general.client_min_major_version].[byond_build < config.general.client_min_minor_version].</font></center>")
 		qdel(src)
 		return
 
@@ -366,7 +365,6 @@
 
 
 #undef UPLOAD_LIMIT
-#undef MIN_CLIENT_VERSION
 
 // checks if a client is afk
 // 3000 frames = 5 minutes

--- a/config/example/config.toml
+++ b/config/example/config.toml
@@ -30,6 +30,11 @@ player_limit = 0
 ## Write 0 to toggle limit off. Must be more than PLAYER_LIMIT in order to work correctly.
 hard_player_limit = 0
 
+## Kick players that have major or minor BYOND build below this numbers.
+## Write numbers of major and minor BYOND build. Writing numbers above existing BYOND builds will result in impossibility to join server.
+client_min_major_version = 514
+client_min_minor_version = 1589
+
 ## Defines the ticklag for the world. Ticklag is the amount of time between game ticks (aka byond ticks) (in 1/10ths of a second).
 ## This also controls the client network update rate, as well as the default client fps (10 / TICKLAG). 0.9 is the normal one, 0.5 is smoother.
 ticklag = 0.625


### PR DESCRIPTION
По просьбе рабочих
```spawn(1) qdel(src)``` - нужен для того, чтобы клиент успел получить сообщение перед тем как его выкинут, это 99.9% гарантия доставки сообщения

<details>
<summary>Чейнджлог</summary>

```yml
🆑
tweak: Теперь игра будет исключать игроков, чья minor и major версия BYOND не совпадает с минимальной допустимой (конфиг).
/🆑
```

</details>

- [x] Pull Request полностью завершен, мне не нужна помощь чтобы его закончить.
- [x] Я внимательно прочитал все свои изменения и багов в них не нашел.
- [x] Я запускал сервер со своими изменениями локально и все протестировал.
- [x] Я ознакомился c [Guide to Contribute](https://github.com/ChaoticOnyx/OnyxBay/blob/dev/docs/contributing.md).
