### PR TITLE
fix(integrals): fix data card reader circuit description

### DIFF
--- a/code/modules/integrated_electronics/subtypes/input.dm
+++ b/code/modules/integrated_electronics/subtypes/input.dm
@@ -1144,8 +1144,8 @@
 /obj/item/integrated_circuit/input/data_card_reader
 	name = "data card reader"
 	desc = "A circuit that can read from and write to data cards."
-	extended_desc = "Setting the \"write mode\" boolean to true will cause any data cards that are used on the assembly to replace\
- their existing function and data strings with the given strings, if it is set to false then using a data card on the assembly will cause\
+	extended_desc = "Setting the \"write mode\" boolean to true will cause any data cards that are used on the assembly to replace \
+ their existing function and data strings with the given strings, if it is set to false then using a data card on the assembly will cause \
  the function and data strings stored on the card to be written to the output pins."
 	icon_state = "card_reader"
 	complexity = 4


### PR DESCRIPTION
Добавил пробелы в описание интегральной схемы "Data card reader".

<details>
<summary>Чейнджлог</summary>

```yml
🆑HNIW
bugfix: починил описание интегралки Data card reader.
/🆑HNIW
```

</details>


- [x] Pull Request полностью завершен, мне не нужна помощь чтобы его закончить.
- [x] Я внимательно прочитал все свои изменения и багов в них не нашел.
- [ ] Я запускал сервер со своими изменениями локально и все протестировал.
- [x] Я ознакомился c [Guide to Contribute](https://github.com/ChaoticOnyx/OnyxBay/blob/dev/docs/contributing.md).
