### PR TITLE
tweak(borgs): borgs modules now restoring in global pull after going in cryo, changing module or destroying

### DIFF
--- a/code/game/machinery/cryopod.dm
+++ b/code/game/machinery/cryopod.dm
@@ -360,7 +360,7 @@
 /obj/machinery/cryopod/robot/despawn_occupant()
 	var/mob/living/silicon/robot/R = occupant
 	if(!istype(R)) return ..()
-
+	
 	qdel(R.mmi)
 	for(var/obj/item/I in R.module) // the tools the borg has; metal, glass, guns etc
 		for(var/obj/item/O in I) // the things inside the tools, if anything; mainly for janiborg trash bags

--- a/code/modules/mob/living/silicon/robot/robot.dm
+++ b/code/modules/mob/living/silicon/robot/robot.dm
@@ -82,6 +82,7 @@
 	var/viewalerts = 0
 	var/modtype = "Default"
 	var/selected_module
+	var/restore_modtype_in_global_pull = FALSE
 	var/lower_mod = 0
 	var/jetpack = 0
 	var/datum/effect/effect/system/trail/ion/ion_trail = null
@@ -237,9 +238,14 @@
 			mmi = null
 		else
 			QDEL_NULL(mmi)
+
 	if(connected_ai)
 		connected_ai.connected_robots -= src
 	connected_ai = null
+
+	if(restore_modtype_in_global_pull)
+		GLOB.robot_module_types |= modtype
+
 	QDEL_NULL(wires)
 	QDEL_NULL(module)
 	QDEL_NULL(inv1)
@@ -304,6 +310,7 @@
 		to_chat(usr, SPAN("notice", "You have already selected a module."))
 		return
 	modtype = selected_module
+	restore_modtype_in_global_pull = TRUE
 	sensor_mode = 0
 	active_hud = null
 

--- a/code/modules/mob/living/silicon/robot/robot_upgrades.dm
+++ b/code/modules/mob/living/silicon/robot/robot_upgrades.dm
@@ -39,6 +39,9 @@
 /obj/item/borg/upgrade/reset/action(mob/living/silicon/robot/R)
 	if(..()) return 0
 	R.uneq_all()
+	if(R.restore_modtype_in_global_pull)
+		GLOB.robot_module_types |= R.modtype
+		R.restore_modtype_in_global_pull = FALSE
 	R.modtype = initial(R.modtype)
 	R.hands.icon_state = initial(R.hands.icon_state)
 
@@ -72,6 +75,9 @@
 			if (R.shown_robot_modules)
 				R.shown_robot_modules = !R.shown_robot_modules
 				R.hud_used.update_robot_modules_display()
+			if(R.restore_modtype_in_global_pull)
+				GLOB.robot_module_types |= R.modtype
+				R.restore_modtype_in_global_pull = FALSE
 			R.module.Reset(R)
 			qdel(R.module)
 			R.module = null


### PR DESCRIPTION
Теперь доступные для выбора модули освобождаются, если оригинальный носитель уходит в крио, меняет модуль в робототехнике или лопается.

<details>
<summary>Чейнджлог</summary>

```yml
🆑
tweak: Доступные для выбора модули боргов теперь освобождаются, если оригинальный носитель уходит в крио, меняет модуль в робототехнике или уничтожается.
/🆑
```

</details>

- [x] Pull Request полностью завершен, мне не нужна помощь чтобы его закончить.
- [x] Я внимательно прочитал все свои изменения и багов в них не нашел.
- [x] Я запускал сервер со своими изменениями локально и все протестировал.
- [x] Я ознакомился c [Guide to Contribute](https://github.com/ChaoticOnyx/OnyxBay/blob/dev/docs/contributing.md).
