### PR TITLE
fix(constructable_frame): replace wrong macro

### DIFF
--- a/code/game/machinery/constructable_frame.dm
+++ b/code/game/machinery/constructable_frame.dm
@@ -124,12 +124,11 @@
 	else
 		to_chat(user, SPAN("notice", "You remove \the [circuit] and other components."))
 		for(var/obj/item/I in components)
-			I.forceMove(src.loc)
-	circuit.forceMove(src.loc)
+			I.forceMove(get_turf(src))
+	circuit.forceMove(get_turf(src))
 	circuit = null
-	UNSETEMPTY(req_components)
-	UNSETEMPTY(req_components)
-	UNSETEMPTY(components)
+	LAZYCLEARLIST(req_components)
+	LAZYCLEARLIST(components)
 	state = STAGE_CIRCUIT
 	update_desc()
 	update_icon()


### PR DESCRIPTION
Заменил макрос с `UNSETEMPTY` на `LAZYCLEARLIST`, вместо уродливого `src.loc` использовал `get_turf(src)`. Из-за неправильно выбранного макроса список `components` не очищался.

<details>
<summary>Чейнджлог</summary>

```yml
🆑
bugfix: исправлен баг с "наложением" компонентов при сборке машинерии.
/🆑
```

</details>

fix #9732
fix #9934

- [x] Pull Request полностью завершен, мне не нужна помощь чтобы его закончить.
- [x] Я внимательно прочитал все свои изменения и багов в них не нашел.
- [x] Я запускал сервер со своими изменениями локально и все протестировал.
- [x] Я ознакомился c [Guide to Contribute](https://github.com/ChaoticOnyx/OnyxBay/blob/dev/docs/contributing.md).
