### PR TITLE
tweak(mobs): adds ghost notifications for new larva and mimics

### DIFF
--- a/code/datums/events/mimics_invasion.dm
+++ b/code/datums/events/mimics_invasion.dm
@@ -44,7 +44,7 @@
 		if(spawned < PLAYABLE_MIMICS)
 			M.controllable = TRUE
 			GLOB.available_mobs_for_possess += M
-			notify_ghosts("A new mimic available", null, M, posses_mob = TRUE)
+			notify_ghosts("A new mimic available", null, M, action = NOTIFY_FOLLOW, posses_mob = TRUE)
 		else
 			M.controllable = FALSE
 

--- a/code/modules/mob/living/carbon/alien/larva/larva.dm
+++ b/code/modules/mob/living/carbon/alien/larva/larva.dm
@@ -65,9 +65,7 @@
 		GLOB.xenomorphs.add_antagonist(mind, 1)
 
 /mob/living/carbon/alien/larva/proc/larva_announce_to_ghosts()
-	for(var/mob/observer/ghost/O in GLOB.ghost_mob_list)
-		if(O.client && !jobban_isbanned(O, MODE_XENOMORPH))
-			to_chat(O, SPAN("notice", "A new alien larva has been born! ([ghost_follow_link(src, O)]) (<a href='byond://?src=\ref[src];occupy=1'>OCCUPY</a>)"))
+	notify_ghosts("A new alien larva has been born!(<a href='byond://?src=\ref[src];occupy=1'>Occupy</a>)", source = src, action = NOTIFY_FOLLOW)
 
 /mob/living/carbon/alien/larva/update_living_sight()
 	..()


### PR DESCRIPTION
Теперь при появлении новой лярвы появляются красивые иконки в правом верхнем углу, и если окно с игрой свернуто, то оно начинает подсвечиваться и мигать. 
А на мимиков наконец-то теперь можно будет предварительно зафоловиться, чтобы вообще понять, где они находятся.

<details>
<summary>Чейнджлог</summary>

```yml
🆑
tweak: Появление новой лярвы теперь сопровождается уведомляющей иконкой, а если окно с игрой свернуто, то оно начинает подсвечиваться и мигать, как это происходит с мимиками .
tweak: Теперь появившихся мимиков можно предварительно зафоловить, чтобы оценить, где они находятся.
/🆑
```

</details>

- [x] Pull Request полностью завершен, мне не нужна помощь чтобы его закончить.
- [x] Я внимательно прочитал все свои изменения и багов в них не нашел.
- [x] Я запускал сервер со своими изменениями локально и все протестировал.
- [x] Я ознакомился c [Guide to Contribute](https://github.com/ChaoticOnyx/OnyxBay/blob/dev/docs/contributing.md).
