### PR TITLE
tweak(ghost): change verb names & add analyze health verb

### DIFF
--- a/code/_onclick/ghost.dm
+++ b/code/_onclick/ghost.dm
@@ -40,12 +40,12 @@
 	if(user.client)
 		if(user.gas_scan)
 			print_atmos_analysis(user, atmosanalyzer_scan(src))
-		else if(user.chem_scan)
+		if(user.chem_scan)
 			reagent_scanner_scan(user, src)
-		else if(user.rads_scan)
+		if(user.rads_scan)
 			var/dose = SSradiation.get_total_absorbed_dose_at_turf(get_turf(src), AVERAGE_HUMAN_WEIGHT)
 			to_chat(user, EXAMINE_BLOCK(SPAN_NOTICE("Radiation: [fmt_siunit(dose, "Gy/s", 3)].")))
-		else if(user.inquisitiveness)
+		if(user.inquisitiveness)
 			user.examinate(src)
 	return
 

--- a/code/_onclick/ghost.dm
+++ b/code/_onclick/ghost.dm
@@ -51,7 +51,7 @@
 
 /mob/living/attack_ghost(mob/observer/ghost/user)
 	if(user.client && user.health_scan)
-		to_chat(user, EXAMINE_BLOCK(medical_scan_results(src, 1)))
+		show_browser(user, medical_scan_results(src, TRUE), "window=scanconsole;size=430x350")
 	return ..()
 
 // ---------------------------------------

--- a/code/modules/mob/observer/ghost/ghost.dm
+++ b/code/modules/mob/observer/ghost/ghost.dm
@@ -307,7 +307,7 @@ This is the proc mobs get to turn into a ghost. Forked from ghostize due to comp
 
 /mob/observer/ghost/verb/toggle_medHUD()
 	set category = "Ghost"
-	set name = "Toggle Medical HUD"
+	set name = "ToggleHUD Medical HUD"
 	set desc = "Toggles Medical HUD allowing you to see how everyone is doing"
 
 	if(!client)
@@ -319,7 +319,7 @@ This is the proc mobs get to turn into a ghost. Forked from ghostize due to comp
 
 /mob/observer/ghost/verb/toggle_antagHUD()
 	set category = "Ghost"
-	set name = "Toggle Antag HUD"
+	set name = "ToggleHUD Antag HUD"
 	set desc = "Toggles Antag HUD allowing you to see who is the antagonist"
 
 	if(!client)
@@ -472,9 +472,18 @@ This is the proc mobs get to turn into a ghost. Forked from ghostize due to comp
 
 	show_browser(usr, medical_scan_results(H, TRUE), "window=scanconsole;size=430x350")
 
+/mob/observer/ghost/verb/toggle_inquisition()
+	set category = "Ghost"
+	set name = "ToggleCheck Inquisitiveness"
+	set desc = "Sets whether your ghost examines everything on click by default"
+
+	inquisitiveness = !inquisitiveness
+
+	to_chat(src, SPAN_NOTICE("You [inquisitiveness ? "now" : "no longer"] examine everything you click on."))
+
 /mob/observer/ghost/verb/toggle_health_scan()
 	set category = "Ghost"
-	set name = "Toggle Health Scan"
+	set name = "ToggleCheck Health Scan"
 	set desc = "Toggles whether you health-scan living beings on click"
 
 	health_scan = !health_scan
@@ -483,7 +492,7 @@ This is the proc mobs get to turn into a ghost. Forked from ghostize due to comp
 
 /mob/observer/ghost/verb/toggle_chem_scan()
 	set category = "Ghost"
-	set name = "Toggle Chem Scan"
+	set name = "ToggleCheck Chem Scan"
 	set desc = "Toggles whether you scan living beings for chemicals and addictions on click"
 
 	chem_scan = !chem_scan
@@ -492,7 +501,7 @@ This is the proc mobs get to turn into a ghost. Forked from ghostize due to comp
 
 /mob/observer/ghost/verb/toggle_gas_scan()
 	set category = "Ghost"
-	set name = "Toggle Gas Scan"
+	set name = "ToggleCheck Gas Scan"
 	set desc = "Toggles whether you analyze gas contents on click"
 
 	gas_scan = !gas_scan
@@ -501,7 +510,7 @@ This is the proc mobs get to turn into a ghost. Forked from ghostize due to comp
 
 /mob/observer/ghost/verb/check_radiation()
 	set category = "Ghost"
-	set name = "Toggle Rads Scan"
+	set name = "ToggleCheck Rads Scan"
 	set desc = "Toggles whether you analyze radiation on click"
 
 	rads_scan = !rads_scan
@@ -582,7 +591,7 @@ This is the proc mobs get to turn into a ghost. Forked from ghostize due to comp
 
 /mob/observer/ghost/verb/toggle_ghostsee()
 	set category = "Ghost"
-	set name = "Toggle Ghost Vision"
+	set name = "ToggleVision Ghost Vision"
 	set desc = "Toggles your ability to see things only ghosts can see, like other ghosts"
 
 	ghostvision = !ghostvision
@@ -592,7 +601,7 @@ This is the proc mobs get to turn into a ghost. Forked from ghostize due to comp
 	to_chat(src, SPAN_NOTICE("You [ghostvision ? "now" : "no longer"] have ghost vision."))
 
 /mob/observer/ghost/verb/toggle_darkness()
-	set name = "Toggle Darkness"
+	set name = "ToggleVision Darkness"
 	set category = "Ghost"
 
 	seeindarkness = !seeindarkness
@@ -600,15 +609,6 @@ This is the proc mobs get to turn into a ghost. Forked from ghostize due to comp
 	updateghostsight()
 
 	to_chat(src, SPAN_NOTICE("You [seeindarkness ? "now" : "no longer"] see in darkness."))
-
-/mob/observer/ghost/verb/toggle_inquisition()
-	set category = "Ghost"
-	set name = "Toggle Inquisitiveness"
-	set desc = "Sets whether your ghost examines everything on click by default"
-
-	inquisitiveness = !inquisitiveness
-
-	to_chat(src, SPAN_NOTICE("You [inquisitiveness ? "now" : "no longer"] examine everything you click on."))
 
 /mob/observer/ghost/proc/updateghostprefs()
 	anonsay = cmptext(get_preference_value("CHAT_GHOSTANONSAY"), GLOB.PREF_YES)

--- a/code/modules/mob/observer/ghost/ghost.dm
+++ b/code/modules/mob/observer/ghost/ghost.dm
@@ -466,6 +466,12 @@ This is the proc mobs get to turn into a ghost. Forked from ghostize due to comp
 /mob/observer/ghost/PostIncorporealMovement()
 	stop_following()
 
+/mob/observer/ghost/verb/analyse_health(mob/living/carbon/human/H in GLOB.human_mob_list)
+	set category = null
+	set name = "Analyse Health"
+
+	show_browser(usr, medical_scan_results(H, TRUE), "window=scanconsole;size=430x350")
+
 /mob/observer/ghost/verb/toggle_health_scan()
 	set category = "Ghost"
 	set name = "Toggle Health Scan"


### PR DESCRIPTION
Согласно запросу от @Kostil дорабатываю свои улучшения.

- Вернул верб "Analyze Health" для просмотра состояния гуманоидов.
- Результаты сканирования здоровья отправляются в отдельное окно, как было до моего проекта.
- Переименовал вербы согласно #10255.

<details>
<summary>Демонстрация</summary>

![dreamseeker_FOvXglVYzm](https://github.com/ChaoticOnyx/OnyxBay/assets/118671019/0719a00b-4bd0-446c-8e3e-cf48cd9b4756)

</details>

<details>
<summary>Чейнджлог</summary>

```yml
🆑
tweak: изменены названия некоторых вербов у призраков.
tweak: результаты сканирования здоровья призраками отправляются в отдельное окно.
rscadd: добавлен верб "Analyze Health" призракам для просмотра состояния гуманоидов.
/🆑
```

</details>

resolve #10255
close #10229
close #10225

- [x] Pull Request полностью завершен, мне не нужна помощь чтобы его закончить.
- [x] Я внимательно прочитал все свои изменения и багов в них не нашел.
- [x] Я запускал сервер со своими изменениями локально и все протестировал.
- [x] Я ознакомился c [Guide to Contribute](https://github.com/ChaoticOnyx/OnyxBay/blob/dev/docs/contributing.md).
