### PR TITLE
fix(painkillers): clamps effectiveness multiplier between 0 and 1

### DIFF
--- a/code/modules/reagents/Chemistry-Reagents/painkillers.dm
+++ b/code/modules/reagents/Chemistry-Reagents/painkillers.dm
@@ -35,7 +35,7 @@
 	if(affecting_dose < effective_dose) //some ease-in ease-out for the effect
 		effectiveness = (affecting_dose / effective_dose) * effectiveness
 	if(M.chem_traces[type] > tolerance_threshold)
-		effectiveness *= 1.0 - ((M.chem_traces[type] - tolerance_threshold) * tolerance_mult)
+		effectiveness *= clamp(1.0 - ((M.chem_traces[type] - tolerance_threshold) * tolerance_mult), 0, 1)
 	M.add_chemical_effect(CE_PAINKILLER, pain_power * effectiveness)
 
 /datum/reagent/painkiller/proc/handle_painkiller_overdose(mob/living/carbon/M, affecting_dose)


### PR DESCRIPTION
Фиксит возможность множителя уходить в негативные значения, оставляя пользователя в вечном пейнкрите до тех пор, пока не выйдет весь трамадол или же не остановится сердце.

<details>
<summary>Чейнджлог</summary>

```yml
🆑
bugfix: Трамадол выше толерантности больше не оставляет в пейнкрите.
/🆑
```

</details>

- [x] Pull Request полностью завершен, мне не нужна помощь чтобы его закончить.
- [x] Я внимательно прочитал все свои изменения и багов в них не нашел.
- [ ] Я запускал сервер со своими изменениями локально и все протестировал.
- [x] Я ознакомился c [Guide to Contribute](https://github.com/ChaoticOnyx/OnyxBay/blob/dev/docs/contributing.md).
