### PR TITLE
fix(neurolace): neurolace don't revive mobs without brains

### DIFF
--- a/code/modules/organs/internal/stack.dm
+++ b/code/modules/organs/internal/stack.dm
@@ -51,7 +51,7 @@
 /obj/item/organ/internal/stack/replaced()
 	if(!..()) return 0
 
-	if(owner && !backup_inviable())
+	if(owner && !backup_inviable() && owner.has_brain())
 		var/current_owner = owner
 		var/mob/dead_owner = find_dead_player(ownerckey, 1)
 		if(istype(dead_owner))


### PR DESCRIPTION
Забыл фикс в ПР вкинуть.
close #5181
<details>
<summary>Чейнджлог</summary>

```yml
🆑KreeperHLC
bugfix: В мартышку больше нельзя вселиться через нейронить если у неё нет мозгов.
/🆑
```

</details>

- [x] Pull Request полностью завершен, мне не нужна помощь чтобы его закончить.
- [x] Я внимательно прочитал все свои изменения и багов в них не нашел.
- [ ] Я запускал сервер со своими изменениями локально и все протестировал.
- [x] Я ознакомился c [Guide to Contribute](https://github.com/ChaoticOnyx/OnyxBay/blob/dev/docs/contributing.md).
