### PR TITLE
fix(mine_items): correct inhand drill icon name

### DIFF
--- a/code/modules/mining/mine_items.dm
+++ b/code/modules/mining/mine_items.dm
@@ -58,6 +58,7 @@
 /obj/item/pickaxe/drill
 	name = "mining drill" //Can dig sand as well!
 	icon_state = "handdrill"
+	item_state = "jackhammer"
 	desc = "The most basic of mining drills, for short excavations and small mineral extractions."
 	power = 100 //It will remove the rock in one go, but SLOWLY
 	drill_verb = "drilling"


### PR DESCRIPTION
_Думаю, можно упустить CL._ Указал правильное название для иконки дрели в руках персонажа. Сервер не запускал, но должно нормально работать.

<details>
<summary>Чейнджлог</summary>

```yml
🆑
bugfix: исправлено отображение дрели на персонажах.
/🆑
```

</details>

fix #10036

- [x] Pull Request полностью завершен, мне не нужна помощь чтобы его закончить.
- [x] Я внимательно прочитал все свои изменения и багов в них не нашел.
- [ ] Я запускал сервер со своими изменениями локально и все протестировал.
- [x] Я ознакомился c [Guide to Contribute](https://github.com/ChaoticOnyx/OnyxBay/blob/dev/docs/contributing.md).
