### PR TITLE
tweak(loadout): remove infinite items spawning

### DIFF
--- a/code/modules/client/preference_setup/loadout/lists/pets.dm
+++ b/code/modules/client/preference_setup/loadout/lists/pets.dm
@@ -2,6 +2,7 @@
 	sort_category = "Pets"
 	path = /mob/living/simple_animal/corgi/pet
 	var/list/paths
+	var/static/list/pets_name = list()
 
 /datum/gear/pet/New()
 	..()
@@ -12,11 +13,12 @@
 	. = ..()
 	if(.)
 		var/list/gears = user.client.prefs.gear_list[user.client.prefs.gear_slot]
-		var/list/pets = list()
-		for(var/pet_type in subtypesof(/datum/gear/pet))
-			var/datum/gear/pet/pet = new pet_type()
-			pets.Add(pet.display_name)
-			qdel(pet)
+		if(!length(pets_name))
+			for(var/pet_type in subtypesof(/datum/gear/pet))
+				var/datum/gear/pet/pet = new pet_type()
+				pets_name.Add(pet.display_name)
+				qdel(pet)
+		var/list/pets = pets_name.Copy()
 		pets.Remove(display_name)
 		for(var/gear in gears)
 			if(gear in pets)

--- a/code/modules/client/preference_setup/loadout/loadout.dm
+++ b/code/modules/client/preference_setup/loadout/loadout.dm
@@ -239,7 +239,7 @@ var/list/hash_to_gear = list()
 		var/display_class
 		var/discountText
 		if(ticked && !gear_allowed_to_equip(G, user))
-			toggle_gear(G)
+			pref.gear_list[pref.gear_slot] -= G.display_name
 			ticked = FALSE
 		if(G != selected_gear)
 			if(ticked)
@@ -292,6 +292,8 @@ var/list/hash_to_gear = list()
 				I.Blend(gear_virtual_item.color, ICON_MULTIPLY)
 
 		I.Scale(I.Width() * 2, I.Height() * 2)
+
+		QDEL_NULL(gear_virtual_item)
 
 		. += "<td style='width: 80%;' class='block'>"
 

--- a/code/modules/mob/living/simple_animal/simple_animal.dm
+++ b/code/modules/mob/living/simple_animal/simple_animal.dm
@@ -90,6 +90,7 @@
 		bodyparts = decls_repository.get_decl(bodyparts)
 
 /mob/living/simple_animal/Destroy()
+	mob_ai.holder = null
 	QDEL_NULL(mob_ai)
 	panic_target = null
 	. = ..()


### PR DESCRIPTION
Произошел выстрел в член.

Кто-то из нас (Эпикус или я) забыл удалять предмет после спавна.
Еще я дебильную штуку делал: пытался толгнуть предмет донатера, который стал не донатером, из-за этого могли бы быть рантаймы, но я полнейший идиот и забыл передать аргумент user, поэтому это все падало в рантайм и никто этого не заметил, вообщем я перенес туда то, что я хотел сделать.
Разлинковал принудительно в симпл мобе связь с mob_ai.
Сделал небольшую оптимизацию списка петов, хотя это сейчас бесполезно, у нас только один набор петов.

<details>
<summary>Чейнджлог</summary>

```yml
🆑
bugfix: Педалям теперь не срет об не удаленным мобе из лоадаута.
/🆑
```

</details>

- [x] Pull Request полностью завершен, мне не нужна помощь чтобы его закончить.
- [x] Я внимательно прочитал все свои изменения и багов в них не нашел.
- [x] Я запускал сервер со своими изменениями локально и все протестировал.
- [x] Я ознакомился c [Guide to Contribute](https://github.com/ChaoticOnyx/OnyxBay/blob/dev/docs/contributing.md).
