### PR TITLE
fix(airlock): correct item dropped during brace installation

### DIFF
--- a/code/game/machinery/doors/airlock.dm
+++ b/code/game/machinery/doors/airlock.dm
@@ -606,17 +606,17 @@ About the new airlock wires panel:
 		return brace.attackby(C, user)
 
 	if(!brace && istype(C, /obj/item/airlock_brace))
-		var/obj/item/airlock_brace/A = C
+		var/obj/item/airlock_brace/B = C
 		if(!density)
-			to_chat(user, "You must close \the [src] before installing \the [A]!")
+			to_chat(user, "You must close \the [src] before installing \the [B]!")
 			return
 
-		if((!A.req_access.len && !A.req_one_access) && (alert("\the [A]'s 'Access Not Set' light is flashing. Install it anyway?", "Access not set", "Yes", "No") == "No"))
+		if((!B.req_access.len && !B.req_one_access) && (alert("\the [B]'s 'Access Not Set' light is flashing. Install it anyway?", "Access not set", "Yes", "No") == "No"))
 			return
 
-		if(do_after(user, 50, src) && density && user.drop(brace, src))
-			to_chat(user, "You successfully install \the [A]. \The [src] has been locked.")
-			brace = A
+		if(do_after(user, 50, src) && density && user.drop(B, src))
+			to_chat(user, "You successfully install \the [B]. \The [src] has been locked.")
+			brace = B
 			brace.airlock = src
 			update_icon()
 		return


### PR DESCRIPTION
TobyHorny все сломал. Бонусом заменил название переменной с `A` на `B`, ибо объект в сокращении `brace`, а не `airlock`.

<details>
<summary>Чейнджлог</summary>

```yml
🆑
bugfix: скобы снова вешаются на шлюзы.
/🆑
```

</details>

fix #9874

- [x] Pull Request полностью завершен, мне не нужна помощь чтобы его закончить.
- [x] Я внимательно прочитал все свои изменения и багов в них не нашел.
- [x] Я запускал сервер со своими изменениями локально и все протестировал.
- [x] Я ознакомился c [Guide to Contribute](https://github.com/ChaoticOnyx/OnyxBay/blob/dev/docs/contributing.md).
