### PR TITLE
feat(maptext): add splash text

### DIFF
--- a/baystation12.dme
+++ b/baystation12.dme
@@ -69,6 +69,7 @@
 #include "code\__defines\subsystem-priority.dm"
 #include "code\__defines\subsystems.dm"
 #include "code\__defines\targeting.dm"
+#include "code\__defines\text.dm"
 #include "code\__defines\tgui.dm"
 #include "code\__defines\think.dm"
 #include "code\__defines\tools.dm"

--- a/baystation12.dme
+++ b/baystation12.dme
@@ -1551,6 +1551,7 @@
 #include "code\modules\awaymissions\pamphlet.dm"
 #include "code\modules\awaymissions\trigger.dm"
 #include "code\modules\awaymissions\zlevel.dm"
+#include "code\modules\splash_text\splash_text.dm"
 #include "code\modules\client\asset_cache.dm"
 #include "code\modules\client\client_defines.dm"
 #include "code\modules\client\client_helpers.dm"

--- a/code/__defines/_planes+layers.dm
+++ b/code/__defines/_planes+layers.dm
@@ -157,10 +157,7 @@
 	#define OBSERVER_LAYER              5.1
 	#define OBFUSCATION_LAYER           5.2
 
-	#define TYPING_LAYER                11
-
-	#define CHAT_LAYER                  12.0001
-	#define CHAT_LAYER_MAX              12.9999
+	#define TYPING_LAYER                10
 
 	#define BASE_AREA_LAYER             999
 
@@ -176,6 +173,10 @@
 	#define EYE_GLOW_LAYER         		1
 	#define BEAM_PROJECTILE_LAYER  		2
 	#define SUPERMATTER_WALL_LAYER 		3
+	#define SPLASH_TEXT_LAYER           4
+
+	#define CHAT_LAYER                  5.0001
+	#define CHAT_LAYER_MAX              5.9999
 
 #define OBFUSCATION_PLANE				5 // AI
 

--- a/code/__defines/text.dm
+++ b/code/__defines/text.dm
@@ -1,0 +1,4 @@
+/// Prepares a text to be used for maptext. Use this so it doesn't look hideous.
+#define MAPTEXT(text) {"<span class='maptext'>[##text]</class>"}
+/// Macro from Lummox used to get height from a MeasureText proc
+#define WXH_TO_HEIGHT(measurement) text2num(copytext(##measurement, findtextEx(##measurement, "x") + 1))

--- a/code/datums/chatmessage.dm
+++ b/code/datums/chatmessage.dm
@@ -18,8 +18,6 @@
 #define CHAT_LAYER_Z_STEP           0.0001
 /// The number of z-layer 'slices' usable by the chat message layering
 #define CHAT_LAYER_MAX_Z            ((CHAT_LAYER_MAX - CHAT_LAYER) / CHAT_LAYER_Z_STEP)
-/// Macro from Lummox used to get height from a MeasureText proc
-#define WXH_TO_HEIGHT(x)            text2num(copytext(x, findtextEx(x, "x") + 1))
 #define CHAT_MESSAGE_APPEAR_STATE   1
 #define CHAT_MESSAGE_FADEOUT_STATE  2
 
@@ -144,7 +142,7 @@
 
 	// Approximate text height
 	var/static/regex/html_metachars = new(@"&[A-Za-z]{1,7};", "g")
-	var/complete_text = "<span class='center maptext[size ? " [size]" : ""]' style='color: [tgt_color]'>[text]</span>"
+	var/complete_text = MAPTEXT("<span class='center[size ? " [size]" : ""]' style='color: [tgt_color]'>[text]</span>")
 	var/mheight = WXH_TO_HEIGHT(owned_by.MeasureText(complete_text, null, CHAT_MESSAGE_WIDTH))
 	approx_lines = max(1, mheight / CHAT_MESSAGE_APPROX_LHEIGHT)
 

--- a/code/modules/atmospherics/components/binary_devices/pump.dm
+++ b/code/modules/atmospherics/components/binary_devices/pump.dm
@@ -62,6 +62,7 @@ Thus, the two variables affect pump operation are set in New():
 	if(!allowed(user))
 		return
 	target_pressure = max_pressure_setting
+	show_splash_text(user, "target pressure set to [target_pressure] kPa")
 
 /obj/machinery/atmospherics/binary/pump/on
 	icon_state = "map_on"

--- a/code/modules/client/preference_setup/global/preferences.dm
+++ b/code/modules/client/preference_setup/global/preferences.dm
@@ -99,8 +99,8 @@ var/global/list/_client_preferences_by_type
 /datum/client_preference/splashes
 	description = "Show Splashes (Runechat-Like-Popups)"
 	key = "CHAT_SPLASHES"
-	options = list(GLOB.PREF_YES, GLOB.PREF_NO)
 	default_value = GLOB.PREF_YES
+	options = list(GLOB.PREF_YES, GLOB.PREF_NO)
 
 /datum/client_preference/play_admin_midis
 	description ="Play admin midis"

--- a/code/modules/client/preference_setup/global/preferences.dm
+++ b/code/modules/client/preference_setup/global/preferences.dm
@@ -96,6 +96,12 @@ var/global/list/_client_preferences_by_type
 	options = list(GLOB.PREF_YES, GLOB.PREF_NO)
 	default_value = GLOB.PREF_YES
 
+/datum/client_preference/splashes
+	description = "Show Splashes (Runechat-Like-Popups)"
+	key = "CHAT_SPLASHES"
+	options = list(GLOB.PREF_YES, GLOB.PREF_NO)
+	default_value = GLOB.PREF_YES
+
 /datum/client_preference/play_admin_midis
 	description ="Play admin midis"
 	key = "SOUND_MIDI"

--- a/code/modules/splash_text/splash_text.dm
+++ b/code/modules/splash_text/splash_text.dm
@@ -29,7 +29,7 @@
 	if(!viewer_client)
 		return
 
-	if(client.get_preference_value(/datum/client_preference/splashes) != GLOB.PREF_YES)
+	if(viewer_client.get_preference_value(/datum/client_preference/splashes) != GLOB.PREF_YES)
 		return
 
 	var/bounds_width = world.icon_size

--- a/code/modules/splash_text/splash_text.dm
+++ b/code/modules/splash_text/splash_text.dm
@@ -29,6 +29,9 @@
 	if(!viewer_client)
 		return
 
+	if(client.get_preference_value(/datum/client_preference/splashes) != GLOB.PREF_YES)
+		return
+
 	var/bounds_width = world.icon_size
 	if(ismovable(src))
 		var/atom/movable/M = src

--- a/code/modules/splash_text/splash_text.dm
+++ b/code/modules/splash_text/splash_text.dm
@@ -1,0 +1,77 @@
+#define SPLASH_TEXT_WIDTH 200
+#define SPLASH_TEXT_SPAWN_TIME (0.2 SECONDS)
+#define SPLASH_TEXT_VISIBILITY_TIME (0.7 SECONDS)
+#define SPLASH_TEXT_TOTAL_LIFETIME(mult) (SPLASH_TEXT_SPAWN_TIME + SPLASH_TEXT_VISIBILITY_TIME * mult)
+/// The increase in duration per character in seconds.
+#define SPLASH_TEXT_LIFETIME_PER_CHAR_MULT (0.05)
+/// The amount of characters needed before this increase takes place.
+#define SPLASH_TEXT_LIFETIME_INCREASE_MIN (10)
+
+///Creates text that will float from the atom upwards to the viewer.
+/atom/proc/show_splash_text(mob/viewer, text)
+	INVOKE_ASYNC(src, .proc/animate_splash_text, viewer, text)
+
+///Creates text that will float from the atom upwards to the viewers in range.
+/atom/proc/show_splash_text_to_viewers(message, self_message, vision_distance = 7, list/ignored_mobs)
+	var/list/hearers = list()
+	var/list/garbage_obj = list() // TO-DO: add more helpers to exclude searching objects.
+	get_mobs_and_objs_in_view_fast(get_turf(src), vision_distance, hearers, garbage_obj, checkghosts = TRUE)
+	hearers -= ignored_mobs
+
+	for(var/hearer in hearers)
+		if(is_blind(hearer))
+			continue
+		show_splash_text(hearer, (hearer == src && self_message) || message)
+
+///Private proc, use 'show_splash_text' or 'show_splash_text_to_viewers' instead.
+/atom/proc/animate_splash_text(mob/viewer, text)
+	var/client/viewer_client = viewer?.client
+	if(!viewer_client)
+		return
+
+	var/bounds_width = world.icon_size
+	if(ismovable(src))
+		var/atom/movable/M = src
+		bounds_width = M.bound_width
+
+	var/image/splash_image = image(loc = isturf(src) ? src : get_atom_on_turf(src), layer = SPLASH_TEXT_LAYER)
+	splash_image.plane = EFFECTS_ABOVE_LIGHTING_PLANE
+	splash_image.alpha = 0
+	splash_image.appearance_flags = RESET_ALPHA | RESET_COLOR | RESET_TRANSFORM
+	splash_image.maptext = MAPTEXT("<span style='text-align: center; -dm-text-outline: 1px #0005'>[text]</span>")
+	splash_image.maptext_x = (SPLASH_TEXT_WIDTH - bounds_width) * (-0.5)
+	splash_image.maptext_width = SPLASH_TEXT_WIDTH
+	splash_image.maptext_height = WXH_TO_HEIGHT(viewer_client.MeasureText(text, null, SPLASH_TEXT_WIDTH))
+
+	add_image_to_client(splash_image, viewer_client)
+
+	var/lifetime_mult = 1 + max(0, length(strip_html_properly(text)) - SPLASH_TEXT_LIFETIME_INCREASE_MIN) * SPLASH_TEXT_LIFETIME_PER_CHAR_MULT
+
+	animate(
+		splash_image,
+		pixel_y = world.icon_size * 1.2,
+		time = SPLASH_TEXT_TOTAL_LIFETIME(lifetime_mult),
+		easing = SINE_EASING
+	)
+
+	animate(
+		alpha = 255,
+		time = SPLASH_TEXT_SPAWN_TIME,
+		easing = CUBIC_EASING | EASE_OUT,
+		flags = ANIMATION_PARALLEL
+	)
+
+	animate(
+		alpha = 0,
+		time = SPLASH_TEXT_VISIBILITY_TIME * lifetime_mult,
+		easing = CUBIC_EASING | EASE_IN
+	)
+
+	addtimer(CALLBACK(GLOBAL_PROC, .proc/remove_image_from_client, splash_image, viewer_client), SPLASH_TEXT_TOTAL_LIFETIME(lifetime_mult), TIMER_DELETE_ME)
+
+#undef SPLASH_TEXT_WIDTH
+#undef SPLASH_TEXT_SPAWN_TIME
+#undef SPLASH_TEXT_VISIBILITY_TIME
+#undef SPLASH_TEXT_TOTAL_LIFETIME
+#undef SPLASH_TEXT_LIFETIME_PER_CHAR_MULT
+#undef SPLASH_TEXT_LIFETIME_INCREASE_MIN

--- a/code/modules/splash_text/splash_text.dm
+++ b/code/modules/splash_text/splash_text.dm
@@ -7,12 +7,12 @@
 /// The amount of characters needed before this increase takes place.
 #define SPLASH_TEXT_LIFETIME_INCREASE_MIN (10)
 
-///Creates text that will float from the atom upwards to the viewer.
+/// Creates text that will float from the atom upwards to the viewer.
 /atom/proc/show_splash_text(mob/viewer, text)
 	INVOKE_ASYNC(src, .proc/animate_splash_text, viewer, text)
 
-///Creates text that will float from the atom upwards to the viewers in range.
-/atom/proc/show_splash_text_to_viewers(message, self_message, vision_distance = 7, list/ignored_mobs)
+/// Creates text that will float from the atom upwards to the viewers in range.
+/atom/proc/show_splash_text_to_viewers(message, self_message, vision_distance = 7, list/mob/ignored_mobs)
 	var/list/hearers = list()
 	var/list/garbage_obj = list() // TO-DO: add more helpers to exclude searching objects.
 	get_mobs_and_objs_in_view_fast(get_turf(src), vision_distance, hearers, garbage_obj, checkghosts = TRUE)
@@ -23,7 +23,7 @@
 			continue
 		show_splash_text(hearer, (hearer == src && self_message) || message)
 
-///Private proc, use 'show_splash_text' or 'show_splash_text_to_viewers' instead.
+/// Private proc, use 'show_splash_text' or 'show_splash_text_to_viewers' instead.
 /atom/proc/animate_splash_text(mob/viewer, text)
 	var/client/viewer_client = viewer?.client
 	if(!viewer_client)


### PR DESCRIPTION
Изменение давления в трубах, смена количества переливаемого из емкости в емкость реагента и иные действия не дают пользователям фидбека, мое решение - сплеш текст. Он достаточно быстро читается игроком, после чего уходит в небытие, не засоряя лишней информацией чат. Для демонстрации добавил сплеши насосам.

`show_splash_text` - показывает сплеш одному конкретному пользователю

`show_splash_text_to_viewers` - показывает сплеш всем пользователям в радиусе

<details>
<summary>Демонстрация</summary>

![dreamseeker_Nhgv0mDFJR](https://user-images.githubusercontent.com/118671019/233869868-d95ca67c-3daa-4a51-b4d2-3544d0b453ad.gif)

</details>

<details>
<summary>Чейнджлог</summary>

```yml
🆑
rscadd: добавлен сплеш текст при включении насоса.
/🆑
```

</details>

- [x] Pull Request полностью завершен, мне не нужна помощь чтобы его закончить.
- [x] Я внимательно прочитал все свои изменения и багов в них не нашел.
- [x] Я запускал сервер со своими изменениями локально и все протестировал.
- [x] Я ознакомился c [Guide to Contribute](https://github.com/ChaoticOnyx/OnyxBay/blob/dev/docs/contributing.md).
