### PR TITLE
fix(human/say()) Fixing "cant say" problem in a little bit low pressures

### DIFF
--- a/code/modules/mob/living/carbon/human/say.dm
+++ b/code/modules/mob/living/carbon/human/say.dm
@@ -32,14 +32,14 @@
 				L.last_successful_breath = world.time - 2 MINUTES
 				return ..(message, alt_name = alt_name, language = language)
 
-			to_chat(src, "<span class='warning'>You don't have enough air in [L] to make a sound!</span>")
+			visible_message(SPAN("warning", "[src] moves his lips as if trying to say something"), SPAN("danger", "You don't have enough air in [L] to make a sound!"))
 			return FALSE
 		else if(L.breath_fail_ratio > 0.7)
-			return whisper_say(length(message) > 5 ? stars(message) : message, language, alt_name)
+			return ..(length(message) > 5 ? stars(message, 50) : message, alt_name = alt_name, language = language, whispering = whispering)
 		else if(L.breath_fail_ratio > 0.4)
-			return whisper_say(length(message) > 10 ? stars(message) : message, language, alt_name)
-	else
-		return ..(message, alt_name = alt_name, language = language, whispering = whispering)
+			return ..(length(message) > 10 ? stars(message, 50) : message, alt_name = alt_name, language = language, whispering = whispering)
+
+	return ..(message, alt_name = alt_name, language = language, whispering = whispering)
 
 
 /mob/living/carbon/human/proc/forcesay(list/append)

--- a/code/modules/mob/mob_helpers.dm
+++ b/code/modules/mob/mob_helpers.dm
@@ -180,14 +180,11 @@ var/list/global/organ_rel_size = list(
 	return zone
 
 
-/proc/stars(message, not_changing_char_chance)
-	if (not_changing_char_chance == null)
-		not_changing_char_chance = 25
-	else if (not_changing_char_chance < 0)
+/proc/stars(message, not_changing_char_chance = 25)
+	if (not_changing_char_chance < 0)
 		return null
-	else
-		if (not_changing_char_chance >= 100)
-			return message
+	if (not_changing_char_chance >= 100)
+		return message
 
 	var/message_length = length_char(message)
 	var/output_message = ""

--- a/code/modules/mob/mob_helpers.dm
+++ b/code/modules/mob/mob_helpers.dm
@@ -180,32 +180,38 @@ var/list/global/organ_rel_size = list(
 	return zone
 
 
-/proc/stars(n, pr)
-	if (pr == null)
-		pr = 25
-	if (pr < 0)
+/proc/stars(message, not_changing_char_chance)
+	if (not_changing_char_chance == null)
+		not_changing_char_chance = 25
+	else if (not_changing_char_chance < 0)
 		return null
 	else
-		if (pr >= 100)
-			return n
-	var/te = n
-	var/t = ""
-	n = length_char(n)
-	var/p = null
-	p = 1
-	var/intag = 0
-	while(p <= n)
-		var/char = copytext_char(te, p, p + 1)
+		if (not_changing_char_chance >= 100)
+			return message
+
+	var/message_length = length_char(message)
+	var/output_message = ""
+	var/intag = FALSE
+
+	var/first_char = copytext_char(message, 1, 2) //for not to processing message as emote if first char would made into "*"
+	if (first_char == "<")
+		intag = TRUE
+	output_message = text("[][]", output_message, first_char)
+
+	var/pointer = 2
+
+	while(pointer <= message_length)
+		var/char = copytext_char(message, pointer, pointer + 1)
 		if (char == "<") //let's try to not break tags
-			intag = !intag
-		if (intag || char == " " || prob(pr))
-			t = text("[][]", t, char)
+			intag = TRUE
+		if (intag || char == " " || prob(not_changing_char_chance))
+			output_message = text("[][]", output_message, char)
 		else
-			t = text("[]*", t)
+			output_message = text("[]*", output_message)
 		if (char == ">")
-			intag = !intag
-		p++
-	return t
+			intag = FALSE
+		pointer++
+	return output_message
 
 // This is temporary effect, often caused by alcohol
 /proc/slur(phrase)


### PR DESCRIPTION
Теперь say больше не вылетает без каких-либо сообщений при немного пониженном давлении.
Так же убрана рекурсия, вызывавшая сотни раз подряд say(), после одно лишь сообщения.

Переписан proc/stars() на нормальные названия переменных, а также первый символ сообщения больше не меняется на "*", из-за чего сообщение в последствии процессилось, как эмоут, вылетая с ошибкой.

fix #10072
fix #9446
fix #8834

<details>
<summary>Чейнджлог</summary>

```yml
🆑
bugfix: Возможность говорить больше не отрубается при малейших изменениях в давлении.
/🆑
```

</details>

- [x] Pull Request полностью завершен, мне не нужна помощь чтобы его закончить.
- [x] Я внимательно прочитал все свои изменения и багов в них не нашел.
- [x] Я запускал сервер со своими изменениями локально и все протестировал.
- [x] Я ознакомился c [Guide to Contribute](https://github.com/ChaoticOnyx/OnyxBay/blob/dev/docs/contributing.md).
