### PR TITLE
fix(xeno-spawn): prevents xenos from spawning and laying eggs if disabled by server

### DIFF
--- a/code/datums/events/stray_facehugger.dm
+++ b/code/datums/events/stray_facehugger.dm
@@ -7,6 +7,9 @@
 	difficulty = 60
 	fire_only_once = TRUE
 
+/datum/event/stray_facehugger/check_conditions()
+	. = config.misc.aliens_allowed
+
 /datum/event/stray_facehugger/get_mtth()
 	. = ..()
 	. -= (SSevents.triggers.roles_count["Security"] * (20 MINUTES))

--- a/code/datums/events/xenomorph_infestation.dm
+++ b/code/datums/events/xenomorph_infestation.dm
@@ -7,6 +7,9 @@
 	difficulty = 90
 	fire_only_once = TRUE
 
+/datum/event/xenomorph_infestation/check_conditions()
+	. = config.misc.aliens_allowed
+
 /datum/event/xenomorph_infestation/get_mtth()
 	. = ..()
 	. -= (SSevents.triggers.living_players_count * (3 MINUTES))

--- a/code/modules/mob/living/carbon/human/species/xenomorphs/alien_powers.dm
+++ b/code/modules/mob/living/carbon/human/species/xenomorphs/alien_powers.dm
@@ -109,7 +109,7 @@
 	set category = "Abilities"
 
 	if(!config.misc.alien_eggs_allowed)
-		to_chat(src, SPAN_WARNING("Laying eggs is prohibited by server."))
+		to_chat(src, SPAN_WARNING("Laying eggs is prohibited by the server."))
 		return
 
 	if(locate(/obj/structure/alien/egg) in get_turf(src))

--- a/code/modules/mob/living/carbon/human/species/xenomorphs/alien_powers.dm
+++ b/code/modules/mob/living/carbon/human/species/xenomorphs/alien_powers.dm
@@ -108,6 +108,11 @@
 	set desc = "Lay an egg to produce huggers to impregnate prey with."
 	set category = "Abilities"
 
+	if(!config.misc.alien_eggs_allowed)
+		to_chat(src, SPAN_WARNING("Laying eggs is prohibited by server."))
+		log_debug("\The [src] attempted to lay an alien egg, but was interrupted by server configuration.")
+		return
+
 	if(locate(/obj/structure/alien/egg) in get_turf(src))
 		to_chat(src, SPAN("alium", "There's already an egg here."))
 		return

--- a/code/modules/mob/living/carbon/human/species/xenomorphs/alien_powers.dm
+++ b/code/modules/mob/living/carbon/human/species/xenomorphs/alien_powers.dm
@@ -110,7 +110,6 @@
 
 	if(!config.misc.alien_eggs_allowed)
 		to_chat(src, SPAN_WARNING("Laying eggs is prohibited by server."))
-		log_debug("\The [src] attempted to lay an alien egg, but was interrupted by server configuration.")
 		return
 
 	if(locate(/obj/structure/alien/egg) in get_turf(src))


### PR DESCRIPTION
Добавил проверки на конфиг в датумы ивентов и создающий яйца прок.

<details>
<summary>Чейнджлог</summary>

```yml
🆑
bugfix: админ-кнопки "toggle aliens" и "toggle alien eggs" снова работают как задумано. 
/🆑
```

</details>

close #7622

- [x] Pull Request полностью завершен, мне не нужна помощь чтобы его закончить.
- [x] Я внимательно прочитал все свои изменения и багов в них не нашел.
- [x] Я запускал сервер со своими изменениями локально и все протестировал.
- [x] Я ознакомился c [Guide to Contribute](https://github.com/ChaoticOnyx/OnyxBay/blob/dev/docs/contributing.md).
