### PR TITLE
fix(protolathe): Правильная проверка наличия материалов протолатом

### DIFF
--- a/code/modules/research/protolathe.dm
+++ b/code/modules/research/protolathe.dm
@@ -148,7 +148,7 @@
 	queue.Cut(index, index + 1)
 	return
 
-/obj/machinery/r_n_d/protolathe/proc/canBuild(datum/design/D, amount_build)
+/obj/machinery/r_n_d/protolathe/proc/canBuild(datum/design/D, amount_build = 1)
 	for(var/M in D.materials)
 		if(materials[M] < D.materials[M] * mat_efficiency * amount_build)
 			return 0


### PR DESCRIPTION
Из-за не прописанного дефолтного значения, вся математика умножалась на ноль и протолат печатал бесконечно. Пофикшено прописанным дефолтным значением.

Closes #8442

<details>
<summary>Чейнджлог</summary>

```yml
🆑
bugfix: Протолат больше не печатает без наличия нужных материалов
/🆑
```

</details>

- [x] Pull Request полностью завершен, мне не нужна помощь чтобы его закончить.
- [x] Я внимательно прочитал все свои изменения и багов в них не нашел.
- [x] Я запускал сервер со своими изменениями локально и все протестировал.
- [x] Я ознакомился c [Guide to Contribute](https://github.com/ChaoticOnyx/OnyxBay/blob/dev/docs/contributing.md).
