### PR TITLE
fix(see_in_dark): removes nightvision from meson hud

### DIFF
--- a/code/modules/mob/living/carbon/human/species/species.dm
+++ b/code/modules/mob/living/carbon/human/species/species.dm
@@ -523,7 +523,7 @@ The slots that you can use are found in items_clothing.dm and are the inventory 
 	if(!H.druggy)
 		H.set_see_in_dark(max(
 			H.see_in_dark,
-			H.sight & (SEE_TURFS|SEE_MOBS|SEE_OBJS) ? 8 : H.see_in_dark,
+			(H.sight & (SEE_TURFS|SEE_MOBS|SEE_OBJS)) == (SEE_TURFS|SEE_MOBS|SEE_OBJS) ? 8 : H.see_in_dark,
 			darksight_range + H.equipment_darkness_modifier
 		))
 		if(H.equipment_see_invis)


### PR DESCRIPTION
Убирает ночное виденье у мезонных очков, которого быть не должно.
(И даёт его, если у моба включены флаги на виденье всех турфов, объектов и мобов).
Исправлена некорректная проверка H.sight на включенные флаги
<details>
  <summary>мезонки</summary>
  
![image](https://user-images.githubusercontent.com/107106680/233831846-1d041e54-e9d2-4ca8-b38d-653edd0f27f5.png)
![image](https://user-images.githubusercontent.com/107106680/233831852-a98c2fdd-a4c6-4b2f-9da6-a3c6227f5de5.png)
</details>

fix #9922 
исправленный #10164 

<details>
<summary>Чейнджлог</summary>

```yml
🆑
bugfix: Мезонные очки более не работают как очки ночного виденья.
/🆑
```

</details>

- [x] Pull Request полностью завершен, мне не нужна помощь чтобы его закончить.
- [x] Я внимательно прочитал все свои изменения и багов в них не нашел.
- [x] Я запускал сервер со своими изменениями локально и все протестировал.
- [x] Я ознакомился c [Guide to Contribute](https://github.com/ChaoticOnyx/OnyxBay/blob/dev/docs/contributing.md).
