### PR TITLE
fix(cargo): change mining satchel slot

### DIFF
--- a/code/datums/outfits/jobs/cargo.dm
+++ b/code/datums/outfits/jobs/cargo.dm
@@ -23,7 +23,9 @@
 	uniform = /obj/item/clothing/under/rank/miner
 	id_type = /obj/item/card/id/cargo/mining
 	pda_type = /obj/item/device/pda/shaftminer
-	backpack_contents = list(/obj/item/crowbar = 1, /obj/item/storage/ore = 1)
+	pda_slot = slot_l_store
+	backpack_contents = list(/obj/item/crowbar = 1)
+	belt = /obj/item/storage/ore
 	flags = OUTFIT_HAS_BACKPACK|OUTFIT_EXTENDED_SURVIVAL
 
 /decl/hierarchy/outfit/job/cargo/mining/New()


### PR DESCRIPTION
Сумки шахтёров больше не теряются на шаттле и спавнятся у них на поясе.

fix #6268

<details>
<summary>Чейнджлог</summary>

```yml
🆑FloweY
bugfix: Шахтёрские сумки больше не теряются на шаттле после спавна.
/🆑
```

</details>

- [x] Pull Request полностью завершен, мне не нужна помощь чтобы его закончить.
- [x] Я внимательно прочитал все свои изменения и багов в них не нашел.
- [x] Я запускал сервер со своими изменениями локально и все протестировал.
- [x] Я ознакомился c [Guide to Contribute](https://github.com/ChaoticOnyx/OnyxBay/blob/dev/docs/contributing.md).