### PR TITLE
feat(farlook): adds view shifting to all mobs (free of charge)

### DIFF
--- a/baystation12.dme
+++ b/baystation12.dme
@@ -1953,6 +1953,7 @@
 #include "code\modules\mob\living\damage_procs.dm"
 #include "code\modules\mob\living\death.dm"
 #include "code\modules\mob\living\default_language.dm"
+#include "code\modules\mob\living\farlook.dm"
 #include "code\modules\mob\living\life.dm"
 #include "code\modules\mob\living\living.dm"
 #include "code\modules\mob\living\living_defense.dm"

--- a/code/__defines/ces/signals_mob.dm
+++ b/code/__defines/ces/signals_mob.dm
@@ -9,3 +9,6 @@
 
 /// Called on `/mob/living/set_stat` (/mob/living, old_stat, new_stat)
 #define SIGNAL_STAT_SET "set_stat"
+
+/// Called on `/mob/proc/shift_view` (/mob, old_stat, new_stat)
+#define SIGNAL_VIEW_SHIFTED_SET "view_shift_set"

--- a/code/_onclick/click.dm
+++ b/code/_onclick/click.dm
@@ -48,6 +48,25 @@
 	var/dragged = modifiers["drag"]
 	if(dragged && !modifiers[dragged])
 		return
+	if(modifiers["right"])
+		if(modifiers["shift"] && modifiers["ctrl"])
+			CtrlShiftRightClickOn(A)
+			return 1
+		if(modifiers["alt"] && modifiers["ctrl"])
+			CtrlAltRightClickOn(A)
+			return 1
+		if(modifiers["shift"] && modifiers["alt"])
+			ShiftAltRightClickOn(A)
+			return 1
+		if(modifiers["alt"])
+			AltRightClickOn(A)
+			return 1
+		if(modifiers["shift"])
+			ShiftRightClickOn(A)
+			return 1
+		if(modifiers["ctrl"])
+			CtrlRightClickOn(A)
+			return 1
 	if(modifiers["shift"] && modifiers["ctrl"])
 		CtrlShiftClickOn(A)
 		return 1
@@ -312,6 +331,72 @@
 	return
 
 /atom/proc/CtrlAltClick(mob/user)
+	return
+
+
+
+/*
+	Rclick.
+*/
+
+/*
+	Control+Rclick
+*/
+
+/mob/proc/CtrlRightClickOn(atom/A)
+	A.CtrlRightClick(src)
+
+/atom/proc/CtrlRightClick(mob/user)
+	return
+
+/*
+	Alt+Rclick
+*/
+
+/mob/proc/AltRightClickOn(atom/A)
+	A.AltRightClick(src)
+
+/atom/proc/AltRightClick(mob/user)
+	return
+
+/*
+	Shift+Rclick
+*/
+
+/mob/proc/ShiftRightClickOn(atom/A)
+	A.ShiftRightClick(src)
+
+/atom/proc/ShiftRightClick(mob/user)
+	return
+
+/*
+	Control+Alt+Rclick
+*/
+
+/mob/proc/CtrlAltRightClickOn(atom/A)
+	A.CtrlAltRightClick(src)
+
+/atom/proc/CtrlAltRightClick(mob/user)
+	return
+
+/*
+	Control+Shift+Rclick
+*/
+
+/mob/proc/CtrlShiftRightClickOn(atom/A)
+	A.CtrlShiftRightClick(src)
+
+/atom/proc/CtrlShiftRightClick(mob/user)
+	return
+
+/*
+	Shift+Alt+Rclick
+*/
+
+/mob/proc/ShiftAltRightClickOn(atom/A)
+	A.ShiftAltRightClick(src)
+
+/atom/proc/ShiftAltRightClick(mob/user)
 	return
 
 /*

--- a/code/game/objects/items.dm
+++ b/code/game/objects/items.dm
@@ -765,6 +765,8 @@ modules/mob/living/carbon/human/life.dm if you die, you will be zoomed out.
 		return
 	if(zoom)
 		return
+	if(user.is_view_shifted)
+		return
 
 	var/devicename = zoomdevicename || name
 
@@ -787,17 +789,13 @@ modules/mob/living/carbon/human/life.dm if you die, you will be zoomed out.
 	var/viewoffset = WORLD_ICON_SIZE * tileoffset
 	switch(user.dir)
 		if (NORTH)
-			user.client.pixel_x = 0
-			user.client.pixel_y = viewoffset
+			user.shift_view(0, viewoffset)
 		if (SOUTH)
-			user.client.pixel_x = 0
-			user.client.pixel_y = -viewoffset
+			user.shift_view(0, -viewoffset)
 		if (EAST)
-			user.client.pixel_x = viewoffset
-			user.client.pixel_y = 0
+			user.shift_view(viewoffset, 0)
 		if (WEST)
-			user.client.pixel_x = -viewoffset
-			user.client.pixel_y = 0
+			user.shift_view(-viewoffset, 0)
 
 	user.visible_message("\The [user] peers through [zoomdevicename ? "the [zoomdevicename] of [src]" : "[src]"].")
 
@@ -806,6 +804,7 @@ modules/mob/living/carbon/human/life.dm if you die, you will be zoomed out.
 	register_signal(src, SIGNAL_DIR_SET, /obj/item/proc/unzoom)
 	register_signal(src, SIGNAL_ITEM_UNEQUIPPED, /obj/item/proc/zoom_drop)
 	register_signal(user, SIGNAL_STAT_SET, /obj/item/proc/unzoom)
+	register_signal(user, SIGNAL_VIEW_SHIFTED_SET, /obj/item/proc/unzoom)
 
 /obj/item/proc/zoom_drop(obj/item/I, mob/user)
 	unzoom(user)
@@ -831,6 +830,7 @@ modules/mob/living/carbon/human/life.dm if you die, you will be zoomed out.
 		return
 
 	unregister_signal(user, SIGNAL_STAT_SET)
+	unregister_signal(user, SIGNAL_VIEW_SHIFTED_SET)
 
 	if(!user.client)
 		return
@@ -839,8 +839,7 @@ modules/mob/living/carbon/human/life.dm if you die, you will be zoomed out.
 	if(!user.hud_used.hud_shown)
 		user.toggle_zoom_hud()
 
-	user.client.pixel_x = 0
-	user.client.pixel_y = 0
+	user.shift_view(0, 0)
 	user.visible_message("[zoomdevicename ? "\The [user] looks up from [src]" : "\The [user] lowers [src]"].")
 
 /obj/item/proc/pwr_drain()

--- a/code/game/objects/items.dm
+++ b/code/game/objects/items.dm
@@ -823,6 +823,7 @@ modules/mob/living/carbon/human/life.dm if you die, you will be zoomed out.
 	unregister_signal(src, SIGNAL_MOVED, /obj/item/proc/zoom_move)
 	unregister_signal(src, SIGNAL_DIR_SET)
 	unregister_signal(src, SIGNAL_ITEM_UNEQUIPPED)
+	unregister_signal(user, SIGNAL_VIEW_SHIFTED_SET, /obj/item/proc/unzoom)
 
 	user = user == src ? loc : (user || loc)
 	if(!istype(user))

--- a/code/modules/mob/animations.dm
+++ b/code/modules/mob/animations.dm
@@ -32,15 +32,13 @@ note dizziness decrements automatically in the mob's Life() proc.
 	while(dizziness > 100)
 		if(client)
 			var/amplitude = dizziness*(sin(dizziness * 0.044 * world.time) + 1) / 70
-			client.pixel_x = amplitude * sin(0.008 * dizziness * world.time)
-			client.pixel_y = amplitude * cos(0.008 * dizziness * world.time)
+			shift_view(amplitude * sin(0.008 * dizziness * world.time), amplitude * cos(0.008 * dizziness * world.time))
 
 		sleep(1)
 	//endwhile - reset the pixel offsets to zero
 	is_dizzy = 0
 	if(client)
-		client.pixel_x = 0
-		client.pixel_y = 0
+		shift_view(0, 0)
 
 // jitteriness - copy+paste of dizziness
 /mob/var/is_jittery = 0

--- a/code/modules/mob/living/carbon/human/human_helpers.dm
+++ b/code/modules/mob/living/carbon/human/human_helpers.dm
@@ -68,8 +68,7 @@
 			client.view = world.view
 
 		if (client.pixel_x != 0 || client.pixel_y != 0)
-			client.pixel_y = 0
-			client.pixel_x = 0
+			shift_view(0, 0)
 
 /mob/living/carbon/human/proc/process_glasses(obj/item/clothing/glasses/G)
 	if(machine_visual && !istype(G, /obj/item/clothing/glasses/regular)) //Doesn't allow the use of night vision devices and other funny devices except glasses for vision correction

--- a/code/modules/mob/living/farlook.dm
+++ b/code/modules/mob/living/farlook.dm
@@ -1,8 +1,9 @@
 /atom/CtrlRightClick(mob/living/user)
 	if(!istype(user))
-		return
+		return ..()
 
 	user.do_farlook(get_turf(src))
+	return ..()
 
 // Shifts client's view to selected turf. Max distance 7 tiles.
 /mob/living/proc/do_farlook(turf/T)

--- a/code/modules/mob/living/farlook.dm
+++ b/code/modules/mob/living/farlook.dm
@@ -1,0 +1,40 @@
+/mob/living
+	var/is_view_shifted = FALSE
+
+/mob/living/Move()
+	. = ..()
+	if(. && is_view_shifted)
+		reset_shifted_view()
+
+/atom/CtrlRightClick(mob/living/user)
+	if(!istype(user))
+		return
+
+	user.shift_view_to_turf(get_turf(src))
+
+/mob/living/proc/shift_view_to_turf(turf/T)
+	if(!is_view_shifted)
+		if(!isturf(src.loc))
+			return
+		if(stat)
+			return
+
+		var/turf/position = get_turf(src)
+		var/delta_x = T.x - position.x
+		var/delta_y = T.y - position.y
+
+		if(abs(delta_x) > 7 || abs(delta_y) > 7)
+			return
+		if(delta_x == 0 && delta_y == 0)
+			return
+
+		face_atom(T)
+		visible_message(SPAN_NOTICE("[src] peers into the distance."))
+		animate(client, pixel_x = world.icon_size*delta_x, pixel_y = world.icon_size*delta_y, time = 2, easing = SINE_EASING)
+		is_view_shifted = TRUE
+	else
+		reset_shifted_view()
+
+/mob/living/proc/reset_shifted_view()
+	animate(client, pixel_x = 0, pixel_y = 0, time = 2, easing = SINE_EASING)
+	is_view_shifted = FALSE

--- a/code/modules/mob/living/farlook.dm
+++ b/code/modules/mob/living/farlook.dm
@@ -38,3 +38,4 @@
 
 /mob/living/proc/reset_farlook()
 	shift_view(0, 0, TRUE)
+	unregister_signal(src, SIGNAL_MOVED, /mob/living/proc/reset_farlook)

--- a/code/modules/mob/living/farlook.dm
+++ b/code/modules/mob/living/farlook.dm
@@ -1,18 +1,11 @@
-/mob/living
-	var/is_view_shifted = FALSE
-
-/mob/living/Move()
-	. = ..()
-	if(. && is_view_shifted)
-		reset_shifted_view()
-
 /atom/CtrlRightClick(mob/living/user)
 	if(!istype(user))
 		return
 
-	user.shift_view_to_turf(get_turf(src))
+	user.do_farlook(get_turf(src))
 
-/mob/living/proc/shift_view_to_turf(turf/T)
+// Shifts client's view to selected turf. Max distance 7 tiles.
+/mob/living/proc/do_farlook(turf/T)
 	if(!is_view_shifted)
 		if(!isturf(src.loc))
 			return
@@ -28,13 +21,19 @@
 		if(delta_x == 0 && delta_y == 0)
 			return
 
+		register_signal(src, SIGNAL_MOVED, /mob/living/proc/reset_farlook)
+
 		face_atom(T)
 		visible_message(SPAN_NOTICE("[src] peers into the distance."))
-		animate(client, pixel_x = world.icon_size*delta_x, pixel_y = world.icon_size*delta_y, time = 2, easing = SINE_EASING)
-		is_view_shifted = TRUE
+		shift_view(world.icon_size*delta_x, world.icon_size*delta_y, TRUE)
 	else
-		reset_shifted_view()
+		reset_farlook()
 
-/mob/living/proc/reset_shifted_view()
-	animate(client, pixel_x = 0, pixel_y = 0, time = 2, easing = SINE_EASING)
-	is_view_shifted = FALSE
+/mob/living/carbon/human/do_farlook(turf/T)
+	if(machine_visual)
+		return
+
+	..(T)
+
+/mob/living/proc/reset_farlook()
+	shift_view(0, 0, TRUE)

--- a/code/modules/mob/mob_defines.dm
+++ b/code/modules/mob/mob_defines.dm
@@ -204,3 +204,5 @@
 	///
 	/// On [/mob] so clientless mobs will throw alerts properly.
 	var/list/alerts = list()
+
+	var/is_view_shifted = FALSE

--- a/code/modules/mob/mob_helpers.dm
+++ b/code/modules/mob/mob_helpers.dm
@@ -712,3 +712,22 @@ var/list/intents = list(I_HELP,I_DISARM,I_GRAB,I_HURT)
 				alert_overlay.layer = FLOAT_LAYER
 				alert_overlay.plane = FLOAT_PLANE
 				A.overlays += alert_overlay
+
+/mob/proc/shift_view(new_pixel_x = 0, new_pixel_y = 0, animate = 0)
+	if(!client)
+		is_view_shifted = FALSE
+		return
+
+	var/old_shifted = is_view_shifted
+	if(animate)
+		animate(client, pixel_x = new_pixel_x, pixel_y = new_pixel_y, time = 2, easing = SINE_EASING)
+	else
+		client.pixel_x = new_pixel_x
+		client.pixel_y = new_pixel_y
+
+	if(new_pixel_x == 0 && new_pixel_y == 0)
+		is_view_shifted = FALSE
+	else
+		is_view_shifted = TRUE
+
+	SEND_SIGNAL(src, SIGNAL_VIEW_SHIFTED_SET, src, old_shifted, is_view_shifted)

--- a/interface/skin.dmf
+++ b/interface/skin.dmf
@@ -229,7 +229,7 @@ macro "borghotkeymode"
 		command = ".winset :map.right-click=true"
 	elem
 		name = "SHIFT+UP"
-		command = ".winset :map.right-click=false \n .release_shift"
+		command = ".winset :map.right-click=false\n.release_shift"
 	elem
 		name = "ALT"
 		command = ".winset :map.right-click=true"
@@ -417,7 +417,7 @@ macro "macro"
 		command = ".winset :map.right-click=true"
 	elem
 		name = "SHIFT+UP"
-		command = ".winset :map.right-click=false \n .release_shift"
+		command = ".winset :map.right-click=false\n.release_shift"
 	elem
 		name = "ALT"
 		command = ".winset :map.right-click=true"
@@ -677,7 +677,7 @@ macro "hotkeymode"
 		command = ".winset :map.right-click=true"
 	elem
 		name = "SHIFT+UP"
-		command = ".winset :map.right-click=false \n .release_shift"
+		command = ".winset :map.right-click=false\n.release_shift"
 	elem
 		name = "ALT"
 		command = ".winset :map.right-click=true"
@@ -859,7 +859,7 @@ macro "borgmacro"
 		command = ".winset :map.right-click=true"
 	elem
 		name = "SHIFT+UP"
-		command = ".winset :map.right-click=false \n .release_shift"
+		command = ".winset :map.right-click=false\n.release_shift"
 	elem
 		name = "ALT"
 		command = ".winset :map.right-click=true"

--- a/interface/skin.dmf
+++ b/interface/skin.dmf
@@ -218,9 +218,24 @@ macro "borghotkeymode"
 	elem 
 		name = "F12"
 		command = "F12"
-	elem 
-		name = "SHIFT+Up"
-		command = ".release_shift"
+	elem
+		name = "CTRL"
+		command = ".winset :map.right-click=true"
+	elem
+		name = "CTRL+UP"
+		command = ".winset :map.right-click=false"
+	elem
+		name = "SHIFT"
+		command = ".winset :map.right-click=true"
+	elem
+		name = "SHIFT+UP"
+		command = ".winset :map.right-click=false \n .release_shift"
+	elem
+		name = "ALT"
+		command = ".winset :map.right-click=true"
+	elem
+		name = "ALT+UP"
+		command = ".winset :map.right-click=false"
 
 macro "macro"
 	elem 
@@ -391,9 +406,24 @@ macro "macro"
 	elem 
 		name = "F12"
 		command = "F12"
-	elem 
-		name = "SHIFT+Up"
-		command = ".release_shift"
+	elem
+		name = "CTRL"
+		command = ".winset :map.right-click=true"
+	elem
+		name = "CTRL+UP"
+		command = ".winset :map.right-click=false"
+	elem
+		name = "SHIFT"
+		command = ".winset :map.right-click=true"
+	elem
+		name = "SHIFT+UP"
+		command = ".winset :map.right-click=false \n .release_shift"
+	elem
+		name = "ALT"
+		command = ".winset :map.right-click=true"
+	elem
+		name = "ALT+UP"
+		command = ".winset :map.right-click=false"
 
 macro "hotkeymode"
 	elem 
@@ -636,9 +666,24 @@ macro "hotkeymode"
 	elem 
 		name = "."
 		command = "move-down"
-	elem 
-		name = "SHIFT+Up"
-		command = ".release_shift"
+	elem
+		name = "CTRL"
+		command = ".winset :map.right-click=true"
+	elem
+		name = "CTRL+UP"
+		command = ".winset :map.right-click=false"
+	elem
+		name = "SHIFT"
+		command = ".winset :map.right-click=true"
+	elem
+		name = "SHIFT+UP"
+		command = ".winset :map.right-click=false \n .release_shift"
+	elem
+		name = "ALT"
+		command = ".winset :map.right-click=true"
+	elem
+		name = "ALT+UP"
+		command = ".winset :map.right-click=false"
 
 macro "borgmacro"
 	elem 
@@ -803,9 +848,24 @@ macro "borgmacro"
 	elem 
 		name = "F12"
 		command = "F12"
-	elem 
-		name = "SHIFT+Up"
-		command = ".release_shift"
+	elem
+		name = "CTRL"
+		command = ".winset :map.right-click=true"
+	elem
+		name = "CTRL+UP"
+		command = ".winset :map.right-click=false"
+	elem
+		name = "SHIFT"
+		command = ".winset :map.right-click=true"
+	elem
+		name = "SHIFT+UP"
+		command = ".winset :map.right-click=false \n .release_shift"
+	elem
+		name = "ALT"
+		command = ".winset :map.right-click=true"
+	elem
+		name = "ALT+UP"
+		command = ".winset :map.right-click=false"
 
 
 menu "menu"


### PR DESCRIPTION
1) Добавил возможность использовать правую кнопку мыши для интеракции с миром при зажатых клавишах модификаторах: альт, шифт, ктрл ктрл+альт, ктрл+шифт, шифт+альт.
2) Добавил возможность смотреть вдаль на КТРЛ+ПКМ.
3) Зарефакторил немного код изменения client.pixel_x/y, чтобы отправлялся сигнал для фикса возможности смещения взгляда при использовании бинокля.


https://user-images.githubusercontent.com/41485301/219688079-d13d24cb-709f-4af0-a8ab-8c25a517cd55.mp4


(пункты 2 и 3 опциональны)

Смотреть вдаль нельзя из шкафчиков и другой штуки, где человек не находится на турфе.

<details>
<summary>Чейнджлог</summary>

```yml
🆑
rscadd: Добавил возможность смотреть вдаль на Контрол+ПКМ.
/🆑
```

</details>

- [x] Pull Request полностью завершен, мне не нужна помощь чтобы его закончить.
- [x] Я внимательно прочитал все свои изменения и багов в них не нашел.
- [x] Я запускал сервер со своими изменениями локально и все протестировал.
- [x] Я ознакомился c [Guide to Contribute](https://github.com/ChaoticOnyx/OnyxBay/blob/dev/docs/contributing.md).
