### PR TITLE
fix(_external_icons): add extra checks to prevent generating icon_states with broken names

### DIFF
--- a/code/modules/organs/external/_external_icons.dm
+++ b/code/modules/organs/external/_external_icons.dm
@@ -67,13 +67,10 @@ var/list/limb_icon_cache = list()
 			var/color = markings[E]
 			var/icon/I = icon(M.icon, "[M.icon_state]-[organ_tag]")
 			I.Blend(color, M.blend)
-			icon_cache_key += "[M.name][color]"
 			ADD_SORTED(sorted, list(list(M.draw_order, I, M)), /proc/cmp_marking_order)
 	for (var/entry in sorted)
 		overlays |= entry[2]
 		mob_icon.Blend(entry[2], entry[3]["layer_blend"])
-
-/obj/item/organ/external/var/icon_cache_key
 
 /obj/item/organ/external/update_icon(regenerate = 0)
 	if (!icon_name)
@@ -97,12 +94,11 @@ var/list/limb_icon_cache = list()
 		if(is_stump())
 			stump_icon = "_s"
 
-		icon_state = "[icon_name][gender][body_build][stump_icon][owner?.mind?.special_role == "Zombie" && owner.species == all_species[SPECIES_HUMAN] ? "_z" : ""]"
+		icon_state = "[icon_name][gender][body_build][stump_icon]"
 
 		if (species)
 			if(species.base_skin_colours && !isnull(species.base_skin_colours[s_base]))
 				icon_state += species.base_skin_colours[s_base]
-			icon_cache_key = "[icon_state]_[species ? species.name : SPECIES_HUMAN]"
 
 		if(force_icon)
 			icon = force_icon
@@ -116,6 +112,17 @@ var/list/limb_icon_cache = list()
 			icon = 'icons/mob/human_races/r_skeleton.dmi'
 		else
 			icon = species.get_icobase(owner)
+			icon_state = "[icon_state][owner?.mind?.special_role == "Zombie" && owner.species == all_species[SPECIES_HUMAN] ? "_z" : ""]"
+
+		var/icon/temp_icon = icon(icon)
+		var/list/icon_states = temp_icon.IconStates()
+		if(!icon_states.Find(icon_state))
+			if(icon_states.Find("[icon_name][gender]"))
+				icon_state = "[icon_name][gender]"
+			else if(icon_states.Find("[icon_name]"))
+				icon_state = "[icon_name]"
+			else
+				CRASH("Can't find proper icon_state for \the [src].")
 
 		mob_icon = apply_colouration(new /icon(icon, icon_state))
 
@@ -126,7 +133,6 @@ var/list/limb_icon_cache = list()
 				var/color = markings[E]
 				var/icon/I = icon(M.icon, "[M.icon_state]-[organ_tag]")
 				I.Blend(color, M.blend)
-				icon_cache_key += "[M.name][color]"
 				ADD_SORTED(sorted, list(list(M.draw_order, I, M)), /proc/cmp_marking_order)
 		for(var/entry in sorted)
 			overlays |= entry[2]
@@ -139,9 +145,6 @@ var/list/limb_icon_cache = list()
 				I.Blend(rgb(h_col[1],h_col[2],h_col[3]), ICON_ADD)
 				limb_icon_cache[cache_key] = I
 			mob_icon.Blend(limb_icon_cache[cache_key], ICON_OVERLAY)
-
-		if(model)
-			icon_cache_key += "_model_[model]"
 
 		if(force_icon && (status & ORGAN_CUT_AWAY))
 			dir = SOUTH // Facing towards the screen
@@ -205,7 +208,6 @@ var/list/robot_hud_colours = list("#ffffff","#cccccc","#aaaaaa","#888888","#6666
 		applying += rgb(,,,180) // Makes the icon translucent, SO INTUITIVE TY BYOND
 
 	else if(status & ORGAN_DEAD)
-		icon_cache_key += "_dead"
 		applying.ColorTone(rgb(10,50,0))
 		applying.SetIntensity(0.7)
 
@@ -214,10 +216,8 @@ var/list/robot_hud_colours = list("#ffffff","#cccccc","#aaaaaa","#888888","#6666
 			applying.Blend(rgb(s_tone, s_tone, s_tone), ICON_ADD)
 		else
 			applying.Blend(rgb(-s_tone,  -s_tone,  -s_tone), ICON_SUBTRACT)
-		icon_cache_key += "_tone_[s_tone]"
 	if(species && species.appearance_flags & HAS_SKIN_COLOR)
 		if(s_col && s_col.len >= 3)
 			applying.Blend(rgb(s_col[1], s_col[2], s_col[3]), s_col_blend)
-			icon_cache_key += "_color_[s_col[1]]_[s_col[2]]_[s_col[3]]_[s_col_blend]"
 
 	return applying

--- a/code/modules/organs/external/head.dm
+++ b/code/modules/organs/external/head.dm
@@ -198,7 +198,6 @@
 					I.Blend(rgb(200 + s_tone, 150 + s_tone, 123 + s_tone), ICON_ADD)
 			else
 				I.Blend(color, ICON_ADD)
-			icon_cache_key += "[M.name][color]"
 			ADD_SORTED(sorted_head_markings, list(list(M.draw_order, I)), /proc/cmp_marking_order)
 	for(var/entry in sorted_head_markings)
 		res.overlays |= entry[2]


### PR DESCRIPTION
Добавил пару проверок, чтоб избежать генерации иконки с неправильным именем, поправил отрисовку протезов на зомби. 

<details>
<summary>Чейнджлог</summary>

```yml
🆑
bugfix: конечности ксеноморфов больше не отращивают людям ксено-головы при прикреплении к телу. 
/🆑
```

</details>

close #10157

- [x] Pull Request полностью завершен, мне не нужна помощь чтобы его закончить.
- [x] Я внимательно прочитал все свои изменения и багов в них не нашел.
- [x] Я запускал сервер со своими изменениями локально и все протестировал.
- [x] Я ознакомился c [Guide to Contribute](https://github.com/ChaoticOnyx/OnyxBay/blob/dev/docs/contributing.md).
