### PR TITLE
feat(storyteller): adds weighted pick for antags depending on their zlevel

### DIFF
--- a/code/game/antagonist/antagonist.dm
+++ b/code/game/antagonist/antagonist.dm
@@ -130,8 +130,11 @@
 				log_debug_verbose("[key_name(player)] is not eligible to become a [role_text]: '[player.current.type]' is not an allowed type of mob!")
 		else
 			log_debug_verbose("[key_name(player)] is eligible to become a [role_text]")
-			candidates |= player
-			candidates[player] = get_candidate_weight(player)
+			var/candidate_weight = get_candidate_weight(player)
+			if(candidate_weight == 0)
+				log_debug_verbose("[key_name(player)] is not eligible to become a [role_text]: Bad location z-level!")
+				continue
+			candidates[player] = candidate_weight
 
 	return candidates
 
@@ -158,8 +161,11 @@
 		else if(!is_mob_type_allowed(player))
 			log_debug_verbose("[key_name(player)] is not eligible to become a [role_text]: '[player.current.type]' is not allowed type of mob!")
 		else
-			potential_candidates |= player
-			potential_candidates[player] = get_candidate_weight(player)
+			var/candidate_weight = get_candidate_weight(player)
+			if(candidate_weight == 0)
+				log_debug_verbose("[key_name(player)] is not eligible to become a [role_text]: Bad location z-level!")
+				continue
+			potential_candidates[player] = candidate_weight
 
 	return potential_candidates
 

--- a/code/game/antagonist/antagonist.dm
+++ b/code/game/antagonist/antagonist.dm
@@ -130,7 +130,9 @@
 				log_debug_verbose("[key_name(player)] is not eligible to become a [role_text]: '[player.current.type]' is not an allowed type of mob!")
 		else
 			log_debug_verbose("[key_name(player)] is eligible to become a [role_text]")
+			var/weight = get_candidate_weight(player)
 			candidates |= player
+			candidates[player] = weight
 
 	return candidates
 
@@ -157,9 +159,24 @@
 		else if(!is_mob_type_allowed(player))
 			log_debug_verbose("[key_name(player)] is not eligible to become a [role_text]: '[player.current.type]' is not allowed type of mob!")
 		else
+			var/weight = get_candidate_weight(player)
 			potential_candidates |= player
+			potential_candidates[player] = weight
 
 	return potential_candidates
+
+/datum/antagonist/proc/get_candidate_weight(datum/mind/player)
+	ASSERT(istype(player))
+	if(isghostmind(player) || isnewplayer(player.current))
+		return 100
+
+	var/player_zlevel = get_z(player.current)
+
+	if(!isPlayerLevel(player_zlevel))
+		return 0
+	if(!isStationLevel(player_zlevel))
+		return 50
+	return 100
 
 /datum/antagonist/proc/attempt_random_spawn()
 	update_current_antag_max(SSticker.mode)
@@ -219,7 +236,7 @@
 
 	//Grab candidates randomly until we have enough.
 	while(candidates.len && pending_antagonists.len < spawn_target)
-		var/datum/mind/player = pick(candidates)
+		var/datum/mind/player = util_pick_weight(candidates)
 		candidates -= player
 		draft_antagonist(player)
 

--- a/code/game/antagonist/antagonist.dm
+++ b/code/game/antagonist/antagonist.dm
@@ -130,9 +130,8 @@
 				log_debug_verbose("[key_name(player)] is not eligible to become a [role_text]: '[player.current.type]' is not an allowed type of mob!")
 		else
 			log_debug_verbose("[key_name(player)] is eligible to become a [role_text]")
-			var/weight = get_candidate_weight(player)
 			candidates |= player
-			candidates[player] = weight
+			candidates[player] = get_candidate_weight(player)
 
 	return candidates
 
@@ -159,9 +158,8 @@
 		else if(!is_mob_type_allowed(player))
 			log_debug_verbose("[key_name(player)] is not eligible to become a [role_text]: '[player.current.type]' is not allowed type of mob!")
 		else
-			var/weight = get_candidate_weight(player)
 			potential_candidates |= player
-			potential_candidates[player] = weight
+			potential_candidates[player] = get_candidate_weight(player)
 
 	return potential_candidates
 

--- a/code/game/antagonist/antagonist.dm
+++ b/code/game/antagonist/antagonist.dm
@@ -129,11 +129,11 @@
 			else
 				log_debug_verbose("[key_name(player)] is not eligible to become a [role_text]: '[player.current.type]' is not an allowed type of mob!")
 		else
-			log_debug_verbose("[key_name(player)] is eligible to become a [role_text]")
 			var/candidate_weight = get_candidate_weight(player)
 			if(candidate_weight == 0)
 				log_debug_verbose("[key_name(player)] is not eligible to become a [role_text]: Bad location z-level!")
 				continue
+			log_debug_verbose("[key_name(player)] is eligible to become a [role_text]")
 			candidates[player] = candidate_weight
 
 	return candidates


### PR DESCRIPTION
close #2469

По факту, это распространяется на все системы выбора антагонистов, не только на сторителлер. На автотрейтор, например, и т.д.

<details>
<summary>Чейнджлог</summary>

```yml
🆑
balance: Сторителлер теперь выдаёт роли людям вне станции с шансом в 2 раза ниже, чем людям на ней.
bugfix: Мобы, находящиеся на з-уровне ЦК больше не могут становиться антагонистами.
/🆑
```

</details>

- [x] Pull Request полностью завершен, мне не нужна помощь чтобы его закончить.
- [x] Я внимательно прочитал все свои изменения и багов в них не нашел.
- [x] Я запускал сервер со своими изменениями локально и все протестировал.
- [x] Я ознакомился c [Guide to Contribute](https://github.com/ChaoticOnyx/OnyxBay/blob/dev/docs/contributing.md).
