### PR TITLE
fix(STD): laser and shotgun can be put in STD

### DIFF
--- a/code/game/objects/items/storage/briefcase.dm
+++ b/code/game/objects/items/storage/briefcase.dm
@@ -24,6 +24,7 @@
 /obj/item/storage/briefcase/std
 	desc = "It's an old-looking briefcase with some high-tech markings. It has a label on it, which reads: \"ONLY WORKS NEAR SPACE\"."
 	origin_tech = list(TECH_BLUESPACE = 3, TECH_ILLEGAL = 3)
+	storage_slots = 10
 	override_w_class = list(/obj/item/gun/energy/laser,
 		/obj/item/gun/projectile/shotgun/pump)
 	var/obj/item/device/uplink/uplink

--- a/code/game/objects/items/storage/briefcase.dm
+++ b/code/game/objects/items/storage/briefcase.dm
@@ -11,7 +11,9 @@
 	mod_reach = 0.75
 	mod_handy = 1.0
 	max_w_class = ITEM_SIZE_NORMAL
-	max_storage_space = DEFAULT_BACKPACK_STORAGE
+	max_storage_space = DEFAULT_BACKPACK_STORAGE + 27
+	override_w_class = list(/obj/item/gun/energy/laser,
+		/obj/item/gun/projectile/shotgun/pump)
 
 /obj/item/storage/briefcase/iaa
 	startswith = list(/obj/item/paper/trade_lic/trade_guide,\

--- a/code/game/objects/items/storage/briefcase.dm
+++ b/code/game/objects/items/storage/briefcase.dm
@@ -11,9 +11,7 @@
 	mod_reach = 0.75
 	mod_handy = 1.0
 	max_w_class = ITEM_SIZE_NORMAL
-	max_storage_space = DEFAULT_BACKPACK_STORAGE + 27
-	override_w_class = list(/obj/item/gun/energy/laser,
-		/obj/item/gun/projectile/shotgun/pump)
+	max_storage_space = DEFAULT_BACKPACK_STORAGE
 
 /obj/item/storage/briefcase/iaa
 	startswith = list(/obj/item/paper/trade_lic/trade_guide,\
@@ -26,6 +24,8 @@
 /obj/item/storage/briefcase/std
 	desc = "It's an old-looking briefcase with some high-tech markings. It has a label on it, which reads: \"ONLY WORKS NEAR SPACE\"."
 	origin_tech = list(TECH_BLUESPACE = 3, TECH_ILLEGAL = 3)
+	override_w_class = list(/obj/item/gun/energy/laser,
+		/obj/item/gun/projectile/shotgun/pump)
 	var/obj/item/device/uplink/uplink
 	var/authentication_complete = FALSE
 	var/del_on_send = TRUE

--- a/code/game/objects/items/storage/briefcase.dm
+++ b/code/game/objects/items/storage/briefcase.dm
@@ -25,8 +25,7 @@
 	desc = "It's an old-looking briefcase with some high-tech markings. It has a label on it, which reads: \"ONLY WORKS NEAR SPACE\"."
 	origin_tech = list(TECH_BLUESPACE = 3, TECH_ILLEGAL = 3)
 	storage_slots = 10
-	override_w_class = list(/obj/item/gun/energy/laser,
-		/obj/item/gun/projectile/shotgun/pump)
+	override_w_class = list(/obj/item/gun/projectile/shotgun/pump)
 	var/obj/item/device/uplink/uplink
 	var/authentication_complete = FALSE
 	var/del_on_send = TRUE

--- a/code/game/objects/items/storage/storage.dm
+++ b/code/game/objects/items/storage/storage.dm
@@ -182,7 +182,7 @@
 		return 0
 
 	total_storage_space += storage_space_used() //Adds up the combined w_classes which will be in the storage item if the item is added to it.
-	if(total_storage_space > max_storage_space)
+	if(total_storage_space > max_storage_space && !(length(override_w_class) && is_type_in_list(W, override_w_class)))
 		if(!stop_messages)
 			to_chat(user, "<span class='notice'>\The [src] is too full, make some space.</span>")
 		return 0


### PR DESCRIPTION
Увеличил место СТД и добавил возможность в него запихнуть помповый дробовик


close #9784 

<details>
<summary>Чейнджлог</summary>

```yml
🆑
bugfix: В СТД теперь можно запихнуть помповый дробовик и лазерную винтовку.
tweak: СТД теперь имеет всего 10 ячеек, размерность сохранена.
/🆑
```

</details>


- [x] Pull Request полностью завершен, мне не нужна помощь чтобы его закончить.
- [x] Я внимательно прочитал все свои изменения и багов в них не нашел.
- [x] Я запускал сервер со своими изменениями локально и все протестировал.
- [x] Я ознакомился c [Guide to Contribute](https://github.com/ChaoticOnyx/OnyxBay/blob/dev/docs/contributing.md).
