### PR TITLE
Refact(log message())

### DIFF
--- a/code/_onclick/other_mobs.dm
+++ b/code/_onclick/other_mobs.dm
@@ -160,7 +160,7 @@
 		return
 	if(istype(A,/mob/living))
 		if(melee_damage_upper == 0)
-			custom_emote(1,"[friendly] [A]!")
+			custom_emote(VISIBLE_MESSAGE,"[friendly] [A]!", "AUTO_EMOTE")
 			return
 		if(ckey)
 			admin_attack_log(src, A, "Has [attacktext] its victim.", "Has been [attacktext] by its attacker.", attacktext)

--- a/code/_onclick/other_mobs.dm
+++ b/code/_onclick/other_mobs.dm
@@ -160,7 +160,7 @@
 		return
 	if(istype(A,/mob/living))
 		if(melee_damage_upper == 0)
-			custom_emote(VISIBLE_MESSAGE,"[friendly] [A]!", "AUTO_EMOTE")
+			visible_emote("[friendly] [A]!")
 			return
 		if(ckey)
 			admin_attack_log(src, A, "Has [attacktext] its victim.", "Has been [attacktext] by its attacker.", attacktext)

--- a/code/datums/elements/last_words.dm
+++ b/code/datums/elements/last_words.dm
@@ -31,7 +31,9 @@ GLOBAL_LIST_EMPTY(last_words)
 
 	for(last; last > 0; last--)
 		var/entry = L.logging[INDIVIDUAL_SAY_LOG][last]
-		if(L.logging[INDIVIDUAL_SAY_LOG][entry]["tag"] == "AUTO_EMOTE")
+		var/tag = L.logging[INDIVIDUAL_SAY_LOG][entry]["tag"]
+		
+		if(tag == "\[AUTO_EMOTE\]")
 			continue
 
 		var/datum/last_words_data/data = new()

--- a/code/datums/elements/last_words.dm
+++ b/code/datums/elements/last_words.dm
@@ -27,19 +27,21 @@ GLOBAL_LIST_EMPTY(last_words)
 		detach(L)
 		return
 
-	var/index = 0
-	for(var/entry in L.logging[INDIVIDUAL_SAY_LOG])
-		index += 1
+	var/last = length(L.logging[INDIVIDUAL_SAY_LOG])
 
-		if(index == length(L.logging[INDIVIDUAL_SAY_LOG]))
-			var/datum/last_words_data/data = new()
+	for(last; last > 0; last--)
+		var/entry = L.logging[INDIVIDUAL_SAY_LOG][last]
+		if(L.logging[INDIVIDUAL_SAY_LOG][entry]["tag"] == "AUTO_EMOTE")
+			continue
 
-			data.words = L.logging[INDIVIDUAL_SAY_LOG][entry]
-			data.time_of_death = L.timeofdeath
-			data.real_name = L.real_name || L.name
-			data.job_title = L.job || "Unemployed"
+		var/datum/last_words_data/data = new()
 
-			GLOB.last_words += data
-			break
+		data.words = L.logging[INDIVIDUAL_SAY_LOG][entry]["message"]
+		data.time_of_death = L.timeofdeath
+		data.real_name = L.real_name || L.name
+		data.job_title = L.job || "Unemployed"
+
+		GLOB.last_words += data
+		break
 
 	detach(L)

--- a/code/game/gamemodes/changeling/helpcode/mobs.dm
+++ b/code/game/gamemodes/changeling/helpcode/mobs.dm
@@ -320,7 +320,7 @@
 /mob/living/simple_animal/hostile/little_changeling/find_target()
 	. = ..()
 	if(.)
-		custom_emote(1, "nashes at [.]")
+		custom_emote(VISIBLE_MESSAGE, "nashes at [.]", "AUTO_EMOTE")
 
 
 /mob/living/simple_animal/hostile/little_changeling/AttackingTarget()

--- a/code/game/gamemodes/changeling/helpcode/mobs.dm
+++ b/code/game/gamemodes/changeling/helpcode/mobs.dm
@@ -204,7 +204,7 @@
 	change_ctate(/datum/click_handler/changeling/infest)
 
 
-/mob/living/simple_animal/hostile/little_changeling/proc/infest(mob/living/carbon/human/target as mob in oview(1))
+/mob/living/simple_animal/hostile/little_changeling/proc/infest(mob/living/carbon/human/target in oview(1))
 	var/datum/changeling/changeling = src.mind.changeling
 	if(!changeling)
 		return

--- a/code/game/gamemodes/changeling/helpcode/mobs.dm
+++ b/code/game/gamemodes/changeling/helpcode/mobs.dm
@@ -320,7 +320,7 @@
 /mob/living/simple_animal/hostile/little_changeling/find_target()
 	. = ..()
 	if(.)
-		custom_emote(VISIBLE_MESSAGE, "nashes at [.]", "AUTO_EMOTE")
+		visible_emote("nashes at [.].")
 
 
 /mob/living/simple_animal/hostile/little_changeling/AttackingTarget()

--- a/code/modules/admin/bluespace_tech.dm
+++ b/code/modules/admin/bluespace_tech.dm
@@ -114,7 +114,7 @@
 /mob/living/carbon/human/bluespace_tech/proc/suicide()
 	if(QDELETED(src))
 		return
-	custom_emote(VISIBLE_MESSAGE, "presses a button on their suit, followed by a polite bow.")
+	custom_emote(VISIBLE_MESSAGE, "presses a button on their suit, followed by a polite bow.", "AUTO_EMOTE")
 	var/datum/effect/effect/system/spark_spread/s = new /datum/effect/effect/system/spark_spread
 	s.set_up(5, 1, src)
 	s.start()

--- a/code/modules/admin/verbs/individual_logging.dm
+++ b/code/modules/admin/verbs/individual_logging.dm
@@ -12,12 +12,12 @@
 		for(var/log_type in M.logging)
 			dat += "<center>[log_type]</center><br>"
 			for(var/entry in M.logging[log_type])
-				dat += "<font size=2px>[entry]: [M.logging[log_type][entry]]</font><br>"
+				dat += "<font size=2px>[entry]: [M.logging[log_type][entry]["message"]]</font><br>"
 			dat += "<hr>"
 	else
 		dat += "<center>[type] of [key_name(M)]</center><br>"
 		for(var/entry in M.logging[type])
-			dat += "<font size=2px>[entry]: [M.logging[type][entry]]</font><hr>"
+			dat += "<font size=2px>[entry]: [M.logging[type][entry]["message"]]</font><hr>"
 
 	var/datum/browser/popup = new(user, "individual_logging_panel", "Individual logging panel", 600, 480)
 	popup.set_content(dat)

--- a/code/modules/emotes/emote_mob.dm
+++ b/code/modules/emotes/emote_mob.dm
@@ -110,7 +110,7 @@
 
 	return pretext + nametext + subtext
 
-/mob/proc/custom_emote(m_type = VISIBLE_MESSAGE, message = null)
+/mob/proc/custom_emote(m_type = VISIBLE_MESSAGE, message = null, tag = "EMOTE")
 
 	if((usr && stat) || (!use_me && usr == src))
 		to_chat(src, "You are unable to emote.")
@@ -129,7 +129,7 @@
 
 	if (message)
 		log_emote("[key_name(src)]: [message]")
-		log_message(input, INDIVIDUAL_SAY_LOG, "\[EMOTE\]")
+		log_message(input, INDIVIDUAL_SAY_LOG, "\[[tag]\]")
 
 	//do not show NPC animal emotes to ghosts, it turns into hellscape
 	var/check_ghosts = client ? /datum/client_preference/ghost_sight : null

--- a/code/modules/mob/living/bot/floorbot.dm
+++ b/code/modules/mob/living/bot/floorbot.dm
@@ -217,7 +217,7 @@
 
 /* Assembly */
 
-/obj/item/storage/toolbox/mechanical/attackby(obj/item/stack/tile/floor/T, mob/user as mob)
+/obj/item/storage/toolbox/mechanical/attackby(obj/item/stack/tile/floor/T, mob/user)
 	if(!istype(T, /obj/item/stack/tile/floor))
 		..()
 		return

--- a/code/modules/mob/living/bot/floorbot.dm
+++ b/code/modules/mob/living/bot/floorbot.dm
@@ -81,7 +81,7 @@
 		addTiles(1)
 
 	if(prob(1))
-		audible_message("<B>[src]</B> makes an excited booping beeping sound!")
+		audible_emote("makes an excited booping beeping sound!")
 
 /mob/living/bot/floorbot/handleAdjacentTarget()
 	if(get_turf(target) == src.loc)

--- a/code/modules/mob/living/bot/floorbot.dm
+++ b/code/modules/mob/living/bot/floorbot.dm
@@ -81,7 +81,7 @@
 		addTiles(1)
 
 	if(prob(1))
-		custom_emote(2, "makes an excited booping beeping sound!")
+		custom_emote(AUDIBLE_MESSAGE, "makes an excited booping beeping sound!", "AUTO_EMOTE")
 
 /mob/living/bot/floorbot/handleAdjacentTarget()
 	if(get_turf(target) == src.loc)

--- a/code/modules/mob/living/bot/floorbot.dm
+++ b/code/modules/mob/living/bot/floorbot.dm
@@ -81,7 +81,7 @@
 		addTiles(1)
 
 	if(prob(1))
-		custom_emote(AUDIBLE_MESSAGE, "makes an excited booping beeping sound!", "AUTO_EMOTE")
+		audible_message("<B>[src]</B> makes an excited booping beeping sound!")
 
 /mob/living/bot/floorbot/handleAdjacentTarget()
 	if(get_turf(target) == src.loc)

--- a/code/modules/mob/living/bot/medbot.dm
+++ b/code/modules/mob/living/bot/medbot.dm
@@ -282,7 +282,7 @@
 
 /* Construction */
 
-/obj/item/storage/firstaid/attackby(obj/item/robot_parts/S, mob/user as mob)
+/obj/item/storage/firstaid/attackby(obj/item/robot_parts/S, mob/user)
 	if ((!istype(S, /obj/item/robot_parts/l_arm)) && (!istype(S, /obj/item/robot_parts/r_arm)))
 		..()
 		return

--- a/code/modules/mob/living/bot/medbot.dm
+++ b/code/modules/mob/living/bot/medbot.dm
@@ -47,7 +47,7 @@
 				var/message = pick(messagevoice)
 				say(message)
 				playsound(src, messagevoice[message], 75, FALSE)
-				visible_message("<B>[src]</B> points at [H.name].")
+				visible_emote("points at [H.name].")
 			break
 
 /mob/living/bot/medbot/UnarmedAttack(mob/living/carbon/human/H, proximity)

--- a/code/modules/mob/living/bot/medbot.dm
+++ b/code/modules/mob/living/bot/medbot.dm
@@ -47,7 +47,7 @@
 				var/message = pick(messagevoice)
 				say(message)
 				playsound(src, messagevoice[message], 75, FALSE)
-				custom_emote(1, "points at [H.name].")
+				custom_emote(VISIBLE_MESSAGE, "points at [H.name].", "AUTO_EMOTE")
 			break
 
 /mob/living/bot/medbot/UnarmedAttack(mob/living/carbon/human/H, proximity)

--- a/code/modules/mob/living/bot/medbot.dm
+++ b/code/modules/mob/living/bot/medbot.dm
@@ -47,7 +47,7 @@
 				var/message = pick(messagevoice)
 				say(message)
 				playsound(src, messagevoice[message], 75, FALSE)
-				custom_emote(VISIBLE_MESSAGE, "points at [H.name].", "AUTO_EMOTE")
+				visible_message("<B>[src]</B> points at [H.name].")
 			break
 
 /mob/living/bot/medbot/UnarmedAttack(mob/living/carbon/human/H, proximity)

--- a/code/modules/mob/living/bot/mulebot.dm
+++ b/code/modules/mob/living/bot/mulebot.dm
@@ -165,13 +165,13 @@
 	update_icons()
 
 /mob/living/bot/mulebot/handleFrustrated()
-	audible_message("<B>[src]</B> makes a sighing buzz.")
+	audible_emote("makes a sighing buzz.")
 	playsound(loc, 'sound/machines/buzz-sigh.ogg', 50, 0)
 	..()
 
 /mob/living/bot/mulebot/handleAdjacentTarget()
 	if(target == src.loc)
-		audible_message("<B>[src]</B> makes a chiming sound.")
+		audible_emote("makes a chiming sound.")
 		playsound(loc, 'sound/machines/chime.ogg', 50, 0)
 		UnarmedAttack(target)
 		resetTarget()
@@ -261,7 +261,7 @@
 			return
 
 	if(crates_only && !istype(C,/obj/structure/closet/crate))
-		audible_message("<B>[src]</B> makes a sighing buzz.")
+		audible_emote("makes a sighing buzz.")
 		playsound(loc, 'sound/machines/buzz-sigh.ogg', 50, 0)
 		return
 

--- a/code/modules/mob/living/bot/mulebot.dm
+++ b/code/modules/mob/living/bot/mulebot.dm
@@ -165,13 +165,13 @@
 	update_icons()
 
 /mob/living/bot/mulebot/handleFrustrated()
-	custom_emote(2, "makes a sighing buzz.")
+	custom_emote(AUDIBLE_MESSAGE, "makes a sighing buzz.", "AUTO_EMOTE")
 	playsound(loc, 'sound/machines/buzz-sigh.ogg', 50, 0)
 	..()
 
 /mob/living/bot/mulebot/handleAdjacentTarget()
 	if(target == src.loc)
-		custom_emote(2, "makes a chiming sound.")
+		custom_emote(AUDIBLE_MESSAGE, "makes a chiming sound.", "AUTO_EMOTE")
 		playsound(loc, 'sound/machines/chime.ogg', 50, 0)
 		UnarmedAttack(target)
 		resetTarget()
@@ -261,7 +261,7 @@
 			return
 
 	if(crates_only && !istype(C,/obj/structure/closet/crate))
-		custom_emote(2, "makes a sighing buzz.")
+		custom_emote(AUDIBLE_MESSAGE, "makes a sighing buzz.", "AUTO_EMOTE")
 		playsound(loc, 'sound/machines/buzz-sigh.ogg', 50, 0)
 		return
 

--- a/code/modules/mob/living/bot/mulebot.dm
+++ b/code/modules/mob/living/bot/mulebot.dm
@@ -165,13 +165,13 @@
 	update_icons()
 
 /mob/living/bot/mulebot/handleFrustrated()
-	custom_emote(AUDIBLE_MESSAGE, "makes a sighing buzz.", "AUTO_EMOTE")
+	audible_message("<B>[src]</B> makes a sighing buzz.")
 	playsound(loc, 'sound/machines/buzz-sigh.ogg', 50, 0)
 	..()
 
 /mob/living/bot/mulebot/handleAdjacentTarget()
 	if(target == src.loc)
-		custom_emote(AUDIBLE_MESSAGE, "makes a chiming sound.", "AUTO_EMOTE")
+		audible_message("<B>[src]</B> makes a chiming sound.")
 		playsound(loc, 'sound/machines/chime.ogg', 50, 0)
 		UnarmedAttack(target)
 		resetTarget()
@@ -261,7 +261,7 @@
 			return
 
 	if(crates_only && !istype(C,/obj/structure/closet/crate))
-		custom_emote(AUDIBLE_MESSAGE, "makes a sighing buzz.", "AUTO_EMOTE")
+		audible_message("<B>[src]</B> makes a sighing buzz.")
 		playsound(loc, 'sound/machines/buzz-sigh.ogg', 50, 0)
 		return
 

--- a/code/modules/mob/living/bot/secbot.dm
+++ b/code/modules/mob/living/bot/secbot.dm
@@ -254,7 +254,7 @@
 			target = M
 			awaiting_surrender = -1
 			say("Level [threat] infraction alert!")
-			custom_emote(1, "points at [M.name]!")
+			custom_emote(VISIBLE_MESSAGE, "points at [M.name]!", "AUTO_EMOTE")
 			playsound(src.loc, pick(threat_found_sounds), 50)
 			return
 
@@ -454,7 +454,7 @@
 		var/mob/custom_target = input("Which subject is dangerous?", "Nearby subjects:") as null|anything in mobs_in_secbot_range
 		if(check_threat(custom_target) > 0)
 			say("Level [check_threat(custom_target)] infraction alert!")
-			custom_emote(1, "points at [custom_target.name]!")
+			custom_emote(VISIBLE_MESSAGE, "points at [custom_target.name]!", "AUTO_EMOTE")
 			playsound(src.loc, pick(threat_found_sounds), 50)
 		else
 			to_chat(usr,"<span class='warning'>This target is safe.</span>")

--- a/code/modules/mob/living/bot/secbot.dm
+++ b/code/modules/mob/living/bot/secbot.dm
@@ -254,7 +254,7 @@
 			target = M
 			awaiting_surrender = -1
 			say("Level [threat] infraction alert!")
-			visible_message("<B>[src]</B> points at [M.name]!")
+			visible_emote("points at [M.name]!")
 			playsound(src.loc, pick(threat_found_sounds), 50)
 			return
 
@@ -454,7 +454,7 @@
 		var/mob/custom_target = input("Which subject is dangerous?", "Nearby subjects:") as null|anything in mobs_in_secbot_range
 		if(check_threat(custom_target) > 0)
 			say("Level [check_threat(custom_target)] infraction alert!")
-			visible_message("<B>[src]</B> points at [custom_target.name]!")
+			visible_emote("points at [custom_target.name]!")
 			playsound(src.loc, pick(threat_found_sounds), 50)
 		else
 			to_chat(usr,"<span class='warning'>This target is safe.</span>")

--- a/code/modules/mob/living/bot/secbot.dm
+++ b/code/modules/mob/living/bot/secbot.dm
@@ -254,7 +254,7 @@
 			target = M
 			awaiting_surrender = -1
 			say("Level [threat] infraction alert!")
-			custom_emote(VISIBLE_MESSAGE, "points at [M.name]!", "AUTO_EMOTE")
+			visible_message("<B>[src]</B> points at [M.name]!")
 			playsound(src.loc, pick(threat_found_sounds), 50)
 			return
 
@@ -454,7 +454,7 @@
 		var/mob/custom_target = input("Which subject is dangerous?", "Nearby subjects:") as null|anything in mobs_in_secbot_range
 		if(check_threat(custom_target) > 0)
 			say("Level [check_threat(custom_target)] infraction alert!")
-			custom_emote(VISIBLE_MESSAGE, "points at [custom_target.name]!", "AUTO_EMOTE")
+			visible_message("<B>[src]</B> points at [custom_target.name]!")
 			playsound(src.loc, pick(threat_found_sounds), 50)
 		else
 			to_chat(usr,"<span class='warning'>This target is safe.</span>")

--- a/code/modules/mob/living/carbon/human/human.dm
+++ b/code/modules/mob/living/carbon/human/human.dm
@@ -756,7 +756,7 @@
 				Stun(3)
 				var/obj/item/organ/internal/stomach/stomach = internal_organs_by_name[BP_STOMACH]
 				if(nutrition <= STOMACH_FULLNESS_SUPER_LOW || !istype(stomach))
-					custom_emote(1, "dry heaves.")
+					custom_emote(VISIBLE_MESSAGE, "dry heaves.", "AUTO_EMOTE")
 				else
 					for(var/a in stomach_contents)
 						var/atom/movable/A = a

--- a/code/modules/mob/living/carbon/human/human_organs.dm
+++ b/code/modules/mob/living/carbon/human/human_organs.dm
@@ -204,66 +204,66 @@
 	// standing is poor
 	if(!(lying || resting))
 		if(((stance_d_l >= 5) && (stance_d_r >= 5))) // Both legs are missing, but hey at least there's nothing to ache
-			custom_emote(VISIBLE_MESSAGE, "can't stand without legs!")
+			custom_emote(VISIBLE_MESSAGE, "can't stand without legs!", "AUTO_EMOTE", "AUTO_EMOTE")
 			Weaken(10)
 		else if(((stance_d_l >= 5) && (stance_d_r > 2)) || ((stance_d_l > 2) && (stance_d_r >= 5))) // One leg is missing and the other one is at least broken
 			if(limb_pain)
 				emote("scream")
 				shock_stage+=5
-			custom_emote(VISIBLE_MESSAGE, "collapses!")
+			custom_emote(VISIBLE_MESSAGE, "collapses!", "AUTO_EMOTE")
 			Weaken(10)
 		else if(((stance_d_l >= 4) && (stance_d_l > 0)) || ((stance_d_l > 0) && (stance_d_r >= 4))) // One leg is totally wrecked and the other one is hurt
 			if(prob(60))
 				if(limb_pain)
 					emote("scream")
 					shock_stage+=50
-				custom_emote(VISIBLE_MESSAGE, "collapses!")
+				custom_emote(VISIBLE_MESSAGE, "collapses!", "AUTO_EMOTE")
 				Weaken(10)
 		else if((stance_d_l >= 2) && (stance_d_r >= 2)) // Both legs are broken
 			if(prob(40))
 				if(limb_pain)
 					emote("scream")
 					shock_stage+=25
-				custom_emote(VISIBLE_MESSAGE, "collapses!")
+				custom_emote(VISIBLE_MESSAGE, "collapses!", "AUTO_EMOTE")
 				Weaken(10)
 		else if(((stance_d_l >= 2) && (stance_d_r > 0)) || ((stance_d_l > 0) && (stance_d_r >= 2))) // One leg is broken and the other one is hort
 			if(prob(30))
 				if(limb_pain)
 					emote("scream")
 					shock_stage+=15
-				custom_emote(VISIBLE_MESSAGE, "collapses!")
+				custom_emote(VISIBLE_MESSAGE, "collapses!", "AUTO_EMOTE")
 				Weaken(7)
 		else if((stance_d_l > 0) && (stance_d_r > 0)) // Borth legs are hurt
 			if(prob(20))
 				if(limb_pain)
 					emote("scream")
 					shock_stage+=12.5
-				custom_emote(VISIBLE_MESSAGE, "collapses!")
+				custom_emote(VISIBLE_MESSAGE, "collapses!", "AUTO_EMOTE")
 				Weaken(5)
 		else if((stance_d_l >= 5) || (stance_d_r >= 5)) // One leg is missing and the other one is ok
 			if(prob(10))
-				custom_emote(VISIBLE_MESSAGE, "collapses!")
+				custom_emote(VISIBLE_MESSAGE, "collapses!", "AUTO_EMOTE")
 				Weaken(3)
 		else if((stance_d_l >= 4) || (stance_d_r >= 4)) // One leg is wrecked and the other one is ok
 			if(prob(8))
 				if(limb_pain)
 					emote("scream")
 					shock_stage+=12.5
-				custom_emote(VISIBLE_MESSAGE, "collapses!")
+				custom_emote(VISIBLE_MESSAGE, "collapses!", "AUTO_EMOTE")
 				Weaken(5)
 		else if((stance_d_l >= 3) || (stance_d_r >= 3)) // One leg is broken + dislocated and the other one is ok
 			if(prob(4))
 				if(limb_pain)
 					emote("scream")
 					shock_stage+=10
-				custom_emote(VISIBLE_MESSAGE, "collapses!")
+				custom_emote(VISIBLE_MESSAGE, "collapses!", "AUTO_EMOTE")
 				Weaken(5)
 		else if((stance_d_l >= 2) || (stance_d_r >= 2)) // One leg is broken and the other one is ok
 			if(prob(2))
 				if(limb_pain)
 					emote("scream")
 					shock_stage+=5
-				custom_emote(VISIBLE_MESSAGE, "collapses!")
+				custom_emote(VISIBLE_MESSAGE, "collapses!", "AUTO_EMOTE")
 				Weaken(3)
 		else
 			return

--- a/code/modules/mob/living/carbon/human/human_organs.dm
+++ b/code/modules/mob/living/carbon/human/human_organs.dm
@@ -204,7 +204,7 @@
 	// standing is poor
 	if(!(lying || resting))
 		if(((stance_d_l >= 5) && (stance_d_r >= 5))) // Both legs are missing, but hey at least there's nothing to ache
-			custom_emote(VISIBLE_MESSAGE, "can't stand without legs!", "AUTO_EMOTE", "AUTO_EMOTE")
+			custom_emote(VISIBLE_MESSAGE, "can't stand without legs!", "AUTO_EMOTE")
 			Weaken(10)
 		else if(((stance_d_l >= 5) && (stance_d_r > 2)) || ((stance_d_l > 2) && (stance_d_r >= 5))) // One leg is missing and the other one is at least broken
 			if(limb_pain)

--- a/code/modules/mob/living/carbon/human/species/station/monkey.dm
+++ b/code/modules/mob/living/carbon/human/species/station/monkey.dm
@@ -112,7 +112,7 @@
 		H.emote(pick("scratch","jump","roll","tail"))
 
 	if(H.get_shock() && H.shock_stage < 40 && prob(3))
-		H.visible_message("<B>[src]</B> chimpers pitifully.")
+		H.visible_emote("chimpers pitifully.")
 
 	if(H.shock_stage > 10 && prob(3))
 		H.emote(pick("cry","whimper"))
@@ -121,7 +121,7 @@
 		H.emote("scream")
 
 	if(!H.restrained() && H.lying && H.shock_stage >= 60 && prob(3))
-		H.visible_message("<B>[src]</B> thrashes in agony.")
+		H.visible_emote("thrashes in agony.")
 
 /datum/species/monkey/get_random_name()
 	return "[lowertext(name)] ([rand(100,999)])"

--- a/code/modules/mob/living/carbon/human/species/station/monkey.dm
+++ b/code/modules/mob/living/carbon/human/species/station/monkey.dm
@@ -112,7 +112,7 @@
 		H.emote(pick("scratch","jump","roll","tail"))
 
 	if(H.get_shock() && H.shock_stage < 40 && prob(3))
-		H.custom_emote("chimpers pitifully")
+		H.custom_emote(VISIBLE_MESSAGE, "chimpers pitifully", "AUTO_EMOTE")
 
 	if(H.shock_stage > 10 && prob(3))
 		H.emote(pick("cry","whimper"))
@@ -121,7 +121,7 @@
 		H.emote("scream")
 
 	if(!H.restrained() && H.lying && H.shock_stage >= 60 && prob(3))
-		H.custom_emote("thrashes in agony")
+		H.custom_emote(VISIBLE_MESSAGE, "thrashes in agony", "AUTO_EMOTE")
 
 /datum/species/monkey/get_random_name()
 	return "[lowertext(name)] ([rand(100,999)])"

--- a/code/modules/mob/living/carbon/human/species/station/monkey.dm
+++ b/code/modules/mob/living/carbon/human/species/station/monkey.dm
@@ -112,7 +112,7 @@
 		H.emote(pick("scratch","jump","roll","tail"))
 
 	if(H.get_shock() && H.shock_stage < 40 && prob(3))
-		H.custom_emote(VISIBLE_MESSAGE, "chimpers pitifully", "AUTO_EMOTE")
+		H.visible_message("<B>[src]</B> chimpers pitifully.")
 
 	if(H.shock_stage > 10 && prob(3))
 		H.emote(pick("cry","whimper"))
@@ -121,7 +121,7 @@
 		H.emote("scream")
 
 	if(!H.restrained() && H.lying && H.shock_stage >= 60 && prob(3))
-		H.custom_emote(VISIBLE_MESSAGE, "thrashes in agony", "AUTO_EMOTE")
+		H.visible_message("<B>[src]</B> thrashes in agony.")
 
 /datum/species/monkey/get_random_name()
 	return "[lowertext(name)] ([rand(100,999)])"

--- a/code/modules/mob/living/carbon/human/species/station/station.dm
+++ b/code/modules/mob/living/carbon/human/species/station/station.dm
@@ -44,7 +44,7 @@
 		H.emote("scream")
 
 	if(!H.restrained() && H.lying && H.shock_stage >= 60 && prob(3))
-		H.custom_emote("thrashes in agony")
+		H.custom_emote(VISIBLE_MESSAGE, "thrashes in agony", "AUTO_EMOTE")
 
 	if(!H.restrained() && H.shock_stage < 40 && prob(3))
 		var/maxdam = 0
@@ -60,19 +60,19 @@
 		var/datum/gender/T = gender_datums[H.get_gender()]
 		if(damaged_organ)
 			if(damaged_organ.status & ORGAN_BLEEDING)
-				H.custom_emote("clutches [T.his] [damaged_organ.name], trying to stop the blood.")
+				H.custom_emote(VISIBLE_MESSAGE, "clutches [T.his] [damaged_organ.name], trying to stop the blood.", "AUTO_EMOTE")
 			else if(damaged_organ.status & ORGAN_BROKEN)
-				H.custom_emote("holds [T.his] [damaged_organ.name] carefully.")
+				H.custom_emote(VISIBLE_MESSAGE, "holds [T.his] [damaged_organ.name] carefully.", "AUTO_EMOTE")
 			else if(damaged_organ.burn_dam > damaged_organ.brute_dam && damaged_organ.organ_tag != BP_HEAD)
-				H.custom_emote("blows on [T.his] [damaged_organ.name] carefully.")
+				H.custom_emote(VISIBLE_MESSAGE, "blows on [T.his] [damaged_organ.name] carefully.", "AUTO_EMOTE")
 			else
-				H.custom_emote("rubs [T.his] [damaged_organ.name] carefully.")
+				H.custom_emote(VISIBLE_MESSAGE, "rubs [T.his] [damaged_organ.name] carefully.", "AUTO_EMOTE")
 
 		for(var/obj/item/organ/I in H.internal_organs)
 			if((I.status & ORGAN_DEAD) || BP_IS_ROBOTIC(I)) continue
 			if(I.damage > 2) if(prob(2))
 				var/obj/item/organ/external/parent = H.get_organ(I.parent_organ)
-				H.custom_emote("clutches [T.his] [parent.name]!")
+				H.custom_emote(VISIBLE_MESSAGE, "clutches [T.his] [parent.name]!", "AUTO_EMOTE")
 
 /datum/species/human/get_ssd(mob/living/carbon/human/H)
 	if(H.stat == CONSCIOUS)

--- a/code/modules/mob/living/carbon/human/species/station/station.dm
+++ b/code/modules/mob/living/carbon/human/species/station/station.dm
@@ -44,7 +44,7 @@
 		H.emote("scream")
 
 	if(!H.restrained() && H.lying && H.shock_stage >= 60 && prob(3))
-		H.visible_message("<B>[src]</B> thrashes in agony.")
+		H.visible_emote("thrashes in agony.")
 
 	if(!H.restrained() && H.shock_stage < 40 && prob(3))
 		var/maxdam = 0
@@ -60,19 +60,19 @@
 		var/datum/gender/T = gender_datums[H.get_gender()]
 		if(damaged_organ)
 			if(damaged_organ.status & ORGAN_BLEEDING)
-				H.visible_message("<B>[src]</B> clutches [T.his] [damaged_organ.name], trying to stop the blood.")
+				H.visible_emote("clutches [T.his] [damaged_organ.name], trying to stop the blood.")
 			else if(damaged_organ.status & ORGAN_BROKEN)
-				H.visible_message("<B>[src]</B> holds [T.his] [damaged_organ.name] carefully.")
+				H.visible_emote("holds [T.his] [damaged_organ.name] carefully.")
 			else if(damaged_organ.burn_dam > damaged_organ.brute_dam && damaged_organ.organ_tag != BP_HEAD)
-				H.visible_message("<B>[src]</B> blows on [T.his] [damaged_organ.name] carefully.")
+				H.visible_emote("blows on [T.his] [damaged_organ.name] carefully.")
 			else
-				H.visible_message("<B>[src]</B> rubs [T.his] [damaged_organ.name] carefully.")
+				H.visible_emote("rubs [T.his] [damaged_organ.name] carefully.")
 
 		for(var/obj/item/organ/I in H.internal_organs)
 			if((I.status & ORGAN_DEAD) || BP_IS_ROBOTIC(I)) continue
 			if(I.damage > 2) if(prob(2))
 				var/obj/item/organ/external/parent = H.get_organ(I.parent_organ)
-				H.visible_message("<B>[src]</B> clutches [T.his] [parent.name]!")
+				H.visible_emote("clutches [T.his] [parent.name]!")
 
 /datum/species/human/get_ssd(mob/living/carbon/human/H)
 	if(H.stat == CONSCIOUS)

--- a/code/modules/mob/living/carbon/human/species/station/station.dm
+++ b/code/modules/mob/living/carbon/human/species/station/station.dm
@@ -44,7 +44,7 @@
 		H.emote("scream")
 
 	if(!H.restrained() && H.lying && H.shock_stage >= 60 && prob(3))
-		H.custom_emote(VISIBLE_MESSAGE, "thrashes in agony", "AUTO_EMOTE")
+		H.visible_message("<B>[src]</B> thrashes in agony.")
 
 	if(!H.restrained() && H.shock_stage < 40 && prob(3))
 		var/maxdam = 0
@@ -60,19 +60,19 @@
 		var/datum/gender/T = gender_datums[H.get_gender()]
 		if(damaged_organ)
 			if(damaged_organ.status & ORGAN_BLEEDING)
-				H.custom_emote(VISIBLE_MESSAGE, "clutches [T.his] [damaged_organ.name], trying to stop the blood.", "AUTO_EMOTE")
+				H.visible_message("<B>[src]</B> clutches [T.his] [damaged_organ.name], trying to stop the blood.")
 			else if(damaged_organ.status & ORGAN_BROKEN)
-				H.custom_emote(VISIBLE_MESSAGE, "holds [T.his] [damaged_organ.name] carefully.", "AUTO_EMOTE")
+				H.visible_message("<B>[src]</B> holds [T.his] [damaged_organ.name] carefully.")
 			else if(damaged_organ.burn_dam > damaged_organ.brute_dam && damaged_organ.organ_tag != BP_HEAD)
-				H.custom_emote(VISIBLE_MESSAGE, "blows on [T.his] [damaged_organ.name] carefully.", "AUTO_EMOTE")
+				H.visible_message("<B>[src]</B> blows on [T.his] [damaged_organ.name] carefully.")
 			else
-				H.custom_emote(VISIBLE_MESSAGE, "rubs [T.his] [damaged_organ.name] carefully.", "AUTO_EMOTE")
+				H.visible_message("<B>[src]</B> rubs [T.his] [damaged_organ.name] carefully.")
 
 		for(var/obj/item/organ/I in H.internal_organs)
 			if((I.status & ORGAN_DEAD) || BP_IS_ROBOTIC(I)) continue
 			if(I.damage > 2) if(prob(2))
 				var/obj/item/organ/external/parent = H.get_organ(I.parent_organ)
-				H.custom_emote(VISIBLE_MESSAGE, "clutches [T.his] [parent.name]!", "AUTO_EMOTE")
+				H.visible_message("<B>[src]</B> clutches [T.his] [parent.name]!")
 
 /datum/species/human/get_ssd(mob/living/carbon/human/H)
 	if(H.stat == CONSCIOUS)

--- a/code/modules/mob/living/default_language.dm
+++ b/code/modules/mob/living/default_language.dm
@@ -36,3 +36,9 @@
 		to_chat(src, "<span class='notice'>You are currently speaking [default_language] by default.</span>")
 	else
 		to_chat(src, "<span class='notice'>Your current default language is your species or mob type default.</span>")
+
+/mob/living/proc/visible_emote(act_desc)
+	visible_message("<B>[src]</B> [act_desc]")
+
+/mob/living/proc/audible_emote(act_desc)
+	audible_message("<B>[src]</B> [act_desc]")

--- a/code/modules/mob/living/say.dm
+++ b/code/modules/mob/living/say.dm
@@ -282,7 +282,7 @@ var/list/channel_to_radio_key = new
 		var/verb = pick(message_data["language"].signlang_verb)
 
 		if(message_data["language"].flags & NONVERBAL && prob(30))
-			src.custom_emote(1, "[verb].")
+			src.custom_emote(VISIBLE_MESSAGE, "[verb].")
 
 		if(message_data["language"].flags & SIGNLANG)
 			if(message_data["log_message"])

--- a/code/modules/mob/living/simple_animal/friendly/corgi.dm
+++ b/code/modules/mob/living/simple_animal/friendly/corgi.dm
@@ -354,7 +354,7 @@
 
 
 		if(prob(1))
-			visible_emote(pick("dances around","chases her tail"))
+			visible_emote(pick("dances around.","chases her tail."))
 			spawn(0)
 				for(var/i in list(1,2,4,8,4,2,1,2,4,8,4,2,1,2,4,8,4,2))
 					set_dir(i)

--- a/code/modules/mob/living/simple_animal/friendly/parrot.dm
+++ b/code/modules/mob/living/simple_animal/friendly/parrot.dm
@@ -300,7 +300,7 @@
 	return
 
 //Mobs with objects
-/mob/living/simple_animal/parrot/attackby(obj/item/O as obj, mob/user)
+/mob/living/simple_animal/parrot/attackby(obj/item/O, mob/user)
 	..()
 	if(!stat && !client && !istype(O, /obj/item/stack/medical))
 		if(O.force)

--- a/code/modules/mob/living/simple_animal/friendly/parrot.dm
+++ b/code/modules/mob/living/simple_animal/friendly/parrot.dm
@@ -409,7 +409,7 @@
 			//Search for item to steal
 			set_interest(search_for_item())
 			if(parrot_interest)
-				visible_emote("looks in [parrot_interest]'s direction and takes flight")
+				visible_emote("looks in [parrot_interest]'s direction and takes flight.")
 				parrot_state = PARROT_SWOOP | PARROT_STEAL
 				icon_state = "parrot_fly"
 			return
@@ -431,7 +431,7 @@
 			if(AM)
 				if(istype(AM, /obj/item) || isliving(AM))	//If stealable item
 					set_interest(AM)
-					visible_emote("turns and flies towards [parrot_interest]")
+					visible_emote("turns and flies towards [parrot_interest].")
 					parrot_state = PARROT_SWOOP | PARROT_STEAL
 					return
 				else	//Else it's a perch

--- a/code/modules/mob/living/simple_animal/friendly/parrot.dm
+++ b/code/modules/mob/living/simple_animal/friendly/parrot.dm
@@ -300,7 +300,7 @@
 	return
 
 //Mobs with objects
-/mob/living/simple_animal/parrot/attackby(obj/item/O as obj, mob/user as mob)
+/mob/living/simple_animal/parrot/attackby(obj/item/O as obj, mob/user)
 	..()
 	if(!stat && !client && !istype(O, /obj/item/stack/medical))
 		if(O.force)

--- a/code/modules/mob/living/simple_animal/hostile/bear.dm
+++ b/code/modules/mob/living/simple_animal/hostile/bear.dm
@@ -75,7 +75,7 @@
 					if(stance_step in list(1,4,7)) //every 3 ticks
 						var/action = pick( list( "growls at [target_mob]", "stares angrily at [target_mob]", "prepares to attack [target_mob]", "closely watches [target_mob]" ) )
 						if(action)
-							custom_emote(1,action)
+							custom_emote(VISIBLE_MESSAGE, action, "AUTO_EMOTE")
 			if(!found_mob)
 				stance_step--
 
@@ -86,7 +86,7 @@
 
 		if(HOSTILE_STANCE_ATTACKING)
 			if(stance_step >= 20)	//attacks for 20 ticks, then it gets tired and needs to rest
-				custom_emote(1, "is worn out and needs to rest." )
+				custom_emote(VISIBLE_MESSAGE, "is worn out and needs to rest.", "AUTO_EMOTE")
 				stance = HOSTILE_STANCE_TIRED
 				stance_step = 0
 				walk(src, 0) //This stops the bear's walking
@@ -111,7 +111,7 @@
 /mob/living/simple_animal/hostile/bear/find_target()
 	. = ..()
 	if(.)
-		custom_emote(1,"stares alertly at [.]")
+		custom_emote(VISIBLE_MESSAGE,"stares alertly at [.]", "AUTO_EMOTE")
 		stance = HOSTILE_STANCE_ALERT
 
 /mob/living/simple_animal/hostile/bear/LoseTarget()
@@ -120,7 +120,7 @@
 /mob/living/simple_animal/hostile/bear/AttackingTarget()
 	if(!Adjacent(target_mob))
 		return
-	custom_emote(1, pick( list("slashes at [target_mob]", "bites [target_mob]") ) )
+	custom_emote(VISIBLE_MESSAGE, pick( list("slashes at [target_mob]", "bites [target_mob]") ), "AUTO_EMOTE")
 
 	var/damage = rand(20,30)
 
@@ -138,28 +138,3 @@
 		//var/obj/mecha/M = target_mob
 		//M.attack_animal(src)
 		//return M
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-

--- a/code/modules/mob/living/simple_animal/hostile/bear.dm
+++ b/code/modules/mob/living/simple_animal/hostile/bear.dm
@@ -73,9 +73,9 @@
 					src.set_dir(get_dir(src,target_mob))	//Keep staring at the mob
 
 					if(stance_step in list(1,4,7)) //every 3 ticks
-						var/action = pick( list( "growls at [target_mob]", "stares angrily at [target_mob]", "prepares to attack [target_mob]", "closely watches [target_mob]" ) )
+						var/action = pick( list( "growls at [target_mob].", "stares angrily at [target_mob].", "prepares to attack [target_mob].", "closely watches [target_mob]." ) )
 						if(action)
-							custom_emote(VISIBLE_MESSAGE, action, "AUTO_EMOTE")
+							visible_emote(action)
 			if(!found_mob)
 				stance_step--
 
@@ -86,7 +86,7 @@
 
 		if(HOSTILE_STANCE_ATTACKING)
 			if(stance_step >= 20)	//attacks for 20 ticks, then it gets tired and needs to rest
-				custom_emote(VISIBLE_MESSAGE, "is worn out and needs to rest.", "AUTO_EMOTE")
+				visible_emote("is worn out and needs to rest.")
 				stance = HOSTILE_STANCE_TIRED
 				stance_step = 0
 				walk(src, 0) //This stops the bear's walking
@@ -111,7 +111,7 @@
 /mob/living/simple_animal/hostile/bear/find_target()
 	. = ..()
 	if(.)
-		custom_emote(VISIBLE_MESSAGE,"stares alertly at [.]", "AUTO_EMOTE")
+		visible_emote("stares alertly at [.].")
 		stance = HOSTILE_STANCE_ALERT
 
 /mob/living/simple_animal/hostile/bear/LoseTarget()
@@ -120,7 +120,7 @@
 /mob/living/simple_animal/hostile/bear/AttackingTarget()
 	if(!Adjacent(target_mob))
 		return
-	custom_emote(VISIBLE_MESSAGE, pick( list("slashes at [target_mob]", "bites [target_mob]") ), "AUTO_EMOTE")
+	visible_emote( pick(list("slashes at [target_mob].", "bites [target_mob].")) )
 
 	var/damage = rand(20,30)
 

--- a/code/modules/mob/living/simple_animal/hostile/carp.dm
+++ b/code/modules/mob/living/simple_animal/hostile/carp.dm
@@ -39,7 +39,7 @@
 /mob/living/simple_animal/hostile/carp/find_target()
 	. = ..()
 	if(.)
-		custom_emote(1,"nashes at [.]")
+		custom_emote(VISIBLE_MESSAGE,"nashes at [.]", "AUTO_EMOTE")
 
 /mob/living/simple_animal/hostile/carp/AttackingTarget()
 	. =..()

--- a/code/modules/mob/living/simple_animal/hostile/carp.dm
+++ b/code/modules/mob/living/simple_animal/hostile/carp.dm
@@ -39,7 +39,7 @@
 /mob/living/simple_animal/hostile/carp/find_target()
 	. = ..()
 	if(.)
-		custom_emote(VISIBLE_MESSAGE,"nashes at [.]", "AUTO_EMOTE")
+		visible_emote("nashes at [.].")
 
 /mob/living/simple_animal/hostile/carp/AttackingTarget()
 	. =..()

--- a/code/modules/mob/living/simple_animal/hostile/maneater.dm
+++ b/code/modules/mob/living/simple_animal/hostile/maneater.dm
@@ -57,7 +57,7 @@
 	. = ..()
 	if(.)
 		playsound(src, 'sound/voice/MEraaargh.ogg', 70, 1)
-		custom_emote(1, "roars at [.]")
+		custom_emote(VISIBLE_MESSAGE, "roars at [.]", "AUTO_EMOTE")
 
 /mob/living/simple_animal/hostile/maneater/AttackingTarget()
 	. =..()

--- a/code/modules/mob/living/simple_animal/hostile/maneater.dm
+++ b/code/modules/mob/living/simple_animal/hostile/maneater.dm
@@ -57,7 +57,7 @@
 	. = ..()
 	if(.)
 		playsound(src, 'sound/voice/MEraaargh.ogg', 70, 1)
-		custom_emote(VISIBLE_MESSAGE, "roars at [.]", "AUTO_EMOTE")
+		visible_emote("roars at [.].")
 
 /mob/living/simple_animal/hostile/maneater/AttackingTarget()
 	. =..()

--- a/code/modules/mob/living/simple_animal/simple_animal.dm
+++ b/code/modules/mob/living/simple_animal/simple_animal.dm
@@ -184,10 +184,10 @@
 	..(icon_gib,1)
 
 /mob/living/simple_animal/proc/visible_emote(act_desc)
-	custom_emote(1, act_desc)
+	custom_emote(VISIBLE_MESSAGE, act_desc, "AUTO_EMOTE")
 
 /mob/living/simple_animal/proc/audible_emote(act_desc)
-	custom_emote(2, act_desc)
+	custom_emote(AUDIBLE_MESSAGE, act_desc, "AUTO_EMOTE")
 
 /mob/living/simple_animal/bullet_act(obj/item/projectile/Proj)
 	if(!Proj || Proj.nodamage)

--- a/code/modules/mob/living/simple_animal/simple_animal.dm
+++ b/code/modules/mob/living/simple_animal/simple_animal.dm
@@ -183,12 +183,6 @@
 /mob/living/simple_animal/gib()
 	..(icon_gib,1)
 
-/mob/living/simple_animal/proc/visible_emote(act_desc)
-	visible_message("<B>[src]</B> [act_desc]")
-
-/mob/living/simple_animal/proc/audible_emote(act_desc)
-	audible_message("<B>[src]</B> [act_desc]")
-
 /mob/living/simple_animal/bullet_act(obj/item/projectile/Proj)
 	if(!Proj || Proj.nodamage)
 		return

--- a/code/modules/mob/living/simple_animal/simple_animal.dm
+++ b/code/modules/mob/living/simple_animal/simple_animal.dm
@@ -184,10 +184,10 @@
 	..(icon_gib,1)
 
 /mob/living/simple_animal/proc/visible_emote(act_desc)
-	custom_emote(VISIBLE_MESSAGE, act_desc, "AUTO_EMOTE")
+	visible_message("<B>[src]</B> [act_desc]")
 
 /mob/living/simple_animal/proc/audible_emote(act_desc)
-	custom_emote(AUDIBLE_MESSAGE, act_desc, "AUTO_EMOTE")
+	audible_message("<B>[src]</B> [act_desc]")
 
 /mob/living/simple_animal/bullet_act(obj/item/projectile/Proj)
 	if(!Proj || Proj.nodamage)

--- a/code/modules/mob/mob_helpers.dm
+++ b/code/modules/mob/mob_helpers.dm
@@ -299,7 +299,9 @@ It's fairly easy to fix if dealing with single letters but not so much with comp
 	if(!islist(logging[message_type]))
 		logging[message_type] = list()
 
-	var/list/timestamped_message = list("[LAZYLEN(logging[message_type]) + 1]\[[time_stamp()]\] [message_tag] [key_name(src)]" = message)
+	var/list/message_data = list("message" = message, "tag" = message_tag)
+
+	var/list/timestamped_message = list("[LAZYLEN(logging[message_type]) + 1]\[[time_stamp()]\] [message_tag] [key_name(src)]" = message_data)
 
 	logging[message_type] += timestamped_message
 

--- a/code/modules/reagents/Chemistry-Reagents/food_drinks.dm
+++ b/code/modules/reagents/Chemistry-Reagents/food_drinks.dm
@@ -316,7 +316,7 @@
 	else
 		M.apply_effect(agony_amount, PAIN, 0)
 		if(prob(5))
-			M.custom_emote(2, "[pick("dry heaves!","coughs!","splutters!")]")
+			M.custom_emote(AUDIBLE_MESSAGE, "[pick("dry heaves!","coughs!","splutters!")]", "AUTO_EMOTE")
 			to_chat(M, "<span class='danger'>You feel like your insides are burning!</span>")
 	if(istype(M, /mob/living/carbon/metroid))
 		M.bodytemperature += rand(0, 15) + metroid_temp_adj
@@ -384,7 +384,7 @@
 	else if(!no_pain)
 		message = "<span class='danger'>Your face and throat burn!</span>"
 		if(prob(25))
-			M.custom_emote(2, "[pick("coughs!","coughs hysterically!","splutters!")]")
+			M.custom_emote(AUDIBLE_MESSAGE, "[pick("coughs!","coughs hysterically!","splutters!")]", "AUTO_EMOTE")
 		M.Weaken(5)
 		M.Stun(6)
 

--- a/code/modules/reagents/Chemistry-Reagents/food_drinks.dm
+++ b/code/modules/reagents/Chemistry-Reagents/food_drinks.dm
@@ -316,7 +316,7 @@
 	else
 		M.apply_effect(agony_amount, PAIN, 0)
 		if(prob(5))
-			M.custom_emote(AUDIBLE_MESSAGE, "[pick("dry heaves!","coughs!","splutters!")]", "AUTO_EMOTE")
+			M.custom_emote(AUDIBLE_MESSAGE, pick("dry heaves!","coughs!","splutters!"), "AUTO_EMOTE")
 			to_chat(M, "<span class='danger'>You feel like your insides are burning!</span>")
 	if(istype(M, /mob/living/carbon/metroid))
 		M.bodytemperature += rand(0, 15) + metroid_temp_adj
@@ -384,7 +384,7 @@
 	else if(!no_pain)
 		message = "<span class='danger'>Your face and throat burn!</span>"
 		if(prob(25))
-			M.custom_emote(AUDIBLE_MESSAGE, "[pick("coughs!","coughs hysterically!","splutters!")]", "AUTO_EMOTE")
+			M.custom_emote(AUDIBLE_MESSAGE, pick("coughs!","coughs hysterically!","splutters!"), "AUTO_EMOTE")
 		M.Weaken(5)
 		M.Stun(6)
 

--- a/code/modules/reagents/reagent_containers/food/_food.dm
+++ b/code/modules/reagents/reagent_containers/food/_food.dm
@@ -261,7 +261,7 @@
 		reagents.trans_to_mob(user, bitesize, CHEM_INGEST)
 	spawn(5)
 		if(!src && !user.client)
-			user.custom_emote(VISIBLE_MESSAGE,"[pick("burps", "cries for more", "burps twice", "looks at the area where the food was")]", "AUTO_EMOTE")
+			user.custom_emote(VISIBLE_MESSAGE, pick("burps", "cries for more", "burps twice", "looks at the area where the food was"), "AUTO_EMOTE")
 			qdel(src)
 	On_Consume(user)
 

--- a/code/modules/reagents/reagent_containers/food/_food.dm
+++ b/code/modules/reagents/reagent_containers/food/_food.dm
@@ -261,7 +261,7 @@
 		reagents.trans_to_mob(user, bitesize, CHEM_INGEST)
 	spawn(5)
 		if(!src && !user.client)
-			user.custom_emote(1,"[pick("burps", "cries for more", "burps twice", "looks at the area where the food was")]")
+			user.custom_emote(VISIBLE_MESSAGE,"[pick("burps", "cries for more", "burps twice", "looks at the area where the food was")]", "AUTO_EMOTE")
 			qdel(src)
 	On_Consume(user)
 

--- a/code/modules/virus2/effects/exotic.dm
+++ b/code/modules/virus2/effects/exotic.dm
@@ -50,7 +50,7 @@
 	mob.nutrition = max(0, mob.nutrition - 25)
 	mob.add_modifier(/datum/modifier/musclerace)
 	if(prob(25))
-		mob.custom_emote(pick("growls", "roars", "snarls", "squeals", "yelps", "barks", "screeches"))
+		mob.custom_emote(AUDIBLE_MESSAGE, pick("growls", "roars", "snarls", "squeals", "yelps", "barks", "screeches"), "AUTO_EMOTE")
 		mob.jitteriness += 10
 	if(prob(45) && mob.reagents.get_reagent_amount(/datum/reagent/mutagen) < 5)
 		mob.custom_pain(pick("Your muscle tissue hurts unbearably!", "Your muscle tissue is burning!", "Your muscle tissue is torn!", "Your muscles are torn!", "Your muscles hurt unbearably!", "Your muscles are burning!", "Your muscles are shrinking!"), 45)
@@ -165,7 +165,7 @@
 	if(..())
 		return
 	mob.nutrition = max(0, mob.nutrition - 1000)
-	mob.custom_emote(message = "hisses")
+	mob.custom_emote(AUDIBLE_MESSAGE, "hisses", "AUTO_EMOTE")
 	if(prob(25))
 		to_chat(mob, SPAN_DANGER("[pick("You want to eat more than anything in this life!", "You feel your stomach begin to devour itself!", "You are ready to kill for food!", "You urgently need to find food!")]"))
 


### PR DESCRIPTION
Делаем разделение эмоутов на сделанные игроком и автоматические.

- Автоматические эмоуты (dry heaves, collapses и т.д.) помечаются тэгом AUTO_EMOTE
- В послерандовый список последних слов больше не добавляются мусорные автоматические эмоуты
- Все custom_emote() приведены к новому формату
- Добавлены макросы VISIBLE_MESSAGE и AUDIBLE_MESSAGE в те места, где раньше просто были цифры 1 или 2.
- Также добавлены состояния видимости или слышимости в те эмоуты, где раньше отсутствовали вовсе
- Переопределены проки visible_emote() и audible_emote() с использования custom_emote() на использование visible_message() и audible_message(). А также они перенесены из /mob/living/simple_animal/ в /mob/living/

<details>
<summary>Чейнджлог</summary>

```yml
🆑
tweak: В послерандовый список последних слов больше не добавляются автоматические эмоуты (dry heaves, collapses и т.д.)
/🆑
```

</details>

- [x] Pull Request полностью завершен, мне не нужна помощь чтобы его закончить.
- [x] Я внимательно прочитал все свои изменения и багов в них не нашел.
- [x] Я запускал сервер со своими изменениями локально и все протестировал.
- [x] Я ознакомился c [Guide to Contribute](https://github.com/ChaoticOnyx/OnyxBay/blob/dev/docs/contributing.md).
