### PR TITLE
fix(machinery): fixes tool istype checks when disassembling

### DIFF
--- a/code/game/machinery/machinery.dm
+++ b/code/game/machinery/machinery.dm
@@ -336,14 +336,14 @@ Class Procs:
 	return 0
 
 /obj/machinery/proc/default_deconstruction_crowbar(mob/user, obj/item/crowbar/C)
-	if(!istype(C))
+	if(!isCrowbar(C))
 		return 0
 	if(!panel_open)
 		return 0
 	. = dismantle()
 
 /obj/machinery/proc/default_deconstruction_screwdriver(mob/user, obj/item/screwdriver/S)
-	if(!istype(S))
+	if(!isScrewdriver(S))
 		return 0
 	playsound(src.loc, 'sound/items/Screwdriver.ogg', 50, 1)
 	panel_open = !panel_open

--- a/code/game/machinery/machinery.dm
+++ b/code/game/machinery/machinery.dm
@@ -335,14 +335,14 @@ Class Procs:
 			return 1
 	return 0
 
-/obj/machinery/proc/default_deconstruction_crowbar(mob/user, obj/item/crowbar/C)
+/obj/machinery/proc/default_deconstruction_crowbar(mob/user, obj/item/C)
 	if(!isCrowbar(C))
 		return 0
 	if(!panel_open)
 		return 0
 	. = dismantle()
 
-/obj/machinery/proc/default_deconstruction_screwdriver(mob/user, obj/item/screwdriver/S)
+/obj/machinery/proc/default_deconstruction_screwdriver(mob/user, obj/item/S)
 	if(!isScrewdriver(S))
 		return 0
 	playsound(src.loc, 'sound/items/Screwdriver.ogg', 50, 1)


### PR DESCRIPTION
Не обнаруженный при тестировании чек на тип предмета вместо макроса коде разборки машинерии.

<details>
<summary>Чейнджлог</summary>

```yml
🆑
bugfix: Мультитул теперь может разбирать машинерию.
/🆑
```

</details>


- [x] Pull Request полностью завершен, мне не нужна помощь чтобы его закончить.
- [x] Я внимательно прочитал все свои изменения и багов в них не нашел.
- [ ] Я запускал сервер со своими изменениями локально и все протестировал.
- [x] Я ознакомился c [Guide to Contribute](https://github.com/ChaoticOnyx/OnyxBay/blob/dev/docs/contributing.md).
