### PR TITLE
fix(storage): correct drawing of storage UI slots

### DIFF
--- a/code/_onclick/hud/screen_objects.dm
+++ b/code/_onclick/hud/screen_objects.dm
@@ -82,6 +82,12 @@
 			usr.ClickOn(master)
 	return 1
 
+/obj/screen/stored
+	name = "stored"
+
+/obj/screen/stored/Click()
+	return 1
+
 /obj/screen/zone_sel
 	name = "damage zone"
 	icon_state = "zone_sel"

--- a/code/game/objects/items/storage/storage_ui/default.dm
+++ b/code/game/objects/items/storage/storage_ui/default.dm
@@ -12,43 +12,47 @@
 
 /datum/storage_ui/default/New(storage)
 	..()
-	boxes = new /obj/screen/storage(  )
+	boxes = new /obj/screen/storage()
 	boxes.SetName("storage")
 	boxes.master = storage
 	boxes.icon_state = "block"
 	boxes.screen_loc = "7,7 to 10,8"
 	boxes.layer = HUD_BASE_LAYER
 
-	storage_start = new /obj/screen/storage(  )
+	storage_start = new /obj/screen/storage()
 	storage_start.SetName("storage")
 	storage_start.master = storage
 	storage_start.icon_state = "storage_start"
 	storage_start.screen_loc = "7,7 to 10,8"
 	storage_start.layer = HUD_BASE_LAYER
-	storage_continue = new /obj/screen/storage(  )
+
+	storage_continue = new /obj/screen/storage()
 	storage_continue.SetName("storage")
 	storage_continue.master = storage
 	storage_continue.icon_state = "storage_continue"
 	storage_continue.screen_loc = "7,7 to 10,8"
 	storage_continue.layer = HUD_BASE_LAYER
-	storage_end = new /obj/screen/storage(  )
+
+	storage_end = new /obj/screen/storage()
 	storage_end.SetName("storage")
 	storage_end.master = storage
 	storage_end.icon_state = "storage_end"
 	storage_end.screen_loc = "7,7 to 10,8"
 	storage_end.layer = HUD_BASE_LAYER
 
-	stored_start = new /obj //we just need these to hold the icon
+	stored_start = new /obj/screen/stored()
 	stored_start.icon_state = "stored_start"
 	stored_start.layer = HUD_BASE_LAYER
-	stored_continue = new /obj
+
+	stored_continue = new /obj/screen/stored()
 	stored_continue.icon_state = "stored_continue"
 	stored_continue.layer = HUD_BASE_LAYER
-	stored_end = new /obj
+
+	stored_end = new /obj/screen/stored()
 	stored_end.icon_state = "stored_end"
 	stored_end.layer = HUD_BASE_LAYER
 
-	closer = new /obj/screen/close(  )
+	closer = new /obj/screen/close()
 	closer.master = storage
 	closer.icon_state = "x"
 	closer.layer = HUD_BASE_LAYER

--- a/code/game/objects/items/storage/storage_ui/default.dm
+++ b/code/game/objects/items/storage/storage_ui/default.dm
@@ -5,9 +5,9 @@
 	var/obj/screen/storage/storage_start //storage UI
 	var/obj/screen/storage/storage_continue
 	var/obj/screen/storage/storage_end
-	var/obj/screen/storage/stored_start
-	var/obj/screen/storage/stored_continue
-	var/obj/screen/storage/stored_end
+	var/obj/screen/stored/stored_start
+	var/obj/screen/stored/stored_continue
+	var/obj/screen/stored/stored_end
 	var/obj/screen/close/closer
 
 /datum/storage_ui/default/New(storage)


### PR DESCRIPTION
Исправляет некорректное отображение слотов в рюкзаках, сумках и любых других контейнерах над темнотой.
Переносит все слоты в контейнерах на HUD_PLANE

![before](https://user-images.githubusercontent.com/107106680/232498680-da672f74-29ee-40aa-8133-5aa88cc113c4.png)

![after](https://user-images.githubusercontent.com/107106680/232498696-a26af303-185e-4de4-a045-6e125357b957.png)

<details>
<summary>Чейнджлог</summary>

```yml
🆑
bugfix: Исправлено некорректное отображение слотов в рюкзаках, сумках и других контейнерах.
/🆑
```

</details>

- [x] Pull Request полностью завершен, мне не нужна помощь чтобы его закончить.
- [x] Я внимательно прочитал все свои изменения и багов в них не нашел.
- [x] Я запускал сервер со своими изменениями локально и все протестировал.
- [x] Я ознакомился c [Guide to Contribute](https://github.com/ChaoticOnyx/OnyxBay/blob/dev/docs/contributing.md).
