### PR TITLE
fix(ability) fix changeling division

### DIFF
--- a/code/game/gamemodes/changeling/powers/division.dm
+++ b/code/game/gamemodes/changeling/powers/division.dm
@@ -49,6 +49,7 @@
 	if(!changeling.geneticpoints)
 		to_chat(my_mob, SPAN("changeling", "We require at least <b>[required_dna]</b> samples of compatible DNA."))
 		return
+		
 	changeling.using_proboscis = TRUE
 	for(var/stage = 1 to 3)
 		switch(stage)

--- a/code/game/gamemodes/changeling/powers/division.dm
+++ b/code/game/gamemodes/changeling/powers/division.dm
@@ -46,6 +46,9 @@
 		to_chat(my_mob, SPAN("changeling", "[T] is of our kind, we cannot transfuse another core into them."))
 		return
 
+	if(!changeling.geneticpoints)
+		to_chat(my_mob, SPAN("changeling", "We require at least <b>[required_dna]</b> samples of compatible DNA."))
+		return
 	changeling.using_proboscis = TRUE
 	for(var/stage = 1 to 3)
 		switch(stage)


### PR DESCRIPTION
Теперь при отсутствии достаточного количества поинтов генов, дивижн не начинается и количество не уходит в минус, а выводится сообщение о том, что поинтов недостаточно. Так это и должно впринципе работать.
Но при этом, чтобы дивижн после покупки начал работать, нужно поглотить кого-нибудь. Но это никто не репортил, поэтому не трогаю. Да и я покумекал, но не допёр как это чинить. Работает и заебись.

close #9983

<details>
<summary>Чейнджлог</summary>

```yml
🆑Nod404
bugfix: Дивижн у генок больше не начинается, если недостаточно очков. И они не уходят в минус.
/🆑
```

</details>

- [x] Pull Request полностью завершен, мне не нужна помощь чтобы его закончить.
- [x] Я внимательно прочитал все свои изменения и багов в них не нашел.
- [x] Я запускал сервер со своими изменениями локально и все протестировал.
- [x] Я ознакомился c [Guide to Contribute](https://github.com/ChaoticOnyx/OnyxBay/blob/dev/docs/contributing.md).
