### PR TITLE
fix(/Move): fixes broken throwing of some things

### DIFF
--- a/code/game/machinery/CableLayer.dm
+++ b/code/game/machinery/CableLayer.dm
@@ -15,7 +15,7 @@
 	..()
 
 /obj/machinery/cablelayer/Move(new_turf,M_Dir)
-	..()
+	. = ..()
 	layCable(new_turf,M_Dir)
 
 /obj/machinery/cablelayer/attack_hand(mob/user)

--- a/code/game/machinery/floorlayer.dm
+++ b/code/game/machinery/floorlayer.dm
@@ -14,7 +14,7 @@
 	..()
 
 /obj/machinery/floorlayer/Move(new_turf,M_Dir)
-	..()
+	. = ..()
 
 	if(on)
 		if(mode["dismantle"])

--- a/code/game/machinery/pipe/construction.dm
+++ b/code/game/machinery/pipe/construction.dm
@@ -346,7 +346,7 @@ Buildable meters
 	return
 
 /obj/item/pipe/Move()
-	..()
+	. = ..()
 	if ((pipe_type in list (PIPE_SIMPLE_BENT, PIPE_SUPPLY_BENT, PIPE_SCRUBBERS_BENT, PIPE_HE_BENT, PIPE_FUEL_BENT)) \
 		&& (src.dir in GLOB.cardinal))
 		src.set_dir(src.dir|turn(src.dir, 90))
@@ -355,7 +355,6 @@ Buildable meters
 			set_dir(1)
 		else if(dir==8)
 			set_dir(4)
-	return
 
 // returns all pipe's endpoints
 

--- a/code/game/machinery/pipe/pipelayer.dm
+++ b/code/game/machinery/pipe/pipelayer.dm
@@ -20,7 +20,7 @@
 	..()
 
 /obj/machinery/pipelayer/Move(new_turf,M_Dir)
-	..()
+	. = ..()
 
 	if(on && a_dis)
 		dismantleFloor(old_turf)

--- a/code/game/mecha/mecha.dm
+++ b/code/game/mecha/mecha.dm
@@ -376,7 +376,6 @@
 	. = ..()
 	if(.)
 		events.fireEvent("onMove",get_turf(src))
-	return
 
 /obj/mecha/relaymove(mob/user,direction)
 	if(user != src.occupant) //While not "realistic", this piece is player friendly.

--- a/code/game/objects/effects/effect_system.dm
+++ b/code/game/objects/effects/effect_system.dm
@@ -127,7 +127,7 @@ steam.start() -- spawns the effect
 	return ..()
 
 /obj/effect/sparks/Move()
-	..()
+	. = ..()
 	var/turf/T = src.loc
 	if (istype(T, /turf))
 		T.hotspot_expose(1000,100)
@@ -227,7 +227,7 @@ steam.start() -- spawns the effect
 	time_to_live = 200
 
 /obj/effect/effect/smoke/bad/Move()
-	..()
+	. = ..()
 	for(var/mob/living/carbon/M in get_turf(src))
 		affect(M)
 
@@ -258,7 +258,7 @@ steam.start() -- spawns the effect
 /obj/effect/effect/smoke/sleepy
 
 /obj/effect/effect/smoke/sleepy/Move()
-	..()
+	. = ..()
 	for(var/mob/living/carbon/M in get_turf(src))
 		affect(M)
 
@@ -286,7 +286,7 @@ steam.start() -- spawns the effect
 	icon_state = "mustard"
 
 /obj/effect/effect/smoke/mustard/Move()
-	..()
+	. = ..()
 	for(var/mob/living/carbon/human/R in get_turf(src))
 		affect(R)
 

--- a/code/game/objects/items/weapons/weaponry.dm
+++ b/code/game/objects/items/weapons/weaponry.dm
@@ -155,7 +155,7 @@
 	set_next_think(world.time + 1 SECOND)
 
 /obj/effect/energy_net/Move()
-	..()
+	. = ..()
 
 	if(buckled_mob)
 		buckled_mob.forceMove(loc, unbuckle_mob = FALSE)

--- a/code/game/objects/structures/janicart.dm
+++ b/code/game/objects/structures/janicart.dm
@@ -231,7 +231,7 @@
 
 
 /obj/structure/bed/chair/janicart/Move()
-	..()
+	. = ..()
 	if(buckled_mob)
 		if(buckled_mob.buckled == src)
 			buckled_mob.loc = loc

--- a/code/game/objects/structures/window.dm
+++ b/code/game/objects/structures/window.dm
@@ -385,7 +385,7 @@
 /obj/structure/window/Move()
 	var/ini_dir = dir
 	update_nearby_tiles(need_rebuild=1)
-	..()
+	. = ..()
 	set_dir(ini_dir)
 	update_nearby_tiles(need_rebuild=1)
 

--- a/code/modules/assembly/proximity.dm
+++ b/code/modules/assembly/proximity.dm
@@ -100,9 +100,8 @@
 
 
 /obj/item/device/assembly/prox_sensor/Move()
-	..()
+	. = ..()
 	sense()
-	return
 
 
 /obj/item/device/assembly/prox_sensor/interact(mob/user)//TODO: Change this to the wires thingy

--- a/code/modules/mob/living/silicon/robot/robot.dm
+++ b/code/modules/mob/living/silicon/robot/robot.dm
@@ -1007,7 +1007,6 @@
 						var/datum/matter_synth/glass.add_charge(1000)
 						spawn(0) //give the stacks a chance to delete themselves if necessary
 */
-		return
 
 /mob/living/silicon/robot/proc/self_destruct()
 	gib()

--- a/code/modules/mob/living/simple_animal/friendly/corgi.dm
+++ b/code/modules/mob/living/simple_animal/friendly/corgi.dm
@@ -41,7 +41,7 @@
 	response_harm   = "kicks"
 
 /mob/living/simple_animal/corgi/Move(a, b, flag)
-	..()
+	. = ..()
 	update_hat()
 
 /mob/living/simple_animal/corgi/Life()

--- a/code/modules/mob/living/simple_animal/friendly/kobold.dm
+++ b/code/modules/mob/living/simple_animal/friendly/kobold.dm
@@ -32,6 +32,6 @@
 		flick("kobold_act",src)
 
 /mob/living/simple_animal/kobold/Move(dir)
-	..()
+	. = ..()
 	if(!stat)
 		flick("kobold_walk",src)

--- a/code/modules/mob/living/simple_animal/worm.dm
+++ b/code/modules/mob/living/simple_animal/worm.dm
@@ -104,7 +104,8 @@
 
 /mob/living/simple_animal/space_worm/Move()
 	var/attachementNextPosition = loc
-	if(..())
+	. = ..()
+	if(.)
 		if(previous)
 			previous.Move(attachementNextPosition)
 		update_icon()

--- a/code/modules/mob/mob_movement.dm
+++ b/code/modules/mob/mob_movement.dm
@@ -182,8 +182,6 @@
 
 	SEND_SIGNAL(src, SIGNAL_MOVED, src, old_loc, loc)
 
-	return
-
 /proc/step_glide(atom/movable/am, dir, glide_size_override)
 	am.set_glide_size(glide_size_override)
 	return step(am, dir)

--- a/code/modules/power/singularity/particle_accelerator/particle_accelerator.dm
+++ b/code/modules/power/singularity/particle_accelerator/particle_accelerator.dm
@@ -136,7 +136,7 @@ So, hopefully this is helpful if any more icons are to be added/changed/wonderin
 
 
 /obj/structure/particle_accelerator/Move()
-	..()
+	. = ..()
 	if(master && master.active)
 		master.toggle_power()
 		investigate_log("was moved whilst active; it <font color='red'>powered down</font>.","singulo")

--- a/code/modules/reagents/reagent_dispenser.dm
+++ b/code/modules/reagents/reagent_dispenser.dm
@@ -226,7 +226,8 @@
 	return ..()
 
 /obj/structure/reagent_dispensers/fueltank/Move()
-	if (..() && modded)
+	. = ..()
+	if (. && modded)
 		leak_fuel(amount_per_transfer_from_this/10.0)
 
 /obj/structure/reagent_dispensers/fueltank/proc/leak_fuel(amount)

--- a/code/modules/xenoarcheaology/artifacts/artifact.dm
+++ b/code/modules/xenoarcheaology/artifacts/artifact.dm
@@ -232,7 +232,7 @@
 	return
 
 /obj/machinery/artifact/Move()
-	..()
+	. = ..()
 	if(main_effect)
 		main_effect.UpdateMove()
 	if(secondary_effect)


### PR DESCRIPTION
Исправляет знаменитую невозможность бросать такие предметы как трубы и сенсоры движения, вызванную некорректным использованием ..() в Move().


fix #9162 

<details>
<summary>Чейнджлог</summary>

```yml
🆑
bugfix: Вы снова можете бросать трубы и датчики движения, не попадая в себя.
/🆑
```

</details>

- [x] Pull Request полностью завершен, мне не нужна помощь чтобы его закончить.
- [x] Я внимательно прочитал все свои изменения и багов в них не нашел.
- [x] Я запускал сервер со своими изменениями локально и все протестировал.
- [x] Я ознакомился c [Guide to Contribute](https://github.com/ChaoticOnyx/OnyxBay/blob/dev/docs/contributing.md).
