### PR TITLE
fix(devices): change multitool description

### DIFF
--- a/code/game/objects/items/devices/multitool.dm
+++ b/code/game/objects/items/devices/multitool.dm
@@ -5,7 +5,7 @@
 
 /obj/item/device/multitool
 	name = "multitool"
-	desc = "This small, handheld device is made of durable, insulated plastic, and tipped with electrodes, perfect for interfacing with numerous machines."
+	desc = "This small, handheld device is made of durable alloy steel and tipped with electrodes, perfect for interfacing with numerous machines."
 	description_info = "Multitools are incredibly versatile and can be used on a wide variety of machines. The most common use for this is to trip a device's wires without having to cut them. Simply click on an object with exposed wiring to use it. There might be other uses, as well..."
 	description_fluff = "The common, every day multitool is descended from certain electrical tools from Earth's early space age. Though none too cheap, they are incredibly handy, and can be found in any self-respecting technician's toolbox."
 	description_antag = "This handy little tool can get you through doors, turn off power, and anything else you might need."


### PR DESCRIPTION
Multitool now is made of *alloy steel* according to materials with which it's made in autolathe.


close #9861

<details>
<summary>Чейнджлог</summary>

```yml
🆑
bugfix: Исправлено описание мультитула на более подходящее к действительности.
/🆑
```

</details>


- [x] Pull Request полностью завершен, мне не нужна помощь чтобы его закончить.
- [x] Я внимательно прочитал все свои изменения и багов в них не нашел.
- [ ] Я запускал сервер со своими изменениями локально и все протестировал.
- [x] Я ознакомился c [Guide to Contribute](https://github.com/ChaoticOnyx/OnyxBay/blob/dev/docs/contributing.md).
