### PR TITLE
fix(signaler): fixing signaler tgui and deadman's switch

### DIFF
--- a/code/modules/assembly/signaler.dm
+++ b/code/modules/assembly/signaler.dm
@@ -35,6 +35,12 @@
 /obj/item/device/assembly/signaler/attack_self(mob/user)
 	tgui_interact(user)
 
+/obj/item/device/assembly/signaler/tgui_host(mob/user)
+	if(holder)
+		return holder
+	else
+		return ..()
+
 /obj/item/device/assembly/signaler/tgui_interact(mob/user, datum/tgui/ui)
 	ui = SStgui.try_update_ui(user, src, ui)
 	if(!ui)

--- a/code/modules/assembly/signaler.dm
+++ b/code/modules/assembly/signaler.dm
@@ -134,7 +134,7 @@
 	radio_connection = radio_controller.add_object(src, frequency, RADIO_CHAT)
 	return
 
-/obj/item/device/assembly/signaler/Process()
+/obj/item/device/assembly/signaler/think()
 	if(!deadman)
 		return
 	var/mob/M = src.loc


### PR DESCRIPTION
Исправляет неоткрывающиеся TGUI у сигналера, если тот был собран с игнайтером и другими компонентами в одно целое.
Также исправляет нерабочую обработку сигналера, при активированной мёртвой руке. То есть сигналер с мёртвой хваткой теперь снова срабатывает с шансом в 5%, если был выбит из рук.

<details>
<summary>Чейнджлог</summary>

```yml
🆑
bugfix: Исправляет невозможность воспользоваться сигналером, если к тому был присоединён игнайтер.
/🆑
```

</details>

- [x] Pull Request полностью завершен, мне не нужна помощь чтобы его закончить.
- [x] Я внимательно прочитал все свои изменения и багов в них не нашел.
- [x] Я запускал сервер со своими изменениями локально и все протестировал.
- [x] Я ознакомился c [Guide to Contribute](https://github.com/ChaoticOnyx/OnyxBay/blob/dev/docs/contributing.md).
