### PR TITLE
tweak(spontaneous_appendicitis): add extra antag and crew checks

### DIFF
--- a/code/datums/events/spontaneous_appendicitis.dm
+++ b/code/datums/events/spontaneous_appendicitis.dm
@@ -7,7 +7,7 @@
 	difficulty = 25
 
 /datum/event/spontaneous_appendicitis/check_conditions()
-	. = SSevents.triggers.living_players_count >= 5 && SSevents.triggers.roles_count["Medical"]
+	. = SSevents.triggers.living_players_count >= 5 && SSevents.triggers.roles_count["Medical"] >= 2
 
 /datum/event/spontaneous_appendicitis/get_mtth()
 	. = ..()

--- a/code/datums/events/spontaneous_appendicitis.dm
+++ b/code/datums/events/spontaneous_appendicitis.dm
@@ -17,7 +17,7 @@
 /datum/event/spontaneous_appendicitis/on_fire()
 	var/list/candidates
 	for(var/mob/living/carbon/human/C in GLOB.player_list)
-		if(C.client && C.stat != DEAD && (C?.mind?.changeling || C?.mind?.vampire))
+		if(C.client && C.stat != DEAD && !(C?.mind?.changeling || C?.mind?.vampire))
 			LAZYADD(candidates, C)
 
 	if(!length(candidates))

--- a/code/datums/events/spontaneous_appendicitis.dm
+++ b/code/datums/events/spontaneous_appendicitis.dm
@@ -6,6 +6,9 @@
 	mtth = 3 HOURS
 	difficulty = 25
 
+/datum/event/spontaneous_appendicitis/check_conditions()
+	. = SSevents.triggers.living_players_count >= 5 && SSevents.triggers.roles_count["Medical"]
+
 /datum/event/spontaneous_appendicitis/get_mtth()
 	. = ..()
 	. -= (SSevents.triggers.roles_count["Medical"] * (18 MINUTES))

--- a/code/datums/events/spontaneous_appendicitis.dm
+++ b/code/datums/events/spontaneous_appendicitis.dm
@@ -15,11 +15,18 @@
 	. = max(1 HOUR, .)
 
 /datum/event/spontaneous_appendicitis/on_fire()
-	for(var/mob/living/carbon/human/H in shuffle(GLOB.living_mob_list_))
-		if(H.client && H.stat != DEAD)
-			var/obj/item/organ/internal/appendix/A = H.internal_organs_by_name[BP_APPENDIX]
-			if(!istype(A) || A?.inflamed)
-				continue
-			A.inflamed = TRUE
-			A.update_icon()
-			break
+	var/list/candidates
+	for(var/mob/living/carbon/human/C in GLOB.player_list)
+		if(C.client && C.stat != DEAD && (C?.mind?.changeling || C?.mind?.vampire))
+			LAZYADD(candidates, C)
+
+	if(!length(candidates))
+		return
+
+	for(var/mob/living/carbon/human/H in shuffle(candidates))
+		var/obj/item/organ/internal/appendix/A = H.internal_organs_by_name[BP_APPENDIX]
+		if(!istype(A) || A?.inflamed)
+			continue
+		A.inflamed = TRUE
+		A.update_icon()
+		break


### PR DESCRIPTION
Прошу простить за двойной ПР. ~~Требуется помощь геймдизайна.~~

<details>
<summary>Чейнджлог</summary>

```yml
🆑
tweak: у вампиров и генокрадов больше не может воспалиться аппендикс.
balance: при онлайне ниже 5 игроков и отсутствии медиков событие с воспалением аппендикса не выпадает.
/🆑
```

</details>

<details>
<summary>Вопросы к геймдизайнерам</summary>

```
1. Устраивают ли вас текущие проверки на антагонистов?
1.1 Если нет, то кого нужно добавить/убрать?
2. Устраивают ли вас ограничение по онлайну и медикам?
2.1 Если да, то:
2.1.1 Сколько минимально медиков должно быть на смене?
2.1.1 Сколько минимально игроков должно быть на смене?
2.2 Если нет, то что требуется изменить?
```

</details>

resolve #9602
resolve #10086

- [x] Pull Request полностью завершен, мне не нужна помощь чтобы его закончить.
- [x] Я внимательно прочитал все свои изменения и багов в них не нашел.
- [x] Я запускал сервер со своими изменениями локально и все протестировал.
- [x] Я ознакомился c [Guide to Contribute](https://github.com/ChaoticOnyx/OnyxBay/blob/dev/docs/contributing.md).
