### PR TITLE
fix(mine): fix mineral clasters

### DIFF
--- a/code/modules/mining/mine_turfs.dm
+++ b/code/modules/mining/mine_turfs.dm
@@ -160,6 +160,7 @@ var/list/mining_floors = list()
 	ore_overlay = image('icons/obj/mining.dmi', "rock_[mineral.icon_tag]")
 	ore_overlay.appearance_flags = DEFAULT_APPEARANCE_FLAGS | RESET_COLOR
 	ore_overlay.turf_decal_layerise()
+	ore_left = mineral.result_amount
 	update_icon()
 	if(mineral.icon_tag == "diamond")
 		explosion_block = 3
@@ -451,7 +452,6 @@ var/list/mining_floors = list()
 		mineral_name = lowertext(mineral_name)
 		if(mineral_name && (mineral_name in ore_data))
 			mineral = ore_data[mineral_name]
-			ore_left = mineral.result_amount
 			UpdateMineral()
 	MineralSpread()
 


### PR DESCRIPTION
close #10026
<details>
<summary>Чейнджлог</summary>

```yml
🆑KreeperHLC
bugfix: Теперь руда должна спавниться везде.
/🆑
```

</details>

- [x] Pull Request полностью завершен, мне не нужна помощь чтобы его закончить.
- [x] Я внимательно прочитал все свои изменения и багов в них не нашел.
- [ ] Я запускал сервер со своими изменениями локально и все протестировал.
- [x] Я ознакомился c [Guide to Contribute](https://github.com/ChaoticOnyx/OnyxBay/blob/dev/docs/contributing.md).
