### PR TITLE
feat(ghosts): minor ghost QOL features

### DIFF
--- a/code/__defines/ces/signals_mob.dm
+++ b/code/__defines/ces/signals_mob.dm
@@ -12,3 +12,6 @@
 
 /// Called on `/mob/proc/shift_view` (/mob, old_stat, new_stat)
 #define SIGNAL_VIEW_SHIFTED_SET "view_shift_set"
+
+/// Called on `/mob/proc/ghostize` (/mob, can_reenter_corpse)
+#define SIGNAL_MOB_GHOSTIZED "mob_ghostized"

--- a/code/__defines/chat.dm
+++ b/code/__defines/chat.dm
@@ -23,3 +23,6 @@
 #define MESSAGE_TYPE_ATTACKLOG "attacklog"
 #define MESSAGE_TYPE_DEBUG "debug"
 #define MESSAGE_TYPE_UIDEBUG "uidebug"
+
+/// Adds a generic box around whatever message you're sending in chat. Really makes things stand out.
+#define EXAMINE_BLOCK(str) ("<div class='Examine'>" + str + "</div>")

--- a/code/_helpers/atmospherics.dm
+++ b/code/_helpers/atmospherics.dm
@@ -13,12 +13,15 @@
 	return 1
 
 /proc/print_atmos_analysis(user, list/result)
-	for(var/line in result)
-		to_chat(user, "<span class='notice'>[line]</span>")
+	if(!length(result))
+		return
+
+	to_chat(user, EXAMINE_BLOCK(jointext(result, "\n")))
 
 /proc/atmosanalyzer_scan(atom/target, datum/gas_mixture/mixture, advanced)
 	. = list()
-	. += "<span class='notice'>Results of the analysis of \the [target]:</span>"
+	. += SPAN_NOTICE("Results of the analysis of \the [target]:")
+
 	if(!mixture)
 		mixture = target.return_air()
 
@@ -26,16 +29,16 @@
 		var/pressure = mixture.return_pressure()
 		var/total_moles = mixture.total_moles
 
-		if (total_moles>0)
+		if(total_moles>0)
 			if(abs(pressure - ONE_ATMOSPHERE) < 10)
-				. += "<span class='notice'>Pressure: [round(pressure,0.1)] kPa</span>"
+				. += SPAN_NOTICE("Pressure: [round(pressure, 0.1)] kPa")
 			else
-				. += "<span class='warning'>Pressure: [round(pressure,0.1)] kPa</span>"
+				. += SPAN_WARNING("Pressure: [round(pressure, 0.1)] kPa")
 			for(var/mix in mixture.gas)
 				var/percentage = round(mixture.gas[mix]/total_moles * 100, advanced ? 0.01 : 1)
 				if(!percentage)
 					continue
-				. += "<span class='notice'>[gas_data.name[mix]]: [percentage]%</span>"
+				. += SPAN_NOTICE("[gas_data.name[mix]]: [percentage]%")
 				if(advanced)
 					var/list/traits = list()
 					if(gas_data.flags[mix] & XGM_GAS_FUEL)
@@ -46,7 +49,8 @@
 						traits += "contaminates clothing with toxic residue"
 					if(gas_data.flags[mix] & XGM_GAS_FUSION_FUEL)
 						traits += "can be used to fuel fusion reaction"
-					. += "\t<span class='notice'>Specific heat: [gas_data.specific_heat[mix]] J/(mol*K), Molar mass: [gas_data.molar_mass[mix]] kg/mol.[traits.len ? "\n\tThis gas [english_list(traits)]" : ""]</span>"
-			. += "<span class='notice'>Temperature: [round(CONV_KELVIN_CELSIUS(mixture.temperature))]&deg;C / [round(mixture.temperature)]K</span>"
+					. += "\t" + SPAN_NOTICE("Specific heat: [gas_data.specific_heat[mix]] J/(mol*K), Molar mass: [gas_data.molar_mass[mix]] kg/mol.[traits.len ? "\n\tThis gas [english_list(traits)]" : ""]")
+			. += SPAN_NOTICE("Temperature: [round(CONV_KELVIN_CELSIUS(mixture.temperature))]&deg;C / [round(mixture.temperature)]K")
 			return
-	. += "<span class='warning'>\The [target] has no gases!</span>"
+
+	. += SPAN_WARNING("\The [target] has no gases!")

--- a/code/_onclick/ghost.dm
+++ b/code/_onclick/ghost.dm
@@ -1,15 +1,3 @@
-/client/var/inquisitive_ghost = 1
-/mob/observer/ghost/verb/toggle_inquisition() // warning: unexpected inquisition
-	set name = "Toggle Inquisitiveness"
-	set desc = "Sets whether your ghost examines everything on click by default"
-	set category = "Ghost"
-	if(!client) return
-	client.inquisitive_ghost = !client.inquisitive_ghost
-	if(client.inquisitive_ghost)
-		to_chat(src, "<span class='notice'>You will now examine everything you click on.</span>")
-	else
-		to_chat(src, "<span class='notice'>You will no longer examine things you click on.</span>")
-
 /mob/observer/ghost/DblClickOn(atom/A, params)
 	if(can_reenter_corpse && mind && mind.current)
 		if(A == mind.current || (mind.current in A)) // double click your corpse or whatever holds it
@@ -17,15 +5,18 @@
 			return
 
 	// Things you might plausibly want to follow
-	if(istype(A,/atom/movable))
+	if(ismovable(A))
 		ManualFollow(A)
+
 	// Otherwise jump
-	else
+	else if(A.loc)
 		stop_following()
 		forceMove(get_turf(A))
 
 /mob/observer/ghost/ClickOn(atom/A, params)
-	if(!canClick()) return
+	if(!canClick())
+		return
+
 	setClickCooldown(DEFAULT_QUICK_COOLDOWN)
 
 	// You are responsible for checking config.ghost.ghost_interaction when you override this function
@@ -35,16 +26,29 @@
 		var/target_turf = get_turf(A)
 		if(target_turf)
 			AltClickOn(target_turf)
-	else
-		A.attack_ghost(src)
+
+	A.attack_ghost(src)
 
 // Oh by the way this didn't work with old click code which is why clicking shit didn't spam you
-/atom/proc/attack_ghost(mob/observer/ghost/user as mob)
+/atom/proc/attack_ghost(mob/observer/ghost/user)
 	if(!istype(user))
 		return
-	if(user.client && user.client.inquisitive_ghost)
-		user.examinate(src)
+	if(user.client)
+		if(user.gas_scan)
+			print_atmos_analysis(user, atmosanalyzer_scan(src))
+		else if(user.chem_scan)
+			reagent_scanner_scan(user, src)
+		else if(user.rads_scan)
+			var/dose = SSradiation.get_total_absorbed_dose_at_turf(get_turf(src), AVERAGE_HUMAN_WEIGHT)
+			to_chat(user, EXAMINE_BLOCK(SPAN_NOTICE("Radiation: [fmt_siunit(dose, "Gy/s", 3)].")))
+		else if(user.inquisitiveness)
+			user.examinate(src)
 	return
+
+/mob/living/attack_ghost(mob/observer/ghost/user)
+	if(user.client && user.health_scan)
+		to_chat(user, EXAMINE_BLOCK(medical_scan_results(src, 1)))
+	return ..()
 
 // ---------------------------------------
 // And here are some good things for free:

--- a/code/game/objects/items/devices/scanners.dm
+++ b/code/game/objects/items/devices/scanners.dm
@@ -591,7 +591,7 @@ REAGENT SCANNER
 	var/details = 0
 	var/recent_fail = 0
 
-/obj/item/device/reagent_scanner/afterattack(obj/O, mob/user as mob, proximity)
+/obj/item/device/reagent_scanner/afterattack(obj/O, mob/user, proximity)
 	if(!proximity)
 		return
 	if (user.incapacitated())
@@ -601,20 +601,30 @@ REAGENT SCANNER
 	if(!istype(O))
 		return
 
-	if(!isnull(O.reagents))
-		var/dat = ""
-		if(O.reagents.reagent_list.len > 0)
-			var/one_percent = O.reagents.total_volume / 100
-			for (var/datum/reagent/R in O.reagents.reagent_list)
-				dat += "\n \t <span class='notice'>[R][details ? ": [R.volume / one_percent]%" : ""]</span>"
-		if(dat)
-			to_chat(user, "<span class='notice'>Chemicals found: [dat]</span>")
-		else
-			to_chat(user, "<span class='notice'>No active chemical agents found in [O].</span>")
-	else
-		to_chat(user, "<span class='notice'>No significant chemical agents found in [O].</span>")
+	reagent_scanner_scan(user, O)
 
 	return
+
+/proc/reagent_scanner_scan(mob/user, atom/target)
+	if(!istype(target))
+		return
+	if(!isnull(target.reagents))
+		var/list/reagents_out
+		var/list/reagents_block
+
+		for(var/datum/reagent/reagent in target.reagents.reagent_list)
+			LAZYADD(reagents_block, SPAN_NOTICE("[round(reagent.volume, 0.001)] units of [reagent.name]\n"))
+
+		if(!length(reagents_block))
+			LAZYADD(reagents_out, SPAN_NOTICE("No active chemical agents found in \the [target]."))
+		else
+			LAZYADD(reagents_out, SPAN_NOTICE("\The [target] contains the following reagents:\n"))
+			LAZYADD(reagents_out, reagents_block)
+			reagents_block.Cut()
+
+		var/message = EXAMINE_BLOCK(jointext(reagents_out, ""))
+
+		to_chat(user, message)
 
 /obj/item/device/reagent_scanner/adv
 	name = "advanced reagent scanner"

--- a/code/game/objects/objs.dm
+++ b/code/game/objects/objs.dm
@@ -91,7 +91,7 @@
 		if(!ai_in_use && !is_in_use)
 			in_use = 0
 
-/obj/attack_ghost(mob/user)
+/obj/attack_ghost(mob/observer/ghost/user)
 	ui_interact(user)
 	tgui_interact(user)
 	..()
@@ -164,13 +164,13 @@
 
 /obj/_examine_text(mob/user, infix, suffix)
 	. = ..()
-	
+
 	if(hasHUD(user, HUD_SCIENCE))
 		. += "\nStopping Power:"
 
 		. += "\nα-particle: [fmt_siunit(CONV_JOULE_ELECTRONVOLT(rad_resist[RADIATION_ALPHA_PARTICLE]), "eV", 3)]"
 		. += "\nβ-particle: [fmt_siunit(CONV_JOULE_ELECTRONVOLT(rad_resist[RADIATION_BETA_PARTICLE]), "eV", 3)]"
-	
+
 	return .
 
 /obj/proc/wrench_floor_bolts(mob/user, delay=20)

--- a/code/game/objects/structures/crates_lockers/closets.dm
+++ b/code/game/objects/structures/crates_lockers/closets.dm
@@ -148,7 +148,11 @@
 		else
 			. += "\nIt is full."
 
-	if(isghost(user) && user.client?.inquisitive_ghost)
+	if(isghost(user))
+		var/mob/observer/ghost/G = user
+		if(!G.inquisitiveness)
+			return
+
 		if(src.opened)
 			return
 

--- a/code/modules/client/preference_setup/global/preferences.dm
+++ b/code/modules/client/preference_setup/global/preferences.dm
@@ -153,35 +153,11 @@ var/global/list/_client_preferences_by_type
 	key = "SOUND_HITMARKER"
 	category = PREF_CATEGORY_AUDIO
 
-/datum/client_preference/ghost_ears
-	description ="Ghost ears"
-	key = "CHAT_GHOSTEARS"
-	category = PREF_CATEGORY_GHOST
-	options = list(GLOB.PREF_ALL_SPEECH, GLOB.PREF_NEARBY)
-
-/datum/client_preference/ghost_sight
-	description ="Ghost sight"
-	key = "CHAT_GHOSTSIGHT"
-	category = PREF_CATEGORY_GHOST
-	options = list(GLOB.PREF_ALL_EMOTES, GLOB.PREF_NEARBY)
-
-/datum/client_preference/ghost_radio
-	description ="Ghost radio"
-	key = "CHAT_GHOSTRADIO"
-	category = PREF_CATEGORY_GHOST
-	options = list(GLOB.PREF_ALL_CHATTER, GLOB.PREF_NEARBY)
-
 /datum/client_preference/language_display
 	description = "Display Language Names"
 	key = "LANGUAGE_DISPLAY"
 	category = PREF_CATEGORY_CHAT
 	options = list(GLOB.PREF_FULL, GLOB.PREF_SHORTHAND, GLOB.PREF_OFF)
-
-/datum/client_preference/ghost_follow_link_length
-	description ="Ghost Follow Links"
-	key = "CHAT_GHOSTFOLLOWLINKLENGTH"
-	category = PREF_CATEGORY_GHOST
-	options = list(GLOB.PREF_SHORT, GLOB.PREF_LONG)
 
 /datum/client_preference/show_typing_indicator
 	description ="Typing indicator"
@@ -333,6 +309,62 @@ var/global/list/_client_preferences_by_type
 	category = PREF_CATEGORY_CONTROL
 	default_value = GLOB.PREF_NO
 
+/********************
+* Ghost Preferences *
+********************/
+/datum/client_preference/ghost_ears
+	description ="Ghost ears"
+	key = "CHAT_GHOSTEARS"
+	category = PREF_CATEGORY_GHOST
+	options = list(GLOB.PREF_ALL_SPEECH, GLOB.PREF_NEARBY)
+
+/datum/client_preference/ghost_sight
+	description ="Ghost sight"
+	key = "CHAT_GHOSTSIGHT"
+	category = PREF_CATEGORY_GHOST
+	options = list(GLOB.PREF_ALL_EMOTES, GLOB.PREF_NEARBY)
+
+/datum/client_preference/ghost_radio
+	description ="Ghost radio"
+	key = "CHAT_GHOSTRADIO"
+	category = PREF_CATEGORY_GHOST
+	options = list(GLOB.PREF_ALL_CHATTER, GLOB.PREF_NEARBY)
+
+/datum/client_preference/ghost_follow_link_length
+	description ="Ghost Follow Links"
+	key = "CHAT_GHOSTFOLLOWLINKLENGTH"
+	category = PREF_CATEGORY_GHOST
+	options = list(GLOB.PREF_SHORT, GLOB.PREF_LONG)
+
+/datum/client_preference/affects_ghost/changed(mob/preference_mob, new_value)
+	var/mob/observer/ghost/preference_ghost = preference_mob
+	if(istype(preference_ghost))
+		preference_ghost.updateghostprefs()
+		preference_ghost.updateghostsight()
+
+/datum/client_preference/affects_ghost/ghost_anonymous_chat
+	description = "Ghost anonymous chat"
+	key = "CHAT_GHOSTANONSAY"
+	category = PREF_CATEGORY_GHOST
+	options = list(GLOB.PREF_NO, GLOB.PREF_YES)
+
+/datum/client_preference/affects_ghost/ghost_see_ghosts
+	description = "Ghost see ghosts"
+	key = "GHOST_SEEGHOSTS"
+	category = PREF_CATEGORY_GHOST
+	options = list(GLOB.PREF_NO, GLOB.PREF_YES)
+
+/datum/client_preference/affects_ghost/ghost_inquisitiveness
+	description = "Ghost inquisitiveness"
+	key = "GHOST_INQUISITIVENESS"
+	category = PREF_CATEGORY_GHOST
+	options = list(GLOB.PREF_NO, GLOB.PREF_YES)
+
+/datum/client_preference/affects_ghost/ghost_lighting
+	description = "Ghost lighting"
+	key = "GHOST_DARKVISION"
+	category = PREF_CATEGORY_GHOST
+	options = list(GLOB.PREF_NO, GLOB.PREF_YES)
 
 /********************
 * General Staff Preferences *

--- a/code/modules/client/settings.dm
+++ b/code/modules/client/settings.dm
@@ -59,6 +59,7 @@
 
 			if(key && value)
 				owner.set_preference(key, value)
+				SScharacter_setup.queue_preferences_save(owner.prefs)
 				tgui_update()
 
 			return TRUE

--- a/code/modules/mob/observer/ghost/ghost.dm
+++ b/code/modules/mob/observer/ghost/ghost.dm
@@ -21,15 +21,20 @@ var/global/list/image/ghost_sightless_images = list() //this is a list of images
 	var/started_as_observer //This variable is set to 1 when you enter the game as an observer.
 							//If you died in the game and are a ghost - this will remain as null.
 							//Note that this is not a reliable way to determine if admins started as observers, since they change mobs a lot.
-	var/has_enabled_antagHUD = 0
-	var/medHUD = 0
-	var/antagHUD = 0
 	var/atom/movable/following = null
 	var/glide_before_follow = 0
-	var/admin_ghosted = 0
-	var/anonsay = 0
-	var/ghostvision = 1 //is the ghost able to see things humans can't?
-	var/seedarkness = 1
+
+	var/admin_ghosted = FALSE
+
+	var/has_enabled_antagHUD = FALSE
+	var/medHUD = FALSE
+	var/antagHUD = FALSE
+
+	var/health_scan = FALSE
+	var/chem_scan = FALSE
+	var/rads_scan = FALSE
+	var/gas_scan = FALSE
+
 	/// Wheather ghost's message will contain owner's ckey.
 	var/anonsay = FALSE
 	/// Wheather the ghost can see other ghosts.
@@ -55,29 +60,25 @@ var/global/list/image/ghost_sightless_images = list() //this is a list of images
 		attack_logs_ = body.attack_logs_ //preserve our attack logs by copying them to our ghost
 
 		set_appearance(body)
-		if(body.mind && body.mind.name)
-			name = body.mind.name
-		else
-			if(body.real_name)
-				name = body.real_name
-			else
-				if(gender == MALE)
-					name = capitalize(pick(GLOB.first_names_male)) + " " + capitalize(pick(GLOB.last_names))
-				else
-					name = capitalize(pick(GLOB.first_names_female)) + " " + capitalize(pick(GLOB.last_names))
+
+		name = body.mind?.name
+		if(isnull(name))
+			name = body.real_name
 
 		mind = body.mind //we don't transfer the mind but we keep a reference to it.
 	else
 		spawn(10) // wait for the observer mob to receive the client's key
 			mind = new /datum/mind(key)
 			mind.set_current(src)
+
 	if(!T)
 		T = pick(GLOB.latejoin | GLOB.latejoin_cryo | GLOB.latejoin_gateway) //Safety in case we cannot find the body's position
+
 	forceMove(T)
 	set_glide_size(16)
 
-	if(!name) //To prevent nameless ghosts
-		name = capitalize(pick(GLOB.first_names_male)) + " " + capitalize(pick(GLOB.last_names))
+	if(isnull(name))
+		name = capitalize(pick(gender == MALE ? GLOB.first_names_male : GLOB.first_names_female)) + " " + capitalize(pick(GLOB.last_names))
 	real_name = name
 
 	if(GLOB.cult)
@@ -189,20 +190,28 @@ Works together with spawning an observer, noted above.
 	return 1
 
 /mob/proc/ghostize(can_reenter_corpse = CORPSE_CAN_REENTER)
-	// Are we the body of an aghosted admin? If so, don't make a ghost.
-	if(teleop && istype(teleop, /mob/observer/ghost))
-		var/mob/observer/ghost/G = teleop
-		if(G.admin_ghosted)
-			return
-	if(key)
-		hide_fullscreens()
-		var/mob/observer/ghost/ghost = new(src)	//Transfer safety to observer spawning proc.
-		ghost.can_reenter_corpse = can_reenter_corpse
-		ghost.timeofdeath = src.stat == DEAD ? src.timeofdeath : world.time
-		ghost.key = key
-		if(ghost.client && !ghost.client.holder && !config.ghost.allow_antag_hud)		// For new ghosts we remove the verb from even showing up if it's not allowed.
-			ghost.verbs -= /mob/observer/ghost/verb/toggle_antagHUD	// Poor guys, don't know what they are missing!
-		return ghost
+	if(!key)
+		return
+	if(copytext(key, 1, 2) == "@")
+		return
+
+	var/mob/observer/ghost/ghost = (!QDELETED(teleop) && isghost(teleop)) ? teleop : new(src)
+
+	hide_fullscreens()
+	ghost.key = key
+	ghost.can_reenter_corpse = can_reenter_corpse
+	ghost.timeofdeath = src.stat == DEAD ? src.timeofdeath : world.time
+
+	if(!ghost.client?.holder && !config.ghost.allow_antag_hud)
+		ghost.verbs -= /mob/observer/ghost/verb/toggle_antagHUD
+
+	if(ghost.client)
+		ghost.updateghostprefs()
+		ghost.updateghostsight()
+
+	SEND_SIGNAL(src, SIGNAL_MOB_GHOSTIZED)
+
+	return ghost
 
 /*
 This is the proc mobs get to turn into a ghost. Forked from ghostize due to compatibility issues.
@@ -279,7 +288,7 @@ This is the proc mobs get to turn into a ghost. Forked from ghostize due to comp
 	if(!(mind && mind.current && mind.current.loc && can_reenter_corpse))
 		to_chat(src, SPAN("warning", "You have no body."))
 		return
-	if(mind.current.key && copytext(mind.current.key,1,2)!="@")	//makes sure we don't accidentally kick any clients
+	if(mind.current.key && copytext(mind.current.key,1,2) != "@")	//makes sure we don't accidentally kick any clients
 		to_chat(src, SPAN("warning", "Another consciousness is in your body... It is resisting you."))
 		return
 	stop_following()
@@ -295,81 +304,115 @@ This is the proc mobs get to turn into a ghost. Forked from ghostize due to comp
 
 /mob/observer/ghost/verb/toggle_medHUD()
 	set category = "Ghost"
-	set name = "Toggle MedicHUD"
+	set name = "Toggle Medical HUD"
 	set desc = "Toggles Medical HUD allowing you to see how everyone is doing"
-	if(!client)
-		return
-	if(medHUD)
-		medHUD = 0
-		to_chat(src, "<span class='notice'>Medical HUD Disabled</span>")
-	else
-		medHUD = 1
-		to_chat(src, "<span class='notice'>Medical HUD Enabled</span>")
-/mob/observer/ghost/verb/toggle_antagHUD()
-	set category = "Ghost"
-	set name = "Toggle AntagHUD"
-	set desc = "Toggles AntagHUD allowing you to see who is the antagonist"
 
 	if(!client)
 		return
-	var/mentor = is_mentor(usr.client)
+
+	medHUD = !medHUD
+
+	to_chat(src, SPAN_NOTICE("Medical HUD has been [medHUD ? "enabled" : "disabled"]"))
+
+/mob/observer/ghost/verb/toggle_antagHUD()
+	set category = "Ghost"
+	set name = "Toggle Antag HUD"
+	set desc = "Toggles Antag HUD allowing you to see who is the antagonist"
+
+	if(!client)
+		return
+
+	var/mentor = is_mentor(client)
 	if(!config.ghost.allow_antag_hud && (!client.holder || mentor))
-		to_chat(src, "<span class='warning'>Admins have disabled this for this round.</span>")
+		to_chat(src, SPAN_WARNING("Admins have disabled this for this round."))
 		return
-	var/mob/observer/ghost/M = src
-	if(jobban_isbanned(M, "AntagHUD"))
-		to_chat(src, "<span class='danger'>You have been banned from using this feature</span>")
+
+	if(jobban_isbanned(src, "AntagHUD"))
+		to_chat(src, SPAN_DANGER("You have been banned from using this feature"))
 		return
-	if(config.ghost.antag_hud_restricted && !M.has_enabled_antagHUD && (!client.holder || mentor))
-		var/response = alert(src, "If you turn this on, you will not be able to take any part in the round.","Are you sure you want to turn this feature on?","Yes","No")
-		if(response == "No") return
-		M.can_reenter_corpse = 0
-	if(!M.has_enabled_antagHUD && (!client.holder || mentor))
-		M.has_enabled_antagHUD = 1
-	if(M.antagHUD)
-		M.antagHUD = 0
-		to_chat(src, "<span class='notice'>AntagHUD Disabled</span>")
-	else
-		M.antagHUD = 1
-		to_chat(src, "<span class='notice'>AntagHUD Enabled</span>")
-/mob/observer/ghost/verb/dead_tele(A in area_repository.get_areas_by_z_level())
+
+	if(config.ghost.antag_hud_restricted && !has_enabled_antagHUD && (!client.holder || mentor))
+		var/response = tgui_alert(src, "If you turn this on, you will not be able to take any part in the round.", "Toggle Antag HUD", list("Yes", "No"))
+		if(response == "No")
+			return
+		can_reenter_corpse = 0
+
+	if(!has_enabled_antagHUD && (!client.holder || mentor))
+		has_enabled_antagHUD = TRUE
+
+	antagHUD = !antagHUD
+
+	to_chat(src, SPAN_NOTICE("Antag HUD has been [antagHUD ? "enabled" : "disabled"]"))
+
+/mob/observer/ghost/verb/dead_tele()
 	set category = "Ghost"
 	set name = "Teleport"
 	set desc= "Teleport to a location"
 
-	var/area/thearea = area_repository.get_areas_by_z_level()[A]
-	if(!thearea)
-		to_chat(src, "No area available.")
+	if(!client)
 		return
 
-	var/list/area_turfs = get_area_turfs(thearea, shall_check_if_holy() ? list(/proc/is_holy_turf) : list())
-	if(!area_turfs.len)
-		to_chat(src, "<span class='warning'>This area has been entirely made into sacred grounds, you cannot enter it while you are in this plane of existence!</span>")
+	var/response = tgui_input_list(src, "Choose an area to teleport to.", "Teleport", area_repository.get_areas_by_z_level())
+	if(!response)
+		return
+
+	var/area/chosen_area = response
+	if(!chosen_area)
+		to_chat(src, "Chosen area is unavailable.")
+		return
+
+	var/list/area_turfs = get_area_turfs(chosen_area, shall_check_if_holy() ? list(/proc/is_holy_turf) : list())
+	if(!length(area_turfs))
+		to_chat(src, SPAN_WARNING("This area has been entirely made into sacred grounds, you cannot enter it while you are in this plane of existence!"))
 		return
 
 	ghost_to_turf(pick(area_turfs))
 
-/mob/observer/ghost/verb/dead_tele_coord(tx as num, ty as num, tz as num)
+/mob/observer/ghost/verb/dead_tele_coord()
 	set category = "Ghost"
 	set name = "Teleport to Coordinate"
 	set desc= "Teleport to a coordinate"
 
-	var/turf/T = locate(tx, ty, tz)
+	if(!client)
+		return
+
+	var/turf_x = tgui_input_number(src, "Choose a X coordinate.", "Teleport to Coordinate")
+	if(isnull(turf_x))
+		return
+	var/turf_y = tgui_input_number(src, "Choose an Y coordinate.", "Teleport to Coordinate")
+	if(isnull(turf_y))
+		return
+	var/turf_z = tgui_input_number(src, "Choose a Z coordinate.", "Teleport to Coordinate")
+	if(isnull(turf_z))
+		return
+
+	var/turf/T = locate(turf_x, turf_y, turf_z)
 	if(T)
 		ghost_to_turf(T)
 	else
-		to_chat(src, "<span class='warning'>Invalid coordinates.</span>")
-/mob/observer/ghost/verb/follow(datum/follow_holder/fh in get_follow_targets())
+		to_chat(src, SPAN_WARNING("Invalid coordinates."))
+
+/mob/observer/ghost/verb/follow()
 	set category = "Ghost"
 	set name = "Follow"
 	set desc = "Follow and haunt a mob."
 
-	if(!fh.show_entry()) return
-	ManualFollow(fh.followed_instance)
+	if(!client)
+		return
+
+	var/response = tgui_input_list(src, "Choose a target to follow.", "Follow", get_follow_targets())
+	if(!response)
+		return
+
+	var/datum/follow_holder/holder = response
+	if(!holder.show_entry())
+		return
+
+	ManualFollow(holder.followed_instance)
 
 /mob/observer/ghost/proc/ghost_to_turf(turf/target_turf)
 	if(check_is_holy_turf(target_turf))
-		to_chat(src, "<span class='warning'>The target location is holy grounds!</span>")
+		to_chat(src, SPAN_WARNING("The target location is holy grounds!"))
 		return
 	stop_following()
 	forceMove(target_turf)
@@ -403,35 +446,56 @@ This is the proc mobs get to turn into a ghost. Forked from ghostize due to comp
 /mob/observer/ghost/move_to_turf(atom/movable/am, old_loc, new_loc)
 	var/turf/T = get_turf(new_loc)
 	if(check_is_holy_turf(T))
-		to_chat(src, "<span class='warning'>You cannot follow something standing on holy grounds!</span>")
+		to_chat(src, SPAN_WARNING("You cannot follow something standing on holy grounds!"))
 		return
 	..()
 
 /mob/observer/ghost/memory()
-	set hidden = 1
-	to_chat(src, "<span class='warning'>You are dead! You have no mind to store memory!</span>")
+	set hidden = TRUE
+	to_chat(src, SPAN_WARNING("You are dead! You have no mind to store memory!"))
+
 /mob/observer/ghost/add_memory()
-	set hidden = 1
-	to_chat(src, "<span class='warning'>You are dead! You have no mind to store memory!</span>")
+	set hidden = TRUE
+	to_chat(src, SPAN_WARNING("You are dead! You have no mind to store memory!"))
+
 /mob/observer/ghost/PostIncorporealMovement()
 	stop_following()
 
-/mob/observer/ghost/verb/analyze_air()
-	set name = "Analyze Air"
+/mob/observer/ghost/verb/toggle_health_scan()
 	set category = "Ghost"
+	set name = "Toggle Health Scan"
+	set desc = "Toggles whether you health-scan living beings on click"
 
-	var/turf/t = get_turf(src)
-	if(t)
-		print_atmos_analysis(src, atmosanalyzer_scan(t))
+	health_scan = !health_scan
+
+	to_chat(src, SPAN_NOTICE("Health scan has been [health_scan ? "enabled" : "disabled"]"))
+
+/mob/observer/ghost/verb/toggle_chem_scan()
+	set category = "Ghost"
+	set name = "Toggle Chem Scan"
+	set desc = "Toggles whether you scan living beings for chemicals and addictions on click"
+
+	chem_scan = !chem_scan
+
+	to_chat(src, SPAN_NOTICE("Chem scan has been [chem_scan ? "enabled" : "disabled"]"))
+
+/mob/observer/ghost/verb/toggle_gas_scan()
+	set category = "Ghost"
+	set name = "Toggle Gas Scan"
+	set desc = "Toggles whether you analyze gas contents on click"
+
+	gas_scan = !gas_scan
+
+	to_chat(src, SPAN_NOTICE("Gas scan has been [gas_scan ? "enabled" : "disabled"]"))
 
 /mob/observer/ghost/verb/check_radiation()
-	set name = "Check Radiation"
 	set category = "Ghost"
+	set name = "Toggle Rads Scan"
+	set desc = "Toggles whether you analyze radiation on click"
 
-	var/turf/t = get_turf(src)
-	if(t)
-		var/dose = SSradiation.get_total_absorbed_dose_at_turf(t, AVERAGE_HUMAN_WEIGHT)
-		to_chat(src, SPAN("notice", "Radiation: [fmt_siunit(dose, "Gy/s", 3)]."))
+	rads_scan = !rads_scan
+
+	to_chat(src, SPAN_NOTICE("Radiation scan has been [gas_scan ? "enabled" : "disabled"]"))
 
 /mob/observer/ghost/verb/view_manfiest()
 	set name = "Show Crew Manifest"
@@ -442,11 +506,6 @@ This is the proc mobs get to turn into a ghost. Forked from ghostize due to comp
 	dat += html_crew_manifest()
 
 	show_browser(src, dat, "window=manifest;size=370x420;can_close=1")
-
-/mob/observer/ghost/verb/analyse_health(mob/living/carbon/human/H as mob in GLOB.human_mob_list)
-	set category = null
-	set name = "Analyse Health"
-	show_browser(usr, medical_scan_results(H,1), "window=scanconsole;size=430x350")
 
 //This is called when a ghost is drag clicked to something.
 /mob/observer/ghost/MouseDrop(atom/over)
@@ -467,7 +526,7 @@ This is the proc mobs get to turn into a ghost. Forked from ghostize due to comp
 
 /mob/observer/ghost/proc/try_possession(mob/living/M)
 	if(!config.ghost.ghosts_can_possess_animals)
-		to_chat(src, "<span class='warning'>Ghosts are not permitted to possess animals.</span>")
+		to_chat(src, SPAN_WARNING("Ghosts are not permitted to possess animals."))
 		return 0
 	if(!M.can_be_possessed_by(src))
 		return 0
@@ -476,7 +535,7 @@ This is the proc mobs get to turn into a ghost. Forked from ghostize due to comp
 /mob/observer/ghost/pointed(atom/A as mob|obj|turf in view())
 	if(!..())
 		return 0
-	usr.visible_message("<span class='deadsay'><b>[src]</b> points to [A]</span>")
+	usr.visible_message(SPAN_DEADSAY("<b>[src]</b> points to [A]"))
 	return 1
 
 /mob/observer/ghost/proc/show_hud_icon(icon_state, make_visible)
@@ -495,13 +554,11 @@ This is the proc mobs get to turn into a ghost. Forked from ghostize due to comp
 /mob/observer/ghost/verb/toggle_anonsay()
 	set category = "Ghost"
 	set name = "Toggle Anonymous Chat"
-	set desc = "Toggles showing your key in dead chat."
+	set desc = "Toggles showing your key in dead chat"
 
-	src.anonsay = !src.anonsay
-	if(anonsay)
-		to_chat(src, "<span class='info'>Your key won't be shown when you speak in dead chat.</span>")
-	else
-		to_chat(src, "<span class='info'>Your key will be publicly visible again.</span>")
+	anonsay = !anonsay
+
+	to_chat(src, anonsay ? SPAN_INFO("Your key won't be shown when you speak in dead chat.") : SPAN_INFO("Your key will be publicly visible again."))
 
 /mob/observer/ghost/canface()
 	return 1
@@ -513,17 +570,34 @@ This is the proc mobs get to turn into a ghost. Forked from ghostize due to comp
 	return check_rights(R_ADMIN, 0, src)
 
 /mob/observer/ghost/verb/toggle_ghostsee()
+	set category = "Ghost"
 	set name = "Toggle Ghost Vision"
 	set desc = "Toggles your ability to see things only ghosts can see, like other ghosts"
-	set category = "Ghost"
-	ghostvision = !(ghostvision)
+
+	ghostvision = !ghostvision
+
 	updateghostsight()
-	to_chat(src, "You [(ghostvision?"now":"no longer")] have ghost vision.")
+
+	to_chat(src, SPAN_NOTICE("You [ghostvision ? "now" : "no longer"] have ghost vision."))
+
 /mob/observer/ghost/verb/toggle_darkness()
 	set name = "Toggle Darkness"
 	set category = "Ghost"
-	seedarkness = !(seedarkness)
+
+	seeindarkness = !seeindarkness
+
 	updateghostsight()
+
+	to_chat(src, SPAN_NOTICE("You [seeindarkness ? "now" : "no longer"] see in darkness."))
+
+/mob/observer/ghost/verb/toggle_inquisition()
+	set category = "Ghost"
+	set name = "Toggle Inquisitiveness"
+	set desc = "Sets whether your ghost examines everything on click by default"
+
+	inquisitiveness = !inquisitiveness
+
+	to_chat(src, SPAN_NOTICE("You [inquisitiveness ? "now" : "no longer"] examine everything you click on."))
 
 /mob/observer/ghost/proc/updateghostprefs()
 	anonsay = cmptext(get_preference_value("CHAT_GHOSTANONSAY"), GLOB.PREF_YES)
@@ -608,20 +682,20 @@ This is the proc mobs get to turn into a ghost. Forked from ghostize due to comp
 	set name = "Respawn"
 	set category = "OOC"
 
-	if (!(config.misc.abandon_allowed))
-		to_chat(usr, "<span class='notice'>Respawn is disabled.</span>")
+	if(!(config.misc.abandon_allowed))
+		to_chat(src, SPAN_NOTICE("Respawn is disabled."))
 		return
-	if (!SSticker.mode)
-		to_chat(usr, "<span class='notice'><B>You may not attempt to respawn yet.</B></span>")
+	if(!SSticker.mode)
+		to_chat(src, SPAN_NOTICE("<B>You may not attempt to respawn yet.</B>"))
 		return
-	if (SSticker.mode.deny_respawn)
-		to_chat(usr, "<span class='notice'>Respawn is disabled for this roundtype.</span>")
+	if(SSticker.mode.deny_respawn)
+		to_chat(src, SPAN_NOTICE("Respawn is disabled for this roundtype."))
 		return
 	else if(!MayRespawn(1, config.misc.respawn_delay))
 		return
 
-	to_chat(usr, "You can respawn now, enjoy your new life!")
-	to_chat(usr, "<span class='notice'><B>Make sure to play a different character, and please roleplay correctly!</B></span>")
+	to_chat(src, "You can respawn now, enjoy your new life!")
+	to_chat(src, SPAN_NOTICE("<B>Make sure to play a different character, and please roleplay correctly!</B>"))
 	announce_ghost_joinleave(client, 0)
 
 	var/mob/new_player/M = new /mob/new_player()

--- a/code/modules/mob/observer/ghost/ghost.dm
+++ b/code/modules/mob/observer/ghost/ghost.dm
@@ -30,6 +30,14 @@ var/global/list/image/ghost_sightless_images = list() //this is a list of images
 	var/anonsay = 0
 	var/ghostvision = 1 //is the ghost able to see things humans can't?
 	var/seedarkness = 1
+	/// Wheather ghost's message will contain owner's ckey.
+	var/anonsay = FALSE
+	/// Wheather the ghost can see other ghosts.
+	var/ghostvision = TRUE
+	/// Wheather the ghost has night vision enabled.
+	var/seeindarkness = TRUE
+	/// Wheather the ghost will examine everything it clicks on.
+	var/inquisitiveness = TRUE
 
 	var/obj/item/device/multitool/ghost_multitool
 
@@ -517,23 +525,29 @@ This is the proc mobs get to turn into a ghost. Forked from ghostize due to comp
 	seedarkness = !(seedarkness)
 	updateghostsight()
 
+/mob/observer/ghost/proc/updateghostprefs()
+	anonsay = cmptext(get_preference_value("CHAT_GHOSTANONSAY"), GLOB.PREF_YES)
+	ghostvision = cmptext(get_preference_value("GHOST_SEEGHOSTS"), GLOB.PREF_YES)
+	seeindarkness = cmptext(get_preference_value("GHOST_DARKVISION"), GLOB.PREF_YES)
+	inquisitiveness = cmptext(get_preference_value("GHOST_INQUISITIVENESS"), GLOB.PREF_YES)
+
 /mob/observer/ghost/proc/updateghostsight()
-	if (!seedarkness)
+	if(seeindarkness)
 		set_see_invisible(SEE_INVISIBLE_NOLIGHTING)
 	else
 		set_see_invisible(ghostvision ? SEE_INVISIBLE_OBSERVER : SEE_INVISIBLE_LIVING)
 	updateghostimages()
 
 /mob/observer/ghost/proc/updateghostimages()
-	if (!client)
+	if(!client)
 		return
 	client.images -= ghost_sightless_images
 	client.images -= ghost_darkness_images
-	if(!seedarkness)
+	if(!seeindarkness)
 		client.images |= ghost_sightless_images
 		if(ghostvision)
 			client.images |= ghost_darkness_images
-	else if(seedarkness && !ghostvision)
+	else if(seeindarkness && !ghostvision)
 		client.images |= ghost_sightless_images
 	client.images -= ghost_image //remove ourself
 

--- a/code/modules/mob/observer/ghost/login.dm
+++ b/code/modules/mob/observer/ghost/login.dm
@@ -1,7 +1,10 @@
 /mob/observer/ghost/Login()
 	..()
 
-	if (ghost_image)
+	if(ghost_image)
 		ghost_image.appearance = src
 		ghost_image.appearance_flags = DEFAULT_APPEARANCE_FLAGS | RESET_ALPHA
+
+	updateghostprefs()
+	updateghostsight()
 	updateghostimages()

--- a/code/modules/power/cable.dm
+++ b/code/modules/power/cable.dm
@@ -99,15 +99,13 @@ var/list/possible_cable_coil_colours
 	. = ..()                       // then go ahead and delete the cable
 
 
-// Ghost examining the cable -> tells him the power
-/obj/structure/cable/attack_ghost(mob/user)
-	if(user.client && user.client.inquisitive_ghost)
+/obj/structure/cable/attack_ghost(mob/observer/ghost/user)
+	if(user.inquisitiveness)
 		user.examinate(src)
-		// following code taken from attackby (multitool)
 		if(powernet && (powernet.avail > 0))
-			to_chat(user, "<span class='warning'>[get_wattage()] in power network.</span>")
+			to_chat(user, SPAN_WARNING("[get_wattage()] in power network."))
 		else
-			to_chat(user, "<span class='warning'>The cable is not powered.</span>")
+			to_chat(user, SPAN_WARNING("The cable is not powered."))
 	return
 
 ///////////////////////////////////


### PR DESCRIPTION
Сделал игру на призраках немного удобнее.

- Настройки "ночное зрение", "анонимный чат", "любознательность" и "зрение призрака" переходят между раундами, если установлены через Fake Nano / TGUI.
- Обновлены сканеры здоровья, радиации и газов, добавлен сканер химических веществ. Переключить режим работы каждого из них можно во вкладке "Ghosts", срабатывают по клику на тайл.
- Выборочно исправил "страшные" куски кода, часть старых вербов обновил и подключил к ним TGUI Input (отключается в настройках).

<details>
<summary>Чейнджлог</summary>

```yml
🆑
rscadd: параметры призраков, выбранные через Fake Nano / TGUI настройки, сохраняются между раундами. Добавлены настройки: "ночное зрение", "анонимный чат", "любознательность" и "зрение призрака".
rscadd: обновлены сканеры призраком - срабатывают при клике по тайлу, включаются во вкладке "Ghosts".
rscadd: добавлен сканер химикатов призракам.
/🆑
```

</details>

- [x] Pull Request полностью завершен, мне не нужна помощь чтобы его закончить.
- [x] Я внимательно прочитал все свои изменения и багов в них не нашел.
- [x] Я запускал сервер со своими изменениями локально и все протестировал.
- [x] Я ознакомился c [Guide to Contribute](https://github.com/ChaoticOnyx/OnyxBay/blob/dev/docs/contributing.md).
