### PR TITLE
tweak(rotation): added alt+click rotation for some objects.

### DIFF
--- a/code/game/machinery/pipe/construction.dm
+++ b/code/game/machinery/pipe/construction.dm
@@ -347,9 +347,9 @@ Buildable meters
 		return
 	src.set_dir(turn(src.dir, -90))
 	if(pipe_type in list (PIPE_SIMPLE_STRAIGHT, PIPE_SUPPLY_STRAIGHT, PIPE_SCRUBBERS_STRAIGHT, PIPE_UNIVERSAL, PIPE_HE_STRAIGHT, PIPE_MVALVE, PIPE_DVALVE, PIPE_SVALVE, PIPE_FUEL_STRAIGHT))
-		if(dir==2)
+		if(dir == 2)
 			set_dir(1)
-		else if(dir==8)
+		else if(dir == 8)
 			set_dir(4)
 	else if(pipe_type in list (PIPE_MANIFOLD4W, PIPE_SUPPLY_MANIFOLD4W, PIPE_SCRUBBERS_MANIFOLD4W, PIPE_FUEL_MANIFOLD4W))
 		set_dir(2)

--- a/code/game/machinery/pipe/construction.dm
+++ b/code/game/machinery/pipe/construction.dm
@@ -345,6 +345,22 @@ Buildable meters
 	//src.pipe_set_dir(get_pipe_dir())
 	return
 
+/obj/item/pipe/AltClick(mob/user)
+	if ( usr.stat || usr.restrained() )
+		return
+
+	src.set_dir(turn(src.dir, -90))
+
+	if (pipe_type in list (PIPE_SIMPLE_STRAIGHT, PIPE_SUPPLY_STRAIGHT, PIPE_SCRUBBERS_STRAIGHT, PIPE_UNIVERSAL, PIPE_HE_STRAIGHT, PIPE_MVALVE, PIPE_DVALVE, PIPE_SVALVE, PIPE_FUEL_STRAIGHT))
+		if(dir==2)
+			set_dir(1)
+		else if(dir==8)
+			set_dir(4)
+	else if (pipe_type in list (PIPE_MANIFOLD4W, PIPE_SUPPLY_MANIFOLD4W, PIPE_SCRUBBERS_MANIFOLD4W, PIPE_FUEL_MANIFOLD4W))
+		set_dir(2)
+	//src.pipe_set_dir(get_pipe_dir())
+	return
+
 /obj/item/pipe/Move()
 	..()
 	if ((pipe_type in list (PIPE_SIMPLE_BENT, PIPE_SUPPLY_BENT, PIPE_SCRUBBERS_BENT, PIPE_HE_BENT, PIPE_FUEL_BENT)) \

--- a/code/game/machinery/pipe/construction.dm
+++ b/code/game/machinery/pipe/construction.dm
@@ -343,7 +343,7 @@ Buildable meters
 	return
 
 /obj/item/pipe/AltClick(mob/user)
-	if(user.stat | user.restrained())
+	if(user.stat || user.restrained())
 		return
 	src.set_dir(turn(src.dir, -90))
 	if(pipe_type in list (PIPE_SIMPLE_STRAIGHT, PIPE_SUPPLY_STRAIGHT, PIPE_SCRUBBERS_STRAIGHT, PIPE_UNIVERSAL, PIPE_HE_STRAIGHT, PIPE_MVALVE, PIPE_DVALVE, PIPE_SVALVE, PIPE_FUEL_STRAIGHT))

--- a/code/game/machinery/pipe/construction.dm
+++ b/code/game/machinery/pipe/construction.dm
@@ -333,9 +333,9 @@ Buildable meters
 		return
 	src.set_dir(turn(src.dir, -90))
 	if(pipe_type in list (PIPE_SIMPLE_STRAIGHT, PIPE_SUPPLY_STRAIGHT, PIPE_SCRUBBERS_STRAIGHT, PIPE_UNIVERSAL, PIPE_HE_STRAIGHT, PIPE_MVALVE, PIPE_DVALVE, PIPE_SVALVE, PIPE_FUEL_STRAIGHT))
-		if(dir==2)
+		if(dir == 2)
 			set_dir(1)
-		else if(dir==8)
+		else if(dir == 8)
 			set_dir(4)
 	else if(pipe_type in list (PIPE_MANIFOLD4W, PIPE_SUPPLY_MANIFOLD4W, PIPE_SCRUBBERS_MANIFOLD4W, PIPE_FUEL_MANIFOLD4W))
 		set_dir(2)

--- a/code/game/machinery/pipe/construction.dm
+++ b/code/game/machinery/pipe/construction.dm
@@ -325,38 +325,33 @@ Buildable meters
 
 // rotate the pipe item clockwise
 
-/obj/item/pipe/verb/rotate()
+/obj/item/pipe/verb/rotate(mob/user)
 	set category = "Object"
 	set name = "Rotate Pipe"
 	set src in view(1)
-
-	if ( usr.stat || usr.restrained() )
+	if(user.stat | user.restrained())
 		return
-
 	src.set_dir(turn(src.dir, -90))
-
-	if (pipe_type in list (PIPE_SIMPLE_STRAIGHT, PIPE_SUPPLY_STRAIGHT, PIPE_SCRUBBERS_STRAIGHT, PIPE_UNIVERSAL, PIPE_HE_STRAIGHT, PIPE_MVALVE, PIPE_DVALVE, PIPE_SVALVE, PIPE_FUEL_STRAIGHT))
+	if(pipe_type in list (PIPE_SIMPLE_STRAIGHT, PIPE_SUPPLY_STRAIGHT, PIPE_SCRUBBERS_STRAIGHT, PIPE_UNIVERSAL, PIPE_HE_STRAIGHT, PIPE_MVALVE, PIPE_DVALVE, PIPE_SVALVE, PIPE_FUEL_STRAIGHT))
 		if(dir==2)
 			set_dir(1)
 		else if(dir==8)
 			set_dir(4)
-	else if (pipe_type in list (PIPE_MANIFOLD4W, PIPE_SUPPLY_MANIFOLD4W, PIPE_SCRUBBERS_MANIFOLD4W, PIPE_FUEL_MANIFOLD4W))
+	else if(pipe_type in list (PIPE_MANIFOLD4W, PIPE_SUPPLY_MANIFOLD4W, PIPE_SCRUBBERS_MANIFOLD4W, PIPE_FUEL_MANIFOLD4W))
 		set_dir(2)
 	//src.pipe_set_dir(get_pipe_dir())
 	return
 
 /obj/item/pipe/AltClick(mob/user)
-	if ( usr.stat || usr.restrained() )
+	if(user.stat | user.restrained())
 		return
-
 	src.set_dir(turn(src.dir, -90))
-
-	if (pipe_type in list (PIPE_SIMPLE_STRAIGHT, PIPE_SUPPLY_STRAIGHT, PIPE_SCRUBBERS_STRAIGHT, PIPE_UNIVERSAL, PIPE_HE_STRAIGHT, PIPE_MVALVE, PIPE_DVALVE, PIPE_SVALVE, PIPE_FUEL_STRAIGHT))
+	if(pipe_type in list (PIPE_SIMPLE_STRAIGHT, PIPE_SUPPLY_STRAIGHT, PIPE_SCRUBBERS_STRAIGHT, PIPE_UNIVERSAL, PIPE_HE_STRAIGHT, PIPE_MVALVE, PIPE_DVALVE, PIPE_SVALVE, PIPE_FUEL_STRAIGHT))
 		if(dir==2)
 			set_dir(1)
 		else if(dir==8)
 			set_dir(4)
-	else if (pipe_type in list (PIPE_MANIFOLD4W, PIPE_SUPPLY_MANIFOLD4W, PIPE_SCRUBBERS_MANIFOLD4W, PIPE_FUEL_MANIFOLD4W))
+	else if(pipe_type in list (PIPE_MANIFOLD4W, PIPE_SUPPLY_MANIFOLD4W, PIPE_SCRUBBERS_MANIFOLD4W, PIPE_FUEL_MANIFOLD4W))
 		set_dir(2)
 	//src.pipe_set_dir(get_pipe_dir())
 	return

--- a/code/game/objects/structures/window.dm
+++ b/code/game/objects/structures/window.dm
@@ -309,61 +309,48 @@
 	return
 
 
-/obj/structure/window/proc/rotate()
+/obj/structure/window/proc/rotate(mob/user)
 	set name = "Rotate Window Counter-Clockwise"
 	set category = "Object"
 	set src in oview(1)
-
-	if(usr.incapacitated())
+	if(user.incapacitated())
 		return 0
-
 	if(is_full_window()) // No point in rotating a window if it is full
 		return 0
-
 	if(anchored)
-		to_chat(usr, "It is fastened to the floor therefore you can't rotate it!")
+		to_chat(user, "It is fastened to the floor therefore you can't rotate it!")
 		return 0
-
 	update_nearby_tiles(need_rebuild=1) //Compel updates before
 	set_dir(turn(dir, 90))
 	updateSilicate()
 	update_nearby_tiles(need_rebuild=1)
 	return
-
 
 /obj/structure/window/AltClick(mob/user)
-	if(usr.incapacitated())
+	if(user.incapacitated())
 		return 0
-
 	if(is_full_window()) // No point in rotating a window if it is full
 		return 0
-
 	if(anchored)
-		to_chat(usr, "It is fastened to the floor therefore you can't rotate it!")
+		to_chat(user, "It is fastened to the floor therefore you can't rotate it!")
 		return 0
-
 	update_nearby_tiles(need_rebuild=1) //Compel updates before
 	set_dir(turn(dir, 90))
 	updateSilicate()
 	update_nearby_tiles(need_rebuild=1)
 	return
 
-
-/obj/structure/window/proc/revrotate()
+/obj/structure/window/proc/revrotate(mob/user)
 	set name = "Rotate Window Clockwise"
 	set category = "Object"
 	set src in oview(1)
-
-	if(usr.incapacitated())
+	if(user.incapacitated())
 		return 0
-
 	if(is_full_window()) // No point in rotating a window if it is full
 		return 0
-
 	if(anchored)
-		to_chat(usr, "It is fastened to the floor therefore you can't rotate it!")
+		to_chat(user, "It is fastened to the floor therefore you can't rotate it!")
 		return 0
-
 	update_nearby_tiles(need_rebuild=1) //Compel updates before
 	set_dir(turn(dir, 270))
 	updateSilicate()

--- a/code/game/objects/structures/window.dm
+++ b/code/game/objects/structures/window.dm
@@ -331,6 +331,24 @@
 	return
 
 
+/obj/structure/window/AltClick(mob/user)
+	if(usr.incapacitated())
+		return 0
+
+	if(is_full_window()) // No point in rotating a window if it is full
+		return 0
+
+	if(anchored)
+		to_chat(usr, "It is fastened to the floor therefore you can't rotate it!")
+		return 0
+
+	update_nearby_tiles(need_rebuild=1) //Compel updates before
+	set_dir(turn(dir, 90))
+	updateSilicate()
+	update_nearby_tiles(need_rebuild=1)
+	return
+
+
 /obj/structure/window/proc/revrotate()
 	set name = "Rotate Window Clockwise"
 	set category = "Object"

--- a/code/modules/mining/drilling/drill.dm
+++ b/code/modules/mining/drilling/drill.dm
@@ -355,7 +355,7 @@
 	if(user.stat)
 		return
 	if(src.anchored)
-		to_chat(usr, "It is anchored in place!")
+		to_chat(user, "It is anchored in place!")
 		return 0
 	src.set_dir(turn(src.dir, 90))
 	return

--- a/code/modules/mining/drilling/drill.dm
+++ b/code/modules/mining/drilling/drill.dm
@@ -361,7 +361,7 @@
 	return
 
 /obj/machinery/mining/brace/AltClick(mob/user)
-	if(usr.stat)
+	if(user.stat)
 		return
 	if(src.anchored)
 		to_chat(usr, "It is anchored in place!")

--- a/code/modules/mining/drilling/drill.dm
+++ b/code/modules/mining/drilling/drill.dm
@@ -348,26 +348,23 @@
 	connected.check_supports()
 	connected = null
 
-/obj/machinery/mining/brace/verb/rotate()
+/obj/machinery/mining/brace/verb/rotate(mob/user)
 	set name = "Rotate"
 	set category = "Object"
 	set src in oview(1)
-
-	if(usr.stat) return
-
-	if (src.anchored)
+	if(user.stat)
+		return
+	if(src.anchored)
 		to_chat(usr, "It is anchored in place!")
 		return 0
-
 	src.set_dir(turn(src.dir, 90))
-	return 1
+	return
 
 /obj/machinery/mining/brace/AltClick(mob/user)
-	if(usr.stat) return
-
-	if (src.anchored)
+	if(usr.stat)
+		return
+	if(src.anchored)
 		to_chat(usr, "It is anchored in place!")
 		return 0
-
 	src.set_dir(turn(src.dir, 90))
-	return 1
+	return

--- a/code/modules/mining/drilling/drill.dm
+++ b/code/modules/mining/drilling/drill.dm
@@ -361,3 +361,13 @@
 
 	src.set_dir(turn(src.dir, 90))
 	return 1
+
+/obj/machinery/mining/brace/AltClick(mob/user)
+	if(usr.stat) return
+
+	if (src.anchored)
+		to_chat(usr, "It is anchored in place!")
+		return 0
+
+	src.set_dir(turn(src.dir, 90))
+	return 1

--- a/code/modules/mining/drilling/drill.dm
+++ b/code/modules/mining/drilling/drill.dm
@@ -364,7 +364,7 @@
 	if(user.stat)
 		return
 	if(src.anchored)
-		to_chat(usr, "It is anchored in place!")
+		to_chat(user, "It is anchored in place!")
 		return 0
 	src.set_dir(turn(src.dir, 90))
 	return

--- a/code/modules/power/singularity/emitter.dm
+++ b/code/modules/power/singularity/emitter.dm
@@ -34,29 +34,26 @@
 	anchored = 1
 	state = 2
 
-/obj/machinery/power/emitter/verb/rotate()
+/obj/machinery/power/emitter/verb/rotate(mob/user)
 	set name = "Rotate"
 	set category = "Object"
 	set src in oview(1)
-
-	if(usr.incapacitated())
+	if(user.incapacitated())
 		return
-
 	if(anchored)
-		to_chat(usr, "It is fastened to the floor!")
+		to_chat(user, "It is fastened to the floor!")
 		return 0
 	set_dir(turn(dir, 90))
-	return 1
+	return
 
 /obj/machinery/power/emitter/AltClick(mob/user)
-	if(usr.incapacitated())
+	if(user.incapacitated())
 		return
-
 	if(anchored)
-		to_chat(usr, "It is fastened to the floor!")
+		to_chat(user, "It is fastened to the floor!")
 		return 0
 	set_dir(turn(dir, 90))
-	return 1
+	return
 
 /obj/machinery/power/emitter/Initialize()
 	. = ..()

--- a/code/modules/power/singularity/emitter.dm
+++ b/code/modules/power/singularity/emitter.dm
@@ -48,6 +48,16 @@
 	set_dir(turn(dir, 90))
 	return 1
 
+/obj/machinery/power/emitter/AltClick(mob/user)
+	if(usr.incapacitated())
+		return
+
+	if(anchored)
+		to_chat(usr, "It is fastened to the floor!")
+		return 0
+	set_dir(turn(dir, 90))
+	return 1
+
 /obj/machinery/power/emitter/Initialize()
 	. = ..()
 	if(state == 2 && anchored)

--- a/code/modules/recycling/disposal-construction.dm
+++ b/code/modules/recycling/disposal-construction.dm
@@ -116,31 +116,28 @@
 
 
 // flip and rotate verbs
-/obj/structure/disposalconstruct/proc/rotate()
+/obj/structure/disposalconstruct/proc/rotate(mob/user)
 	set category = "Object"
 	set name = "Rotate Pipe"
 	set src in view(1)
-
-	if(usr.incapacitated())
+	if(user.incapacitated())
 		return
-
 	if(anchored)
-		to_chat(usr, "You must unfasten the pipe before rotating it.")
+		to_chat(user, "You must unfasten the pipe before rotating it.")
 		return
-
 	set_dir(turn(dir, -90))
 	update()
+	return
 
 /obj/structure/disposalconstruct/AltClick(mob/user)
-	if(usr.incapacitated())
+	if(user.incapacitated())
 		return
-
 	if(anchored)
-		to_chat(usr, "You must unfasten the pipe before rotating it.")
+		to_chat(user, "You must unfasten the pipe before rotating it.")
 		return
-
 	set_dir(turn(dir, -90))
 	update()
+	return
 
 /obj/structure/disposalconstruct/proc/flip()
 	set category = "Object"

--- a/code/modules/recycling/disposal-construction.dm
+++ b/code/modules/recycling/disposal-construction.dm
@@ -131,6 +131,17 @@
 	set_dir(turn(dir, -90))
 	update()
 
+/obj/structure/disposalconstruct/AltClick(mob/user)
+	if(usr.incapacitated())
+		return
+
+	if(anchored)
+		to_chat(usr, "You must unfasten the pipe before rotating it.")
+		return
+
+	set_dir(turn(dir, -90))
+	update()
+
 /obj/structure/disposalconstruct/proc/flip()
 	set category = "Object"
 	set name = "Flip Pipe"

--- a/code/modules/xenoarcheaology/tools/suspension_generator.dm
+++ b/code/modules/xenoarcheaology/tools/suspension_generator.dm
@@ -256,6 +256,12 @@
 	else
 		set_dir(turn(dir, -90))
 
+/obj/machinery/suspension_gen/AltClick(mob/user)
+	if(anchored)
+		to_chat(usr, SPAN("warning", "You cannot rotate [src], it has been firmly fixed to the floor."))
+	else
+		set_dir(turn(dir, -90))
+
 /obj/effect/suspension_field
 	name = "energy field"
 	icon = 'icons/effects/effects.dmi'

--- a/code/modules/xenoarcheaology/tools/suspension_generator.dm
+++ b/code/modules/xenoarcheaology/tools/suspension_generator.dm
@@ -236,31 +236,32 @@
 	deactivate()
 	return ..()
 
-/obj/machinery/suspension_gen/verb/rotate_ccw()
+/obj/machinery/suspension_gen/verb/rotate_ccw(mob/user)
 	set src in view(1)
 	set name = "Rotate suspension gen (counter-clockwise)"
 	set category = "Object"
-
 	if(anchored)
-		to_chat(usr, SPAN("warning", "You cannot rotate [src], it has been firmly fixed to the floor."))
+		to_chat(user, SPAN("warning", "You cannot rotate [src], it has been firmly fixed to the floor."))
 	else
 		set_dir(turn(dir, 90))
+	return
 
-/obj/machinery/suspension_gen/verb/rotate_cw()
+/obj/machinery/suspension_gen/verb/rotate_cw(mob/user)
 	set src in view(1)
 	set name = "Rotate suspension gen (clockwise)"
 	set category = "Object"
-
 	if(anchored)
-		to_chat(usr, SPAN("warning", "You cannot rotate [src], it has been firmly fixed to the floor."))
+		to_chat(user, SPAN("warning", "You cannot rotate [src], it has been firmly fixed to the floor."))
 	else
 		set_dir(turn(dir, -90))
+	return
 
 /obj/machinery/suspension_gen/AltClick(mob/user)
 	if(anchored)
-		to_chat(usr, SPAN("warning", "You cannot rotate [src], it has been firmly fixed to the floor."))
+		to_chat(user, SPAN("warning", "You cannot rotate [src], it has been firmly fixed to the floor."))
 	else
 		set_dir(turn(dir, -90))
+	return
 
 /obj/effect/suspension_field
 	name = "energy field"


### PR DESCRIPTION
Теперь трубы, мусоропроводные трубы, эмиттеры, крепления дрели, стеклянные панели и генераторы подавляющего поля можно вращать используя альт+клик.

fix #9814

<details>
<summary>Чейнджлог</summary>

```yml
🆑
tweak: теперь трубы, мусоропроводные трубы, эмиттеры, крепления дрели, стеклянные панели и генераторы подавляющего поля можно вращать используя альт+клик.
/🆑
```

</details>

- [x] Pull Request полностью завершен, мне не нужна помощь чтобы его закончить.
- [x] Я внимательно прочитал все свои изменения и багов в них не нашел.
- [x] Я запускал сервер со своими изменениями локально и все протестировал.
- [x] Я ознакомился c [Guide to Contribute](https://github.com/ChaoticOnyx/OnyxBay/blob/dev/docs/contributing.md).
