### PR TITLE
fix(mimic) No more unavailable for possessing mimics in GLOB.available_mobs_for_possess list

### DIFF
--- a/code/datums/events/mimics_invasion.dm
+++ b/code/datums/events/mimics_invasion.dm
@@ -43,6 +43,7 @@
 
 		if(spawned < PLAYABLE_MIMICS)
 			M.controllable = TRUE
+			GLOB.available_mobs_for_possess += M
 			notify_ghosts("A new mimic available", null, M, posses_mob = TRUE)
 		else
 			M.controllable = FALSE

--- a/code/modules/mob/living/deity/phenomena/transmutation.dm
+++ b/code/modules/mob/living/deity/phenomena/transmutation.dm
@@ -12,8 +12,10 @@
 /datum/phenomena/animate/activate(atom/a)
 	..()
 	a.visible_message("\The [a] begins to shift and twist...")
-	var/mob/living/simple_animal/hostile/mimic/mimic = new(get_turf(a), a)
+	var/mob/living/simple_animal/hostile/mimic/mimic = new(get_turf(a), a, make_controllable = TRUE)
+	log_and_message_admins("A mimic has spawned", null, get_turf(a), mimic)
 	mimic.faction = linked.form.faction
+	notify_ghosts("A new mimic available", null, mimic, posses_mob = TRUE)
 
 /datum/phenomena/warp
 	name = "Warp Body"

--- a/code/modules/mob/living/simple_animal/hostile/mimic.dm
+++ b/code/modules/mob/living/simple_animal/hostile/mimic.dm
@@ -38,8 +38,6 @@ var/global/list/protected_objects = list(
 	faction = "mimic"
 	move_to_delay = 8
 
-	controllable = TRUE
-
 	var/obj/copy_of
 	var/weakref/creator // the creator
 	var/destroy_objects = FALSE
@@ -52,7 +50,7 @@ var/global/list/protected_objects = list(
 	var/_in_trap_mode = FALSE
 	var/obj/item/mimic_trap/trap
 
-/mob/living/simple_animal/hostile/mimic/New(newloc, obj/o, mob/living/creator)
+/mob/living/simple_animal/hostile/mimic/New(newloc, obj/o, mob/living/creator, make_controllable = FALSE)
 	..()
 
 	o = o || default_appearance
@@ -74,6 +72,10 @@ var/global/list/protected_objects = list(
 	mimicry(o)
 
 	health = maxHealth
+	if(make_controllable)
+		controllable = TRUE
+		GLOB.available_mobs_for_possess += src
+
 	register_signal(src, SIGNAL_MOVED, .proc/_on_moved)
 
 /mob/living/simple_animal/hostile/mimic/proc/_on_moved()

--- a/code/modules/projectiles/projectile/animate.dm
+++ b/code/modules/projectiles/projectile/animate.dm
@@ -9,5 +9,5 @@
 /obj/item/projectile/animate/Bump(atom/change, forced = FALSE)
 	if((istype(change, /obj/item) || istype(change, /obj/structure)) && !is_type_in_list(change, protected_objects))
 		var/obj/O = change
-		new /mob/living/simple_animal/hostile/mimic/(O.loc, O, firer)
+		new /mob/living/simple_animal/hostile/mimic/(O.loc, O, firer, TRUE)
 	..()


### PR DESCRIPTION
В списке Ghost-Possess больше не будут появляться мимики, недоступные для игры.

<details>
<summary>Чейнджлог</summary>

```yml
🆑
bugfix: В списке Ghost-Possess больше не будут появляться недоступные для игры мимики.
/🆑
```

</details>

- [x] Pull Request полностью завершен, мне не нужна помощь чтобы его закончить.
- [x] Я внимательно прочитал все свои изменения и багов в них не нашел.
- [x] Я запускал сервер со своими изменениями локально и все протестировал.
- [x] Я ознакомился c [Guide to Contribute](https://github.com/ChaoticOnyx/OnyxBay/blob/dev/docs/contributing.md).
