### PR TITLE
fix(chem_smoke) Correct smoke duration calculation

### DIFF
--- a/code/game/objects/effects/chem/chemsmoke.dm
+++ b/code/game/objects/effects/chem/chemsmoke.dm
@@ -185,7 +185,7 @@
 				continue
 			if(T in targetTurfs)
 				spawn(0)
-					spawnSmoke(T, I, range)
+					spawnSmoke(T, I, smoke_duration, range)
 
 //------------------------------------------
 // Randomizes and spawns the smoke effect.


### PR DESCRIPTION
В бухгалтерии все перепутали и передавали неправильные аргументы в функцию. 

Теперь дым больше не пропадает за 1 тик.
<details>
<summary>Чейнджлог</summary>

```yml
🆑
bugfix: Теперь длительность существования химического дыма считается корректно. Он больше не пропадает через 1 тик.
/🆑
```

</details>

- [x] Pull Request полностью завершен, мне не нужна помощь чтобы его закончить.
- [x] Я внимательно прочитал все свои изменения и багов в них не нашел.
- [x] Я запускал сервер со своими изменениями локально и все протестировал.
- [x] Я ознакомился c [Guide to Contribute](https://github.com/ChaoticOnyx/OnyxBay/blob/dev/docs/contributing.md).
