### PR TITLE
Экстренный фикс H/E труб.

### DIFF
--- a/code/modules/atmospherics/he_pipes.dm
+++ b/code/modules/atmospherics/he_pipes.dm
@@ -25,6 +25,7 @@
 	..()
 	initialize_directions_he = initialize_directions	// The auto-detection from /pipe is good enough for a simple HE pipe
 	color = "#404040" //we don't make use of the fancy overlay system for colours, use this to set the default.
+	START_PROCESSING(SSmachines, src)
 
 /obj/machinery/atmospherics/pipe/simple/heat_exchanging/atmos_init()
 	..()


### PR DESCRIPTION
У ЕОСовцев сломалась карта из-за сломанного процессинга труб. Временный фикс, в дальнейшем привяжите это к atmos_init() у pipe_network.

Bob.

<details>
<summary>Чейнджлог</summary>

```yml
🆑
bugfix: Heat Exchanger pipes no longer abide by network processing rules.
/🆑
```

</details>


- [x] Pull Request полностью завершен, мне не нужна помощь чтобы его закончить.
- [x] Я внимательно прочитал все свои изменения и багов в них не нашел.
- [x] Я запускал сервер со своими изменениями локально и все протестировал.
- [x] Я ознакомился c [Guide to Contribute](https://github.com/ChaoticOnyx/OnyxBay/blob/dev/docs/contributing.md).
