### PR TITLE
refact(armor): refactor clothing armor to use dedicated subtypes 

### DIFF
--- a/baystation12.dme
+++ b/baystation12.dme
@@ -277,6 +277,8 @@
 #include "code\datums\appearances\appearance_manager.dm"
 #include "code\datums\appearances\automatic\_base.dm"
 #include "code\datums\appearances\automatic\cardborg.dm"
+#include "code\datums\armor\_armor.dm"
+#include "code\datums\armor\_atom_armor.dm"
 #include "code\datums\colors\color_generator.dm"
 #include "code\datums\communication\_defines.dm"
 #include "code\datums\communication\aooc.dm"

--- a/code/__defines/damage_organs.dm
+++ b/code/__defines/damage_organs.dm
@@ -11,7 +11,25 @@
 #define CUT       "cut"
 #define BRUISE    "bruise"
 #define PIERCE    "pierce"
-#define LASER     "laser"
+
+/// Involved in checking whether a disease can infest or spread
+#define BIO "bio"
+/// Involves in a shockwave, usually from an explision
+#define BOMB "bomb"
+/// Involves a solid projectile
+#define BULLET "bullet"
+// Ivolves a EMP or energy-based projectile
+#define ENERGY "energy"
+/// Involves a laser
+#define LASER "laser"
+/// Involves a melee attack or thrown object
+#define MELEE "melee"
+
+/// Used to modify all of the armor values at once
+#define ARMOR_ALL "armor_all"
+
+/// Armor values that are used for the damage
+#define ARMOR_LIST_DAMAGE(...) list(BIO, BOMB, BULLET, ENERGY, LASER, MELEE)
 
 #define STUN      "stun"
 #define WEAKEN    "weaken"

--- a/code/datums/armor/_armor.dm
+++ b/code/datums/armor/_armor.dm
@@ -1,3 +1,4 @@
+/// Assosciative list of type -> armor. Used to ensure we always hold a reference to default armor datums
 GLOBAL_LIST_INIT(armor_by_type, generate_armor_type_cache())
 
 /proc/generate_armor_type_cache()
@@ -8,6 +9,7 @@ GLOBAL_LIST_INIT(armor_by_type, generate_armor_type_cache())
 		armor_type.GenerateTag()
 	return armor_cache
 
+/// Gets an armor type datum using the given type by formatting it into the expected datum tag
 /proc/get_armor_by_type(armor_type)
 	var/datum/armor/armor = locate(replacetext("[armor_type]", "/", "-"))
 	if(armor)
@@ -39,6 +41,7 @@ GLOBAL_LIST_INIT(armor_by_type, generate_armor_type_cache())
 /datum/armor/proc/GenerateTag()
 	tag = replacetext("[type]", "/", "-")
 
+/// Generate a brand new armor datum with the modifiers given, if ARMOR_ALL is specified only that modifier is used
 /datum/armor/proc/generate_new_with_modifiers(list/modifiers)
 	var/datum/armor/new_armor = new
 
@@ -61,6 +64,7 @@ GLOBAL_LIST_INIT(armor_by_type, generate_armor_type_cache())
 /datum/armor/immune/generate_new_with_modifiers(list/modifiers)
 	return src
 
+/// Generate a brand new armor datum with the multiplier given, if ARMOR_ALL is specified only that modifer is used
 /datum/armor/proc/generate_new_with_multipliers(list/multipliers)
 	var/datum/armor/new_armor = new
 
@@ -83,6 +87,7 @@ GLOBAL_LIST_INIT(armor_by_type, generate_armor_type_cache())
 /datum/armor/immune/generate_new_with_multipliers(list/multiplier)
 	return src
 
+/// Generate a brand new armor datum with the values given, if a value is not present it carries over
 /datum/armor/proc/generate_new_with_specific(list/values)
 	var/datum/armor/new_armor = new
 
@@ -105,6 +110,7 @@ GLOBAL_LIST_INIT(armor_by_type, generate_armor_type_cache())
 /datum/armor/immune/generate_new_with_specific(list/values)
 	return src
 
+/// Gets the rating of armor for the specified rating
 /datum/armor/proc/get_rating(rating)
 	if(!(rating in ARMOR_LIST_DAMAGE()))
 		CRASH("Attempted to get a non-existant rating '[rating]'")
@@ -113,6 +119,7 @@ GLOBAL_LIST_INIT(armor_by_type, generate_armor_type_cache())
 /datum/armor/immune/get_rating(rating)
 	return 100
 
+/// Converts all the ratings of the armor into a list, optionally inversed
 /datum/armor/proc/get_rating_list(inverse = FALSE)
 	var/list/ratings = list()
 	for(var/rating in ARMOR_LIST_DAMAGE())
@@ -128,11 +135,13 @@ GLOBAL_LIST_INIT(armor_by_type, generate_armor_type_cache())
 		ratings[rating] = 100
 	return ratings
 
+/// Returns a new armor datum with the given armor added onto this one
 /datum/armor/proc/add_other_armor(datum/armor/other)
 	if(ispath(other))
 		other = get_armor_by_type(other)
 	return generate_new_with_modifiers(other.get_rating_list())
 
+/// Returns a new armor datum with the given armor removed from this one
 /datum/armor/proc/substract_other_armor(datum/armor/other)
 	if(ispath(other))
 		other = get_armor_by_type(other)

--- a/code/datums/armor/_armor.dm
+++ b/code/datums/armor/_armor.dm
@@ -1,0 +1,137 @@
+GLOBAL_LIST_INIT(armor_by_type, generate_armor_type_cache())
+
+/proc/generate_armor_type_cache()
+	var/list/armor_cache = list()
+	for(var/datum/armor/armor_type in subtypesof(/datum/armor))
+		armor_type = new armor_type
+		armor_cache[armor_type.type] = armor_type
+		armor_type.GenerateTag()
+	return armor_cache
+
+/proc/get_armor_by_type(armor_type)
+	var/datum/armor/armor = locate(replacetext("[armor_type]", "/", "-"))
+	if(armor)
+		return armor
+	if(armor_type == /datum/armor)
+		CRASH("Attempted to get the base armor type, you probably meant to use /datum/armor/none")
+	CRASH("Attempted to get an armor type that did not exist! '[armor_type]'")
+
+/datum/armor
+	var/bio = 0
+	var/bomb = 0
+	var/bullet = 0
+	var/energy = 0
+	var/laser = 0
+	var/melee = 0
+
+/// A version of armor with no protection
+/datum/armor/none
+
+/// A version of armor that cannot be modified and will always return itself when modified
+/datum/armor/immune
+
+/datum/armor/Destroy()
+	tag = null
+	return ..()
+
+/datum/armor/proc/GenerateTag()
+	tag = replacetext("[type]", "/", "-")
+
+/datum/armor/proc/generate_new_with_modifiers(list/modifiers)
+	var/datum/armor/new_armor = new
+
+	var/all_keys = ARMOR_LIST_DAMAGE()
+	if(ARMOR_ALL in modifiers)
+		var/modifier_all = modifiers[ARMOR_ALL]
+		if(!modifier_all)
+			return src
+		for(var/mod in all_keys)
+			new_armor.vars[mod] += modifier_all
+		return new_armor
+
+	for(var/modifier in modifiers)
+		if(modifier in all_keys)
+			new_armor.vars[modifier] += modifiers[modifier]
+		else
+			CRASH("Attempt to call generate_new_with_modifiers with illegal modifier '[modifier]'! Ignoring it")
+	return new_armor
+
+/datum/armor/immune/generate_new_with_modifiers(list/modifiers)
+	return src
+
+/datum/armor/proc/generate_new_with_multipliers(list/multipliers)
+	var/datum/armor/new_armor = new
+
+	var/all_keys = ARMOR_LIST_DAMAGE()
+	if(ARMOR_ALL in multipliers)
+		var/multiplier_all = multipliers[ARMOR_ALL]
+		if(!multiplier_all)
+			return src
+		for(var/mult in all_keys)
+			new_armor.vars[mult] *= multiplier_all
+		return new_armor
+
+	for(var/multiplier in multipliers)
+		if(multiplier in all_keys)
+			new_armor.vars[multiplier] *= multipliers[multiplier]
+		else
+			CRASH("Attempt to call generate_new_with_multipliers with illegal modifier '[multiplier]'! Ignoring it")
+	return new_armor
+
+/datum/armor/immune/generate_new_with_multipliers(list/multiplier)
+	return src
+
+/datum/armor/proc/generate_new_with_specific(list/values)
+	var/datum/armor/new_armor = new
+
+	var/all_keys = ARMOR_LIST_DAMAGE()
+	if(ARMOR_ALL in values)
+		var/value_all = values[ARMOR_ALL]
+		if(!value_all)
+			return src
+		for(var/val in all_keys)
+			new_armor.vars[val] = value_all
+		return new_armor
+
+	for(var/value in values)
+		if(value in all_keys)
+			new_armor.vars[value] = values[value]
+		else
+			new_armor.vars[value] = vars[value]
+	return new_armor
+
+/datum/armor/immune/generate_new_with_specific(list/values)
+	return src
+
+/datum/armor/proc/get_rating(rating)
+	if(!(rating in ARMOR_LIST_DAMAGE()))
+		CRASH("Attempted to get a non-existant rating '[rating]'")
+	return vars[rating]
+
+/datum/armor/immune/get_rating(rating)
+	return 100
+
+/datum/armor/proc/get_rating_list(inverse = FALSE)
+	var/list/ratings = list()
+	for(var/rating in ARMOR_LIST_DAMAGE())
+		var/value = vars[rating]
+		if(inverse)
+			value *= -1
+		ratings[rating] = value
+	return ratings
+
+/datum/armor/immune/get_rating_list(inverse)
+	var/list/ratings = ..()
+	for(var/rating in ratings)
+		ratings[rating] = 100
+	return ratings
+
+/datum/armor/proc/add_other_armor(datum/armor/other)
+	if(ispath(other))
+		other = get_armor_by_type(other)
+	return generate_new_with_modifiers(other.get_rating_list())
+
+/datum/armor/proc/substract_other_armor(datum/armor/other)
+	if(ispath(other))
+		other = get_armor_by_type(other)
+	return generate_new_with_modifiers(other.get_rating_list(TRUE))

--- a/code/datums/armor/_armor.dm
+++ b/code/datums/armor/_armor.dm
@@ -30,7 +30,9 @@ GLOBAL_LIST_INIT(armor_by_type, generate_armor_type_cache())
 /// A version of armor that cannot be modified and will always return itself when modified
 /datum/armor/immune
 
-/datum/armor/Destroy()
+/datum/armor/Destroy(force = FALSE)
+	if(!force && tag)
+		return QDEL_HINT_LETMELIVE
 	tag = null
 	return ..()
 

--- a/code/datums/armor/_armor.dm
+++ b/code/datums/armor/_armor.dm
@@ -2,7 +2,7 @@ GLOBAL_LIST_INIT(armor_by_type, generate_armor_type_cache())
 
 /proc/generate_armor_type_cache()
 	var/list/armor_cache = list()
-	for(var/datum/armor/armor_type in subtypesof(/datum/armor))
+	for(var/datum/armor/armor_type as anything in subtypesof(/datum/armor))
 		armor_type = new armor_type
 		armor_cache[armor_type.type] = armor_type
 		armor_type.GenerateTag()

--- a/code/datums/armor/_atom_armor.dm
+++ b/code/datums/armor/_atom_armor.dm
@@ -1,0 +1,17 @@
+/atom/proc/get_armor()
+	return armor || get_armor_by_type(armor_type)
+
+/atom/proc/get_armor_rating(damage_type)
+	var/datum/armor/armor = get_armor()
+	return armor.get_rating(damage_type)
+
+/atom/proc/set_armor(datum/armor/armor)
+	if(src.armor == armor)
+		return
+	if(!(src.armor?.type in GLOB.armor_by_type))
+		qdel(src.armor)
+	src.armor = ispath(armor) ? get_armor_by_type(armor) : armor
+
+/atom/proc/set_armor_rating(damage_type, rating)
+	var/datum/armor/armor = get_armor()
+	set_armor(armor.generate_new_with_specific(list("[damage_type]" = rating)))

--- a/code/game/antagonist/outsider/abductor/equipment/abductors_gear.dm
+++ b/code/game/antagonist/outsider/abductor/equipment/abductors_gear.dm
@@ -857,7 +857,11 @@ Congratulations! You are now trained for invasive xenobiology research!"}
 	name = "alien jumpsuit"
 	icon_state = "abductor"
 	item_state = "black"
-	armor = list(melee = 0, bullet = 0, laser = 0, energy = 0, bomb = 10)
+	armor_type = /datum/armor/under_ubductor
+
+/datum/armor/under_ubductor
+	bio = 10
+	bomb = 10
 
 //TOOL BELT
 /obj/item/storage/belt/abductor

--- a/code/game/antagonist/outsider/abductor/equipment/abductors_gear.dm
+++ b/code/game/antagonist/outsider/abductor/equipment/abductors_gear.dm
@@ -16,7 +16,7 @@
 					slot_r_hand_str = "armor",
 				)
 	blood_overlay_type = "armor"
-	armor = list(MELEE = 15, BULLET = 15, LASER = 15, ENERGY = 25, BOMB = 15, BIO = 15)
+	armor_type = /datum/armor/abductor_stealth
 	species_restricted = list(SPECIES_ABDUCTOR)
 	allowed = list(
 		/obj/item/abductor,
@@ -32,8 +32,22 @@
 	var/cooldown = 0
 	var/datum/icon_snapshot/disguise
 	action_button_name = "Activate Vest"
-	var/stealth_armor = list(MELEE = 15, BULLET = 15, LASER = 15, ENERGY = 25, BOMB = 15, BIO = 15)
-	var/combat_armor = list(MELEE = 50, BULLET = 50, LASER = 50, ENERGY = 50, BOMB = 50, BIO = 50)
+
+/datum/armor/abductor_combat
+	melee = 50
+	bullet = 50
+	laser = 50
+	energy = 50
+	bomb = 50
+	bio = 50
+
+/datum/armor/abductor_stealth
+	melee = 15
+	bullet = 15
+	laser = 15
+	energy = 25
+	bomb = 15
+	bio = 15
 
 /obj/item/clothing/suit/armor/abductor/vest/equipped(mob/user)
 	DeactivateStealth()
@@ -49,12 +63,12 @@
 		if(VEST_STEALTH)
 			mode = VEST_COMBAT
 			DeactivateStealth()
-			armor = combat_armor
+			set_armor(/datum/armor/abductor_combat)
 			icon_state = "vest_combat"
 			body_parts_covered = UPPER_TORSO|LOWER_TORSO
 		if(VEST_COMBAT)// TO STEALTH
 			mode = VEST_STEALTH
-			armor = stealth_armor
+			set_armor(/datum/armor/abductor_stealth)
 			body_parts_covered = UPPER_TORSO|LOWER_TORSO|ARMS|HANDS|LEGS
 			icon_state = "vest_stealth"
 	if(ishuman(loc))

--- a/code/game/atoms.dm
+++ b/code/game/atoms.dm
@@ -41,6 +41,11 @@
 	var/chat_color
 	var/chat_color_darkened
 
+	/// Type path to armor datum, used on atom Initialization
+	var/datum/armor/armor_type = /datum/armor/none
+	/// Armor datum used to calculate atom's damage
+	var/datum/armor/armor
+
 /atom/New(loc, ...)
 	CAN_BE_REDEFINED(TRUE)
 	//atom creation method that preloads variables at creation

--- a/code/game/gamemodes/changeling/changeling.dm
+++ b/code/game/gamemodes/changeling/changeling.dm
@@ -33,10 +33,10 @@
 
 	// Adding a biostructure if we still don't have one.
 	if(isliving(src) && !istype(src, /mob/living/carbon/brain))
-		var/obj/item/organ/internal/biostructure/BIO = locate() in contents
-		if(!BIO)
-			BIO = new /obj/item/organ/internal/biostructure(src)
-			BIO.change_host(src)
+		var/obj/item/organ/internal/biostructure/struct = locate() in contents
+		if(!struct)
+			struct = new /obj/item/organ/internal/biostructure(src)
+			struct.change_host(src)
 			log_debug("New changeling biostructure spawned in [name] / [real_name] ([key]).")
 
 	changeling.reset_my_mob(src) // Just to be sure.

--- a/code/game/gamemodes/changeling/changeling_datum.dm
+++ b/code/game/gamemodes/changeling/changeling_datum.dm
@@ -91,16 +91,16 @@ var/global/list/possible_changeling_IDs = list("Alpha","Beta","Gamma","Delta","E
 		my_mob.verbs -= /datum/changeling/proc/EvolutionMenu
 
 		// Biostructural stuff
-		var/obj/item/organ/internal/biostructure/BIO
+		var/obj/item/organ/internal/biostructure/struct
 		if(istype(my_mob, /mob/living/carbon/brain))
-			BIO = my_mob.loc
+			struct = my_mob.loc
 		else
-			BIO = locate() in my_mob.contents
-		if(!BIO) // We lost our biostructure somewhere, everything's broken, let's just give up and fucking die.
+			struct = locate() in my_mob.contents
+		if(!struct) // We lost our biostructure somewhere, everything's broken, let's just give up and fucking die.
 			to_chat(my_mob, SPAN("changeling", "Strangely enough, we feel like dying right now. The only thing we know, it's not our fault."))
 			die()
 			return FALSE
-		BIO.change_host(L) // Biostructure object gets moved here
+		struct.change_host(L) // Biostructure object gets moved here
 
 	if(ishuman(L))
 		var/mob/living/carbon/human/H = L

--- a/code/game/gamemodes/changeling/helpcode/mobs.dm
+++ b/code/game/gamemodes/changeling/helpcode/mobs.dm
@@ -4,31 +4,31 @@
 	set name = "Transform into little changeling"
 	set desc = "If we find ourselves inside a severed limb we will grow little limbs and jaws."
 
-	var/obj/item/organ/internal/biostructure/BIO = loc
+	var/obj/item/organ/internal/biostructure/struct = loc
 
 	// So, all that fake limb reattachment may get bugged out in a blink of an eye. We do this for sanity's sake.
 	// It's easier to just reset the biostructure's position back to the chest than spend days debugging its random trips to anywhereland and back.
-	BIO.parent_organ = BP_CHEST
+	struct.parent_organ = BP_CHEST
 
-	var/limb_to_del = BIO.loc
+	var/limb_to_del = struct.loc
 
-	if(istype(BIO.loc, /obj/item/organ/external/leg))
-		var/mob/living/simple_animal/hostile/little_changeling/leg_chan/leg_ling = new (get_turf(BIO.loc))
+	if(istype(struct.loc, /obj/item/organ/external/leg))
+		var/mob/living/simple_animal/hostile/little_changeling/leg_chan/leg_ling = new (get_turf(struct.loc))
 		mind.transfer_to(leg_ling)
 
-	else if(istype(BIO.loc, /obj/item/organ/external/arm))
-		var/mob/living/simple_animal/hostile/little_changeling/arm_chan/arm_ling = new (get_turf(BIO.loc))
+	else if(istype(struct.loc, /obj/item/organ/external/arm))
+		var/mob/living/simple_animal/hostile/little_changeling/arm_chan/arm_ling = new (get_turf(struct.loc))
 		mind.transfer_to(arm_ling)
 
-	else if(istype(BIO.loc, /obj/item/organ/external/head))
-		var/mob/living/simple_animal/hostile/little_changeling/head_chan/head_ling = new (get_turf(BIO.loc))
+	else if(istype(struct.loc, /obj/item/organ/external/head))
+		var/mob/living/simple_animal/hostile/little_changeling/head_chan/head_ling = new (get_turf(struct.loc))
 		mind.transfer_to(head_ling)
 
 	else
 		headcrab_runaway() // Because byond doesn't want to update verbs sometimes this engine is a fucking mess
 		return
 
-	BIO.loc.visible_message(SPAN("warning", "[BIO.loc] suddenly grows little legs!"), \
+	struct.loc.visible_message(SPAN("warning", "[struct.loc] suddenly grows little legs!"), \
 							SPAN("changeling", "<font size='2'><b>We have just transformed into mobile but vulnerable form! We must find a new host quickly!</b></font>"))
 	qdel(limb_to_del)
 
@@ -40,23 +40,23 @@
 	if(mind.changeling.is_regenerating())
 		return
 
-	var/obj/item/organ/internal/biostructure/BIO = loc
+	var/obj/item/organ/internal/biostructure/struct = loc
 
 	var/mob/living/simple_animal/hostile/little_changeling/headcrab/HC = new (get_turf(src))
 
 	// Edge case handling. It's intended to be here instead of datum/changeling/transfer_to() for reasons.
 	var/obj/item/organ/external/E
-	if(ishuman(BIO.loc))
-		var/mob/living/carbon/human/H = BIO.loc
-		E = H.get_organ(BIO.parent_organ)
-	else if(istype(BIO.loc, /obj/item/organ/external))
-		E = BIO.loc
-	E?.implants -= BIO
+	if(ishuman(struct.loc))
+		var/mob/living/carbon/human/H = struct.loc
+		E = H.get_organ(struct.parent_organ)
+	else if(istype(struct.loc, /obj/item/organ/external))
+		E = struct.loc
+	E?.implants -= struct
 
-	BIO.parent_organ = BP_CHEST // So we DEFINITELY won't end up inside a prosthetic limb.
+	struct.parent_organ = BP_CHEST // So we DEFINITELY won't end up inside a prosthetic limb.
 	mind.transfer_to(HC)
 
-	HC.visible_message(SPAN("danger", "[BIO] suddenly grows tiny eyes and reforms it's appendages into legs!"), \
+	HC.visible_message(SPAN("danger", "[struct] suddenly grows tiny eyes and reforms it's appendages into legs!"), \
 					   SPAN("changeling", "<font size='2'><b>We are in our weakest form! WE MUST SURVIVE!</b></font>"))
 
 
@@ -109,17 +109,17 @@
 
 
 /mob/living/simple_animal/hostile/little_changeling/death(gibbed, deathmessage = "has been ripped open!", show_dead_message)
-	var/obj/item/organ/internal/biostructure/BIO = locate() in contents
-	if(BIO)
-		BIO.removed()
+	var/obj/item/organ/internal/biostructure/struct = locate() in contents
+	if(struct)
+		struct.removed()
 		return
 	..()
 
 
 /mob/living/simple_animal/hostile/little_changeling/Destroy()
-	var/obj/item/organ/internal/biostructure/BIO = locate() in contents
-	if(BIO)
-		BIO.removed()
+	var/obj/item/organ/internal/biostructure/struct = locate() in contents
+	if(struct)
+		struct.removed()
 		return
 	..()
 
@@ -400,9 +400,9 @@
 
 /mob/living/simple_animal/hostile/little_changeling/headcrab/death(gibbed, deathmessage = "went limp and collapsed!", show_dead_message)
 	cloaked = 0
-	var/obj/item/organ/internal/biostructure/BIO = locate() in contents
-	if(BIO)
-		BIO.die()
+	var/obj/item/organ/internal/biostructure/struct = locate() in contents
+	if(struct)
+		struct.die()
 	..()
 	qdel(src) // The headcrab is supposed to be the biostructure itself (but with tiny legs), not a separate entity
 

--- a/code/game/gamemodes/changeling/powers/cauldron.dm
+++ b/code/game/gamemodes/changeling/powers/cauldron.dm
@@ -22,11 +22,11 @@
 	if(changeling.recursive_enhancement == TRUE)
 		transfer_amount = 20
 
-	var/obj/item/organ/internal/biostructure/BIO = locate() in contents
-	if(!BIO)
+	var/obj/item/organ/internal/biostructure/struct = locate() in contents
+	if(!struct)
 		return
 
-	BIO.chem_cauldron.trans_to_mob(target, transfer_amount)
+	struct.chem_cauldron.trans_to_mob(target, transfer_amount)
 
 	feedback_add_details("changeling_powers", "CS")
 
@@ -79,10 +79,10 @@
 			to_chat(src, SPAN("changeling", "Not enough chemicals."))
 			return
 
-	var/obj/item/organ/internal/biostructure/BIO = locate() in contents
-	if(!BIO)
+	var/obj/item/organ/internal/biostructure/struct = locate() in contents
+	if(!struct)
 		return
-	BIO.chem_cauldron.add_reagent(target_chem, amount)
+	struct.chem_cauldron.add_reagent(target_chem, amount)
 
 	if(target_chem == /datum/reagent/toxin/plasma)
 		amount *= 2
@@ -106,10 +106,10 @@
 
 	var/mob/living/carbon/human/C = src
 
-	var/obj/item/organ/internal/biostructure/BIO = locate() in contents
-	if(!BIO)
+	var/obj/item/organ/internal/biostructure/struct = locate() in contents
+	if(!struct)
 		return FALSE
-	BIO.chem_cauldron.clear_reagents()
+	struct.chem_cauldron.clear_reagents()
 
 	C.adjustToxLoss(10)
 	verbs -= /mob/proc/prepare_changeling_chemical_sting

--- a/code/game/gamemodes/changeling/powers/detach_limb.dm
+++ b/code/game/gamemodes/changeling/powers/detach_limb.dm
@@ -64,11 +64,11 @@
 	else if(organ_to_remove.organ_tag == BP_HEAD)
 		L = new /mob/living/simple_animal/hostile/little_changeling/head_chan(get_turf(H))
 
-	var/obj/item/organ/internal/biostructure/BIO = H.internal_organs_by_name[BP_CHANG]
-	if(organ_to_remove.organ_tag == BIO.parent_organ)
-		organ_to_remove.internal_organs.Remove(BIO) // Preventing biostructure from going through an unnecessary removed() and risking to get bugged
+	var/obj/item/organ/internal/biostructure/struct = H.internal_organs_by_name[BP_CHANG]
+	if(organ_to_remove.organ_tag == struct.parent_organ)
+		organ_to_remove.internal_organs.Remove(struct) // Preventing biostructure from going through an unnecessary removed() and risking to get bugged
 		H.mind.transfer_to(L)
-		BIO.parent_organ = BP_CHEST
+		struct.parent_organ = BP_CHEST
 
 	organ_to_remove.droplimb(TRUE)
 	qdel(organ_to_remove)

--- a/code/game/gamemodes/changeling/powers/disjunction.dm
+++ b/code/game/gamemodes/changeling/powers/disjunction.dm
@@ -50,7 +50,7 @@
 		playsound(H.loc, 'sound/effects/bonebreak3.ogg', 100, 1)
 	playsound(H.loc, 'sound/effects/bonebreak4.ogg', 100, 1)
 
-	var/obj/item/organ/internal/biostructure/BIO = H.internal_organs_by_name[BP_CHANG]
+	var/obj/item/organ/internal/biostructure/struct = H.internal_organs_by_name[BP_CHANG]
 	var/mob_to_receive_mind
 
 	var/mob/living/simple_animal/hostile/little_changeling/leg_chan/leg_ling
@@ -61,36 +61,36 @@
 
 	if(H.has_limb(BP_L_LEG))
 		leg_ling = new (get_turf(H))
-		if(BIO.parent_organ == BP_L_LEG)
+		if(struct.parent_organ == BP_L_LEG)
 			mob_to_receive_mind = leg_ling
 
 	if(H.has_limb(BP_R_LEG))
 		leg_ling2 = new (get_turf(H))
-		if(BIO.parent_organ == BP_R_LEG)
+		if(struct.parent_organ == BP_R_LEG)
 			mob_to_receive_mind = leg_ling2
 
 	if(H.has_limb(BP_L_ARM))
 		arm_ling = new (get_turf(H))
-		if(BIO.parent_organ == BP_L_ARM)
+		if(struct.parent_organ == BP_L_ARM)
 			mob_to_receive_mind = arm_ling
 
 	if(H.has_limb(BP_R_ARM))
 		arm_ling2 = new (get_turf(H))
-		if(BIO.parent_organ == BP_R_ARM)
+		if(struct.parent_organ == BP_R_ARM)
 			mob_to_receive_mind = arm_ling2
 
 	if(H.has_limb(BP_HEAD))
 		head_ling = new (get_turf(H))
-		if(BIO.parent_organ == BP_HEAD)
+		if(struct.parent_organ == BP_HEAD)
 			mob_to_receive_mind = head_ling
 
 	var/mob/living/simple_animal/hostile/little_changeling/chest_chan/chest_ling = new (get_turf(H))
-	if(BIO.parent_organ == BP_CHEST || BIO.parent_organ == BP_GROIN)
+	if(struct.parent_organ == BP_CHEST || struct.parent_organ == BP_GROIN)
 		mob_to_receive_mind = chest_ling
 
 	if(mob_to_receive_mind)
 		H.mind.transfer_to(mob_to_receive_mind)
-		BIO.parent_organ = BP_CHEST
+		struct.parent_organ = BP_CHEST
 
 	gibs(H.loc, H.dna)
 	for(var/obj/item/I in H.contents)

--- a/code/game/gamemodes/changeling/powers/move_biostructure.dm
+++ b/code/game/gamemodes/changeling/powers/move_biostructure.dm
@@ -42,8 +42,8 @@
 		return
 
 	var/mob/living/carbon/human/H = my_mob
-	var/obj/item/organ/internal/biostructure/BIO = H.internal_organs_by_name[BP_CHANG]
-	if(!BIO)  // Should never happen, but still.
+	var/obj/item/organ/internal/biostructure/struct = H.internal_organs_by_name[BP_CHANG]
+	if(!struct)  // Should never happen, but still.
 		log_debug("Changeling Shenanigans: [my_mob] ([my_mob.key]) had no biostructure during move_biostructure() call. Please, inform developers.")
 		return
 
@@ -77,16 +77,16 @@
 		return
 
 	var/obj/item/organ/external/BIO_parent = null
-	BIO_parent = H.get_organ(BIO.parent_organ)
+	BIO_parent = H.get_organ(struct.parent_organ)
 	if(!BIO_parent)
 		to_chat(H, SPAN("changeling", "We are missing that limb."))
 		return
 
-	BIO_parent.internal_organs.Remove(BIO)
+	BIO_parent.internal_organs.Remove(struct)
 
-	BIO.parent_organ = new_parent.organ_tag
-	BIO_parent = H.get_organ(BIO.parent_organ)
+	struct.parent_organ = new_parent.organ_tag
+	BIO_parent = H.get_organ(struct.parent_organ)
 	if(!BIO_parent)
-		CRASH("[BIO] spawned in [H] without a parent organ: [BIO.parent_organ].")
-	BIO_parent.internal_organs |= BIO
+		CRASH("[struct] spawned in [H] without a parent organ: [struct.parent_organ].")
+	BIO_parent.internal_organs |= struct
 	to_chat(H, SPAN("changeling", "Our biostructure is now in \the [new_parent]."))

--- a/code/game/gamemodes/cult/cult_items.dm
+++ b/code/game/gamemodes/cult/cult_items.dm
@@ -55,10 +55,16 @@
 	desc = "A hood worn by the followers of Nar-Sie."
 	flags_inv = HIDEFACE
 	body_parts_covered = HEAD
-	armor = list(melee = 30, bullet = 10, laser = 5,energy = 5, bomb = 0, bio = 0)
+	armor_type = /datum/armor/culthood
 	cold_protection = HEAD
 	min_cold_protection_temperature = SPACE_HELMET_MIN_COLD_PROTECTION_TEMPERATURE
 	siemens_coefficient = 0.8 //That's a pretty cool opening in the hood. Also: Cloth making physical contact to the skull.
+
+/datum/armor/culthood
+	bullet = 10
+	energy = 5
+	laser = 5
+	melee = 30
 
 /obj/item/clothing/head/culthood/magus
 	name = "magus helm"
@@ -66,7 +72,14 @@
 	desc = "A helm worn by the followers of Nar-Sie."
 	flags_inv = HIDEFACE | BLOCKHAIR
 	body_parts_covered = HEAD|FACE|EYES
-	armor = list(melee = 50, bullet = 40, laser = 30, energy = 20, bomb = 15, bio = 0)
+	armor_type = /datum/armor/magushelm
+
+/datum/armor/magushelm
+	bomb = 15
+	bullet = 40
+	energy = 20
+	laser = 30
+	melee = 50
 
 /obj/item/clothing/head/culthood/alt
 	icon_state = "cult_hoodalt"
@@ -77,9 +90,17 @@
 	icon_state = "cultrobes"
 	body_parts_covered = UPPER_TORSO|LOWER_TORSO|LEGS|ARMS
 	allowed = list(/obj/item/book/tome,/obj/item/melee/cultblade)
-	armor = list(melee = 35, bullet = 30, laser = 25,energy = 20, bomb = 25, bio = 10)
+	armor_type = /datum/armor/cultrobes
 	flags_inv = HIDEJUMPSUIT
 	siemens_coefficient = 0.6
+
+/datum/armor/cultrobes
+	bio = 10
+	bomb = 25
+	bullet = 30
+	energy = 20
+	laser = 25
+	melee = 35
 
 /obj/item/clothing/suit/cultrobes/alt
 	icon_state = "cultrobesalt"
@@ -90,7 +111,15 @@
 	icon_state = "magusred"
 	body_parts_covered = UPPER_TORSO|LOWER_TORSO|LEGS|FEET|ARMS|HANDS
 	flags_inv = HIDEGLOVES|HIDESHOES|HIDEJUMPSUIT
-	armor = list(melee = 75, bullet = 50, laser = 55, energy = 40, bomb = 50, bio = 10)
+	armor_type = /datum/armor/magusrobes
+
+/datum/armor/magusrobes
+	bio = 10
+	bomb = 50
+	bullet = 50
+	energy = 40
+	laser = 55
+	melee = 75
 
 /obj/item/clothing/suit/cultrobes/magusred/New()
 	..()
@@ -100,7 +129,7 @@
 	name = "cult helmet"
 	desc = "A space worthy helmet used by the followers of Nar-Sie."
 	icon_state = "cult_helmet"
-	armor = list(melee = 60, bullet = 60, laser = 60,energy = 15, bomb = 30, bio = 100) //Real tanky shit.
+	armor_type = /datum/armor/culthelm
 	siemens_coefficient = 0.3 //Bone is not very conducive to electricity.
 	rad_resist = list(
 		RADIATION_ALPHA_PARTICLE = 1.0,
@@ -108,12 +137,20 @@
 		RADIATION_HAWKING = 1 ELECTRONVOLT
 	)
 
+/datum/armor/culthelm
+	bio = 100
+	bomb = 30
+	bullet = 60
+	energy = 15
+	laser = 60
+	melee = 60
+
 /obj/item/clothing/suit/space/cult
 	name = "cult armour"
 	icon_state = "cult_armour"
 	desc = "A bulky suit of armour, bristling with spikes. It looks space proof."
 	allowed = list(/obj/item/book/tome,/obj/item/melee/cultblade,/obj/item/tank,/obj/item/device/suit_cooling_unit)
-	armor = list(melee = 60, bullet = 50, laser = 60,energy = 15, bomb = 30, bio = 100)
+	armor_type = /datum/armor/cultarmor
 	siemens_coefficient = 0.2
 	body_parts_covered = UPPER_TORSO|LOWER_TORSO|LEGS|ARMS|HANDS
 	rad_resist = list(
@@ -121,6 +158,14 @@
 		RADIATION_BETA_PARTICLE = 1.0,
 		RADIATION_HAWKING = 1 ELECTRONVOLT
 	)
+
+/datum/armor/cultarmor
+	bio = 100
+	bomb = 30
+	bullet = 50
+	energy = 15
+	laser = 60
+	melee = 60
 
 /obj/item/clothing/suit/space/cult/New()
 	..()

--- a/code/game/gamemodes/events/holidays/Christmas.dm
+++ b/code/game/gamemodes/events/holidays/Christmas.dm
@@ -62,4 +62,3 @@
 	desc = "A crappy paper hat that you are REQUIRED to wear."
 	flags_inv = 0
 	body_parts_covered = 0
-	armor = list(melee = 0, bullet = 0, laser = 0,energy = 0, bomb = 0, bio = 0)

--- a/code/game/objects/items.dm
+++ b/code/game/objects/items.dm
@@ -4,6 +4,8 @@
 	w_class = ITEM_SIZE_NORMAL
 	mouse_drag_pointer = MOUSE_ACTIVE_POINTER
 
+	armor_type = /datum/armor/none
+
 	rad_resist = list(
 		RADIATION_ALPHA_PARTICLE = 35 MEGA ELECTRONVOLT,
 		RADIATION_BETA_PARTICLE = 6 MEGA ELECTRONVOLT,
@@ -63,7 +65,6 @@
 	var/slowdown_accessory // How much an accessory will slow you down when attached to a worn article of clothing.
 	var/canremove = 1 //Mostly for Ninja code at this point but basically will not allow the item to be removed if set to 0. /N
 	var/force_drop = FALSE // Allows the item to be manually dropped by the wielder even if canremove is set to FALSE.
-	var/list/armor = list(melee = 0, bullet = 0, laser = 0,energy = 0, bomb = 0, bio = 0)
 	var/list/allowed = null //suit storage stuff.
 	var/obj/item/device/uplink/hidden_uplink = null // All items can have an uplink hidden inside, just remember to add the triggers.
 	var/zoomdevicename = null //name used for message when binoculars/scope is used

--- a/code/modules/clothing/clothing.dm
+++ b/code/modules/clothing/clothing.dm
@@ -234,6 +234,7 @@ BLIND     // can't see anything
 	gender = PLURAL //Carn: for grammarically correct text-parsing
 	w_class = ITEM_SIZE_SMALL
 	icon = 'icons/obj/clothing/gloves.dmi'
+	armor_type = /datum/armor/gloves
 	siemens_coefficient = 0.75
 	var/wired = FALSE
 	var/wire_color
@@ -246,6 +247,11 @@ BLIND     // can't see anything
 	attack_verb = list("challenged")
 	species_restricted = list("exclude", SPECIES_NABBER, SPECIES_UNATHI, SPECIES_TAJARA, SPECIES_VOX)
 	blood_overlay_type = "bloodyhands"
+
+/datum/armor/gloves
+	bullet = 5
+	laser = 5
+	melee = 10
 
 /obj/item/clothing/gloves/Initialize()
 	if(item_flags & ITEM_FLAG_PREMODIFIED)
@@ -385,12 +391,27 @@ BLIND     // can't see anything
 	slot_flags = SLOT_HEAD
 	w_class = ITEM_SIZE_SMALL
 
+	armor_type = /datum/armor/head
+
 	var/light_overlay = "helmet_light"
 	var/light_applied
 	var/brightness_on
 	var/on = 0
 
 	blood_overlay_type = "helmetblood"
+
+/datum/armor/head_light
+	melee = 5
+
+/datum/armor/head
+	bullet = 5
+	laser = 5
+	melee = 5
+
+/datum/armor/head_hard
+	bullet = 10
+	laser = 5
+	melee = 10
 
 /obj/item/clothing/head/get_mob_overlay(mob/user_mob, slot)
 	var/image/ret = ..()
@@ -579,7 +600,15 @@ BLIND     // can't see anything
 	species_restricted = list("exclude", SPECIES_NABBER, SPECIES_UNATHI, SPECIES_TAJARA, SPECIES_VOX)
 	blood_overlay_type = "shoeblood"
 
-	armor = list(melee = 25, bullet = 25, laser = 25,energy = 15, bomb = 25, bio = 10)
+	armor_type = /datum/armor/shoes
+
+/datum/armor/shoes
+	bio = 10
+	bomb = 25
+	bullet = 25
+	energy = 15
+	laser = 25
+	melee = 25
 
 /obj/item/clothing/shoes/Destroy()
 	if(holding)
@@ -657,11 +686,16 @@ BLIND     // can't see anything
 	var/fire_resist = 100 CELSIUS
 	body_parts_covered = UPPER_TORSO|LOWER_TORSO|ARMS|LEGS
 	allowed = list(/obj/item/tank/emergency)
-	armor = list(melee = 5, bullet = 5, laser = 5,energy = 0, bomb = 0, bio = 0)
+	armor_type = /datum/armor/suit
 	slot_flags = SLOT_OCLOTHING
 	blood_overlay_type = "suitblood"
 	siemens_coefficient = 0.9
 	w_class = ITEM_SIZE_NORMAL
+
+/datum/armor/suit
+	bullet = 5
+	laser = 5
+	melee = 5
 
 /obj/item/clothing/suit/update_clothing_icon()
 	if (ismob(src.loc))
@@ -694,7 +728,7 @@ BLIND     // can't see anything
 	body_parts_covered = UPPER_TORSO|LOWER_TORSO|LEGS|ARMS
 	permeability_coefficient = 0.90
 	slot_flags = SLOT_ICLOTHING
-	armor = list(melee = 5, bullet = 5, laser = 5,energy = 0, bomb = 0, bio = 0)
+	armor_type = /datum/armor/under
 	w_class = ITEM_SIZE_NORMAL
 	force = 0
 	species_restricted = list("exclude", SPECIES_NABBER, SPECIES_MONKEY)
@@ -714,6 +748,11 @@ BLIND     // can't see anything
 	var/worn_state = null
 	valid_accessory_slots = list(ACCESSORY_SLOT_UTILITY,ACCESSORY_SLOT_HOLSTER,ACCESSORY_SLOT_ARMBAND,ACCESSORY_SLOT_RANK,ACCESSORY_SLOT_DEPT,ACCESSORY_SLOT_DECOR,ACCESSORY_SLOT_MEDAL,ACCESSORY_SLOT_INSIGNIA)
 	restricted_accessory_slots = list(ACCESSORY_SLOT_UTILITY,ACCESSORY_SLOT_HOLSTER,ACCESSORY_SLOT_ARMBAND,ACCESSORY_SLOT_RANK,ACCESSORY_SLOT_DEPT)
+
+/datum/armor/under
+	bullet = 5
+	laser = 5
+	melee = 5
 
 /obj/item/clothing/under/New()
 	..()

--- a/code/modules/clothing/custom_clothing.dm
+++ b/code/modules/clothing/custom_clothing.dm
@@ -3,6 +3,7 @@
 /////////////////////////////////////////////////////////////////////////
 
 // HentaiStorm
+
 /obj/item/clothing/suit/storage/toggle/det_trench/gilded
 	name = "detective gilded trenchcoat"
 	desc = "A gilded trenchcoat sewn for especially distinguished detectives."
@@ -13,12 +14,20 @@
 	matter = list(MATERIAL_GOLD = 2000)
 
 // Schutze88
+
 /obj/item/clothing/suit/armor/hos/jensen/fieldcoat
 	name = "military trenchcoat"
 	desc = "A military trenchcoat with a leather belt and long, custom collar. Looks kinda old, but is kept in a good shape."
 	icon_state = "dalek_coat"
 	item_state = "dalek_coat"
-	armor = list(melee = 45, bullet = 35, laser = 35, energy = 10, bomb = 10, bio = 0)
+	armor_type = /datum/armor/fieldcoat
+
+/datum/armor/fieldcoat
+	bomb = 10
+	bullet = 35
+	energy = 10
+	laser = 35
+	melee = 45
 
 /obj/item/clothing/suit/armor/hos/jensen/fieldcoat/mob_can_equip(mob/user)
 	.=..()
@@ -27,15 +36,24 @@
 		return 0
 
 // TaTarin
+
 /obj/item/clothing/head/helmet/police
 	name = "police helmet"
 	desc = "It's a helmet specifically designed for police use. Comfortable and robust."
 	icon_state = "helmet_police"
 	valid_accessory_slots = null
 	body_parts_covered = HEAD|FACE|EYES //face shield
-	armor = list(melee = 55, bullet = 55, laser = 55, energy = 25, bomb = 35, bio = 5)
+	armor_type = /datum/armor/helm_police
 	siemens_coefficient = 0.6
 	action_button_name = "Toggle Visor"
+
+/datum/armor/helm_police
+	bio = 5
+	bomb = 25
+	bullet = 55
+	energy = 25
+	laser = 55
+	melee = 55
 
 /obj/item/clothing/head/helmet/police/attack_self(mob/user)
 	togglevisor(user)
@@ -45,7 +63,7 @@
 	desc = "A synthetic armor vest with a large webbing and additional ballistic plates. Has a name badge on the frontal plate, that reads 'Sgt. Bauer'"
 	icon_state = "policevest"
 	item_state = "policevest"
-	armor = list(melee = 40, bullet = 40, laser = 45, energy = 15, bomb = 30, bio = 0)
+	armor_type = /datum/armor/vest_police
 	allowed = list(
 		/obj/item/gun/energy,
 		/obj/item/device/radio,
@@ -60,6 +78,13 @@
 		/obj/item/grenade,
 		)
 
+/datum/armor/vest_police
+	bomb = 30
+	bullet = 40
+	energy = 15
+	laser = 45
+	melee = 40
+
 //Terror
 
 /obj/item/clothing/head/helmet/german
@@ -68,9 +93,17 @@
 	icon_state = "wehrhelm"
 	valid_accessory_slots = null
 	body_parts_covered = HEAD
-	armor = list(melee = 45, bullet = 60, laser = 45,energy = 10, bomb = 40, bio = 2)
+	armor_type = /datum/armor/helm_german
 	siemens_coefficient = 1
 	has_visor = 0
+
+/datum/armor/helm_german
+	bio = 2
+	bomb = 40
+	bullet = 60
+	energy = 10
+	laser = 45
+	melee = 45
 
 //Schutze88
 
@@ -78,14 +111,28 @@
 	name = "ancient cap"
 	desc = "An ancient cap, how did it survived to these days?"
 	icon_state = "capger"
-	armor = list(melee = 25, bullet = 10, laser = 10,energy = 10, bomb = 10, bio = 0)
+	armor_type = /datum/armor/head_german
+
+/datum/armor/head_german
+	bomb = 10
+	bullet = 10
+	energy = 10
+	laser = 10
+	melee = 25
 
 /obj/item/clothing/suit/armor/hos/german
 	name = "ancient trenchcoat"
 	desc = "An ancient trenchcoat, how did it survived to these days? There's a label on the neck that reads 'Hergestellt von Hugo Boss'"
 	icon_state = "trenchcoatger"
 	item_state = "trenchcoatger"
-	armor = list(melee = 35, bullet = 15, laser = 15, energy = 10, bomb = 10, bio = 0)
+	armor_type = /datum/armor/suit_german
+
+/datum/armor/suit_german
+	bomb = 10
+	bullet = 15
+	energy = 10
+	laser = 15
+	melee = 35
 
 /obj/item/clothing/suit/armor/hos/german/mob_can_equip(mob/user)
 	.=..()
@@ -109,7 +156,14 @@
 	desc = "A loose, unbelted trenchcoat of military style. Has a \"MILITA\" writen on chest."
 	icon_state = "hostrench"
 	item_state = "hostrench"
-	armor = list(melee = 15, bullet = 10, laser = 10, energy = 10, bomb = 10, bio = 0)
+	armor_type = /datum/armor/suit_stylish
+
+/datum/armor/suit_stylish
+	bomb = 10
+	bullet = 10
+	energy = 10
+	laser = 10
+	melee = 15
 
 // Item below belong to i-dont-fucking-know-who
 // Please, sign it ASAP
@@ -118,7 +172,6 @@
     name = "comfy greatcoat"
     desc = "A greatcoat that is holding small pieces of dirt and such. It feels underarmored, yet you're absolutely sure that it will keep out the cold."
     icon_state = "redcoat"
-    armor = list(melee = 0, bullet = 0, laser = 0, energy = 0, bomb = 0, bio = 0)
 
 /obj/item/clothing/suit/storage/toggle/det_trench/warfare/mob_can_equip(mob/user)
 	.=..()
@@ -149,7 +202,7 @@
 	desc = "A synthetic armor vest with a large webbing and additional ballistic plates. Instead of a label, there's a small picture of a bearded man beating someone down in a maintenance area."
 	icon_state = "policevest_dark"
 	item_state = "policevest_dark"
-	armor = list(melee = 40, bullet = 40, laser = 45, energy = 15, bomb = 30, bio = 0)
+	armor_type = /datum/armor/suit_police
 	allowed = list(
 		/obj/item/gun/energy,
 		/obj/item/device/radio,
@@ -164,7 +217,15 @@
 		/obj/item/grenade
 		)
 
+/datum/armor/suit_police
+	bomb = 30
+	bullet = 40
+	energy = 15
+	laser = 45
+	melee = 40
+
 // NoTips
+
 /obj/item/clothing/suit/fire/firefighter/atmos
 	name = "atmospherics firesuit"
 	desc = "A suit that protects you against your mistakes in the engineering."
@@ -193,6 +254,7 @@
 	finished[2] = /obj/item/clothing/suit/fire/firefighter/atmos
 
 // Animusin
+
 /obj/item/clothing/suit/storage/toggle/heart_jacket
 	name = "heart jacket"
 	desc = "A black leather jacket with heart."

--- a/code/modules/clothing/glasses/glasses.dm
+++ b/code/modules/clothing/glasses/glasses.dm
@@ -248,9 +248,16 @@
 	action_button_name = "Toggle Goggles"
 	toggleable = TRUE
 	see_invisible = SEE_INVISIBLE_NOLIGHTING
-	armor = list(melee = 20, bullet = 20, laser = 20, energy = 15, bomb = 20, bio = 0)
+	armor_type = /datum/armor/glasses_tac
 	siemens_coefficient = 0.6
 	electric = TRUE
+
+/datum/armor/glasses_tac
+	bomb = 20
+	bullet = 20
+	energy = 15
+	laser = 20
+	melee = 20
 
 /obj/item/clothing/glasses/magma_dark_glasses
 	name = "dark gar glasses"

--- a/code/modules/clothing/gloves/boxing.dm
+++ b/code/modules/clothing/gloves/boxing.dm
@@ -2,11 +2,17 @@
 	name = "boxing gloves"
 	desc = "Because you really needed another excuse to punch your crewmates."
 	icon_state = "boxing"
-	armor = list(melee = 15, bullet = 10, laser = 10, energy = 5, bomb = 0, bio = 0)
+	armor_type = /datum/armor/gloves_boxing
+
+/datum/armor/gloves_boxing
+	bullet = 10
+	energy = 5
+	laser = 10
+	melee = 15
 
 /obj/item/clothing/gloves/boxing/attackby(obj/item/W, mob/user)
 	if(isWirecutter(W) || istype(W, /obj/item/scalpel) || isCoil(W))
-		to_chat(user, SPAN("notice", "That won't work."))//Nope
+		to_chat(user, SPAN("notice", "That won't work."))
 		return
 	..()
 

--- a/code/modules/clothing/gloves/color.dm
+++ b/code/modules/clothing/gloves/color.dm
@@ -1,7 +1,6 @@
 /obj/item/clothing/gloves/color
 	desc = "A pair of gloves, they don't look special in any way."
 	icon_state = "white"
-	armor = list(melee = 10, bullet = 5, laser = 5, energy = 0, bomb = 0, bio = 0)
 
 /obj/item/clothing/gloves/color/modified
 	item_flags = ITEM_FLAG_PREMODIFIED
@@ -16,7 +15,6 @@
 	name = "rainbow gloves"
 	desc = "A pair of gloves, they don't look special in any way."
 	icon_state = "rainbow"
-	armor = list(melee = 10, bullet = 5, laser = 5, energy = 0, bomb = 0, bio = 0)
 
 /obj/item/clothing/gloves/color/long_evening_gloves
 	name = "long evening gloves"
@@ -27,7 +25,6 @@
 	name = "fingerless gloves"
 	desc = "A pair of fingerless gloves, they look like they belong to a soul hungry for rebellion."
 	icon_state = "color_fingerless"
-	armor = list(melee = 5, bullet = 5, laser = 5, energy = 0, bomb = 0, bio = 0)
 
 /obj/item/clothing/gloves/rainbow/modified
 	item_flags = ITEM_FLAG_PREMODIFIED

--- a/code/modules/clothing/gloves/miscellaneous.dm
+++ b/code/modules/clothing/gloves/miscellaneous.dm
@@ -2,8 +2,14 @@
 	desc = "Regal blue gloves, with a nice gold trim. Swanky."
 	name = "captain's gloves"
 	icon_state = "captain"
-	armor = list(melee = 20, bullet = 10, laser = 10, energy = 5, bomb = 0, bio = 0)
+	armor_type = /datum/armor/gloves_captain
 	siemens_coefficient = 0 // These are ELITE
+
+/datum/armor/gloves_captain
+	bullet = 10
+	energy = 5
+	laser = 10
+	melee = 20
 
 /obj/item/clothing/gloves/insulated
 	desc = "These gloves will protect the wearer from electric shocks."
@@ -12,7 +18,14 @@
 	icon_state = "white"
 	siemens_coefficient = 0
 	permeability_coefficient = 0.05
-	armor = list(melee = 10, bullet = 5, laser = 10, energy = 10, bomb = 0, bio = 30)
+	armor_type = /datum/armor/gloves_insulated
+
+/datum/armor/gloves_insulated
+	bio = 30
+	bullet = 5
+	energy = 10
+	laser = 10
+	melee = 10
 
 /obj/item/clothing/gloves/insulated/cheap                             //Cheap Chinese Crap
 	desc = "These gloves are cheap copies of the coveted gloves, no way this can end badly."
@@ -31,12 +44,18 @@
 	item_state = "black"
 	siemens_coefficient = 0.50
 	permeability_coefficient = 0.05
-	armor = list(melee = 15, bullet = 10, laser = 10, energy = 5, bomb = 0, bio = 0)
+	armor_type = /datum/armor/gloves_forensic
 
 	cold_protection = HANDS
 	min_cold_protection_temperature = GLOVES_MIN_COLD_PROTECTION_TEMPERATURE
 	heat_protection = HANDS
 	max_heat_protection_temperature = GLOVES_MAX_HEAT_PROTECTION_TEMPERATURE
+
+/datum/armor/gloves_forensic
+	bullet = 10
+	energy = 5
+	laser = 10
+	melee = 15
 
 /obj/item/clothing/gloves/thick
 	desc = "These work gloves are thick and fire-resistant."
@@ -44,12 +63,18 @@
 	icon_state = "black"
 	siemens_coefficient = 0.5
 	permeability_coefficient = 0.05
-	armor = list(melee = 15, bullet = 10, laser = 10, energy = 5, bomb = 0, bio = 0)
+	armor_type = /datum/armor/gloves_thick
 
 	cold_protection = HANDS
 	min_cold_protection_temperature = GLOVES_MIN_COLD_PROTECTION_TEMPERATURE
 	heat_protection = HANDS
 	max_heat_protection_temperature = GLOVES_MAX_HEAT_PROTECTION_TEMPERATURE
+
+/datum/armor/gloves_thick
+	bullet = 10
+	energy = 5
+	laser = 10
+	melee = 15
 
 /obj/item/clothing/gloves/thick/modified
 	item_flags = ITEM_FLAG_PREMODIFIED
@@ -58,8 +83,16 @@
 	desc = "These tactical gloves are somewhat fire and impact-resistant."
 	name = "\improper SWAT Gloves"
 	force = 5
-	armor = list(melee = 45, bullet = 60, laser = 60,energy = 25, bomb = 50, bio = 10)
+	armor_type = /datum/armor/gloves_swat
 	siemens_coefficient = 0.3
+
+/datum/armor/gloves_swat
+	bio = 10
+	bomb = 50
+	bullet = 60
+	energy = 25
+	laser = 60
+	melee = 45
 
 /obj/item/clothing/gloves/thick/security
 	name = "\improper Security Gloves"
@@ -71,11 +104,19 @@
 	siemens_coefficient = 0
 	permeability_coefficient = 0.05
 	force = 5
-	armor = list(melee = 45, bullet = 60, laser = 60,energy = 25, bomb = 50, bio = 10)
+	armor_type = /datum/armor/gloves_thick_combat
 	cold_protection = HANDS
 	min_cold_protection_temperature = GLOVES_MIN_COLD_PROTECTION_TEMPERATURE
 	heat_protection = HANDS
 	max_heat_protection_temperature = GLOVES_MAX_HEAT_PROTECTION_TEMPERATURE
+
+/datum/armor/gloves_thick_combat
+	bio = 10
+	bomb = 50
+	bullet = 60
+	energy = 25
+	laser = 60
+	melee = 45
 
 /obj/item/clothing/gloves/thick/botany
 	desc = "These leather work gloves protect against thorns, barbs, prickles, spikes and other harmful objects of floral origin."
@@ -92,7 +133,10 @@
 	siemens_coefficient = 1.1 //thin latex gloves, much more conductive than fabric gloves (basically a capacitor for AC)
 	permeability_coefficient = 0.01
 	germ_level = 0
-	armor = list(melee = 0, bullet = 0, laser = 0,energy = 0, bomb = 0, bio = 70)
+	armor_type = /datum/armor/gloves_latex
+
+/datum/armor/gloves_latex
+	bio = 70
 
 /obj/item/clothing/gloves/latex/modified
 	item_flags = ITEM_FLAG_PREMODIFIED
@@ -110,7 +154,13 @@
 	name = "work gloves"
 	icon_state = "work"
 	siemens_coefficient = 0.50
-	armor = list(melee = 15, bullet = 10, laser = 10, energy = 5, bomb = 0, bio = 0)
+	armor_type = /datum/armor/gloves_duty
+
+/datum/armor/gloves_duty
+	bullet = 10
+	energy = 5
+	laser = 10
+	melee = 15
 
 /obj/item/clothing/gloves/duty/modified
 	item_flags = ITEM_FLAG_PREMODIFIED
@@ -122,7 +172,14 @@
 	force = 5
 	siemens_coefficient = 0.50
 	permeability_coefficient = 0.05
-	armor = list(melee = 30, bullet = 10, laser = 10, energy = 15, bomb = 20, bio = 0)
+	armor_type = /datum/armor/gloves_tactical
+
+/datum/armor/gloves_tactical
+	bomb = 20
+	bullet = 10
+	energy = 15
+	laser = 10
+	melee = 30
 
 /obj/item/clothing/gloves/guards
 	desc = "A pair of synthetic gloves and arm pads reinforced with armor plating."
@@ -132,4 +189,11 @@
 	w_class = ITEM_SIZE_NORMAL
 	siemens_coefficient = 0.7
 	permeability_coefficient = 0.03
-	armor = list(melee = 40, bullet = 40, laser = 40, energy = 25, bomb = 30, bio = 0)
+	armor_type = /datum/armor/gloves_guards
+
+/datum/armor/gloves_guards
+	bomb = 30
+	bullet = 40
+	energy = 25
+	laser = 40
+	melee = 40

--- a/code/modules/clothing/gloves/stun.dm
+++ b/code/modules/clothing/gloves/stun.dm
@@ -24,7 +24,7 @@
 		cut_fingertops()
 	wire_color = base_gloves.wire_color
 	siemens_coefficient = base_gloves.siemens_coefficient
-	armor = base_gloves.armor
+	base_gloves.set_armor(get_armor())
 	base_gloves.forceMove(src)
 
 /obj/item/clothing/gloves/stun/Destroy()

--- a/code/modules/clothing/head/beanies.dm
+++ b/code/modules/clothing/head/beanies.dm
@@ -7,7 +7,6 @@
 		slot_r_hand_str = "helmet",
 		)
 	siemens_coefficient = 0.9
-	armor = list(melee = 5, bullet = 5, laser = 5,energy = 0, bomb = 0, bio = 0)
 
 /obj/item/clothing/head/beanie/red
 	name = "red beanie"

--- a/code/modules/clothing/head/hardhat.dm
+++ b/code/modules/clothing/head/hardhat.dm
@@ -6,11 +6,19 @@
 	brightness_on = 4 //luminosity when on
 	light_overlay = "hardhat_light"
 	w_class = ITEM_SIZE_NORMAL
-	armor = list(melee = 45, bullet = 35, laser = 35,energy = 10, bomb = 20, bio = 10)
+	armor_type = /datum/armor/head_hardhat
 	flags_inv = 0
 	siemens_coefficient = 0.5
 	heat_protection = HEAD
 	max_heat_protection_temperature = FIRE_HELMET_MAX_HEAT_PROTECTION_TEMPERATURE
+
+/datum/armor/head_hardhat
+	bio = 10
+	bomb = 20
+	bullet = 35
+	energy = 10
+	laser = 25
+	melee = 45
 
 /obj/item/clothing/head/hardhat/orange
 	icon_state = "hardhat0_orange"

--- a/code/modules/clothing/head/helmet.dm
+++ b/code/modules/clothing/head/helmet.dm
@@ -10,7 +10,7 @@
 	restricted_accessory_slots = list(ACCESSORY_SLOT_HELM_C)
 	item_flags = ITEM_FLAG_THICKMATERIAL
 	body_parts_covered = HEAD
-	armor = list(melee = 50, bullet = 50, laser = 50, energy = 25, bomb = 35, bio = 0)
+	armor_type = /datum/armor/head_helmet
 	flags_inv = HIDEEARS|BLOCKHEADHAIR
 	cold_protection = HEAD
 	min_cold_protection_temperature = HELMET_MIN_COLD_PROTECTION_TEMPERATURE
@@ -25,6 +25,13 @@
 		RADIATION_BETA_PARTICLE = 5 MEGA ELECTRONVOLT,
 		RADIATION_HAWKING = 1 ELECTRONVOLT
 	)
+
+/datum/armor/head_helmet
+	bomb = 35
+	bullet = 50
+	energy = 25
+	laser = 50
+	melee = 50
 
 /obj/item/clothing/head/helmet/attack_self(mob/user)
 	if(has_visor)
@@ -50,26 +57,50 @@
 	desc = "It's a helmet specifically designed to protect against close range attacks."
 	icon_state = "helmet_riot"
 	valid_accessory_slots = null
-	body_parts_covered = HEAD|FACE|EYES //face shield
-	armor = list(melee = 85, bullet = 50, laser = 50, energy = 25, bomb = 35, bio = 5)
+	body_parts_covered = HEAD|FACE|EYES
+	armor_type = /datum/armor/head_helmet_riot
 	siemens_coefficient = 0.5
 	action_button_name = "Toggle Visor"
+
+/datum/armor/head_helmet_riot
+	bio = 5
+	bomb = 35
+	bullet = 50
+	energy = 25
+	laser = 50
+	melee = 85
 
 /obj/item/clothing/head/helmet/ablative
 	name = "ablative helmet"
 	desc = "A helmet made from advanced materials which protects against concentrated energy weapons."
 	icon_state = "helmet_reflect"
 	valid_accessory_slots = null
-	armor = list(melee = 50, bullet = 50, laser = 90, energy = 60, bomb = 35, bio = 2)
+	armor_type = /datum/armor/head_helmet_ablative
 	siemens_coefficient = 0
+
+/datum/armor/head_helmet_ablative
+	bio = 2
+	bomb = 35
+	bullet = 50
+	energy = 60
+	laser = 90
+	melee = 50
 
 /obj/item/clothing/head/helmet/ballistic
 	name = "ballistic helmet"
 	desc = "A helmet with reinforced plating to protect against ballistic projectiles."
 	icon_state = "helmet_bulletproof"
 	valid_accessory_slots = null
-	armor = list(melee = 50, bullet = 90, laser = 50, energy = 5, bomb = 35, bio = 2)
+	armor_type = /datum/armor/head_helmet_ballistic
 	siemens_coefficient = 0.6
+
+/datum/armor/head_helmet_ballistic
+	bio = 2
+	bomb = 35
+	bullet = 90
+	energy = 5
+	laser = 50
+	melee = 50
 
 /obj/item/clothing/head/helmet/gladiator
 	name = "gladiator helmet"
@@ -87,9 +118,17 @@
 	item_state = "caphelmet"
 	desc = "A special extra-durable helmet designed for the most fashionable of military figureheads."
 	flags_inv = HIDEFACE|BLOCKHAIR
-	armor = list(melee = 65, bullet = 65, laser = 65,energy = 35, bomb = 45, bio = 10)
+	armor_type = /datum/armor/head_helmet_captain
 	siemens_coefficient = 0.5
 	has_visor = 0
+
+/datum/armor/head_helmet_captain
+	bio = 10
+	bomb = 45
+	bullet = 65
+	energy = 35
+	laser = 65
+	melee = 65
 
 //Non-powersuit ERT helmets.
 //Commander
@@ -102,9 +141,17 @@
 		slot_l_hand_str = "syndicate-helm-green",
 		slot_r_hand_str = "syndicate-helm-green",
 		)
-	armor = list(melee = 62, bullet = 50, laser = 50,energy = 35, bomb = 10, bio = 2)
+	armor_type = /datum/armor/head_helmet_ert
 	siemens_coefficient = 0.5
 	has_visor = 0
+
+/datum/armor/head_helmet_ert
+	bio = 2
+	bomb = 10
+	bullet = 50
+	energy = 35
+	laser = 50
+	melee = 62
 
 //Security
 /obj/item/clothing/head/helmet/ert/security
@@ -129,18 +176,26 @@
 	name = "\improper SWAT helmet"
 	desc = "They're often used by highly trained SWAT Members."
 	icon_state = "swat"
-	armor = list(melee = 85, bullet = 85, laser = 85,energy = 55, bomb = 50, bio = 50)
+	armor_type = /datum/armor/head_helmet_swat
 	cold_protection = HEAD
 	min_cold_protection_temperature = SPACE_HELMET_MIN_COLD_PROTECTION_TEMPERATURE
 	siemens_coefficient = 0.3
 	has_visor = 0
+
+/datum/armor/head_helmet_swat
+	bio = 50
+	bomb = 50
+	bullet = 85
+	energy = 55
+	laser = 85
+	melee = 85
 
 /obj/item/clothing/head/helmet/augment
 	name = "Augment Array"
 	desc = "A helmet with optical and cranial augments coupled to it."
 	icon_state = "v62"
 	valid_accessory_slots = null
-	armor = list(melee = 70, bullet = 60, laser = 50,energy = 25, bomb = 50, bio = 10)
+	armor_type = /datum/armor/head_helmet_augment
 	flags_inv = HIDEEARS|HIDEEYES
 	body_parts_covered = HEAD|EYES|BLOCKHEADHAIR
 	cold_protection = HEAD
@@ -148,20 +203,44 @@
 	siemens_coefficient = 0.4
 	has_visor = 0
 
+/datum/armor/head_helmet_augment
+	bio = 10
+	bomb = 50
+	bullet = 60
+	energy = 25
+	laser = 05
+	melee = 70
+
 /obj/item/clothing/head/helmet/syndi
 	name = "heavy helmet"
 	desc = "A heavily reinforced helmet painted with red markings. Feels like it could take a lot of punishment."
 	icon_state = "helmet_merc"
-	armor = list(melee = 75, bullet = 75, laser = 75, energy = 50, bomb = 50, bio = 50)
+	armor_type = /datum/head_helmet_syndi
 	siemens_coefficient = 0.4
+
+/datum/armor/head_helmet_syndi
+	bio = 50
+	bomb = 50
+	bullet = 75
+	energy = 50
+	laser = 75
+	melee = 75
 
 /obj/item/clothing/head/helmet/thunderdome
 	name = "\improper Thunderdome helmet"
 	desc = "<i>'Let the battle commence!'</i>"
 	icon_state = "thunderdome"
 	valid_accessory_slots = null
-	armor = list(melee = 80, bullet = 60, laser = 50,energy = 10, bomb = 25, bio = 10)
+	armor_type = /datum/armor/head_helmet_thunerdome
 	cold_protection = HEAD
 	min_cold_protection_temperature = SPACE_HELMET_MIN_COLD_PROTECTION_TEMPERATURE
 	siemens_coefficient = 1
 	has_visor = 0
+
+/datum/armor/head_helmet_thunerdome
+	bio = 10
+	bomb = 25
+	bullet = 60
+	energy = 10
+	laser = 50
+	melee = 90

--- a/code/modules/clothing/head/helmet.dm
+++ b/code/modules/clothing/head/helmet.dm
@@ -215,7 +215,7 @@
 	name = "heavy helmet"
 	desc = "A heavily reinforced helmet painted with red markings. Feels like it could take a lot of punishment."
 	icon_state = "helmet_merc"
-	armor_type = /datum/head_helmet_syndi
+	armor_type = /datum/armor/head_helmet_syndi
 	siemens_coefficient = 0.4
 
 /datum/armor/head_helmet_syndi

--- a/code/modules/clothing/head/jobs.dm
+++ b/code/modules/clothing/head/jobs.dm
@@ -5,7 +5,7 @@
 	desc = "It's a hat used by chefs to keep hair out of your food. Judging by the food in the mess, they don't work."
 	icon_state = "chefhat"
 	item_state = "chefhat"
-	armor = list(melee = 5, bullet = 5, laser = 5,energy = 0, bomb = 0, bio = 0)
+
 
 //Captain
 /obj/item/clothing/head/caphat
@@ -16,7 +16,13 @@
 		slot_l_hand_str = "caphat",
 		slot_r_hand_str = "caphat",
 		)
-	armor = list(melee = 15, bullet = 10, laser = 10,energy = 5, bomb = 0, bio = 0)
+	armor_type = /datum/armor/head_caphat
+
+/datum/armor/head_caphat
+	bullet = 10
+	energy = 5
+	laser = 10
+	melee = 15
 
 /obj/item/clothing/head/caphat/cap
 	name = "captain's cap"
@@ -36,7 +42,7 @@
 	name = "crew resource's hat"
 	desc = "A stylish hat that both protects you from enraged former-crewmembers and gives you a false sense of authority."
 	icon_state = "hopcap"
-	armor = list(melee = 10, bullet = 5, laser = 5,energy = 0, bomb = 0, bio = 0)
+	armor_type = /datum/armor/head_hard
 
 //Chaplain
 /obj/item/clothing/head/chaplain_hood
@@ -45,7 +51,7 @@
 	icon_state = "chaplain_hood"
 	flags_inv = BLOCKHAIR
 	body_parts_covered = HEAD
-	armor = list(melee = 5, bullet = 5, laser = 5,energy = 0, bomb = 0, bio = 0)
+
 
 //Chaplain
 /obj/item/clothing/head/nun_hood
@@ -54,7 +60,7 @@
 	icon_state = "nun_hood"
 	flags_inv = BLOCKHAIR
 	body_parts_covered = HEAD
-	armor = list(melee = 5, bullet = 5, laser = 5,energy = 0, bomb = 0, bio = 0)
+
 
 //Medical
 /obj/item/clothing/head/surgery
@@ -62,7 +68,7 @@
 	desc = "A cap surgeons wear during operations. Keeps their hair from tickling your internal organs."
 	icon_state = "surgcap"
 	flags_inv = BLOCKHEADHAIR
-	armor = list(melee = 5, bullet = 5, laser = 5,energy = 0, bomb = 0, bio = 0)
+
 
 /obj/item/clothing/head/surgery/purple
 	name = "purple surgical cap"
@@ -102,13 +108,13 @@
 	desc = "A beret, an artists favorite headwear."
 	icon_state = "beret"
 	body_parts_covered = 0
-	armor = list(melee = 5, bullet = 5, laser = 5,energy = 0, bomb = 0, bio = 0)
+
 
 /obj/item/clothing/head/beret/sec
 	name = "corporate security beret"
 	desc = "A beret with the security insignia emblazoned on it. For officers that are more inclined towards style than safety."
 	icon_state = "beret_corporate_red"
-	armor = list(melee = 10, bullet = 5, laser = 5,energy = 0, bomb = 0, bio = 0)
+	armor_type = /datum/armor/head_hard
 
 /obj/item/clothing/head/beret/sec/navy/officer
 	name = "corporate security officer beret"
@@ -164,14 +170,22 @@
 	name = "Death Squad beret"
 	desc = "An armored red beret adorned with the crest of NanoTrasen's infamous Death Squad. Doesn't sacrifice style or safety."
 	icon_state = "beret_corporate_red"
-	armor = list(melee = 55, bullet = 55, laser = 35,energy = 20, bomb = 30, bio = 30)
+	armor_type = /datum/armor/head_deathsquad
 	siemens_coefficient = 0.9
+
+/datum/armor/head_deathsquad
+	bio = 30
+	bomb = 30
+	bullet = 55
+	energy = 20
+	laser = 25
+	melee = 55
 
 /obj/item/clothing/head/beret/guard
 	name = "corporate security beret"
 	desc = "A white beret adorned with the crest of NanoTrasen. For security guards that are more inclined towards style than safety."
 	icon_state = "beret_corporate_whitered"
-	armor = list(melee = 10, bullet = 5, laser = 5,energy = 0, bomb = 0, bio = 0)
+	armor_type = /datum/armor/head_hard
 
 /obj/item/clothing/head/beret/plaincolor
 	name = "beret"
@@ -192,8 +206,14 @@
 		slot_l_hand_str = "det_hat",
 		slot_r_hand_str = "det_hat",
 		)
-	armor = list(melee = 30, bullet = 25, laser = 25,energy = 10, bomb = 0, bio = 0)
+	armor_type = /datum/armor/head_det
 	siemens_coefficient = 0.9
+
+/datum/armor/head_det
+	bullet = 25
+	energy = 10
+	laser = 25
+	melee = 30
 
 /obj/item/clothing/head/det/attack_self(mob/user)
 	flags_inv ^= BLOCKHEADHAIR
@@ -213,8 +233,15 @@
 	desc = "The hat of the Head of Security, reinforced with a plasteel plate. For showing the officers who's in charge."
 	icon_state = "hoscap"
 	body_parts_covered = HEAD
-	armor = list(melee = 60, bullet = 60, laser = 60,energy = 35, bomb = 45, bio = 0)
+	armor_type = /datum/armor/head_hos
 	siemens_coefficient = 0.6
+
+/datum/armor/head_hos
+	bomb = 45
+	bullet = 60
+	energy = 35
+	laser = 60
+	melee = 60
 
 /obj/item/clothing/head/HoS/dermal
 	name = "Dermal Armour Patch"

--- a/code/modules/clothing/head/misc.dm
+++ b/code/modules/clothing/head/misc.dm
@@ -10,7 +10,7 @@
 	desc = "It's good to be emperor."
 	siemens_coefficient = 0.9
 	body_parts_covered = 0
-	armor = list(melee = 10, bullet = 5, laser = 5,energy = 0, bomb = 0, bio = 0)
+	armor_type = /datum/armor/head_hard
 
 /obj/item/clothing/head/hairflower
 	name = "hair flower pin"
@@ -44,7 +44,6 @@
 	desc = "A powdered wig."
 	icon_state = "pwig"
 	item_state = "pwig"
-	armor = list(melee = 5, bullet = 5, laser = 0,energy = 0, bomb = 0, bio = 0)
 
 /obj/item/clothing/head/warfarecap
     name = "red peaked cap"
@@ -58,14 +57,13 @@
 	item_state = "tophat"
 	siemens_coefficient = 0.9
 	body_parts_covered = 0
-	armor = list(melee = 5, bullet = 5, laser = 5,energy = 0, bomb = 0, bio = 0)
 
 /obj/item/clothing/head/redcoat
 	name = "redcoat's hat"
 	icon_state = "redcoat"
 	desc = "<i>'I guess it's a redhead.'</i>"
 	body_parts_covered = 0
-	armor = list(melee = 10, bullet = 5, laser = 5,energy = 0, bomb = 0, bio = 0)
+	armor_type = /datum/armor/head_hard
 
 /obj/item/clothing/head/mailman
 	name = "mail cap"
@@ -80,7 +78,6 @@
 	permeability_coefficient = 0.01
 	siemens_coefficient = 0.9
 	body_parts_covered = 0
-	armor = list(melee = 5, bullet = 5, laser = 5,energy = 0, bomb = 0, bio = 0)
 
 /obj/item/clothing/head/hasturhood
 	name = "hastur's hood"
@@ -107,7 +104,7 @@
 	flags_inv = HIDEMASK|HIDEEARS|HIDEEYES|HIDEFACE|BLOCKHAIR
 	siemens_coefficient = 2.0
 	body_parts_covered = HEAD|FACE|EYES
-	armor = list(melee = 10, bullet = 5, laser = 5,energy = 0, bomb = 0, bio = 0)
+	armor_type = /datum/armor/head_hard
 
 /obj/item/clothing/head/cueball
 	name = "cueball helmet"
@@ -124,7 +121,7 @@
 	item_state = "cardborg_h"
 	flags_inv = HIDEMASK|HIDEEARS|HIDEEYES|HIDEFACE
 	body_parts_covered = HEAD|FACE|EYES
-	armor = list(melee = 6, bullet = 0, laser = 0,energy = 0, bomb = 0, bio = 0)
+	armor_type = /datum/armor/head_light
 
 /obj/item/clothing/head/cardborg/Initialize()
 	. = ..()
@@ -165,28 +162,25 @@
 		slot_r_hand_str = "det_hat",
 		)
 	siemens_coefficient = 0.9
-	armor = list(melee = 5, bullet = 5, laser = 5,energy = 0, bomb = 0, bio = 0)
 
 /obj/item/clothing/head/pirate
 	name = "pirate hat"
 	desc = "Yarr."
 	icon_state = "pirate"
 	body_parts_covered = 0
-	armor = list(melee = 5, bullet = 5, laser = 5,energy = 0, bomb = 0, bio = 0)
 
 /obj/item/clothing/head/hgpiratecap
 	name = "pirate hat"
 	desc = "Yarr."
 	icon_state = "hgpiratecap"
 	body_parts_covered = 0
-	armor = list(melee = 10, bullet = 5, laser = 5,energy = 0, bomb = 0, bio = 0)
+	armor_type = /datum/armor/head_hard
 
 /obj/item/clothing/head/bandana
 	name = "pirate bandana"
 	desc = "Yarr."
 	icon_state = "bandana"
 	body_parts_covered = 0
-	armor = list(melee = 5, bullet = 0, laser = 0,energy = 0, bomb = 0, bio = 0)
 
 /obj/item/clothing/head/bandana/green
 	name = "green bandana"
@@ -204,7 +198,6 @@
 	desc = "Gentleman, elite aboard!"
 	icon_state = "bowler"
 	body_parts_covered = 0
-	armor = list(melee = 5, bullet = 5, laser = 5,energy = 0, bomb = 0, bio = 0)
 
 //stylish bs12 hats
 
@@ -213,37 +206,31 @@
 	icon_state = "bowler_hat"
 	desc = "For the gentleman of distinction."
 	body_parts_covered = 0
-	armor = list(melee = 5, bullet = 5, laser = 5,energy = 0, bomb = 0, bio = 0)
 
 /obj/item/clothing/head/beaverhat
 	name = "beaver hat"
 	icon_state = "beaver_hat"
 	desc = "Soft felt makes this hat both comfortable and elegant."
-	armor = list(melee = 5, bullet = 5, laser = 5,energy = 0, bomb = 0, bio = 0)
 
 /obj/item/clothing/head/boaterhat
 	name = "boater hat"
 	icon_state = "boater_hat"
 	desc = "The ultimate in summer fashion."
-	armor = list(melee = 5, bullet = 5, laser = 5,energy = 0, bomb = 0, bio = 0)
 
 /obj/item/clothing/head/fedora
 	name = "fedora"
 	icon_state = "fedora"
 	desc = "A sharp, stylish hat."
-	armor = list(melee = 5, bullet = 5, laser = 5,energy = 0, bomb = 0, bio = 0)
 
 /obj/item/clothing/head/feathertrilby
 	name = "feather trilby"
 	icon_state = "feather_trilby"
 	desc = "A sharp, stylish hat with a feather."
-	armor = list(melee = 5, bullet = 5, laser = 5,energy = 0, bomb = 0, bio = 0)
 
 /obj/item/clothing/head/fez
 	name = "fez"
 	icon_state = "fez"
 	desc = "You should wear a fez. Fezzes are cool."
-	armor = list(melee = 5, bullet = 0, laser = 0,energy = 0, bomb = 0, bio = 0)
 
 //end bs12 hats
 
@@ -253,7 +240,6 @@
 	icon_state = "witch"
 	flags_inv = BLOCKHAIR
 	siemens_coefficient = 2.0
-	armor = list(melee = 5, bullet = 5, laser = 5,energy = 0, bomb = 0, bio = 0)
 
 /obj/item/clothing/head/chicken
 	name = "chicken suit head"
@@ -266,14 +252,14 @@
 	flags_inv = BLOCKHAIR
 	siemens_coefficient = 0.7
 	body_parts_covered = HEAD|FACE|EYES
-	armor = list(melee = 10, bullet = 5, laser = 5,energy = 0, bomb = 0, bio = 0)
+	armor_type = /datum/armor/head_hard
 
 /obj/item/clothing/head/bearpelt
 	name = "bear pelt hat"
 	desc = "Fuzzy."
 	icon_state = "bearpelt"
 	siemens_coefficient = 0.7
-	armor = list(melee = 15, bullet = 5, laser = 5,energy = 0, bomb = 0, bio = 0)
+	armor_type = /datum/armor/head_hard
 
 /obj/item/clothing/head/xenos
 	name = "xenos helmet"
@@ -287,7 +273,7 @@
 	flags_inv = HIDEMASK|HIDEEARS|HIDEEYES|HIDEFACE|BLOCKHAIR
 	siemens_coefficient = 2.0
 	body_parts_covered = HEAD|FACE|EYES
-	armor = list(melee = 10, bullet = 5, laser = 5,energy = 0, bomb = 0, bio = 0)
+	armor_type = /datum/armor/head_hard
 
 /obj/item/clothing/head/philosopher_wig
 	name = "natural philosopher's wig"
@@ -299,21 +285,26 @@
 		)
 	flags_inv = BLOCKHAIR
 	body_parts_covered = 0
-	armor = list(melee = 5, bullet = 5, laser = 0,energy = 0, bomb = 0, bio = 0)
 
 /obj/item/clothing/head/hijab
 	name = "hijab"
 	desc = "A veil which is wrapped to cover the head and chest."
 	icon_state = "hijab"
 	flags_inv = BLOCKHAIR
-	armor = list(melee = 5, bullet = 5, laser = 5,energy = 0, bomb = 15, bio = 0)
+	armor_type = /datum/armor/head_hijab
+
+/datum/armor/head_hijab
+	bomb = 15
+	bullet = 5
+	laser = 5
+	melee = 5
 
 /obj/item/clothing/head/kippa
 	name = "kippa"
 	desc = "A small, brimless cap."
 	icon_state = "kippa"
 	body_parts_covered = 0
-	armor = list(melee = 5, bullet = 0, laser = 0,energy = 0, bomb = 0, bio = 0)
+	armor_type = /datum/armor/head_light
 
 /obj/item/clothing/head/turban
 	name = "turban"
@@ -321,14 +312,19 @@
 	icon_state = "turban"
 	body_parts_covered = 0
 	flags_inv = BLOCKHEADHAIR //Shows beards!
-	armor = list(melee = 10, bullet = 5, laser = 5,energy = 0, bomb = 0, bio = 0)
+	armor_type = /datum/armor/head_hard
 
 /obj/item/clothing/head/cowboy_hat
 	name = "cowboy hat"
 	desc = "A wide-brimmed hat, in the prevalent style of America's frontier period. By SolGov law, you are required to wear this hat while watching True Grit."
 	icon_state = "cowboyhat"
 	item_state = "cowboy_hat"
-	armor = list(melee = 10, bullet = 10, laser = 5,energy = 0, bomb = 0, bio = 0)
+	armor_type = /datum/armor/head_cowboy
+
+/datum/armor/head_cowboy
+	bullet = 10
+	laser = 5
+	melee = 10
 
 /obj/item/clothing/head/taqiyah
 	name = "taqiyah"
@@ -336,7 +332,7 @@
 	icon_state = "taqiyah"
 	item_state = "taqiyah"
 	body_parts_covered = 0
-	armor = list(melee = 5, bullet = 0, laser = 0,energy = 0, bomb = 0, bio = 0)
+	armor_type = /datum/armor/head_light
 
 /obj/item/clothing/head/tank
 	name = "padded cap"
@@ -344,7 +340,13 @@
 	icon_state = "tank"
 	flags_inv = BLOCKHEADHAIR
 	color = "#5f5f5f"
-	armor = list(melee = 25, bullet = 10, laser = 10,energy = 5, bomb = 10, bio = 0)
+	armor_type = /datum/armor/head_tank
+
+/datum/armor/head_tank
+	bomb = 10
+	bullet = 10
+	energy = 5
+	melee = 25
 
 /obj/item/clothing/head/tank/olive
 	color = "#727c58"
@@ -360,8 +362,15 @@
 	flags_inv = HIDEMASK|HIDEEARS|HIDEEYES|HIDEFACE|BLOCKHAIR
 	body_parts_covered = HEAD|FACE|EYES
 	flash_protection = FLASH_PROTECTION_MAJOR
-	armor = list(melee = 20, bullet = 10, laser = 10,energy = 5, bomb = 5, bio = 0)
+	armor_type = /datum/armor/head_facecover
 	has_visor = 0
+
+/datum/armor/head_facecover
+	bomb = 5
+	bullet = 10
+	energy = 5
+	laser = 10
+	melee = 20
 
 /obj/item/clothing/head/rasta
 	name = "rasta hat"
@@ -374,28 +383,34 @@
 	icon_state = "sombrero"
 	item_state = "sombrero"
 	desc = "You can practically taste the fiesta."
-	armor = list(melee = 10, bullet = 10, laser = 5,energy = 0, bomb = 30, bio = 0)
+	armor_type = /datum/armor/head_sombrero
+
+/datum/armor/head_sombrero
+	bomb = 30
+	bullet = 10
+	laser = 5
+	melee = 10
 
 /obj/item/clothing/head/samura_hat
 	name = "samurai hat"
 	icon_state = "samura_hat"
 	item_state = "samura_hat"
 	desc = "Asian straw hat with cool stripes of fabric throughout the brim."
-	armor = list(melee = 10, bullet = 10, laser = 5,energy = 0, bomb = 0, bio = 0)
+	armor_type = /datum/armor/head_hard
 
 /obj/item/clothing/head/agua_helmet
 	name = "head-worn aquarium"
 	icon_state = "agua_helmet"
 	item_state = "agua_helmet"
 	desc = "Water with some fishes in the glass aquarium."
-	armor = list(melee = 10, bullet = 10, laser = 5,energy = 0, bomb = 0, bio = 0)
+	armor_type = /datum/armor/head_hard
 
 /obj/item/clothing/head/crown
 	name = "crown"
 	icon_state = "crown"
 	item_state = "crown"
 	desc = "Royal gold worthy of a true ruler of the world."
-	armor = list(melee = 10, bullet = 10, laser = 5,energy = 0, bomb = 0, bio = 0)
+	armor_type = /datum/armor/head_hard
 
 /obj/item/clothing/head/antenna
 	name = "antenna"

--- a/code/modules/clothing/head/misc_special.dm
+++ b/code/modules/clothing/head/misc_special.dm
@@ -21,7 +21,7 @@
 		)
 	matter = list(MATERIAL_STEEL = 3000, MATERIAL_GLASS = 1000)
 	var/up = 0
-	armor = list(melee = 45, bullet = 45, laser = 55, energy = 20, bomb = 20, bio = 0)
+	armor_type = /datum/armor/head_welding
 	flags_inv = (HIDEMASK|HIDEEARS|HIDEEYES|HIDEFACE)
 	body_parts_covered = HEAD|FACE|EYES
 	action_button_name = "Flip Welding Mask"
@@ -31,6 +31,13 @@
 	flash_protection = FLASH_PROTECTION_MAJOR
 	tint = TINT_HEAVY
 	var/obj/item/welding_cover/cover = null
+
+/datum/armor/head_welding
+	bomb = 20
+	bullet = 45
+	energy = 20
+	laser = 55
+	melee = 45
 
 /obj/item/clothing/head/welding/_examine_text(mob/user)
 	. = ..()
@@ -79,7 +86,6 @@
 			icon_state = "[cover ? "[cover.icon_state]welding" : base_state]"
 			item_state = "[cover ? "[cover.icon_state]welding" : base_state]"
 			to_chat(usr, "You flip the [src] down to protect your eyes.")
-			armor = list(melee = 45, bullet = 45, laser = 55, energy = 20, bomb = 20, bio = 0)
 		else
 			src.up = !src.up
 			body_parts_covered &= ~(EYES|FACE)
@@ -89,7 +95,6 @@
 			icon_state = "[cover ? "[cover.icon_state]welding" : base_state]up"
 			item_state = "[cover ? "[cover.icon_state]welding" : base_state]up"
 			to_chat(usr, "You push the [src] up out of your face.")
-			armor = list(melee = 25, bullet = 25, laser = 30, energy = 10, bomb = 10, bio = 0)
 		update_clothing_icon()	//so our mob-overlays
 		update_vision()
 		usr.update_action_buttons()
@@ -150,7 +155,6 @@
 	item_state = "cake0"
 	var/onfire = 0
 	body_parts_covered = HEAD
-	armor = list(melee = 5, bullet = 5, laser = 5,energy = 0, bomb = 0, bio = 0)
 
 /obj/item/clothing/head/cakehat/think()
 	if(!onfire)
@@ -198,7 +202,7 @@
 	flags_inv = HIDEEARS|BLOCKHEADHAIR
 	cold_protection = HEAD
 	min_cold_protection_temperature = HELMET_MIN_COLD_PROTECTION_TEMPERATURE
-	armor = list(melee = 10, bullet = 5, laser = 5,energy = 0, bomb = 0, bio = 0)
+	armor_type = /datum/armor/head_hard
 
 /obj/item/clothing/head/ushanka/attack_self(mob/user as mob)
 	if(icon_state == initial(icon_state))
@@ -226,7 +230,12 @@
 	brightness_on = 2
 	light_overlay = "helmet_light"
 	w_class = ITEM_SIZE_NORMAL
-	armor = list(melee = 15, bullet = 5, laser = 5,energy = 0, bomb = 0, bio = 0)
+	armor_type = /datum/armor/head_pumpkin
+
+/datum/armor/head_pumpkin
+	bullet = 5
+	laser = 5
+	melee = 15
 
 /*
  * Kitty ears
@@ -257,7 +266,7 @@
 	icon_state = "richard"
 	body_parts_covered = HEAD|FACE
 	flags_inv = BLOCKHAIR
-	armor = list(melee = 5, bullet = 5, laser = 5,energy = 0, bomb = 0, bio = 0)
+
 /*
  * Tinfoil hat
  */
@@ -266,9 +275,13 @@
 	desc = "Big brother is watching you!"
 	icon_state = "foilhat"
 	body_parts_covered = 0
-	armor = list(melee = 0, bullet = 0, laser = 5, energy = 5, bomb = 0, bio = 0)
+	armor_type = /datum/armor/head_tinfoil
 	rad_resist = list(
 		RADIATION_ALPHA_PARTICLE = 30 MEGA ELECTRONVOLT,
 		RADIATION_BETA_PARTICLE = 6 MEGA ELECTRONVOLT,
 		RADIATION_HAWKING = 1 ELECTRONVOLT
 	)
+
+/datum/armor/head_tinfoil
+	energy = 5
+	laser = 5

--- a/code/modules/clothing/head/soft_caps.dm
+++ b/code/modules/clothing/head/soft_caps.dm
@@ -8,7 +8,6 @@
 		)
 	var/flipped = 0
 	siemens_coefficient = 0.9
-	armor = list(melee = 5, bullet = 5, laser = 5,energy = 0, bomb = 0, bio = 0)
 
 /obj/item/clothing/head/soft/New()
 	..()
@@ -83,13 +82,18 @@
 	name = "security cap"
 	desc = "It's a field cap in tasteful red color. This one seems to be extra durable."
 	icon_state = "secsoft"
-	armor = list(melee = 10, bullet = 5, laser = 5,energy = 0, bomb = 0, bio = 0)
+	armor_type = /datum/armor/head_hard
 
 /obj/item/clothing/head/soft/sec/fieldcap
 	name = "military cap"
 	desc = "It's a military field cap with a silver emblem on it. This one seems to be extra durable."
 	icon_state = "dalek_cap"
-	armor = list(melee = 35, bullet = 25, laser = 25,energy = 0, bomb = 0, bio = 0)
+	armor_type = /datum/armor/head_fieldcap
+
+/datum/armor/head_fieldcap
+	bullet = 25
+	laser = 25
+	melee = 35
 
 /obj/item/clothing/head/soft/sec/corp
 	name = "corporate security cap"

--- a/code/modules/clothing/masks/animal.dm
+++ b/code/modules/clothing/masks/animal.dm
@@ -3,12 +3,17 @@
     w_class = ITEM_SIZE_SMALL
     siemens_coefficient = 0.7
     body_parts_covered = FACE|EYES
-    armor = list(melee = 5, bullet = 5, laser = 5, energy = 0, bomb = 0, bio = 0)
+    armor_type = /datum/armor/mask_animal
     rad_resist = list(
         RADIATION_ALPHA_PARTICLE = 14.6 MEGA ELECTRONVOLT,
         RADIATION_BETA_PARTICLE = 2.1 MEGA ELECTRONVOLT,
         RADIATION_HAWKING = 1 ELECTRONVOLT
     )
+
+/datum/armor/mask_animal
+	bullet = 5
+	laser = 5
+	melee = 5
 
 /obj/item/clothing/mask/animal_mask/pig
 	name = "pig mask"
@@ -102,4 +107,3 @@
 	// The horse mask doesn't cause voice changes by default, the wizard spell changes the flag as necessary
 	say_messages = list("NEEIIGGGHHHH!", "NEEEIIIIGHH!", "NEIIIGGHH!", "HAAWWWWW!", "HAAAWWW!")
 	say_verbs = list("whinnies", "neighs", "says")
-

--- a/code/modules/clothing/masks/breath.dm
+++ b/code/modules/clothing/masks/breath.dm
@@ -8,7 +8,7 @@
 	w_class = ITEM_SIZE_SMALL
 	gas_transfer_coefficient = 0.10
 	permeability_coefficient = 0.50
-	armor = list(melee = 5, bullet = 3, laser = 3, energy = 0, bomb = 0, bio = 25)
+	armor_type = /datum/armor/mask_breath
 	down_gas_transfer_coefficient = 1
 	down_item_flags = ITEM_FLAG_THICKMATERIAL
 	down_icon_state = "breathdown"
@@ -18,13 +18,26 @@
 		RADIATION_BETA_PARTICLE = 2.6 MEGA ELECTRONVOLT,
 		RADIATION_HAWKING = 1 ELECTRONVOLT
 	)
+
+/datum/armor/mask_breath
+	bio = 25
+	bullet = 3
+	laser = 3
+	melee = 5
+
 /obj/item/clothing/mask/breath/medical
 	desc = "A close-fitting sterile mask that can be manually connected to an air supply for treatment."
 	name = "medical mask"
 	icon_state = "medical"
 	item_state = "medical"
 	permeability_coefficient = 0.01
-	armor = list(melee = 5, bullet = 3, laser = 3, energy = 0, bomb = 0, bio = 35)
+	armor_type = /datum/armor/mask_medical
+
+/datum/armor/mask_medical
+	bio = 35
+	bullet = 3
+	laser = 3
+	melee = 5
 
 /obj/item/clothing/mask/breath/anesthetic
 	desc = "A close-fitting sterile mask that is used by the anesthetic wallmounted pump."

--- a/code/modules/clothing/masks/gasmask.dm
+++ b/code/modules/clothing/masks/gasmask.dm
@@ -13,12 +13,18 @@
 	var/gas_filter_strength = 1			//For gas mask filters
 	var/list/filtered_gases = list("plasma", "sleeping_agent")
 	var/istinted = 0
-	armor = list(melee = 10, bullet = 5, laser = 10, energy = 0, bomb = 0, bio = 75)
+	armor_type = /datum/armor/gas
 	rad_resist = list(
 		RADIATION_ALPHA_PARTICLE = 23 MEGA ELECTRONVOLT,
 		RADIATION_BETA_PARTICLE = 6.6 MEGA ELECTRONVOLT,
 		RADIATION_HAWKING = 1 ELECTRONVOLT
 	)
+
+/datum/armor/gas
+	bio = 75
+	bullet = 5
+	laser = 10
+	melee = 10
 
 /obj/item/clothing/mask/gas/Initialize()
 	. = ..()
@@ -44,7 +50,13 @@
 	icon_state = "gas_mask"
 	item_state = "gas_mask"
 
-	armor = list(melee = 10, bullet = 5, laser = 10, energy = 0, bomb = 0, bio = 55)
+	armor_type = /datum/armor/gas_old
+
+/datum/armor/gas_old
+	bio = 55
+	bullet = 5
+	laser = 10
+	melee = 10
 
 //Plague Dr suit can be found in clothing/suits/bio.dm
 /obj/item/clothing/mask/gas/plaguedoctor
@@ -52,9 +64,16 @@
 	desc = "A modernised version of the classic design, this mask will not only filter out plasma but it can also be connected to an air supply."
 	icon_state = "plaguedoctor"
 	item_state = "plaguedoctor"
-	armor = list(melee = 5, bullet = 5, laser = 5,energy = 2, bomb = 0, bio = 90)
+	armor_type = /datum/armor/gas_plaguedoctor
 	body_parts_covered = HEAD|FACE|EYES
 	siemens_coefficient = 0.9
+
+/datum/armor/gas_plaguedoctor
+	bio = 90
+	bullet = 5
+	energy = 2
+	laser = 5
+	melee = 5
 
 /obj/item/clothing/mask/gas/swat
 	name = "\improper SWAT mask"
@@ -64,7 +83,13 @@
 	istinted = 0
 	siemens_coefficient = 0.5
 	body_parts_covered = FACE|EYES
-	armor = list(melee = 15, bullet = 15, laser = 15, energy = 0, bomb = 0, bio = 75)
+	armor_type = /datum/armor/mask_swat
+
+/datum/armor/mask_swat
+	bio = 75
+	bullet = 15
+	laser = 15
+	melee = 15
 
 /obj/item/clothing/mask/gas/tactical
 	name = "\improper tactical mask"
@@ -80,7 +105,13 @@
 	flags_inv = HIDEEARS
 	istinted = 0
 	siemens_coefficient = 0.9
-	armor = list(melee = 5, bullet = 2.5, laser = 5, energy = 0, bomb = 0, bio = 75)
+	armor_type = /datum/armor/gas_clear
+
+/datum/armor/gas_clear
+	bio = 75
+	bullet = 2.5
+	laser = 5
+	melee = 5
 
 /obj/item/clothing/mask/gas/captain
 	name = "captain's gas mask"
@@ -121,7 +152,13 @@
 	item_state = "swat"
 	istinted = 0
 	siemens_coefficient = 0.5
-	armor = list(melee = 15, bullet = 15, laser = 15, energy = 0, bomb = 0, bio = 75)
+	armor_type = /datum/armor/gas_syndi
+
+/datum/armor/gas_syndi
+	bio = 75
+	bullet = 15
+	laser = 15
+	melee = 15
 
 /obj/item/clothing/mask/gas/clown_hat
 	name = "clown wig and mask"

--- a/code/modules/clothing/masks/miscellaneous.dm
+++ b/code/modules/clothing/masks/miscellaneous.dm
@@ -44,7 +44,7 @@
 	item_flags = 0
 	gas_transfer_coefficient = 0.90
 	permeability_coefficient = 0.01
-	armor = list(melee = 0, bullet = 0, laser = 0,energy = 0, bomb = 0, bio = 60)
+	armor_type = /datum/armor/mask_surgical
 	down_gas_transfer_coefficient = 1
 	down_body_parts_covered = null
 	down_icon_state = "steriledown"
@@ -54,6 +54,9 @@
 		RADIATION_BETA_PARTICLE = 2.2 MEGA ELECTRONVOLT,
 		RADIATION_HAWKING = 1 ELECTRONVOLT
 	)
+
+/datum/armor/mask_surgical
+	bio = 60
 
 /obj/item/clothing/mask/fakemoustache
 	name = "fake moustache"
@@ -154,9 +157,15 @@
 	body_parts_covered = FACE|EYES
 	action_button_name = "Toggle MUI"
 	origin_tech = list(TECH_DATA = 5, TECH_ENGINEERING = 5)
-	armor = list(melee = 10, bullet = 10, laser = 10, energy = 5, bomb = 0, bio = 0) //Well it's made of some sort of plastic.
+	armor_type = /datum/armor/mask_ai
 	var/active = FALSE
 	var/mob/observer/eye/cameranet/eye
+
+/datum/armor/mask_ai
+	bullet = 10
+	energy = 5
+	laser = 10
+	melee = 10
 
 /obj/item/clothing/mask/ai/New()
 	eye = new(src)
@@ -212,12 +221,17 @@
 	flags_inv = HIDEFACE|BLOCKHAIR
 	siemens_coefficient = 0.7
 	body_parts_covered = HEAD|FACE|EYES
-	armor = list(melee = 5, bullet = 5, laser = 5, energy = 0, bomb = 0, bio = 0)
+	armor_type = /datum/armor/mask_rubber
 	rad_resist = list(
 		RADIATION_ALPHA_PARTICLE = 16 MEGA ELECTRONVOLT,
 		RADIATION_BETA_PARTICLE = 3.4 MEGA ELECTRONVOLT,
 		RADIATION_HAWKING = 1 ELECTRONVOLT
 	)
+
+/datum/armor/mask_rubber
+	bullet = 5
+	laser = 5
+	melee = 5
 
 /obj/item/clothing/mask/rubber/trasen
 	name = "Jack Trasen mask"
@@ -293,12 +307,16 @@
 	item_state = "bandblack"
 	item_flags = 0
 	w_class = ITEM_SIZE_SMALL
-	armor = list(melee = 5, bullet = 0, laser = 0, energy = 0, bomb = 0, bio = 15)
+	armor_type = /datum/armor/mask_bandana
 	rad_resist = list(
 		RADIATION_ALPHA_PARTICLE = 12 MEGA ELECTRONVOLT,
 		RADIATION_BETA_PARTICLE = 2.18 MEGA ELECTRONVOLT,
 		RADIATION_HAWKING = 1 ELECTRONVOLT
 	)
+
+/datum/armor/mask_bandana
+	bio = 15
+	melee = 5
 
 /obj/item/clothing/mask/bandana/equipped(mob/user, slot)
 	switch(slot)
@@ -379,8 +397,13 @@
 	icon_state = "skullmask"
 	item_state = "skullmask"
 	w_class = ITEM_SIZE_NORMAL
-	armor = list(melee = 15, bullet = 10, laser = 10, energy = 0, bomb = 0, bio = 0)
+	armor_type = /datum/armor/mask_skull
 	siemens_coefficient = 0.8
+
+/datum/armor/mask_skull
+	bullet = 10
+	laser = 10
+	melee = 15
 
 /obj/item/clothing/mask/plasticbag
 	name = "plastic bag"

--- a/code/modules/clothing/shoes/jobs.dm
+++ b/code/modules/clothing/shoes/jobs.dm
@@ -6,9 +6,16 @@
 	item_flags = ITEM_FLAG_NOSLIP
 	can_hold_knife = 1
 	species_restricted = null
+	armor_type = /datum/armor/shoes_galoshes
 	siemens_coefficient = 0.4
 
-	armor = list(melee = 35, bullet = 30, laser = 30,energy = 35, bomb = 25, bio = 35)
+/datum/armor/shoes_galoshes
+	bio = 35
+	bomb = 25
+	bullet = 30
+	energy = 35
+	laser = 30
+	melee = 35
 
 /obj/item/clothing/shoes/galoshes/Initialize()
 	. = ..()
@@ -19,17 +26,33 @@
 	desc = "Tall synthleather boots with an artificial shine."
 	icon_state = "jackboots"
 	force = 3
-	armor = list(melee = 40, bullet = 40, laser = 40, energy = 15, bomb = 20, bio = 10)
+	armor_type = /datum/armor/shoes_jackboots
 	siemens_coefficient = 0.5
 	can_hold_knife = 1
 	cold_protection = FEET
 	min_cold_protection_temperature = HELMET_MIN_COLD_PROTECTION_TEMPERATURE
 
+/datum/armor/shoes_jackboots
+	bio = 10
+	bomb = 20
+	bullet = 40
+	energy = 15
+	laser = 40
+	melee = 40
+
 /obj/item/clothing/shoes/jackboots/tactical
 	name = "tactical jackboots"
 	desc = "Tall synthleather boots with an artificial shine. These ones seem to be reinforced with some sort of plating."
-	armor = list(melee = 80, bullet = 60, laser = 60, energy = 25, bomb = 50, bio = 10)
+	armor_type = /datum/armor/shoes_tactical
 	siemens_coefficient = 0.4
+
+/datum/armor/shoes_tactical
+	bio = 10
+	bomb = 50
+	bullet = 60
+	energy = 25
+	laser = 60
+	melee = 80
 
 /obj/item/clothing/shoes/jackboots/unathi
 	name = "toe-less jackboots"
@@ -42,9 +65,16 @@
 	name = "workboots"
 	desc = "A pair of steel-toed work boots designed for use in industrial settings. Safety first."
 	icon_state = "workboots"
-	armor = list(melee = 45, bullet = 30, laser = 30, energy = 25, bomb = 20, bio = 0)
+	armor_type = /datum/armor/shoes_workboots
 	siemens_coefficient = 0.4
 	can_hold_knife = 1
+
+/datum/armor/shoes_workboots
+	bomb = 20
+	bullet = 30
+	energy = 25
+	laser = 30
+	melee = 45
 
 /obj/item/clothing/shoes/workboots/toeless
 	name = "toe-less workboots"

--- a/code/modules/clothing/shoes/magboots.dm
+++ b/code/modules/clothing/shoes/magboots.dm
@@ -16,13 +16,21 @@
 	center_of_mass = null
 	randpixel = 0
 
-	armor = list(melee = 80, bullet = 60, laser = 60,energy = 25, bomb = 50, bio = 10)
+	armor_type = /datum/armor/shoes_magboots
 	siemens_coefficient = 0.3
 	rad_resist = list(
 		RADIATION_ALPHA_PARTICLE = 33.8 MEGA ELECTRONVOLT,
 		RADIATION_BETA_PARTICLE = 6.42 MEGA ELECTRONVOLT,
 		RADIATION_HAWKING = 1 ELECTRONVOLT
 	)
+
+/datum/armor/shoes_magboots
+	bio = 10
+	bomb = 50
+	bullet = 60
+	energy = 25
+	laser = 60
+	melee = 80
 
 /obj/item/clothing/shoes/magboots/proc/set_slowdown()
 	slowdown_per_slot[slot_shoes] = shoes? max(0, shoes.slowdown_per_slot[slot_shoes]): 0	//So you can't put on magboots to make you walk faster.

--- a/code/modules/clothing/shoes/miscellaneous.dm
+++ b/code/modules/clothing/shoes/miscellaneous.dm
@@ -6,10 +6,17 @@
 	item_flags = ITEM_FLAG_NOSLIP
 	origin_tech = list(TECH_ILLEGAL = 3)
 	var/list/clothing_choices = list()
-	siemens_coefficient = 0.5
 	species_restricted = null
+	armor_type = /datum/armor/shoes_syndigaloshes
+	siemens_coefficient = 0.5
 
-	armor = list(melee = 40, bullet = 40, laser = 40, energy = 35, bomb = 20, bio = 30)
+/datum/armor/shoes_syndigaloshes
+	bio = 30
+	bomb = 20
+	bullet = 40
+	energy = 35
+	laser = 40
+	melee = 40
 
 /obj/item/clothing/shoes/mime
 	name = "mime shoes"
@@ -20,17 +27,25 @@
 	desc = "When you want to turn up the heat."
 	icon_state = "swat"
 	force = 3
-	armor = list(melee = 80, bullet = 60, laser = 60,energy = 25, bomb = 50, bio = 10)
+	armor_type = /datum/armor/shoes_swat
 	item_flags = ITEM_FLAG_NOSLIP
 	siemens_coefficient = 0.4
 	can_hold_knife = 1
+
+/datum/armor/shoes_swat
+	bio = 10
+	bomb = 50
+	bullet = 60
+	energy = 25
+	laser = 60
+	melee = 80
 
 /obj/item/clothing/shoes/combat //Basically SWAT shoes combined with galoshes.
 	name = "combat boots"
 	desc = "When you REALLY want to turn up the heat."
 	icon_state = "swat"
 	force = 5
-	armor = list(melee = 80, bullet = 60, laser = 60,energy = 25, bomb = 50, bio = 10)
+	armor_type = /datum/armor/shoes_combat
 	item_flags = ITEM_FLAG_NOSLIP
 	siemens_coefficient = 0.1
 	can_hold_knife = 1
@@ -39,6 +54,14 @@
 	min_cold_protection_temperature = SHOE_MIN_COLD_PROTECTION_TEMPERATURE
 	heat_protection = FEET
 	max_heat_protection_temperature = SHOE_MAX_HEAT_PROTECTION_TEMPERATURE
+
+/datum/armor/shoes_combat
+	bio = 10
+	bomb = 50
+	bullet = 60
+	energy = 25
+	laser = 60
+	melee = 80
 
 /obj/item/clothing/shoes/dress
 	name = "dress shoes"
@@ -52,11 +75,17 @@
 	icon_state = "wizard"
 	species_restricted = null
 	body_parts_covered = 0
+	wizard_garb = 1
+	armor_type = /datum/armor/shoes_sandal
 	siemens_coefficient = 1.0
 
-	wizard_garb = 1
-
-	armor = list(melee = 10, bullet = 10, laser = 10, energy = 5, bomb = 10, bio = 3)
+/datum/armor/shoes_sandal
+	bio = 3
+	bomb = 10
+	bullet = 10
+	energy = 5
+	laser = 10
+	melee = 10
 
 /obj/item/clothing/shoes/sandal/marisa
 	desc = "A pair of magic, black shoes."
@@ -107,8 +136,15 @@
 	var/footstep = 1	//used for squeeks whilst walking
 	species_restricted = null
 	siemens_coefficient = 0.5 // these things are kinda rubberish, aint they?
+	armor_type = /datum/armor/shoes_clown
 
-	armor = list(melee = 35, bullet = 35, laser = 35,energy = 15, bomb = 25, bio = 15)
+/datum/armor/shoes_clown
+	bio = 15
+	bomb = 25
+	bullet = 35
+	energy = 15
+	laser = 35
+	melee = 35
 
 /obj/item/clothing/shoes/clown_shoes/New()
 	..()
@@ -131,13 +167,21 @@
 	force = 2
 	siemens_coefficient = 0.5
 
-	armor = list(melee = 40, bullet = 40, laser = 40, energy = 15, bomb = 20, bio = 10)
+	armor_type = /datum/armor/shoes_cult
 
 	cold_protection = FEET
 	min_cold_protection_temperature = SHOE_MIN_COLD_PROTECTION_TEMPERATURE
 	heat_protection = FEET
 	max_heat_protection_temperature = SHOE_MAX_HEAT_PROTECTION_TEMPERATURE
 	species_restricted = null
+
+/datum/armor/shoes_cult
+	bio = 10
+	bomb = 20
+	bullet = 40
+	energy = 15
+	laser = 40
+	melee = 40
 
 /obj/item/clothing/shoes/cyborg
 	name = "cyborg boots"

--- a/code/modules/clothing/spacesuits/alien.dm
+++ b/code/modules/clothing/spacesuits/alien.dm
@@ -2,7 +2,7 @@
 /obj/item/clothing/head/helmet/space/skrell
 	name = "Skrellian helmet"
 	desc = "Smoothly contoured and polished to a shine. Still looks like a fishbowl."
-	armor = list(melee = 20, bullet = 20, laser = 50,energy = 50, bomb = 50, bio = 100)
+	armor_type = /datum/armor/head_helmet_space_skrell
 	max_heat_protection_temperature = SPACE_SUIT_MAX_HEAT_PROTECTION_TEMPERATURE
 	species_restricted = list(SPECIES_SKRELL,SPECIES_HUMAN)
 	rad_resist = list(
@@ -10,6 +10,14 @@
 		RADIATION_BETA_PARTICLE = 8.9 MEGA ELECTRONVOLT,
 		RADIATION_HAWKING = 1 ELECTRONVOLT
 	)
+
+/datum/armor/head_helmet_space_skrell
+	bio = 100
+	bomb = 50
+	bullet = 20
+	energy = 50
+	laser = 50
+	melee = 20
 
 /obj/item/clothing/head/helmet/space/skrell/white
 	icon_state = "skrell_helmet_white"
@@ -20,7 +28,7 @@
 /obj/item/clothing/suit/space/skrell
 	name = "Skrellian voidsuit"
 	desc = "Seems like a wetsuit with reinforced plating seamlessly attached to it. Very chic."
-	armor = list(melee = 20, bullet = 20, laser = 50,energy = 50, bomb = 50, bio = 100)
+	armor_type = /datum/armor/suit_space_skrell
 	allowed = list(/obj/item/device/flashlight,/obj/item/tank,/obj/item/storage/ore,/obj/item/device/t_scanner,/obj/item/pickaxe, /obj/item/rcd)
 	heat_protection = UPPER_TORSO|LOWER_TORSO|LEGS|FEET|ARMS|HANDS
 	max_heat_protection_temperature = SPACE_SUIT_MAX_HEAT_PROTECTION_TEMPERATURE
@@ -30,6 +38,14 @@
 		RADIATION_BETA_PARTICLE = 8.9 MEGA ELECTRONVOLT,
 		RADIATION_HAWKING = 1 ELECTRONVOLT
 	)
+
+/datum/armor/suit_space_skrell
+	bio = 100
+	bomb = 50
+	bullet = 20
+	energy = 50
+	laser = 50
+	melee = 20
 
 /obj/item/clothing/suit/space/skrell/white
 	icon_state = "skrell_suit_white"
@@ -42,7 +58,7 @@
 /obj/item/clothing/suit/space/vox
 	w_class = ITEM_SIZE_NORMAL
 	allowed = list(/obj/item/gun,/obj/item/ammo_magazine,/obj/item/ammo_casing,/obj/item/melee/baton,/obj/item/melee/energy/sword/pirate,/obj/item/handcuffs,/obj/item/tank)
-	armor = list(melee = 60, bullet = 50, laser = 40,energy = 15, bomb = 30, bio = 100)
+	armor_type = /datum/armor/suit_space_vox
 	siemens_coefficient = 0.6
 	heat_protection = UPPER_TORSO|LOWER_TORSO|LEGS|FEET|ARMS|HANDS
 	max_heat_protection_temperature = SPACE_SUIT_MAX_HEAT_PROTECTION_TEMPERATURE
@@ -53,12 +69,20 @@
 		RADIATION_HAWKING = 1 ELECTRONVOLT
 	)
 
+/datum/armor/suit_space_vox
+	bio = 100
+	bomb = 30
+	bullet = 50
+	energy = 15
+	laser = 40
+	melee = 60
+
 /obj/item/clothing/suit/space/vox/New()
 	..()
 	slowdown_per_slot[slot_wear_suit] = 2
 
 /obj/item/clothing/head/helmet/space/vox
-	armor = list(melee = 60, bullet = 50, laser = 40, energy = 15, bomb = 30, bio = 100)
+	armor_type = /datum/armor/helmet_space_vox
 	siemens_coefficient = 0.6
 	flags_inv = 0
 	species_restricted = list(SPECIES_VOX)
@@ -68,20 +92,44 @@
 		RADIATION_HAWKING = 1 ELECTRONVOLT
 	)
 
+/datum/armor/helmet_space_vox
+	bio = 100
+	bomb = 30
+	bullet = 50
+	energy = 15
+	laser = 40
+	melee = 60
+
 /obj/item/clothing/head/helmet/space/vox/pressure
 	name = "alien helmet"
 	icon_state = "vox-pressure"
 	desc = "Hey, wasn't this a prop in \'The Abyss\'?"
-	armor = list(melee = 60, bullet = 50, laser = 40, energy = 30, bomb = 90, bio = 100)
+	armor_type = /datum/armor/head_helmet_vox_pressure
+
+/datum/armor/head_helmet_vox_pressure
+	bio = 100
+	bomb = 90
+	bullet = 50
+	energy = 30
+	laser = 40
+	melee = 60
 
 /obj/item/clothing/suit/space/vox/pressure
 	name = "alien pressure suit"
 	icon_state = "vox-pressure"
 	desc = "A huge, armoured, pressurized suit, designed for distinctly nonhuman proportions."
 	action_button_name = "Toggle Bio-RCD"
-	armor = list(melee = 60, bullet = 50, laser = 40, energy = 30, bomb = 90, bio = 100)
+	armor_type = /datum/armor/suit_space_vox_pressure
 	var/tool_delay = 120 SECONDS
 	var/last_used = 0
+
+/datum/armor/suit_space_vox_pressure
+	bio = 100
+	bomb = 30
+	bullet = 50
+	energy = 40
+	laser = 40
+	melee = 60
 
 /obj/item/clothing/suit/space/vox/pressure/attack_self(mob/user)
 	var/mob/living/carbon/human/H = user
@@ -288,7 +336,15 @@
 	icon_state = "vox-stealth"
 	desc = "A smoothly contoured, matte-black alien helmet."
 	siemens_coefficient = 0
-	armor = list(melee = 25, bullet = 40, laser = 65, energy = 40, bomb = 20, bio = 100)
+	armor_type = /datum/armor/head_helmet_vox_stealth
+
+/datum/armor/head_helmet_vox_stealth
+	bio = 100
+	bomb = 20
+	bullet = 40
+	energy = 40
+	laser = 40
+	melee = 25
 
 /obj/item/clothing/suit/space/vox/stealth
 	name = "alien stealth suit"
@@ -296,8 +352,16 @@
 	desc = "A sleek black suit. It seems to have a tail, and is very light."
 	action_button_name = "Toggle Cloak"
 	siemens_coefficient = 0
-	armor = list(melee = 25, bullet = 30, laser = 65, energy = 30, bomb = 20, bio = 100)
+	armor_type = /datum/armor/suit_space_vox_stealth
 	var/cloak = FALSE
+
+/datum/armor/suit_space_vox_stealth
+	bio = 100
+	bomb = 30
+	bullet = 50
+	energy = 40
+	laser = 40
+	melee = 60
 
 /obj/item/clothing/suit/space/vox/stealth/New()
 	..()
@@ -340,18 +404,34 @@
 	name = "alien goggled helmet"
 	icon_state = "vox-medic"
 	desc = "An alien helmet with enormous goggled lenses."
-	armor = list(melee = 60, bullet = 50, laser = 40,energy = 15, bomb = 30, bio = 100)
+	armor_type = /datum/armor/head_helmet_vox_medic
 	siemens_coefficient = 0.3
+
+/datum/armor/head_helmet_vox_medic
+	bio = 100
+	bomb = 30
+	bullet = 50
+	energy = 40
+	laser = 40
+	melee = 60
 
 /obj/item/clothing/suit/space/vox/medic
 	name = "alien armour"
 	icon_state = "vox-medic"
 	desc = "An almost organic looking nonhuman pressure suit."
 	siemens_coefficient = 0.3
-	armor = list(melee = 60, bullet = 50, laser = 40,energy = 15, bomb = 30, bio = 100)
+	armor_type = /datum/armor/suit_space_vox_medic
 	action_button_name = "Toggle Nanobots"
 	var/nanobots = FALSE
 	var/mob/client //user
+
+/datum/armor/suit_space_vox_medic
+	bio = 100
+	bomb = 30
+	bullet = 50
+	energy = 15
+	laser = 40
+	melee = 60
 
 /obj/item/clothing/suit/space/vox/medic/New()
 	..()

--- a/code/modules/clothing/spacesuits/alien.dm
+++ b/code/modules/clothing/spacesuits/alien.dm
@@ -233,8 +233,24 @@
 	icon_state = "vox-carapace"
 	desc = "An armoured, segmented carapace with glowing purple lights. It looks pretty run-down."
 	action_button_name = "Toggle Protection"
-	armor = list(melee = 60, bullet = 50, laser = 40, energy = 30, bomb = 40, bio = 100)
+	armor_type = /datum/armor/carapace_default
 	var/protection = FALSE
+
+/datum/armor/carapace_default
+	bio = 100
+	bomb = 60
+	bullet = 50
+	energy = 40
+	laser = 40
+	melee = 60
+
+/datum/armor/carapace_protrcted
+	bio = 100
+	bomb = 60
+	bullet = 80
+	energy = 80
+	laser = 80
+	melee = 80
 
 /obj/item/clothing/suit/space/vox/carapace/attack_self(mob/user)
 	var/mob/living/carbon/human/H = user
@@ -246,21 +262,21 @@
 
 /obj/item/clothing/suit/space/vox/carapace/proc/protection(mob/living/carbon/human/H)
 	if(protection)
-		to_chat(H, "<span class='notice'>You deactivate the protection mode.</span>")
-		armor = list(melee = 60, bullet = 50, laser = 40, energy = 30, bomb = 60, bio = 100)
+		to_chat(H, SPAN_NOTICE("You deactivate the protection mode."))
+		set_armor(get_armor_by_type(/datum/armor/carapace_default))
 		siemens_coefficient = 0.6
 		if(istype(H.head, /obj/item/clothing/head/helmet/space/vox/carapace))
-			H.head.armor = list(melee = 60, bullet = 50, laser = 40, energy = 40, bomb = 60, bio = 100)
+			H.head.set_armor(get_armor_by_type(/datum/armor/carapace_default))
 			H.head.siemens_coefficient = 0.6
 			H.head.item_state = "vox-carapace"
 		slowdown_per_slot[slot_wear_suit] = 3
 		item_state = "vox-carapace"
 	else
-		to_chat(H, "<span class='notice'>You activate the protection mode.</span>")
-		armor = list(melee = 80, bullet = 80, laser = 80, energy = 80, bomb = 60, bio = 100)
+		to_chat(H, SPAN_NOTICE("You activate the protection mode."))
+		set_armor(get_armor_by_type(/datum/armor/carapace_protrcted))
 		siemens_coefficient = 0.2
 		if(istype(H.head, /obj/item/clothing/head/helmet/space/vox/carapace))
-			H.head.armor = list(melee = 80, bullet = 80, laser = 80, energy = 80, bomb = 60, bio = 100)
+			H.head.set_armor(get_armor_by_type(/datum/armor/carapace_protrcted))
 			H.head.siemens_coefficient = 0.2
 			H.head.item_state = "vox-carapace-active"
 		slowdown_per_slot[slot_wear_suit] = 20

--- a/code/modules/clothing/spacesuits/bruh
+++ b/code/modules/clothing/spacesuits/bruh
@@ -1,7 +1,0 @@
-/datum/armor
-	bio = 0
-	bomb = 0
-	bullet = 0
-	energy = 0
-	laser = 0
-	melee = 0

--- a/code/modules/clothing/spacesuits/bruh
+++ b/code/modules/clothing/spacesuits/bruh
@@ -1,0 +1,7 @@
+/datum/armor
+	bio = 0
+	bomb = 0
+	bullet = 0
+	energy = 0
+	laser = 0
+	melee = 0

--- a/code/modules/clothing/spacesuits/miscellaneous.dm
+++ b/code/modules/clothing/spacesuits/miscellaneous.dm
@@ -22,11 +22,19 @@
 	desc = "Yarr."
 	icon_state = "pirate"
 	item_state = "pirate"
-	armor = list(melee = 60, bullet = 50, laser = 30,energy = 15, bomb = 30, bio = 30)
+	armor_type = /datum/armor/helm_pirate
 	flags_inv = BLOCKHAIR
 	body_parts_covered = 0
 	siemens_coefficient = 0.9
 	has_visor = 0
+
+/datum/armor/helm_pirate
+	bio = 30
+	bomb = 30
+	bullet = 50
+	energy = 15
+	laser = 30
+	melee = 60
 
 /obj/item/clothing/suit/space/pirate
 	name = "pirate coat"
@@ -34,9 +42,17 @@
 	icon_state = "pirate"
 	w_class = ITEM_SIZE_NORMAL
 	allowed = list(/obj/item/gun,/obj/item/ammo_magazine,/obj/item/ammo_casing,/obj/item/melee/baton,/obj/item/handcuffs,/obj/item/tank/emergency)
-	armor = list(melee = 60, bullet = 50, laser = 30,energy = 15, bomb = 30, bio = 30)
+	armor_type = /datum/armor/suit_pirate
 	siemens_coefficient = 0.9
 	body_parts_covered = UPPER_TORSO|LOWER_TORSO|ARMS
+
+/datum/armor/suit_pirate
+	bio = 30
+	bomb = 30
+	bullet = 50
+	energy = 15
+	laser = 30
+	melee = 60
 
 /obj/item/clothing/suit/space/pirate/New()
 	..()
@@ -74,7 +90,7 @@
 	name = "goliath tailplate"
 	desc = "An old goliath's tailplate. It's exceptionally tough, yet quite soft on the inside and, surprisingly, matches a human head's size."
 	icon_state = "goliathhelm"
-	armor = list(melee = 85, bullet = 65, laser = 65, energy = 35, bomb = 65, bio = 85)
+	armor_type = /datum/armor/helm_goliath
 	siemens_coefficient = 0.5
 	flash_protection = FLASH_PROTECTION_MODERATE
 	action_button_name = null
@@ -83,6 +99,14 @@
 		RADIATION_BETA_PARTICLE = 2.8 MEGA ELECTRONVOLT,
 		RADIATION_HAWKING = 1 ELECTRONVOLT
 	)
+
+/datum/armor/helm_goliath
+	bio = 85
+	bomb = 65
+	bullet = 65
+	energy = 35
+	laser = 65
+	melee = 85
 
 /obj/item/clothing/head/helmet/space/goliath/attack_self(mob/user)
 	return

--- a/code/modules/clothing/spacesuits/rig/rig.dm
+++ b/code/modules/clothing/spacesuits/rig/rig.dm
@@ -156,7 +156,6 @@
 			piece.siemens_coefficient = siemens_coefficient
 		piece.permeability_coefficient = permeability_coefficient
 		piece.unacidable = unacidable
-		if(islist(armor)) piece.armor = armor.Copy()
 
 	set_slowdown_and_vision(!offline)
 	update_icon(1)

--- a/code/modules/clothing/spacesuits/rig/rig.dm
+++ b/code/modules/clothing/spacesuits/rig/rig.dm
@@ -7,7 +7,6 @@
  */
 
 /obj/item/rig
-
 	name = "powersuit control module"
 	icon = 'icons/obj/rig_modules.dmi'
 	desc = "A back-mounted powersuit deployment and control mechanism."
@@ -18,7 +17,7 @@
 	center_of_mass = null
 
 	// These values are passed on to all component pieces.
-	armor = list(melee = 40, bullet = 5, laser = 20,energy = 5, bomb = 35, bio = 100)
+	armor_type = /datum/armor/rig
 	min_cold_protection_temperature = SPACE_SUIT_MIN_COLD_PROTECTION_TEMPERATURE
 	max_heat_protection_temperature = SPACE_SUIT_MAX_HEAT_PROTECTION_TEMPERATURE
 	siemens_coefficient = 0.2
@@ -85,6 +84,14 @@
 	// Wiring! How exciting.
 	var/datum/wires/rig/wires
 	var/datum/effect/effect/system/spark_spread/spark_system
+
+/datum/armor/rig
+	bio = 100
+	bomb = 25
+	bullet = 5
+	energy = 5
+	laser = 20
+	melee = 40
 
 /obj/item/rig/_examine_text(mob/user)
 	. = ..()

--- a/code/modules/clothing/spacesuits/rig/rig.dm
+++ b/code/modules/clothing/spacesuits/rig/rig.dm
@@ -313,11 +313,10 @@
 							if(helmet)
 								helmet.update_light(wearer)
 
-					//sealed pieces become airtight, protecting against diseases
-					if (!seal_target)
-						piece.armor["bio"] = 100
+					if(!seal_target)
+						piece.set_armor_rating(BIO, 100)
 					else
-						piece.armor["bio"] = src.armor["bio"]
+						piece.set_armor_rating(BIO, get_armor_rating(BIO))
 
 				else
 					failed_to_seal = 1

--- a/code/modules/clothing/spacesuits/rig/suits/alien.dm
+++ b/code/modules/clothing/spacesuits/rig/suits/alien.dm
@@ -3,7 +3,7 @@
 	desc = "A cheap NT knock-off of an Unathi battle-rig. Looks like a fish, moves like a fish, steers like a cow."
 	suit_type = "NT breacher"
 	icon_state = "breacher_rig_cheap"
-	armor = list(melee = 60, bullet = 60, laser = 60, energy = 60, bomb = 70, bio = 100)
+	armor_type = /datum/armor/rig_unathi
 	emp_protection = -20
 	online_slowdown = 6
 	offline_slowdown = 10
@@ -15,13 +15,29 @@
 	boot_type = /obj/item/clothing/shoes/magboots/rig/unathi
 	glove_type = /obj/item/clothing/gloves/rig/unathi
 
+/datum/armor/rig_unathi
+	bio = 100
+	bomb = 70
+	bullet = 60
+	energy = 60
+	laser = 60
+	melee = 60
+
 /obj/item/rig/unathi/fancy
 	name = "breacher chassis control module"
 	desc = "An authentic Unathi breacher chassis. Huge, bulky and absurdly heavy. It must be like wearing a tank."
 	suit_type = "breacher chassis"
 	icon_state = "breacher_rig"
-	armor = list(melee = 90, bullet = 90, laser = 90, energy = 90, bomb = 90, bio = 100) //Takes TEN TIMES as much damage to stop someone in a breacher. In exchange, it's slow.
-	vision_restriction = TINT_NONE //Still blind when offline. It is fully armoured after all
+	armor_type = /datum/armor/rig_unathifancy
+	vision_restriction = TINT_NONE
+
+/datum/armor/rig_unathifancy
+	bio = 100
+	bomb = 90
+	bullet = 90
+	energy = 90
+	laser = 90
+	melee = 90
 
 /obj/item/clothing/head/helmet/space/rig/unathi
 	species_restricted = list(SPECIES_UNATHI)

--- a/code/modules/clothing/spacesuits/rig/suits/combat.dm
+++ b/code/modules/clothing/spacesuits/rig/suits/combat.dm
@@ -3,7 +3,7 @@
 	desc = "A sleek and dangerous powersuit for active combat."
 	icon_state = "security_rig"
 	suit_type = "combat powersuit"
-	armor = list(melee = 80, bullet = 65, laser = 55, energy = 15, bomb = 80, bio = 100)
+	armor_type = /datum/armor/rig_combat
 	online_slowdown = 1
 	offline_slowdown = 3
 	offline_vision_restriction = TINT_HEAVY
@@ -16,6 +16,14 @@
 	helm_type = /obj/item/clothing/head/helmet/space/rig/combat
 	boot_type = /obj/item/clothing/shoes/magboots/rig/combat
 	glove_type = /obj/item/clothing/gloves/rig/combat
+
+/datum/armor/rig_combat
+	bio = 100
+	bomb = 80
+	bullet = 65
+	energy = 15
+	laser = 55
+	melee = 80
 
 /obj/item/clothing/head/helmet/space/rig/combat
 	light_overlay = "helmet_light_dual_green"
@@ -49,7 +57,7 @@
 	desc = "An austere powersuit used by paramilitary groups and real soldiers alike."
 	icon_state = "military_rig"
 	suit_type = "military powersuit"
-	armor = list(melee = 80, bullet = 75, laser = 60, energy = 15, bomb = 80, bio = 100)
+	armor_type = /datum/armor/rig_military
 	online_slowdown = 1
 	offline_slowdown = 3
 	offline_vision_restriction = TINT_HEAVY
@@ -62,6 +70,14 @@
 	helm_type = /obj/item/clothing/head/helmet/space/rig/military
 	boot_type = /obj/item/clothing/shoes/magboots/rig/military
 	glove_type = /obj/item/clothing/gloves/rig/military
+
+/datum/armor/rig_military
+	bio = 100
+	bomb = 80
+	bullet = 75
+	energy = 15
+	laser = 60
+	melee = 80
 
 /obj/item/clothing/head/helmet/space/rig/military
 	light_overlay = "helmet_light_dual_green"

--- a/code/modules/clothing/spacesuits/rig/suits/ert.dm
+++ b/code/modules/clothing/spacesuits/rig/suits/ert.dm
@@ -11,7 +11,7 @@
 
 	req_access = list(access_cent_specops)
 
-	armor = list(melee = 60, bullet = 50, laser = 50,energy = 15, bomb = 30, bio = 100)
+	armor_type = /datum/armor/rig_ert
 	allowed = list(/obj/item/device/flashlight, /obj/item/tank,/obj/item/ammo_magazine,/obj/item/ammo_casing,/obj/item/handcuffs, /obj/item/device/t_scanner, /obj/item/rcd, /obj/item/crowbar, \
 	/obj/item/screwdriver, /obj/item/weldingtool, /obj/item/wirecutters, /obj/item/wrench, /obj/item/device/multitool, \
 	/obj/item/device/radio, /obj/item/device/analyzer,/obj/item/storage/briefcase/inflatable, /obj/item/melee/baton, /obj/item/gun, \
@@ -23,6 +23,14 @@
 		/obj/item/rig_module/datajack,
 		/obj/item/rig_module/cooling_unit
 		)
+
+/datum/armor/rig_ert
+	bio = 100
+	bomb = 30
+	bullet = 50
+	energy = 15
+	laser = 50
+	melee = 60
 
 /obj/item/clothing/head/helmet/space/rig/ert
 	light_overlay = "helmet_light_dual"
@@ -44,7 +52,6 @@
 	desc = "A powersuit used by NanoTrasen's elite Emergency Response Teams. Has orange highlights. Armored and space ready."
 	suit_type = "ERT engineer"
 	icon_state = "ert_engineer_rig"
-	armor = list(melee = 60, bullet = 50, laser = 50,energy = 15, bomb = 30, bio = 100)
 
 	glove_type = /obj/item/clothing/gloves/rig/ert/engineer
 
@@ -63,7 +70,7 @@
 	desc = "A powersuit used by NanoTrasen's elite Emergency Response Teams. Has purple highlights. Armored and space ready."
 	suit_type = "ERT sanitation"
 	icon_state = "ert_janitor_rig"
-	armor = list(melee = 60, bullet = 50, laser = 50,energy = 40, bomb = 40, bio = 100)
+	armor_type = /datum/armor/rig_ertjani
 
 	initial_modules = list(
 		/obj/item/rig_module/ai_container,
@@ -73,6 +80,14 @@
 		/obj/item/rig_module/device/decompiler,
 		/obj/item/rig_module/cooling_unit
 		)
+
+/datum/armor/rig_ertjani
+	bio = 100
+	bomb = 40
+	bullet = 50
+	energy = 40
+	laser = 50
+	melee = 60
 
 /obj/item/rig/ert/medical
 	name = "ERT medical powersuit control module"
@@ -107,7 +122,7 @@
 	desc = "That's not red paint. That's real blood."
 	suit_type = "Death Squad"
 	icon_state = "asset_protection_rig"
-	armor = list(melee = 70, bullet = 55, laser = 55,energy = 40, bomb = 70, bio = 100)
+	armor_type = /datum/armor/rig_ertmed
 
 	glove_type = /obj/item/clothing/gloves/rig/ert/assetprotection
 
@@ -122,6 +137,14 @@
 		/obj/item/rig_module/datajack,
 		/obj/item/rig_module/cooling_unit
 		)
+
+/datum/armor/rig_ertmed
+	bio = 100
+	bomb = 70
+	bullet = 50
+	energy = 40
+	laser = 55
+	melee = 70
 
 /obj/item/clothing/gloves/rig/ert/assetprotection
 	siemens_coefficient = 0

--- a/code/modules/clothing/spacesuits/rig/suits/light.dm
+++ b/code/modules/clothing/spacesuits/rig/suits/light.dm
@@ -5,7 +5,7 @@
 	icon_state = "ninja_rig"
 	suit_type = "light suit"
 	allowed = list(/obj/item/gun,/obj/item/ammo_magazine,/obj/item/ammo_casing,/obj/item/melee/baton,/obj/item/handcuffs,/obj/item/tank,/obj/item/device/suit_cooling_unit,/obj/item/cell)
-	armor = list(melee = 50, bullet = 15, laser = 50, energy = 10, bomb = 25, bio = 0)
+	armor_type = /datum/armor/rig_light
 	siemens_coefficient = 0.4
 	emp_protection = 10
 	online_slowdown = 0
@@ -17,6 +17,13 @@
 	helm_type =  /obj/item/clothing/head/helmet/space/rig/light
 	boot_type =  /obj/item/clothing/shoes/magboots/rig/light
 	glove_type = /obj/item/clothing/gloves/rig/light
+
+/datum/armor/rig_light
+	bomb = 25
+	bullet = 15
+	energy = 10
+	laser = 50
+	melee = 50
 
 /obj/item/clothing/suit/space/rig/light
 	name = "suit"
@@ -77,7 +84,7 @@
 	desc = "A unique, vaccum-proof suit of nano-enhanced armor designed specifically for assassins."
 	suit_type = "ominous"
 	icon_state = "ninja_rig"
-	armor = list(melee = 50, bullet = 15, laser = 30, energy = 10, bomb = 25, bio = 100)
+	armor_type = /datum/armor/rig_ninja
 	siemens_coefficient = 0.2 //heavy powersuit level shock protection
 	emp_protection = 40 //change this to 30 if too high.
 	online_slowdown = 0
@@ -103,6 +110,14 @@
 		/obj/item/rig_module/self_destruct,
 		/obj/item/rig_module/cooling_unit
 		)
+
+/datum/armor/rig_ninja
+	bio = 100
+	bomb = 30
+	bullet = 15
+	energy = 10
+	laser = 25
+	melee = 50
 
 /obj/item/rig/light/ninja/verb/rename_suit()
 	set name = "Name Ninja Suit"

--- a/code/modules/clothing/spacesuits/rig/suits/station.dm
+++ b/code/modules/clothing/spacesuits/rig/suits/station.dm
@@ -3,7 +3,6 @@
 	suit_type = "augmented suit"
 	desc = "Prepare for paperwork."
 	icon_state = "internalaffairs_rig"
-	armor = list(melee = 0, bullet = 0, laser = 0,energy = 0, bomb = 0, bio = 0)
 	siemens_coefficient = 0.9
 	online_slowdown = 0
 	offline_slowdown = 0
@@ -42,7 +41,7 @@
 	suit_type = "industrial powersuit"
 	desc = "A heavy, powerful rig used by construction crews and mining corporations."
 	icon_state = "engineering_rig"
-	armor = list(melee = 75, bullet = 35, laser = 35,energy = 15, bomb = 50, bio = 100)
+	armor_type = /datum/armor/rig_industrial
 	online_slowdown = 2
 	offline_slowdown = 10
 	offline_vision_restriction = TINT_HEAVY
@@ -56,6 +55,14 @@
 
 	req_access = list()
 	req_one_access = list()
+
+/datum/armor/rig_industrial
+	bio = 100
+	bomb = 60
+	bullet = 35
+	energy = 15
+	laser = 35
+	melee = 75
 
 /obj/item/clothing/head/helmet/space/rig/industrial
 	brightness_on = 6
@@ -87,7 +94,7 @@
 	suit_type = "EVA powersuit"
 	desc = "A light rig for repairs and maintenance to the outside of habitats and vessels."
 	icon_state = "eva_rig"
-	armor = list(melee = 30, bullet = 10, laser = 20,energy = 25, bomb = 20, bio = 100)
+	armor_type = /datum/armor/rig_eva
 	online_slowdown = 0
 	offline_slowdown = 1
 	offline_vision_restriction = TINT_HEAVY
@@ -101,6 +108,14 @@
 
 	req_access = list()
 	req_one_access = list()
+
+/datum/armor/rig_eva
+	bio = 100
+	bomb = 20
+	bullet = 10
+	energy = 25
+	laser = 20
+	melee = 30
 
 /obj/item/clothing/head/helmet/space/rig/eva
 	light_overlay = "helmet_light_dual"
@@ -129,12 +144,11 @@
 		)
 
 /obj/item/rig/ce
-
 	name = "advanced engineering powersuit control module"
 	suit_type = "engineering powersuit"
 	desc = "An advanced powersuit that protects against hazardous, low pressure environments. Shines with a high polish. Appears compatible with the physiology of most species."
 	icon_state = "ce_rig"
-	armor = list(melee = 40, bullet = 25, laser = 30, energy = 25, bomb = 40, bio = 100)
+	armor_type = /datum/armor/rig_ce
 	online_slowdown = 0
 	offline_slowdown = 0
 	offline_vision_restriction = TINT_HEAVY
@@ -146,6 +160,14 @@
 
 	req_access = list()
 	req_one_access = list()
+
+/datum/armor/rig_ce
+	bio = 100
+	bomb = 40
+	bullet = 25
+	energy = 25
+	laser = 30
+	melee = 40
 
 /obj/item/rig/ce/equipped
 
@@ -168,12 +190,11 @@
 	siemens_coefficient = 0
 
 /obj/item/rig/hazmat
-
 	name = "AMI control module"
 	suit_type = "hazmat powersuit"
 	desc = "An Anomalous Material Interaction powersuit, a prototype NanoTrasen design, protects the wearer against the strangest energies the universe can throw at it."
 	icon_state = "science_rig"
-	armor = list(melee = 45, bullet = 5, laser = 45, energy = 80, bomb = 60, bio = 100)
+	armor_type = /datum/armor/rig_hazmat
 	online_slowdown = 1
 	offline_vision_restriction = TINT_HEAVY
 
@@ -186,6 +207,14 @@
 
 	req_access = list()
 	req_one_access = list()
+
+/datum/armor/rig_hazmat
+	bio = 100
+	bomb = 60
+	bullet = 5
+	energy = 80
+	laser = 45
+	melee = 45
 
 /obj/item/clothing/head/helmet/space/rig/hazmat
 	light_overlay = "helmet_light_dual"
@@ -217,7 +246,7 @@
 	suit_type = "medical powersuit"
 	desc = "A durable suit designed for medical rescue in high-risk areas. Although its armor plating is not that tough, it provides exceptional protection against radiation."
 	icon_state = "medical_rig"
-	armor = list(melee = 40, bullet = 30, laser = 40, energy = 40, bomb = 45, bio = 100)
+	armor_type = /datum/armor/rig_medical
 	online_slowdown = 1
 	offline_vision_restriction = TINT_HEAVY
 
@@ -229,6 +258,14 @@
 	allowed = list(/obj/item/device/flashlight,/obj/item/tank,/obj/item/device/suit_cooling_unit,/obj/item/storage/firstaid,/obj/item/device/healthanalyzer,/obj/item/stack/medical,/obj/item/roller )
 
 	req_access = list(access_medical_equip)
+
+/datum/armor/rig_medical
+	bio = 100
+	bomb = 45
+	bullet = 30
+	energy = 40
+	laser = 40
+	melee = 40
 
 /obj/item/clothing/head/helmet/space/rig/medical
 	camera = /obj/machinery/camera/network/medbay
@@ -259,7 +296,7 @@
 	desc = "A NanoTrasen security powersuit designed for prolonged EVA in dangerous environments."
 	// TODO[V] Make icon_state resembling new naming
 	icon_state = "hazard_rig"
-	armor = list(melee = 60, bullet = 50, laser = 45, energy = 15, bomb = 70, bio = 100)
+	armor_type = /datum/armor/rig_security
 	online_slowdown = 1
 	offline_slowdown = 3
 	offline_vision_restriction = TINT_BLIND
@@ -273,6 +310,14 @@
 
 	req_access = list()
 	req_one_access = list()
+
+/datum/armor/rig_security
+	bio = 100
+	bomb = 70
+	bullet = 50
+	energy = 15
+	laser = 45
+	melee = 60
 
 /obj/item/clothing/head/helmet/space/rig/hazard
 	light_overlay = "helmet_light_dual"
@@ -304,7 +349,7 @@
 	suit_type = "mining powersuit"
 	desc = "An heavy, durable powersuit used for excavation in extremely hazardous environments."
 	icon_state = "mining_rig"
-	armor = list(melee = 80, bullet = 45, laser = 50, energy = 25, bomb = 80, bio = 100)
+	armor_type = /datum/armor/rig_mining
 	online_slowdown = 2
 	offline_slowdown = 10
 	offline_vision_restriction = TINT_HEAVY
@@ -329,6 +374,14 @@
 
 	req_access = list()
 	req_one_access = list()
+
+/datum/armor/rig_mining
+	bio = 100
+	bomb = 80
+	bullet = 45
+	energy = 20
+	laser = 25
+	melee = 80
 
 /obj/item/clothing/head/helmet/space/rig/mining
 	brightness_on = 6

--- a/code/modules/clothing/spacesuits/rig/suits/syndi.dm
+++ b/code/modules/clothing/spacesuits/rig/suits/syndi.dm
@@ -7,7 +7,7 @@
 	desc = "A blood-red powersuit featuring some fairly illegal technology."
 	icon_state = "merc_rig"
 	suit_type = "crimson powersuit"
-	armor = list(melee = 80, bullet = 65, laser = 65, energy = 15, bomb = 80, bio = 100)
+	armor_type = /datum/armor/rig_syndi
 	online_slowdown = 1
 	offline_slowdown = 3
 	offline_vision_restriction = TINT_HEAVY
@@ -26,6 +26,14 @@
 		/obj/item/rig_module/fabricator/energy_net
 		)
 
+/datum/armor/rig_syndi
+	bio = 100
+	bomb = 80
+	bullet = 65
+	energy = 15
+	laser = 65
+	melee = 80
+
 //Has most of the modules removed
 /obj/item/rig/syndi/empty
 	initial_modules = list(
@@ -38,9 +46,17 @@
 	desc = "A blood-red powersuit featuring some fairly illegal technology and real curves."
 	icon_state = "merc_rig_heavy"
 	suit_type = "heavy crimson powersuit"
-	armor = list(melee = 90, bullet = 80, laser = 80, energy = 25, bomb = 90, bio = 100)
+	armor_type = /datum/armor/rig_heavysyndi
 	offline_slowdown = 4
 	online_slowdown = 2
+
+/datum/armor/rig_heavysyndi
+	bio = 100
+	bomb = 90
+	bullet = 80
+	energy = 25
+	laser = 80
+	melee = 90
 
 /obj/item/rig/syndi/heavy/empty
 	initial_modules = list(

--- a/code/modules/clothing/spacesuits/spacesuits.dm
+++ b/code/modules/clothing/spacesuits/spacesuits.dm
@@ -13,7 +13,7 @@
 		slot_r_hand_str = "s_helmet",
 		)
 	permeability_coefficient = 0
-	armor = list(melee = 0, bullet = 0, laser = 0,energy = 0, bomb = 0, bio = 100)
+	armor_type = /datum/armor/helm_space
 	flags_inv = HIDEMASK|HIDEEARS|HIDEEYES|HIDEFACE|BLOCKHAIR
 	body_parts_covered = HEAD|FACE|EYES
 	cold_protection = HEAD
@@ -36,6 +36,9 @@
 		RADIATION_BETA_PARTICLE = 13.2 MEGA ELECTRONVOLT,
 		RADIATION_HAWKING = 1 ELECTRONVOLT
 	)
+
+/datum/armor/helm_space
+	bio = 100
 
 /obj/item/clothing/head/helmet/space/Destroy()
 	if(camera && !ispath(camera))
@@ -87,7 +90,7 @@
 	item_flags = ITEM_FLAG_STOPPRESSUREDAMAGE | ITEM_FLAG_THICKMATERIAL
 	body_parts_covered = UPPER_TORSO|LOWER_TORSO|LEGS|FEET|ARMS|HANDS
 	allowed = list(/obj/item/device/flashlight,/obj/item/tank/emergency,/obj/item/device/suit_cooling_unit)
-	armor = list(melee = 0, bullet = 0, laser = 0,energy = 0, bomb = 0, bio = 100)
+	armor_type = /datum/armor/suit_space
 	flags_inv = HIDEGLOVES|HIDESHOES|HIDEJUMPSUIT|HIDETAIL
 	cold_protection = UPPER_TORSO | LOWER_TORSO | LEGS | FEET | ARMS | HANDS
 	min_cold_protection_temperature = SPACE_SUIT_MIN_COLD_PROTECTION_TEMPERATURE
@@ -96,3 +99,6 @@
 	randpixel = 0
 	species_restricted = list("exclude", SPECIES_NABBER, SPECIES_DIONA, "Xenomorph")
 	valid_accessory_slots = list(ACCESSORY_SLOT_INSIGNIA)
+
+/datum/armor/suit_space
+	bio = 100

--- a/code/modules/clothing/spacesuits/syndi.dm
+++ b/code/modules/clothing/spacesuits/syndi.dm
@@ -4,13 +4,21 @@
 	icon_state = "syndicate"
 	item_state = "syndicate"
 	desc = "A crimson helmet sporting clean lines and durable plating. Engineered to look menacing."
-	armor = list(melee = 60, bullet = 50, laser = 50,energy = 15, bomb = 30, bio = 30)
+	armor_type = /datum/armor/helm_syndispace
 	siemens_coefficient = 0.3
 	rad_resist = list(
 		RADIATION_ALPHA_PARTICLE = 59.4 MEGA ELECTRONVOLT,
 		RADIATION_BETA_PARTICLE = 13.2 MEGA ELECTRONVOLT,
 		RADIATION_HAWKING = 1 ELECTRONVOLT
 	)
+
+/datum/armor/helm_syndispace
+	bio = 30
+	bomb = 30
+	bullet = 50
+	energy = 15
+	laser = 50
+	melee = 60
 
 /obj/item/clothing/suit/space/syndicate
 	name = "red space suit"
@@ -22,13 +30,21 @@
 	desc = "A crimson spacesuit sporting clean lines and durable plating. Robust, reliable, and slightly suspicious."
 	w_class = ITEM_SIZE_NORMAL
 	allowed = list(/obj/item/gun,/obj/item/ammo_magazine,/obj/item/ammo_casing,/obj/item/melee/baton,/obj/item/melee/energy/sword/one_hand,/obj/item/handcuffs,/obj/item/tank/emergency)
-	armor = list(melee = 60, bullet = 50, laser = 50,energy = 15, bomb = 30, bio = 30)
+	armor_type = /datum/armor/suit_syndispace
 	siemens_coefficient = 0.3
 	rad_resist = list(
 		RADIATION_ALPHA_PARTICLE = 59.4 MEGA ELECTRONVOLT,
 		RADIATION_BETA_PARTICLE = 13.2 MEGA ELECTRONVOLT,
 		RADIATION_HAWKING = 1 ELECTRONVOLT
 	)
+
+/datum/armor/suit_syndispace
+	bio = 30
+	bomb = 30
+	bullet = 50
+	energy = 15
+	laser = 50
+	melee = 60
 
 //Green syndicate space suit
 /obj/item/clothing/head/helmet/space/syndicate/green

--- a/code/modules/clothing/spacesuits/void/_void.dm
+++ b/code/modules/clothing/spacesuits/void/_void.dm
@@ -5,7 +5,7 @@
 	icon_state = "void"
 
 	heat_protection = HEAD
-	armor = list(melee = 40, bullet = 5, laser = 20,energy = 5, bomb = 35, bio = 100)
+	armor_type = /datum/armor/helm_void
 	max_heat_protection_temperature = SPACE_SUIT_MAX_HEAT_PROTECTION_TEMPERATURE
 	siemens_coefficient = 0.4
 
@@ -25,13 +25,20 @@
 		RADIATION_HAWKING = 1 ELECTRONVOLT
 	)
 
+/datum/armor/helm_void
+	bio = 100
+	bomb = 35
+	bullet = 5
+	energy = 5
+	laser = 20
+	melee = 40
+
 /obj/item/clothing/suit/space/void
 	name = "voidsuit"
 	icon_state = "void"
-	//item_state = "syndie_hardsuit"
-	w_class = ITEM_SIZE_HUGE//bulky item
+	w_class = ITEM_SIZE_HUGE
 	desc = "A high-tech dark red space suit. Used for AI satellite maintenance."
-	armor = list(melee = 40, bullet = 5, laser = 20,energy = 5, bomb = 35, bio = 100)
+	armor_type = /datum/armor/suit_void
 	allowed = list(/obj/item/device/flashlight,/obj/item/tank,/obj/item/device/suit_cooling_unit)
 	heat_protection = UPPER_TORSO|LOWER_TORSO|LEGS|FEET|ARMS|HANDS
 	max_heat_protection_temperature = SPACE_SUIT_MAX_HEAT_PROTECTION_TEMPERATURE
@@ -62,6 +69,14 @@
 	var/obj/item/tank/tank = null              // Deployable tank, if any.
 
 	action_button_name = "Toggle Helmet"
+
+/datum/armor/suit_void
+	bio = 100
+	bomb = 35
+	bullet = 5
+	energy = 5
+	laser = 20
+	melee = 40
 
 #define VOIDSUIT_INIT_EQUIPMENT(equipment_var, expected_path) \
 if(ispath(##equipment_var, ##expected_path )){\

--- a/code/modules/clothing/spacesuits/void/atmos.dm
+++ b/code/modules/clothing/spacesuits/void/atmos.dm
@@ -9,9 +9,17 @@
 		slot_l_hand_str = "atmos_helm",
 		slot_r_hand_str = "atmos_helm",
 		)
-	armor = list(melee = 40, bullet = 5, laser = 20,energy = 5, bomb = 35, bio = 100)
+	armor_type = /datum/armor/helm_spaceatmo
 	max_heat_protection_temperature = FIRE_HELMET_MAX_HEAT_PROTECTION_TEMPERATURE
 	light_overlay = "helmet_light_dual_low"
+
+/datum/armor/helm_spaceatmo
+	bio = 100
+	bomb = 35
+	bullet = 5
+	energy = 5
+	laser = 20
+	melee = 40
 
 /obj/item/clothing/suit/space/void/atmos
 	name = "atmos voidsuit"
@@ -21,9 +29,17 @@
 		slot_l_hand_str = "atmos_voidsuit",
 		slot_r_hand_str = "atmos_voidsuit",
 	)
-	armor = list(melee = 40, bullet = 5, laser = 20,energy = 5, bomb = 35, bio = 100)
+	armor_type = /datum/armor/suit_spaceatmo
 	max_heat_protection_temperature = FIRESUIT_MAX_HEAT_PROTECTION_TEMPERATURE
 	allowed = list(/obj/item/device/flashlight,/obj/item/tank,/obj/item/device/suit_cooling_unit,/obj/item/storage/toolbox,/obj/item/storage/briefcase/inflatable,/obj/item/device/t_scanner,/obj/item/rcd)
+
+/datum/armor/suit_spaceatmo
+	bio = 100
+	bomb = 35
+	bullet = 5
+	energy = 5
+	laser = 20
+	melee = 40
 
 /obj/item/clothing/suit/space/void/atmos/prepared
 	helmet = /obj/item/clothing/head/helmet/space/void/atmos
@@ -35,16 +51,32 @@
 	desc = "A voidsuit helmet plated with an expensive heat and radiation resistant ceramic."
 	icon_state = "rig0-atmosalt"
 	item_state = "atmosalt_helm"
-	armor = list(melee = 20, bullet = 5, laser = 20,energy = 15, bomb = 45, bio = 100)
+	armor_type = /datum/armor/helm_spaceatmoalt
 	max_heat_protection_temperature = FIRE_HELMET_MAX_HEAT_PROTECTION_TEMPERATURE
 	light_overlay = "helmet_light"
+
+/datum/armor/helm_spaceatmoalt
+	bio = 100
+	bomb = 45
+	bullet = 5
+	energy = 5
+	laser = 20
+	melee = 40
 
 /obj/item/clothing/suit/space/void/atmos/alt
 	desc = "An expensive NanoTrasen voidsuit, rated to withstand extreme heat and even minor radiation without exceeding room temperature within."
 	icon_state = "rig-atmosalt"
 	name = "atmos hardsuit"
-	armor = list(melee = 20, bullet = 5, laser = 20,energy = 15, bomb = 45, bio = 100)
+	armor_type = /datum/armor/suit_spaceatmoalt
 	max_heat_protection_temperature = FIRESUIT_MAX_HEAT_PROTECTION_TEMPERATURE
+
+/datum/armor/suit_spaceatmoalt
+	bio = 100
+	bomb = 45
+	bullet = 5
+	energy = 5
+	laser = 20
+	melee = 40
 
 /obj/item/clothing/suit/space/void/atmos/alt/prepared
 	helmet = /obj/item/clothing/head/helmet/space/void/atmos/alt

--- a/code/modules/clothing/spacesuits/void/engineering.dm
+++ b/code/modules/clothing/spacesuits/void/engineering.dm
@@ -9,7 +9,15 @@
 		slot_l_hand_str = "eng_helm",
 		slot_r_hand_str = "eng_helm",
 		)
-	armor = list(melee = 40, bullet = 5, laser = 20,energy = 5, bomb = 35, bio = 100)
+	armor_type = /datum/armor/helm_spaceengi
+
+/datum/armor/helm_spaceengi
+	bio = 100
+	bomb = 35
+	bullet = 5
+	energy = 5
+	laser = 20
+	melee = 40
 
 /obj/item/clothing/suit/space/void/engineering
 	name = "engineering voidsuit"
@@ -19,8 +27,16 @@
 		slot_l_hand_str = "eng_voidsuit",
 		slot_r_hand_str = "eng_voidsuit",
 	)
-	armor = list(melee = 40, bullet = 5, laser = 20,energy = 5, bomb = 35, bio = 100)
+	armor_type = /datum/armor/suit_spaceengi
 	allowed = list(/obj/item/device/flashlight,/obj/item/tank,/obj/item/device/suit_cooling_unit,/obj/item/storage/toolbox,/obj/item/storage/briefcase/inflatable,/obj/item/device/t_scanner,/obj/item/rcd)
+
+/datum/armor/suit_spaceengi
+	bio = 100
+	bomb = 35
+	bullet = 5
+	energy = 5
+	laser = 20
+	melee = 40
 
 /obj/item/clothing/suit/space/void/engineering/New()
 	..()
@@ -36,14 +52,12 @@
 	desc = "A heavy, radiation-shielded voidsuit helmet with a surprisingly comfortable interior."
 	icon_state = "rig0-engineeringalt"
 	item_state = "engalt_helm"
-	armor = list(melee = 40, bullet = 5, laser = 20,energy = 5, bomb = 45, bio = 100)
 	light_overlay = "helmet_light_dual_low"
 
 /obj/item/clothing/suit/space/void/engineering/alt
 	name = "engineering hardsuit"
 	desc = "A bulky industrial voidsuit. It's a few generations old, but a reliable design and radiation shielding make up for the lack of climate control."
 	icon_state = "rig-engineeringalt"
-	armor = list(melee = 40, bullet = 5, laser = 20,energy = 5, bomb = 45, bio = 100)
 
 /obj/item/clothing/suit/space/void/engineering/alt/New()
 	..()

--- a/code/modules/clothing/spacesuits/void/medical.dm
+++ b/code/modules/clothing/spacesuits/void/medical.dm
@@ -9,8 +9,15 @@
 		slot_l_hand_str = "medical_helm",
 		slot_r_hand_str = "medical_helm",
 		)
-	armor = list(melee = 30, bullet = 5, laser = 20,energy = 5, bomb = 25, bio = 100)
+	armor_type = /datum/armor/helm_spacemed
 
+/datum/armor/helm_spacemed
+	bio = 100
+	bomb = 25
+	bullet = 5
+	energy = 5
+	laser = 20
+	melee = 30
 
 /obj/item/clothing/suit/space/void/medical
 	icon_state = "rig-medical"
@@ -21,7 +28,15 @@
 		slot_r_hand_str = "medical_voidsuit",
 	)
 	allowed = list(/obj/item/device/flashlight,/obj/item/tank,/obj/item/device/suit_cooling_unit,/obj/item/storage/firstaid,/obj/item/device/healthanalyzer,/obj/item/stack/medical,/obj/item/device/antibody_scanner)
-	armor = list(melee = 30, bullet = 5, laser = 20,energy = 5, bomb = 25, bio = 100)
+	armor_type = /datum/armor/suit_spacemed
+
+/datum/armor/suit_spacemed
+	bio = 100
+	bomb = 25
+	bullet = 5
+	energy = 5
+	laser = 20
+	melee = 30
 
 /obj/item/clothing/suit/space/void/medical/prepared
 	helmet = /obj/item/clothing/head/helmet/space/void/medical
@@ -33,7 +48,6 @@
 	desc = "A trendy, lightly radiation-shielded voidsuit helmet trimmed in a fetching blue."
 	icon_state = "rig0-medicalalt"
 	item_state = "medicalalt_helm"
-	armor = list(melee = 30, bullet = 5, laser = 10,energy = 5, bomb = 5, bio = 100)
 	light_overlay = "helmet_light_dual_green"
 
 /obj/item/clothing/suit/space/void/medical/alt
@@ -41,7 +55,6 @@
 	name = "streamlined medical voidsuit"
 	desc = "A more recent model of Vey-Med voidsuit, featuring the latest in radiation shielding technology, without sacrificing comfort or style."
 	allowed = list(/obj/item/device/flashlight,/obj/item/tank,/obj/item/device/suit_cooling_unit,/obj/item/storage/firstaid,/obj/item/device/healthanalyzer,/obj/item/stack/medical,/obj/item/device/antibody_scanner)
-	armor = list(melee = 30, bullet = 5, laser = 10,energy = 5, bomb = 5, bio = 100)
 
 /obj/item/clothing/suit/space/void/medical/alt/New()
 	..()

--- a/code/modules/clothing/spacesuits/void/mining.dm
+++ b/code/modules/clothing/spacesuits/void/mining.dm
@@ -9,13 +9,21 @@
 		slot_l_hand_str = "mining_helm",
 		slot_r_hand_str = "mining_helm",
 		)
-	armor = list(melee = 50, bullet = 5, laser = 20,energy = 5, bomb = 55, bio = 100)
+	armor_type = /datum/armor/helm_spacemine
 	light_overlay = "helmet_light_dual_low"
 	rad_resist = list(
 		RADIATION_ALPHA_PARTICLE = 59.4 MEGA ELECTRONVOLT,
 		RADIATION_BETA_PARTICLE = 13.2 MEGA ELECTRONVOLT,
 		RADIATION_HAWKING = 1 ELECTRONVOLT
 	)
+
+/datum/armor/helm_spacemine
+	bio = 100
+	bomb = 55
+	bullet = 5
+	energy = 5
+	laser = 20
+	melee = 50
 
 /obj/item/clothing/suit/space/void/mining
 	icon_state = "rig-mining"
@@ -25,13 +33,21 @@
 		slot_l_hand_str = "mining_voidsuit",
 		slot_r_hand_str = "mining_voidsuit",
 	)
-	armor = list(melee = 50, bullet = 5, laser = 20,energy = 5, bomb = 55, bio = 100)
+	armor_type = /datum/armor/suit_spacemine
 	allowed = list(/obj/item/device/flashlight,/obj/item/tank,/obj/item/stack/flag,/obj/item/device/suit_cooling_unit,/obj/item/storage/ore,/obj/item/device/t_scanner,/obj/item/pickaxe, /obj/item/rcd)
 	rad_resist = list(
 		RADIATION_ALPHA_PARTICLE = 59.4 MEGA ELECTRONVOLT,
 		RADIATION_BETA_PARTICLE = 13.2 MEGA ELECTRONVOLT,
 		RADIATION_HAWKING = 1 ELECTRONVOLT
 	)
+
+/datum/armor/suit_spacemine
+	bio = 100
+	bomb = 55
+	bullet = 5
+	energy = 5
+	laser = 20
+	melee = 50
 
 /obj/item/clothing/suit/space/void/mining/prepared
 	helmet = /obj/item/clothing/head/helmet/space/void/mining
@@ -42,13 +58,29 @@
 	desc = "An armored voidsuit helmet. Someone must have through they were pretty cool when they painted a mohawk on it."
 	icon_state = "rig0-miningalt"
 	item_state = "miningalt_helm"
-	armor = list(melee = 50, bullet = 15, laser = 20,energy = 5, bomb = 55, bio = 100)
+	armor_type = /datum/armor/helm_spaceminealt
+
+/datum/armor/helm_spaceminealt
+	bio = 100
+	bomb = 55
+	bullet = 15
+	energy = 5
+	laser = 20
+	melee = 50
 
 /obj/item/clothing/suit/space/void/mining/alt
 	icon_state = "rig-miningalt"
 	name = "frontier mining voidsuit"
 	desc = "A cheap prospecting voidsuit. What it lacks in comfort it makes up for in armor plating and street cred."
-	armor = list(melee = 50, bullet = 15, laser = 20,energy = 5, bomb = 55, bio = 100)
+	armor_type = /datum/armor/suit_spaceminealt
+
+/datum/armor/suit_spaceminealt
+	bio = 100
+	bomb = 55
+	bullet = 15
+	energy = 5
+	laser = 20
+	melee = 50
 
 /obj/item/clothing/suit/space/void/mining/alt/prepared
 	helmet = /obj/item/clothing/head/helmet/space/void/mining/alt
@@ -59,13 +91,29 @@
 	desc = "An armored hardsuit helmet. Provides exceptionally good protection against aggressive asteroid dwellers."
 	icon_state = "rig0-miningref"
 	item_state = "miningref_helm"
-	armor = list(melee = 65, bullet = 25, laser = 40, energy = 15, bomb = 65, bio = 100)
+	armor_type = /datum/armor/helm_spaceminereinf
+
+/datum/armor/helm_spaceminereinf
+	bio = 100
+	bomb = 65
+	bullet = 25
+	energy = 15
+	laser = 40
+	melee = 65
 
 /obj/item/clothing/suit/space/void/mining/reinforced
 	icon_state = "rig-miningref"
 	name = "mining hardsuit"
 	desc = "A heavy-duty prospecting hardsuit. What it lacks in comfort it makes up for in armor plating and street cred."
-	armor = list(melee = 65, bullet = 25, laser = 40, energy = 15, bomb = 65, bio = 100)
+	armor_type = /datum/armor/suit_spaceminereinf
+
+/datum/armor/suit_spaceminereinf
+	bio = 100
+	bomb = 65
+	bullet = 25
+	energy = 15
+	laser = 40
+	melee = 65
 
 /obj/item/clothing/suit/space/void/mining/reinforced/prepared
 	helmet = /obj/item/clothing/head/helmet/space/void/mining/reinforced

--- a/code/modules/clothing/spacesuits/void/misc.dm
+++ b/code/modules/clothing/spacesuits/void/misc.dm
@@ -87,7 +87,7 @@
 	siemens_coefficient = 0.5
 
 /datum/armor/suit_space_void_captain
-	bio = `00
+	bio = 10
 	bomb = 55
 	bullet = 60
 	energy = 35

--- a/code/modules/clothing/spacesuits/void/misc.dm
+++ b/code/modules/clothing/spacesuits/void/misc.dm
@@ -6,7 +6,7 @@
 	icon_state = "deathsquad"
 	body_parts_covered = UPPER_TORSO|LOWER_TORSO|LEGS|FEET|ARMS
 	allowed = list(/obj/item/gun, /obj/item/ammo_magazine, /obj/item/ammo_casing, /obj/item/melee/baton, /obj/item/handcuffs, /obj/item/tank)
-	armor = list(melee = 80, bullet = 70, laser = 70, energy = 45, bomb = 65, bio = 100)
+	armor_type = /datum/armor/suit_space_void_swat
 	flags_inv = HIDESHOES|HIDEJUMPSUIT
 	siemens_coefficient = 0.6
 	rad_resist = list(
@@ -14,6 +14,14 @@
 		RADIATION_BETA_PARTICLE = 13.2 MEGA ELECTRONVOLT,
 		RADIATION_HAWKING = 1 ELECTRONVOLT
 	)
+
+/datum/armor/suit_space_void_swat
+	bio = 100
+	bomb = 65
+	bullet = 70
+	energy = 45
+	laser = 70
+	melee = 80
 
 /obj/item/clothing/suit/space/void/swat/New()
 	..()
@@ -27,7 +35,7 @@
 		slot_l_hand_str = "syndicate-helm-black-red",
 		slot_r_hand_str = "syndicate-helm-black-red",
 		)
-	armor = list(melee = 80, bullet = 70, laser = 70, energy = 45, bomb = 65, bio = 100)
+	armor_type = /datum/armor/head_helmet_space_deathsquad
 	item_flags = ITEM_FLAG_STOPPRESSUREDAMAGE | ITEM_FLAG_THICKMATERIAL
 	flags_inv = BLOCKHAIR
 	siemens_coefficient = 0.6
@@ -37,6 +45,13 @@
 		RADIATION_HAWKING = 1 ELECTRONVOLT
 	)
 
+/datum/armor/head_helmet_space_deathsquad
+	bio = 100
+	bomb = 65
+	bullet = 70
+	energy = 45
+	laser = 70
+	melee = 80
 
 // Captain
 /obj/item/clothing/head/helmet/space/void/captain
@@ -47,9 +62,17 @@
 		slot_l_hand_str = "caphelmet",
 		slot_r_hand_str = "caphelmet",
 	)
-	armor = list(melee = 75, bullet = 60, laser = 60, energy = 35, bomb = 55, bio = 100)
+	armor_type = /datum/armor/head_helmet_space_void_captain
 	siemens_coefficient = 0.5
 	light_overlay = "helmet_light_dual"
+
+/datum/armor/head_helmet_space_void_captain
+	bio = 100
+	bomb = 55
+	bullet = 60
+	energy = 35
+	laser = 60
+	melee = 75
 
 /obj/item/clothing/suit/space/void/captain
 	name = "captain's space armor"
@@ -59,9 +82,17 @@
 		slot_l_hand_str = "capspacesuit",
 		slot_r_hand_str = "capspacesuit",
 	)
-	armor = list(melee = 75, bullet = 60, laser = 60, energy = 35, bomb = 55, bio = 100)
+	armor_type = /datum/armor/suit_space_void_captain
 	allowed = list(/obj/item/gun,/obj/item/device/flashlight,/obj/item/tank,/obj/item/device/suit_cooling_unit, /obj/item/ammo_magazine, /obj/item/ammo_casing, /obj/item/melee/baton, /obj/item/handcuffs, /obj/item/disk/nuclear)
 	siemens_coefficient = 0.5
+
+/datum/armor/suit_space_void_captain
+	bio = `00
+	bomb = 55
+	bullet = 60
+	energy = 35
+	laser = 60
+	melee = 75
 
 /obj/item/clothing/suit/space/void/captain/prepared
 	helmet = /obj/item/clothing/head/helmet/space/void/captain
@@ -74,15 +105,31 @@
 	desc = "A radiation-resistant helmet made especially for exploring unknown planetary environments."
 	icon_state = "helm_explorer"
 	item_state = "helm_explorer"
-	armor = list(melee = 20, bullet = 10, laser = 15,energy = 45, bomb = 30, bio = 100)
+	armor_type = /datum/armor/head_helmet_space_void_exploration
 	light_overlay = "explorer_light"
+
+/datum/armor/head_helmet_space_void_exploration
+	bio = 100
+	bomb = 30
+	bullet = 10
+	energy = 45
+	laser = 15
+	melee = 20
 
 /obj/item/clothing/suit/space/void/exploration
 	name = "exploration voidsuit"
 	desc = "A lightweight, radiation-resistant voidsuit, featuring the Expeditionary Corps emblem on its chest plate. Designed for exploring unknown planetary environments."
 	icon_state = "void_explorer"
-	armor = list(melee = 20, bullet = 10, laser = 15,energy = 45, bomb = 30, bio = 100)
+	armor_type = /datum/armor/suit_space_void_exploration
 	allowed = list(/obj/item/device/flashlight,/obj/item/tank,/obj/item/device/suit_cooling_unit,/obj/item/stack/flag,/obj/item/device/healthanalyzer,/obj/item/device/gps,/obj/item/pinpointer/radio,/obj/item/device/radio/beacon,/obj/item/material/hatchet/machete,/obj/item/shovel)
+
+/datum/armor/suit_space_void_exploration
+	bio = 100
+	bomb = 30
+	bullet = 10
+	energy = 45
+	laser = 15
+	melee = 20
 
 /obj/item/clothing/suit/space/void/exploration/prepared
 	helmet = /obj/item/clothing/head/helmet/space/void/exploration
@@ -99,7 +146,15 @@
 		slot_l_hand_str = "eng_helm",
 		slot_r_hand_str = "eng_helm",
 		)
-	armor = list(melee = 50, bullet = 10, laser = 30,energy = 15, bomb = 35, bio = 100)
+	armor_type = /datum/armor/head_helmet_space_void_engineering_salvage
+
+/datum/armor/head_helmet_space_void_engineering_salvage
+	bio = 100
+	bomb = 35
+	bullet = 10
+	energy = 15
+	laser = 30
+	melee = 50
 
 /obj/item/clothing/suit/space/void/engineering/salvage
 	name = "salvage voidsuit"
@@ -109,8 +164,16 @@
 		slot_l_hand_str = "eng_voidsuit",
 		slot_r_hand_str = "eng_voidsuit",
 	)
-	armor = list(melee = 50, bullet = 10, laser = 30,energy = 15, bomb = 35, bio = 100)
+	armor_type = /datum/armor/suit_space_void_engineering_salvage
 	allowed = list(/obj/item/device/flashlight,/obj/item/tank,/obj/item/device/suit_cooling_unit,/obj/item/storage/toolbox,/obj/item/storage/briefcase/inflatable,/obj/item/device/t_scanner,/obj/item/rcd)
+
+/datum/armor/suit_space_void_engineering_salvage
+	bio = 100
+	bomb = 35
+	bullet = 10
+	energy = 15
+	laser = 30
+	melee = 50
 
 /obj/item/clothing/suit/space/void/engineering/salvage/prepared
 	helmet = /obj/item/clothing/head/helmet/space/void/engineering/salvage
@@ -123,18 +186,34 @@
 	desc = "An atmos resistant helmet for space and planet exploration."
 	icon_state = "rig0_pilot"
 	item_state = "pilot_helm"
-	armor = list(melee = 40, bullet = 5, laser = 15,energy = 5, bomb = 5, bio = 100)
+	armor_type = /datum/armor/head_helmet_space_void_pilot
 	max_heat_protection_temperature = FIRE_HELMET_MAX_HEAT_PROTECTION_TEMPERATURE
 	light_overlay = "helmet_light_dual"
+
+/datum/armor/head_helmet_space_void_pilot
+	bio = 100
+	bomb = 5
+	bullet = 5
+	energy = 5
+	laser = 15
+	melee = 40
 
 /obj/item/clothing/suit/space/void/pilot
 	name = "pilot voidsuit"
 	desc = "An atmos resistant voidsuit for space and planet exploration."
 	icon_state = "rig-pilot"
 	item_state = "rig-pilot"
-	armor = list(melee = 40, bullet = 5, laser = 15,energy = 5, bomb = 5, bio = 100)
+	armor_type = /datum/armor/suit_space_void_pilot
 	max_heat_protection_temperature = FIRESUIT_MAX_HEAT_PROTECTION_TEMPERATURE
 	allowed = list(/obj/item/device/flashlight,/obj/item/tank,/obj/item/device/suit_cooling_unit,/obj/item/storage/toolbox,/obj/item/storage/briefcase/inflatable,/obj/item/device/t_scanner,/obj/item/rcd)
+
+/datum/armor/suit_space_void_pilot
+	bio = 100
+	bomb = 5
+	bullet = 5
+	energy = 5
+	laser = 15
+	melee = 40
 
 /obj/item/clothing/suit/space/void/pilot/prepared
 	helmet = /obj/item/clothing/head/helmet/space/void/pilot
@@ -147,18 +226,34 @@
 	desc = "A bulky helmet with some heavy armor plating."
 	icon_state = "hardsuit-helm-knight"
 	item_state = "hardsuit-helm-knight"
-	armor = list(melee = 70, bullet = 35, laser = 35, energy = 25, bomb = 55, bio = 100)
+	armor_type = /datum/armor/head_helmet_space_void_knight
 	siemens_coefficient = 0.7
 	light_overlay = "helmet_light_dual"
+
+/datum/armor/head_helmet_space_void_knight
+	bio = 100
+	bomb = 55
+	bullet = 35
+	energy = 25
+	laser = 35
+	melee = 70
 
 /obj/item/clothing/suit/space/void/knight
 	icon_state = "hardsuit-knight"
 	item_state = "hardsuit-knight"
 	name = "strange voidsuit"
 	desc = "A bulky set of space-proof armor, that looks kinda ancient. 'Lancelot X-40' is written on the front plate."
-	armor = list(melee = 70, bullet = 35, laser = 35, energy = 25, bomb = 55, bio = 100)
+	armor_type = /datum/armor/suit_space_void_knight
 	allowed = list(/obj/item/gun,/obj/item/device/flashlight,/obj/item/tank,/obj/item/device/suit_cooling_unit,/obj/item/melee/baton)
 	siemens_coefficient = 0.7
+
+/datum/armor/suit_space_void_knight
+	bio = 100
+	bomb = 55
+	bullet = 35
+	energy = 25
+	laser = 35
+	melee = 70
 
 
 // Optical
@@ -167,7 +262,15 @@
 	icon_state = "hardsuit-optical"
 	desc = "Strange looking, smoothly contoured helmet. It looks a bit blurry."
 	siemens_coefficient = 0
-	armor = list(melee = 35, bullet = 40, laser = 45, energy = 40, bomb = 20, bio = 100)
+	armor_type = /datum/armor/head_helmet_space_void_optical
+
+/datum/armor/head_helmet_space_void_optical
+	bio = 100
+	bomb = 20
+	bullet = 40
+	energy = 40
+	laser = 45
+	melee = 35
 
 /obj/item/clothing/suit/space/void/optical
 	name = "experimental voidsuit"
@@ -175,8 +278,16 @@
 	desc = "Strange black voidsuit, with some devices attached to it. It looks a bit blurry."
 	action_button_name = "Toggle Optical Disruptor"
 	siemens_coefficient = 0
-	armor = list(melee = 35, bullet = 40, laser = 45, energy = 40, bomb = 20, bio = 100)
+	armor_type = /datum/armor/suit_space_void_optical
 	var/cloak = FALSE
+
+/datum/armor/suit_space_void_optical
+	bio = 100
+	bomb = 20
+	bullet = 40
+	energy = 40
+	laser = 45
+	melee = 35
 
 /obj/item/clothing/suit/space/void/optical/New()
 	..()
@@ -215,24 +326,41 @@
 
 	animate(H,alpha = 85, alpha = 255, time = 10)
 
+
 // Rmc(Only)
 /obj/item/clothing/head/helmet/space/void/rmc_red
 	name = "rmc red helmet"
 	desc = "An atmos resistant helmet for space and planet exploration."
 	icon_state = "rig0_rmc_red"
 	item_state = "rmc_red_helm"
-	armor = list(melee = 40, bullet = 5, laser = 15,energy = 5, bomb = 5, bio = 100)
+	armor_type = /datum/armor/head_helmet_space_void_rmc
 	max_heat_protection_temperature = FIRE_HELMET_MAX_HEAT_PROTECTION_TEMPERATURE
 	light_overlay = "helmet_light_dual"
+
+/datum/armor/head_helmet_space_void_rmc
+	bio = 100
+	bomb = 5
+	bullet = 5
+	energy = 5
+	laser = 15
+	melee = 40
 
 /obj/item/clothing/suit/space/void/rmc_red
 	name = "rmc red voidsuit"
 	desc = "An atmos resistant voidsuit for space and planet exploration."
 	icon_state = "rmc_red"
 	item_state = "rmc_red"
-	armor = list(melee = 40, bullet = 5, laser = 15,energy = 5, bomb = 5, bio = 100)
+	armor_type = /datum/armor/suit_space_void_rmc
 	max_heat_protection_temperature = FIRESUIT_MAX_HEAT_PROTECTION_TEMPERATURE
 	allowed = list(/obj/item/device/flashlight,/obj/item/tank,/obj/item/device/suit_cooling_unit,/obj/item/storage/toolbox,/obj/item/storage/briefcase/inflatable,/obj/item/device/t_scanner,/obj/item/rcd)
+
+/datum/armor/suit_space_void_rmc
+	bio = 100
+	bomb = 5
+	bullet = 5
+	energy = 5
+	laser = 15
+	melee = 40
 
 /obj/item/clothing/suit/space/void/rmc_red/prepared
 	helmet = /obj/item/clothing/head/helmet/space/void/rmc_red
@@ -243,7 +371,7 @@
 	desc = "An atmos resistant helmet for space and planet exploration."
 	icon_state = "rig0_rmc_green"
 	item_state = "rmc_green_helm"
-	armor = list(melee = 40, bullet = 5, laser = 15,energy = 5, bomb = 5, bio = 100)
+	armor_type = /datum/armor/head_helmet_space_void_rmc
 	max_heat_protection_temperature = FIRE_HELMET_MAX_HEAT_PROTECTION_TEMPERATURE
 	light_overlay = "helmet_light_dual"
 
@@ -252,7 +380,7 @@
 	desc = "An atmos resistant voidsuit for space and planet exploration."
 	icon_state = "rmc_green"
 	item_state = "rmc_green"
-	armor = list(melee = 40, bullet = 5, laser = 15,energy = 5, bomb = 5, bio = 100)
+	armor_type = /datum/armor/suit_space_void_rmc
 	max_heat_protection_temperature = FIRESUIT_MAX_HEAT_PROTECTION_TEMPERATURE
 	allowed = list(/obj/item/device/flashlight,/obj/item/tank,/obj/item/device/suit_cooling_unit,/obj/item/storage/toolbox,/obj/item/storage/briefcase/inflatable,/obj/item/device/t_scanner,/obj/item/rcd)
 
@@ -265,7 +393,7 @@
 	desc = "An atmos resistant helmet for space and planet exploration."
 	icon_state = "rig0_rmc_royal"
 	item_state = "rmc_royal_helm"
-	armor = list(melee = 40, bullet = 5, laser = 15,energy = 5, bomb = 5, bio = 100)
+	armor_type = /datum/armor/head_helmet_space_void_rmc
 	max_heat_protection_temperature = FIRE_HELMET_MAX_HEAT_PROTECTION_TEMPERATURE
 	light_overlay = "helmet_light_dual"
 
@@ -274,7 +402,7 @@
 	desc = "An atmos resistant voidsuit for space and planet exploration."
 	icon_state = "rmc_royal"
 	item_state = "rmc_royal"
-	armor = list(melee = 40, bullet = 5, laser = 15,energy = 5, bomb = 5, bio = 100)
+	armor_type = /datum/armor/suit_space_void_rmc
 	max_heat_protection_temperature = FIRESUIT_MAX_HEAT_PROTECTION_TEMPERATURE
 	allowed = list(/obj/item/device/flashlight,/obj/item/tank,/obj/item/device/suit_cooling_unit,/obj/item/storage/toolbox,/obj/item/storage/briefcase/inflatable,/obj/item/device/t_scanner,/obj/item/rcd)
 
@@ -287,16 +415,24 @@
 	desc = "An atmos resistant voidsuit for space and planet exploration."
 	icon_state = "engsuit_spc"
 	item_state = "engsuit_spc"
-	armor = list(melee = 40, bullet = 5, laser = 15,energy = 5, bomb = 5, bio = 100)
+	armor_type = /datum/armor/suit_space_void_spc
 	max_heat_protection_temperature = FIRESUIT_MAX_HEAT_PROTECTION_TEMPERATURE
 	allowed = list(/obj/item/device/flashlight,/obj/item/tank,/obj/item/device/suit_cooling_unit,/obj/item/storage/toolbox,/obj/item/storage/briefcase/inflatable,/obj/item/device/t_scanner,/obj/item/rcd)
+
+/datum/armor/suit_space_void_spc
+	bio = 100
+	bomb = 5
+	bullet = 5
+	energy = 5
+	laser = 15
+	melee = 40
 
 /obj/item/clothing/suit/space/void/secsuit_spc
 	name = "security spc voidsuit"
 	desc = "An atmos resistant voidsuit for space and planet exploration."
 	icon_state = "secsuit_spc"
 	item_state = "secsuit_spc"
-	armor = list(melee = 40, bullet = 5, laser = 15,energy = 5, bomb = 5, bio = 100)
+	armor_type = /datum/armor/suit_space_void_spc
 	max_heat_protection_temperature = FIRESUIT_MAX_HEAT_PROTECTION_TEMPERATURE
 	allowed = list(/obj/item/device/flashlight,/obj/item/tank,/obj/item/device/suit_cooling_unit,/obj/item/storage/toolbox,/obj/item/storage/briefcase/inflatable,/obj/item/device/t_scanner,/obj/item/rcd)
 
@@ -305,24 +441,48 @@
 	desc = "An atmos resistant helmet for space and planet exploration."
 	icon_state = "pilot_spc"
 	item_state = "pilot_spc"
-	armor = list(melee = 40, bullet = 5, laser = 15,energy = 5, bomb = 5, bio = 100)
+	armor_type = /datum/armor/head_helmet_space_void_spc
 	max_heat_protection_temperature = FIRE_HELMET_MAX_HEAT_PROTECTION_TEMPERATURE
 	light_overlay = "helmet_light_dual"
+
+/datum/armor/head_helmet_space_void_spc
+	bio = 100
+	bomb = 5
+	bullet = 5
+	energy = 5
+	laser = 15
+	melee = 40
 
 /obj/item/clothing/head/helmet/space/void/templar
 	name = "templar helmet"
 	desc = "An atmos resistant helmet for space and planet exploration."
 	icon_state = "templar"
 	item_state = "templar"
-	armor = list(melee = 40, bullet = 5, laser = 15,energy = 5, bomb = 5, bio = 100)
+	armor_type = /datum/armor/head_helmet_space_void_templar
 	max_heat_protection_temperature = FIRE_HELMET_MAX_HEAT_PROTECTION_TEMPERATURE
 	light_overlay = "helmet_light_dual"
+
+/datum/armor/head_helmet_space_void_templar
+	bio = 100
+	bomb = 5
+	bullet = 5
+	energy = 5
+	laser = 15
+	melee = 40
 
 /obj/item/clothing/head/helmet/space/void/scuba
 	name = "scuba helmet"
 	desc = "An atmos resistant helmet for space and planet exploration."
 	icon_state = "scuba"
 	item_state = "scuba"
-	armor = list(melee = 40, bullet = 5, laser = 15,energy = 5, bomb = 5, bio = 100)
+	armor_type = /datum/armor/suit_space_void_scuba
 	max_heat_protection_temperature = FIRE_HELMET_MAX_HEAT_PROTECTION_TEMPERATURE
 	light_overlay = "helmet_light_dual"
+
+/datum/armor/suit_space_void_scuba
+	bio = 100
+	bomb = 5
+	bullet = 5
+	energy = 5
+	laser = 15
+	melee = 40

--- a/code/modules/clothing/spacesuits/void/security.dm
+++ b/code/modules/clothing/spacesuits/void/security.dm
@@ -9,8 +9,16 @@
 		slot_l_hand_str = "sec_helm",
 		slot_r_hand_str = "sec_helm",
 		)
-	armor = list(melee = 60, bullet = 40, laser = 40, energy = 5, bomb = 45, bio = 100)
+	armor_type = /datum/armor/helm_secspace
 	siemens_coefficient = 0.7
+
+/datum/armor/helm_secspace
+	bio = 100
+	bomb = 45
+	bullet = 40
+	energy = 5
+	laser = 40
+	melee = 60
 
 /obj/item/clothing/suit/space/void/security
 	icon_state = "rig-sec"
@@ -20,9 +28,17 @@
 		slot_l_hand_str = "sec_voidsuit",
 		slot_r_hand_str = "sec_voidsuit",
 	)
-	armor = list(melee = 60, bullet = 40, laser = 40, energy = 5, bomb = 45, bio = 100)
+	armor_type = /datum/armor/suit_secspace
 	allowed = list(/obj/item/gun,/obj/item/device/flashlight,/obj/item/tank,/obj/item/device/suit_cooling_unit,/obj/item/melee/baton)
 	siemens_coefficient = 0.7
+
+/datum/armor/suit_secspace
+	bio = 100
+	bomb = 45
+	bullet = 40
+	energy = 5
+	laser = 40
+	melee = 60
 
 /obj/item/clothing/suit/space/void/security/prepared
 	helmet = /obj/item/clothing/head/helmet/space/void/security
@@ -34,14 +50,30 @@
 	desc = "A comfortable voidsuit helmet with cranial armor and eight-channel surround sound."
 	icon_state = "rig0-secalt"
 	item_state = "secalt_helm"
-	armor = list(melee = 70, bullet = 50, laser = 50, energy = 5, bomb = 35, bio = 100)
+	armor_type = /datum/armor/helm_secspacealt
+
+/datum/armor/helm_secspacealt
+	bio = 100
+	bomb = 35
+	bullet = 50
+	energy = 5
+	laser = 50
+	melee = 70
 
 /obj/item/clothing/suit/space/void/security/alt
 	icon_state = "rig-secalt"
 	name = "riot security voidsuit"
 	desc = "A somewhat clumsy voidsuit layered with impact and laser-resistant armor plating. Specially designed to dissipate minor electrical charges."
-	armor = list(melee = 70, bullet = 50, laser = 50, energy = 5, bomb = 35, bio = 100)
+	armor_type = /datum/armor/suit_secspacealt
 	allowed = list(/obj/item/gun,/obj/item/device/flashlight,/obj/item/tank,/obj/item/device/suit_cooling_unit,/obj/item/melee/baton)
+
+/datum/armor/suit_secspacealt
+	bio = 100
+	bomb = 45
+	bullet = 40
+	energy = 5
+	laser = 40
+	melee = 60
 
 /obj/item/clothing/suit/space/void/security/alt/prepared
 	helmet = /obj/item/clothing/head/helmet/space/void/security/alt
@@ -53,15 +85,31 @@
 	desc = "A heavily armored voidsuit helmet. Gold trimming radiates its owner's eliteness."
 	icon_state = "rig0-sechos"
 	item_state = "sechos_helm"
-	armor = list(melee = 70, bullet = 55, laser = 55, energy = 25, bomb = 45, bio = 100)
+	armor_type = /datum/armor/helm_hosspace
 	light_overlay = "helmet_light_dual"
+
+/datum/armor/helm_hosspace
+	bio = 100
+	bomb = 45
+	bullet = 55
+	energy = 25
+	laser = 55
+	melee = 70
 
 /obj/item/clothing/suit/space/void/security/hos
 	icon_state = "rig-sechos"
 	name = "security commander voidsuit"
 	desc = "A heavily armored voidsuit. Gold trimming shows who's the boss here, while heavy pauldrons and kama make it extra durable."
-	armor = list(melee = 70, bullet = 55, laser = 55, energy = 25, bomb = 45, bio = 100)
+	armor_type = /datum/armor/suit_hosspace
 	allowed = list(/obj/item/gun,/obj/item/device/flashlight,/obj/item/tank,/obj/item/device/suit_cooling_unit,/obj/item/melee/baton)
+
+/datum/armor/suit_hosspace
+	bio = 100
+	bomb = 45
+	bullet = 55
+	energy = 25
+	laser = 55
+	melee = 70
 
 /obj/item/clothing/suit/space/void/security/hos/prepared
 	helmet = /obj/item/clothing/head/helmet/space/void/security/hos

--- a/code/modules/clothing/spacesuits/void/syndi.dm
+++ b/code/modules/clothing/spacesuits/void/syndi.dm
@@ -4,7 +4,7 @@
 	desc = "An advanced helmet designed for work in special operations. Property of Gorlex Marauders."
 	icon_state = "rig0-syndie"
 	item_state = "syndie_helm"
-	armor = list(melee = 60, bullet = 50, laser = 50,energy = 15, bomb = 35, bio = 100)
+	armor_type = /datum/armor/helm_syndi
 	siemens_coefficient = 0.3
 	species_restricted = list(SPECIES_HUMAN, SPECIES_IPC)
 	camera = /obj/machinery/camera/network/syndicate
@@ -15,6 +15,14 @@
 		RADIATION_HAWKING = 1 ELECTRONVOLT
 	)
 
+/datum/armor/helm_syndi
+	bio = 100
+	bomb = 35
+	bullet = 50
+	energy = 15
+	laser = 50
+	melee = 60
+
 /obj/item/clothing/suit/space/void/syndi
 	icon_state = "rig-syndie"
 	name = "blood-red voidsuit"
@@ -24,7 +32,7 @@
 		slot_r_hand_str = "syndie_voidsuit",
 	)
 	w_class = ITEM_SIZE_LARGE //normally voidsuits are bulky but the syndi voidsuit is 'advanced' or something
-	armor = list(melee = 60, bullet = 50, laser = 50, energy = 15, bomb = 35, bio = 100)
+	armor_type = /datum/armor/void_syndi
 	allowed = list(/obj/item/device/flashlight,/obj/item/tank,/obj/item/device/suit_cooling_unit,/obj/item/gun,/obj/item/ammo_magazine,/obj/item/ammo_casing,/obj/item/melee/baton,/obj/item/melee/energy/sword/one_hand,/obj/item/handcuffs)
 	siemens_coefficient = 0.3
 	species_restricted = list(SPECIES_HUMAN, SPECIES_SKRELL, SPECIES_IPC)
@@ -33,6 +41,14 @@
 		RADIATION_BETA_PARTICLE = 13.2 MEGA ELECTRONVOLT,
 		RADIATION_HAWKING = 1 ELECTRONVOLT
 	)
+
+/datum/armor/void_syndi
+	bio = 100
+	bomb = 35
+	bullet = 50
+	energy = 15
+	laser = 50
+	melee = 60
 
 /obj/item/clothing/suit/space/void/syndi/New()
 	..()

--- a/code/modules/clothing/spacesuits/void/wizard.dm
+++ b/code/modules/clothing/spacesuits/void/wizard.dm
@@ -8,11 +8,19 @@
 		slot_r_hand_str = "wiz_helm",
 		)
 	unacidable = TRUE //No longer shall our kind be foiled by lone chemists with spray bottles!
-	armor = list(melee = 40, bullet = 30, laser = 30, energy = 30, bomb = 35, bio = 100)
+	armor_type = /datum/armor/helm_wizard
 	siemens_coefficient = 0.7
 	sprite_sheets_obj = null
 	wizard_garb = TRUE
 	species_restricted = list(SPECIES_HUMAN, SPECIES_IPC, SPECIES_UNATHI)
+
+/datum/armor/helm_wizard
+	bio = 100
+	bomb = 35
+	bullet = 03
+	energy = 30
+	laser = 30
+	melee = 40
 
 /obj/item/clothing/suit/space/void/wizard
 	icon_state = "rig-wiz"
@@ -20,7 +28,7 @@
 	desc = "A bizarre gem-encrusted suit that radiates magical energies."
 	w_class = ITEM_SIZE_LARGE //normally voidsuits are bulky but this one is magic I suppose
 	unacidable = TRUE
-	armor = list(melee = 50, bullet = 30, laser = 30,energy = 30, bomb = 35, bio = 100)
+	armor_type = /datum/armor/void_wizard
 	siemens_coefficient = 0.7
 	sprite_sheets_obj = null
 	wizard_garb = TRUE
@@ -39,6 +47,14 @@
 				/obj/item/monster_manual,
 				/obj/item/dice/d20/cursed)
 	species_restricted = list(SPECIES_HUMAN, SPECIES_SKRELL, SPECIES_IPC, SPECIES_UNATHI)
+
+/datum/armor/void_wizard
+	bio = 100
+	bomb = 35
+	bullet = 30
+	energy = 30
+	laser = 30
+	melee = 50
 
 /obj/item/clothing/suit/space/void/wizard/New()
 	..()
@@ -66,5 +82,13 @@
 	gas_transfer_coefficient = 0.01
 	permeability_coefficient = 0.02
 	unacidable = TRUE
-	armor = list(melee = 40, bullet = 20, laser = 20,energy = 20, bomb = 35, bio = 100)
+	armor_type = /datum/armor/gloves_wizard
 	siemens_coefficient = 0.7
+
+/datum/armor/gloves_wizard
+	bio = 100
+	bomb = 35
+	bullet = 20
+	energy = 20
+	laser = 20
+	melee = 40

--- a/code/modules/clothing/suits/alien.dm
+++ b/code/modules/clothing/suits/alien.dm
@@ -86,9 +86,16 @@
 	name = "rusted metal armor"
 	desc = "A hodgepodge of various pieces of metal scrapped together into a rudimentary vox-shaped piece of armor."
 	allowed = list(/obj/item/gun, /obj/item/tank)
-	armor = list(melee = 70, bullet = 30, laser = 20,energy = 5, bomb = 40, bio = 0) //Higher melee armor versus lower everything else.
+	armor_type = /datum/armor/suit_vox
 	icon_state = "vox-scrap"
 	icon_state = "vox-scrap"
 	body_parts_covered = UPPER_TORSO|ARMS|LOWER_TORSO|LEGS
 	species_restricted = list(SPECIES_VOX)
 	siemens_coefficient = 1 //Its literally metal
+
+/datum/armor/suit_vox
+	bomb = 40
+	bullet = 30
+	energy = 5
+	laser = 20
+	melee = 70

--- a/code/modules/clothing/suits/armor.dm
+++ b/code/modules/clothing/suits/armor.dm
@@ -70,7 +70,7 @@
 	name = "warden's armoured vest"
 	desc = "An upgraded version of a regular bulletproof vest, featuring custom shoulder pads and silver rank livery."
 	icon_state = "warden_heavy"
-	armor_type = vest_wardenheavy
+	armor_type = /datum/armor/vest_wardenheavy
 	body_parts_covered = UPPER_TORSO|LOWER_TORSO|ARMS
 
 /datum/armor/vest_wardenheavy

--- a/code/modules/clothing/suits/armor.dm
+++ b/code/modules/clothing/suits/armor.dm
@@ -34,8 +34,15 @@
 	body_parts_covered = UPPER_TORSO|LOWER_TORSO
 	cold_protection = UPPER_TORSO|LOWER_TORSO
 	heat_protection = UPPER_TORSO|LOWER_TORSO
-	armor = list(melee = 40, bullet = 40, laser = 40, energy = 15, bomb = 25, bio = 0)
+	armor_type = /datum/armor/vest
 	valid_accessory_slots = list(ACCESSORY_SLOT_INSIGNIA)
+
+/datum/armor/vest
+	bomb = 25
+	bullet = 40
+	energy = 15
+	laser = 40
+	melee = 40
 
 /obj/item/clothing/suit/armor/vest/detective
 	name = "detective armor"
@@ -46,27 +53,48 @@
 	name = "warden's jacket"
 	desc = "An armoured jacket with silver rank pips and livery."
 	icon_state = "warden_jacket"
-	//item_state = "armor"
-	armor = list(melee = 50, bullet = 50, laser = 50, energy = 25, bomb = 40, bio = 10)
+	armor_type = /datum/armor/vest_warden
 	body_parts_covered = UPPER_TORSO|LOWER_TORSO|ARMS|LEGS
 	cold_protection = UPPER_TORSO|LOWER_TORSO|ARMS|LEGS
 	heat_protection = UPPER_TORSO|LOWER_TORSO|ARMS|LEGS
+
+/datum/armor/vest_warden
+	bio = 10
+	bomb = 40
+	bullet = 50
+	energy = 25
+	laser = 50
+	melee = 50
 
 /obj/item/clothing/suit/armor/vest/warden_heavy
 	name = "warden's armoured vest"
 	desc = "An upgraded version of a regular bulletproof vest, featuring custom shoulder pads and silver rank livery."
 	icon_state = "warden_heavy"
-	//item_state = "armor"
-	armor = list(melee = 55, bullet = 55, laser = 55, energy = 25, bomb = 40, bio = 10)
+	armor_type = vest_wardenheavy
 	body_parts_covered = UPPER_TORSO|LOWER_TORSO|ARMS
+
+/datum/armor/vest_wardenheavy
+	bio = 10
+	bomb = 40
+	bullet = 55
+	energy = 25
+	laser = 55
+	melee = 55
 
 /obj/item/clothing/suit/armor/vest/hos_heavy
 	name = "commander's armoured vest"
 	desc = "A custom-made, expensive bulletproof vest with golden rank livery."
 	icon_state = "hos_heavy"
-	//item_state = "armor"
-	armor = list(melee = 65, bullet = 65, laser = 65, energy = 35, bomb = 55, bio = 20)
+	armor_type = /datum/armor/vest_hosheavy
 	body_parts_covered = UPPER_TORSO|LOWER_TORSO
+
+/datum/armor/vest_hosheavy
+	bio = 20
+	bomb = 55
+	bullet = 65
+	energy = 35
+	laser = 65
+	melee = 65
 
 /obj/item/clothing/suit/armor/hos
 	name = "armored coat"
@@ -74,9 +102,17 @@
 	icon_state = "hos"
 	item_state = "hos"
 	body_parts_covered = UPPER_TORSO|LOWER_TORSO|ARMS|LEGS
-	armor = list(melee = 65, bullet = 65, laser = 65, energy = 35, bomb = 55, bio = 20)
+	armor_type = /datum/armor/armor_hos
 	flags_inv = HIDEJUMPSUIT
 	siemens_coefficient = 0.6
+
+/datum/armor/armor_hos
+	bio = 20
+	bomb = 55
+	bullet = 65
+	energy = 35
+	laser = 65
+	melee = 65
 
 /obj/item/clothing/suit/armor/hos/jensen
 	name = "armored trenchcoat"
@@ -89,8 +125,7 @@
 	name = "captain's carapace"
 	desc = "An extremely expensive piece of exclusive, hand-crafted corporate armor. YOU are in charge!"
 	icon_state = "capcarapace"
-	//item_state = "capcarapace"
-	armor = list(melee = 85, bullet = 70, laser = 70, energy = 35, bomb = 55, bio = 20)
+	armor_type = /datum/armor/vest_capcarapace
 	allowed = list(
 		/obj/item/gun,
 		/obj/item/device/flashlight,
@@ -107,6 +142,14 @@
 		)
 	siemens_coefficient = 0.5
 
+/datum/armor/vest_capcarapace
+	bio = 20
+	bomb = 55
+	bullet = 70
+	energy = 35
+	laser = 70
+	melee = 85
+
 //Non-hardsuit ERT armor.
 //Commander
 /obj/item/clothing/suit/armor/vest/ert
@@ -115,7 +158,14 @@
 	icon_state = "ertarmor_cmd"
 	item_state = "armor"
 	body_parts_covered = UPPER_TORSO|LOWER_TORSO|ARMS
-	armor = list(melee = 65, bullet = 65, laser = 65, energy = 40, bomb = 20, bio = 0)
+	armor_type = /datum/armor/vest_ert
+
+/datum/armor/vest_ert
+	bomb = 20
+	bullet = 65
+	energy = 40
+	laser = 65
+	melee = 65
 
 //Security
 /obj/item/clothing/suit/armor/vest/ert/security
@@ -148,9 +198,16 @@
 	valid_accessory_slots = list(ACCESSORY_SLOT_INSIGNIA, ACCESSORY_SLOT_ARMOR_A, ACCESSORY_SLOT_ARMOR_L)
 	restricted_accessory_slots = list(ACCESSORY_SLOT_INSIGNIA, ACCESSORY_SLOT_ARMOR_A, ACCESSORY_SLOT_ARMOR_L)
 	body_parts_covered = UPPER_TORSO|LOWER_TORSO
-	armor = list(melee = 80, bullet = 35, laser = 35, energy = 15, bomb = 25, bio = 0)
+	armor_type = /datum/armor/armor_riot
 	siemens_coefficient = 0.5
 	starting_accessories = list(/obj/item/clothing/accessory/armguards/riot, /obj/item/clothing/accessory/legguards/riot)
+
+/datum/armor/armor_riot
+	bomb = 25
+	bullet = 25
+	energy = 15
+	laser = 35
+	melee = 80
 
 /obj/item/clothing/suit/armor/bulletproof
 	name = "ballistic vest"
@@ -160,9 +217,16 @@
 	valid_accessory_slots = list(ACCESSORY_SLOT_INSIGNIA, ACCESSORY_SLOT_ARMOR_A, ACCESSORY_SLOT_ARMOR_L)
 	restricted_accessory_slots = list(ACCESSORY_SLOT_INSIGNIA, ACCESSORY_SLOT_ARMOR_A, ACCESSORY_SLOT_ARMOR_L)
 	body_parts_covered = UPPER_TORSO|LOWER_TORSO
-	armor = list(melee = 35, bullet = 85, laser = 35, energy = 15, bomb = 25, bio = 0)
+	armor_type = /datum/armor/armor_bulletproof
 	siemens_coefficient = 0.7
 	starting_accessories = list(/obj/item/clothing/accessory/armguards/ballistic, /obj/item/clothing/accessory/legguards/ballistic)
+
+/datum/armor/armor_bulletproof
+	bomb = 25
+	bullet = 85
+	energy = 15
+	laser = 35
+	melee = 85
 
 /obj/item/clothing/suit/armor/bulletproof/vest //because apparently some map uses this somewhere and I'm too lazy to go looking for and replacing it.
 	starting_accessories = null
@@ -175,9 +239,15 @@
 	valid_accessory_slots = list(ACCESSORY_SLOT_INSIGNIA, ACCESSORY_SLOT_ARMOR_A, ACCESSORY_SLOT_ARMOR_L)
 	restricted_accessory_slots = list(ACCESSORY_SLOT_INSIGNIA, ACCESSORY_SLOT_ARMOR_A, ACCESSORY_SLOT_ARMOR_L)
 	body_parts_covered = UPPER_TORSO|LOWER_TORSO
-	armor = list(melee = 35, bullet = 35, laser = 85, energy = 60, bomb = 0, bio = 0)
+	armor_type = /datum/armor/armor_laserproof
 	siemens_coefficient = 0
 	starting_accessories = list(/obj/item/clothing/accessory/armguards/ablative, /obj/item/clothing/accessory/legguards/ablative)
+
+/datum/armor/armor_laserproof
+	bullet = 35
+	energy = 60
+	laser = 85
+	melee = 25
 
 /obj/item/clothing/suit/armor/laserproof/handle_shield(mob/user, damage, atom/damage_source = null, mob/attacker = null, def_zone = null, attack_text = "the attack")
 	if(istype(damage_source, /obj/item/projectile/energy) || istype(damage_source, /obj/item/projectile/beam))
@@ -269,7 +339,14 @@
 	flags_inv = HIDEGLOVES|HIDESHOES|HIDEJUMPSUIT
 	valid_accessory_slots = list(ACCESSORY_SLOT_INSIGNIA)
 	siemens_coefficient = 0
-	armor = list(melee = 90, bullet = 90, laser = 90, energy = 55, bomb = 90, bio = 50)
+	armor_type = /datum/armor/armor_swat
+
+/datum/armor/armor_swat
+	bomb = 90
+	bullet = 90
+	energy = 55
+	laser = 90
+	melee = 90
 
 /obj/item/clothing/suit/armor/swat/officer
 	name = "officer jacket"
@@ -281,8 +358,15 @@
 	cold_protection = UPPER_TORSO|LOWER_TORSO|ARMS
 	heat_protection = UPPER_TORSO|LOWER_TORSO|ARMS
 	valid_accessory_slots = list(ACCESSORY_SLOT_INSIGNIA)
-	armor = list(melee = 42, bullet = 75, laser = 42, energy = 10, bomb = 25, bio = 0)
+	armor_type = /datum/armor/armor_officer
 	flags_inv = 0
+
+/datum/armor/armor_officer
+	bomb = 25
+	bullet = 75
+	energy = 10
+	laser = 42
+	melee = 42
 
 /obj/item/clothing/suit/armor/heavy // A more balanced version of SWAT armor
 	name = "heavy armor"
@@ -294,7 +378,14 @@
 	body_parts_covered = UPPER_TORSO|LOWER_TORSO|LEGS|FEET|ARMS|HANDS
 	flags_inv = HIDEGLOVES|HIDESHOES|HIDEJUMPSUIT
 	siemens_coefficient = 0
-	armor = list(melee = 75, bullet = 75, laser = 75, energy = 50, bomb = 50, bio = 50)
+	armor_type = /datum/armor/armor_heavy
+
+/datum/armor/armor_heavy
+	bomb = 50
+	bullet = 76
+	energy = 50
+	laser = 75
+	melee = 75
 
 /obj/item/clothing/suit/armor/heavy/New()
 	..()

--- a/code/modules/clothing/suits/armor.dm
+++ b/code/modules/clothing/suits/armor.dm
@@ -208,7 +208,6 @@
 	icon_state = "reactiveoff"
 	item_state = "reactiveoff"
 	blood_overlay_type = "armorblood"
-	armor = list(melee = 0, bullet = 0, laser = 0, energy = 0, bomb = 0, bio = 0)
 
 /obj/item/clothing/suit/armor/reactive/New()
 	..()

--- a/code/modules/clothing/suits/bio.dm
+++ b/code/modules/clothing/suits/bio.dm
@@ -8,7 +8,7 @@
 		)
 	desc = "A hood that protects the head and face from biological comtaminants."
 	permeability_coefficient = 0
-	armor = list(melee = 5, bullet = 2.5, laser = 2.5,energy = 0, bomb = 0, bio = 100)
+	armor_type = /datum/armor/head_bio
 	flags_inv = HIDEMASK|HIDEEARS|HIDEEYES|BLOCKHAIR
 	item_flags = ITEM_FLAG_THICKMATERIAL
 	body_parts_covered = HEAD|FACE|EYES
@@ -18,6 +18,12 @@
 		RADIATION_BETA_PARTICLE = 7.7 MEGA ELECTRONVOLT,
 		RADIATION_HAWKING = 1 ELECTRONVOLT
 	)
+
+/datum/armor/head_bio
+	bio = 100
+	bullet = 2.5
+	laser = 2.5
+	melee = 5
 
 /obj/item/clothing/suit/bio_suit
 	name = "bio suit"
@@ -32,7 +38,7 @@
 	permeability_coefficient = 0
 	body_parts_covered = UPPER_TORSO|LOWER_TORSO|LEGS|FEET|ARMS|HANDS
 	allowed = list(/obj/item/tank/emergency,/obj/item/pen,/obj/item/device/flashlight/pen,/obj/item/device/healthanalyzer,/obj/item/device/ano_scanner,/obj/item/clothing/head/bio_hood,/obj/item/clothing/mask/gas,/obj/item/device/antibody_scanner)
-	armor = list(melee = 5, bullet = 0, laser = 0,energy = 0, bomb = 0, bio = 100)
+	armor_type = /datum/armor/suit_bio
 	flags_inv = HIDEGLOVES|HIDESHOES|HIDEJUMPSUIT|HIDETAIL
 	item_flags = ITEM_FLAG_THICKMATERIAL
 	siemens_coefficient = 0.9
@@ -41,6 +47,10 @@
 		RADIATION_BETA_PARTICLE = 7.7 MEGA ELECTRONVOLT,
 		RADIATION_HAWKING = 1 ELECTRONVOLT
 	)
+
+/datum/armor/suit_bio
+	bio = 100
+	melee = 5
 
 /obj/item/clothing/suit/bio_suit/New()
 	..()

--- a/code/modules/clothing/suits/jobs.dm
+++ b/code/modules/clothing/suits/jobs.dm
@@ -108,7 +108,14 @@
 	blood_overlay_type = "coatblood"
 	body_parts_covered = UPPER_TORSO|LOWER_TORSO|ARMS
 	allowed = list(/obj/item/tank/emergency,/obj/item/device/flashlight,/obj/item/gun/energy,/obj/item/gun/projectile,/obj/item/ammo_magazine,/obj/item/ammo_casing,/obj/item/melee/baton,/obj/item/handcuffs,/obj/item/storage/fancy/cigarettes,/obj/item/flame/lighter,/obj/item/device/taperecorder)
-	armor = list(melee = 35, bullet = 35, laser = 35, energy = 20, bomb = 25, bio = 0)
+	armor_type = /datum/armor/suit_dettrench
+
+/datum/armor/suit_dettrench
+	bomb = 25
+	bullet = 35
+	energy = 20
+	laser = 35
+	melee = 35
 
 /obj/item/clothing/suit/storage/toggle/det_trench/grey
 	icon_state = "detective2_open"
@@ -118,7 +125,6 @@
 
 /obj/item/clothing/suit/storage/toggle/det_trench/ft
 	desc = "A rugged canvas trenchcoat, designed and created by TX Fabrication Corp. This one wouldn't block much of anything."
-	armor = list(melee = 0, bullet = 0, laser = 0, energy = 0, bomb = 0, bio = 0)
 
 /obj/item/clothing/suit/storage/civ_trench
 	name = "brown trenchcoat"
@@ -129,7 +135,12 @@
 	blood_overlay_type = "coatblood"
 	body_parts_covered = UPPER_TORSO|LOWER_TORSO|ARMS
 	allowed = list(/obj/item/tank/emergency,/obj/item/device/flashlight,/obj/item/storage/fancy/cigarettes,/obj/item/flame/lighter,/obj/item/device/taperecorder)
-	armor = list(melee = 10, bullet = 10, laser = 10, energy = 0, bomb = 0, bio = 0)
+	armor_type = /datum/armor/suit_civtrench
+
+/datum/armor/suit_civtrench
+	bullet = 10
+	laser = 10
+	melee = 10
 
 /obj/item/clothing/suit/storage/civ_trench/grey
 	name = "grey trenchcoat"
@@ -145,7 +156,13 @@
 	body_parts_covered = UPPER_TORSO|ARMS
 	blood_overlay_type = "armorblood"
 	allowed = list(/obj/item/tank/emergency,/obj/item/device/flashlight,/obj/item/gun/energy,/obj/item/gun/projectile,/obj/item/ammo_magazine,/obj/item/ammo_casing,/obj/item/melee/baton,/obj/item/handcuffs,/obj/item/device/taperecorder)
-	armor = list(melee = 10, bullet = 10, laser = 15, energy = 10, bomb = 0, bio = 0)
+	armor_type = /datum/armor/suit_forensics
+
+/datum/armor/suit_forensics
+	bullet = 10
+	energy = 10
+	laser = 15
+	melee = 10
 
 /obj/item/clothing/suit/storage/toggle/forensics/toggle()
 	if(!CanPhysicallyInteract(usr))

--- a/code/modules/clothing/suits/labcoat.dm
+++ b/code/modules/clothing/suits/labcoat.dm
@@ -8,9 +8,15 @@
 	blood_overlay_type = "coatblood"
 	body_parts_covered = UPPER_TORSO|ARMS
 	allowed = list(/obj/item/device/analyzer,/obj/item/stack/medical,/obj/item/reagent_containers/dropper,/obj/item/reagent_containers/syringe,/obj/item/reagent_containers/hypospray,/obj/item/device/healthanalyzer,/obj/item/device/flashlight/pen,/obj/item/reagent_containers/vessel/bottle/chemical,/obj/item/reagent_containers/vessel/beaker,/obj/item/reagent_containers/pill,/obj/item/storage/pill_bottle,/obj/item/paper,/obj/item/device/antibody_scanner)
-	armor = list(melee = 5, bullet = 5, laser = 5,energy = 0, bomb = 0, bio = 50)
+	armor_type = /datum/armor/suit_lab
 	valid_accessory_slots = list(ACCESSORY_SLOT_ARMBAND)
 	restricted_accessory_slots = list(ACCESSORY_SLOT_ARMBAND)
+
+/datum/armor/suit_lab
+	bio = 50
+	energy = 5
+	laser = 5
+	melee = 5
 
 /obj/item/clothing/suit/storage/toggle/labcoat/cmo
 	name = "chief medical officer's labcoat"
@@ -55,7 +61,13 @@
 	icon_state = "labcoat_vir_open"
 	icon_open = "labcoat_vir_open"
 	icon_closed = "labcoat_vir"
-	armor = list(melee = 5, bullet = 5, laser = 5,energy = 0, bomb = 0, bio = 60)
+	armor_type = /datum/armor/suit_virolab
+
+/datum/armor/suit_virolab
+	bio = 60
+	bullet = 5
+	laser = 5
+	melee = 5
 
 /obj/item/clothing/suit/storage/toggle/labcoat/science
 	name = "Scientist labcoat"
@@ -90,5 +102,4 @@
 	icon_state = "labcoat_xy"
 	icon_open = "labcoat_xy_open"
 	icon_closed = "labcoat_xy"
-	armor = list(melee = 10, bullet = 5, laser = 5,energy = 0, bomb = 0, bio = 20)
 	species_restricted = list(SPECIES_IPC)

--- a/code/modules/clothing/suits/miscellaneous.dm
+++ b/code/modules/clothing/suits/miscellaneous.dm
@@ -667,10 +667,16 @@
 	body_parts_covered = UPPER_TORSO|LOWER_TORSO
 	cold_protection = UPPER_TORSO|LOWER_TORSO
 	min_cold_protection_temperature = ARMOR_MIN_COLD_PROTECTION_TEMPERATURE
-	armor = list(melee = 25, bullet = 10, laser = 0, energy = 40, bomb = 0, bio = 10)
+	armor_type = /datum/armor/suit_goatcape
 	action_button_name = "Toggle hood"
 	hoodtype = /obj/item/clothing/head/goatcapehood
 	siemens_coefficient = 0.6
+
+/datum/armor/suit_goatcape
+	bio = 10
+	bullet = 10
+	energy = 40
+	melee = 25
 
 /obj/item/clothing/head/goatcapehood
 	name = "goat head hood"
@@ -680,4 +686,9 @@
 	cold_protection = HEAD
 	flags_inv = HIDEEARS | BLOCKHAIR
 	min_cold_protection_temperature = ARMOR_MIN_COLD_PROTECTION_TEMPERATURE
-	armor = list(melee = 25, bullet = 10, laser = 0, energy = 40, bomb = 0, bio = 10)
+	armor_type = /datum/armor/head_goathood
+
+/datum/armor/head_goathood
+	bullet = 10
+	energy = 40
+	melee = 25

--- a/code/modules/clothing/suits/toggles.dm
+++ b/code/modules/clothing/suits/toggles.dm
@@ -72,11 +72,14 @@
 	body_parts_covered = UPPER_TORSO|LOWER_TORSO|ARMS
 	cold_protection = UPPER_TORSO|LOWER_TORSO|ARMS
 	min_cold_protection_temperature = ARMOR_MIN_COLD_PROTECTION_TEMPERATURE
-	armor = list(melee = 0, bullet = 0, laser = 0,energy = 0, bomb = 0, bio = 10)
+	armor_type = /datum/armor/suit_wintercoat
 	action_button_name = "Toggle Winter Hood"
 	hoodtype = /obj/item/clothing/head/winterhood
 	allowed = list (/obj/item/pen, /obj/item/paper, /obj/item/device/flashlight,/obj/item/storage/fancy/cigarettes, /obj/item/storage/box/matches, /obj/item/reagent_containers/vessel/flask)
 	siemens_coefficient = 0.6
+
+/datum/armor/suit_wintercoat
+	bio = 10
 
 /obj/item/clothing/head/winterhood
 	name = "winter hood"
@@ -90,27 +93,46 @@
 /obj/item/clothing/suit/storage/hooded/wintercoat/captain
 	name = "captain's winter coat"
 	icon_state = "coatcaptain"
-	armor = list(melee = 20, bullet = 15, laser = 20, energy = 10, bomb = 15, bio = 0)
+	armor_type = /datum/armor/suit_capwintercoat
+
+/datum/armor/suit_capwintercoat
+	bomb = 15
+	bullet = 15
+	energy = 10
+	laser = 20
+	melee = 20
 
 /obj/item/clothing/suit/storage/hooded/wintercoat/security
 	name = "security winter coat"
 	icon_state = "coatsecurity"
-	armor = list(melee = 25, bullet = 20, laser = 20, energy = 15, bomb = 20, bio = 0)
+	armor_type = /datum/armor/suit_secwintercoat
+
+/datum/armor/suit_secwintercoat
+	bomb = 20
+	bullet = 20
+	energy = 15
+	laser = 20
+	melee = 25
 
 /obj/item/clothing/suit/storage/hooded/wintercoat/medical
 	name = "medical winter coat"
 	icon_state = "coatmedical"
-	armor = list(melee = 0, bullet = 0, laser = 0,energy = 0, bomb = 0, bio = 50)
+	armor_type = /datum/armor/suit_medwintercoat
+
+/datum/armor/suit_medwintercoat
+	bio = 50
 
 /obj/item/clothing/suit/storage/hooded/wintercoat/science
 	name = "science winter coat"
 	icon_state = "coatscience"
-	armor = list(melee = 0, bullet = 0, laser = 0,energy = 0, bomb = 10, bio = 0)
+	armor_type = /datum/armor/suit_sciwintercoat
+
+/datum/armor/suit_sciwintercoat
+	bomb = 10
 
 /obj/item/clothing/suit/storage/hooded/wintercoat/engineering
 	name = "engineering winter coat"
 	icon_state = "coatengineer"
-	armor = list(melee = 0, bullet = 0, laser = 0, energy = 0, bomb = 0, bio = 0)
 
 /obj/item/clothing/suit/storage/hooded/wintercoat/engineering/atmos
 	name = "atmospherics winter coat"
@@ -127,12 +149,22 @@
 /obj/item/clothing/suit/storage/hooded/wintercoat/miner
 	name = "mining winter coat"
 	icon_state = "coatminer"
-	armor = list(melee = 10, bullet = 0, laser = 0, energy = 0, bomb = 0, bio = 0)
+	armor_type = /datum/armor/suit_minewintercoat
+
+/datum/armor/suit_minewintercoat
+	melee = 10
 
 /obj/item/clothing/suit/storage/hooded/wintercoat/centcom
 	name = "centcom winter coat"
 	icon_state = "coatcentcom"
-	armor = list(melee = 20, bullet = 15, laser = 20, energy = 10, bomb = 15, bio = 0)
+	armor_type = /datum/armor/suit_centwintercoat
+
+/datum/armor/suit_centwintercoat
+	bomb = 15
+	bullet = 15
+	energy = 10
+	laser = 20
+	melee = 20
 
 /obj/item/clothing/suit/storage/hooded/wintercoat/hop
 	name = "hop winter coat"
@@ -149,12 +181,18 @@
 /obj/item/clothing/suit/storage/hooded/wintercoat/ce
 	name = "ce winter coat"
 	icon_state = "coatce"
-	armor = list(melee = 0, bullet = 0, laser = 0, energy = 10, bomb = 0, bio = 0)
+	armor_type = /datum/armor/suit_cewintercoat
+
+/datum/armor/suit_cewintercoat
+	energy = 10
 
 /obj/item/clothing/suit/storage/hooded/wintercoat/cmo
 	name = "cmo winter coat"
 	icon_state = "coatcmo"
-	armor = list(melee = 0, bullet = 0, laser = 0, energy = 0, bomb = 0, bio = 10)
+	armor_type = /datum/armor/suit_cmowintercoat
+
+/datum/armor/suit_cmowintercoat
+	bio = 10
 
 /obj/item/clothing/suit/storage/hooded/wintercoat/chemistry
 	name = "chemistry winter coat"
@@ -163,7 +201,10 @@
 /obj/item/clothing/suit/storage/hooded/wintercoat/viro
 	name = "viro winter coat"
 	icon_state = "coatviro"
-	armor = list(melee = 0, bullet = 0, laser = 0, energy = 0, bomb = 0, bio = 10)
+	armor_type = /datum/armor/suit_virowintercoat
+
+/datum/armor/suit_virowintercoat
+	bio = 10
 
 /obj/item/clothing/suit/storage/hooded/wintercoat/paramed
 	name = "paramed winter coat"
@@ -172,7 +213,10 @@
 /obj/item/clothing/suit/storage/hooded/wintercoat/rd
 	name = "rd winter coat"
 	icon_state = "coatrd"
-	armor = list(melee = 0, bullet = 0, laser = 10, energy = 0, bomb = 10, bio = 0)
+	armor_type = /datum/armor/suit_rdwintercoat
+
+/datum/armor/suit_rdwintercoat
+	bomb = 10
 
 /obj/item/clothing/suit/storage/hooded/wintercoat/robotics
 	name = "robotics winter coat"

--- a/code/modules/clothing/suits/utility.dm
+++ b/code/modules/clothing/suits/utility.dm
@@ -17,8 +17,8 @@
 		slot_l_hand_str = "fire_suit",
 		slot_r_hand_str = "fire_suit",
 	)
-	w_class = ITEM_SIZE_HUGE//bulky item
-	armor = list(melee = 20, bullet = 10, laser = 15,energy = 5, bomb = 0, bio = 0)
+	w_class = ITEM_SIZE_HUGE
+	armor_type = /datum/armor/suit_fire
 	gas_transfer_coefficient = 0.90
 	permeability_coefficient = 0.50
 	body_parts_covered = UPPER_TORSO|LOWER_TORSO|LEGS|FEET|ARMS|HANDS
@@ -28,6 +28,12 @@
 	heat_protection = UPPER_TORSO|LOWER_TORSO|LEGS|FEET|ARMS|HANDS
 	max_heat_protection_temperature = FIRESUIT_MAX_HEAT_PROTECTION_TEMPERATURE
 	cold_protection = UPPER_TORSO | LOWER_TORSO | LEGS | FEET | ARMS | HANDS
+
+/datum/armor/suit_fire
+	bullet = 10
+	energy = 5
+	laser = 15
+	melee = 20
 
 /obj/item/clothing/suit/fire/New()
 	..()
@@ -39,7 +45,6 @@
 		slot_l_hand_str = "firefighter",
 		slot_r_hand_str = "firefighter",
 	)
-
 
 /obj/item/clothing/suit/fire/heavy
 	name = "firesuit"
@@ -62,7 +67,7 @@
 	name = "bomb hood"
 	desc = "Use in case of bomb."
 	icon_state = "bombsuit"
-	armor = list(melee = 70, bullet = 15, laser = 30, energy = 50, bomb = 90, bio = 0)
+	armor_type = /datum/armor/head_bombhood
 	flags_inv = HIDEMASK|HIDEEARS|HIDEEYES|BLOCKHAIR
 	body_parts_covered = HEAD|FACE|EYES
 	siemens_coefficient = 0
@@ -72,6 +77,13 @@
 		RADIATION_HAWKING = 1 ELECTRONVOLT
 	)
 
+/datum/armor/head_bombhood
+	bomb = 90
+	bullet = 15
+	energy = 50
+	laser = 30
+	melee = 70
+
 /obj/item/clothing/suit/bomb_suit
 	name = "bomb suit"
 	desc = "A suit designed for safety when handling explosives."
@@ -79,11 +91,18 @@
 	w_class = ITEM_SIZE_HUGE//bulky item
 	gas_transfer_coefficient = 0.01
 	permeability_coefficient = 0.01
-	armor = list(melee = 70, bullet = 15, laser = 30, energy = 50, bomb = 90, bio = 0)
+	armor_type = /datum/armor/suit_bombsuit
 	flags_inv = HIDEJUMPSUIT|HIDETAIL
 	heat_protection = UPPER_TORSO|LOWER_TORSO
 	max_heat_protection_temperature = ARMOR_MAX_HEAT_PROTECTION_TEMPERATURE
 	siemens_coefficient = 0
+
+/datum/armor/suit_bombsuit
+	bomb = 90
+	bullet = 15
+	energy = 50
+	laser = 30
+	melee = 70
 
 /obj/item/clothing/suit/bomb_suit/New()
 	..()
@@ -107,12 +126,15 @@
 	desc = "A hood with radiation protective properties. Label: Made with lead, do not eat insulation."
 	flags_inv = BLOCKHAIR
 	body_parts_covered = HEAD|FACE|EYES
-	armor = list(melee = 0, bullet = 0, laser = 0,energy = 0, bomb = 0, bio = 60)
+	armor_type = /datum/armor/head_radiation
 	rad_resist = list(
 		RADIATION_ALPHA_PARTICLE = 44.6 MEGA ELECTRONVOLT,
 		RADIATION_BETA_PARTICLE = 17.6 MEGA ELECTRONVOLT,
 		RADIATION_HAWKING = 1 ELECTRONVOLT
 	)
+
+/datum/armor/head_radiation
+	bio = 60
 
 /obj/item/clothing/suit/radiation
 	name = "Radiation suit"
@@ -127,7 +149,7 @@
 	permeability_coefficient = 0.50
 	body_parts_covered = UPPER_TORSO|LOWER_TORSO|LEGS|ARMS|HANDS|FEET
 	allowed = list(/obj/item/device/flashlight, /obj/item/device/geiger, /obj/item/tank/emergency,/obj/item/clothing/head/radiation,/obj/item/clothing/mask/gas)
-	armor = list(melee = 0, bullet = 0, laser = 0,energy = 0, bomb = 0, bio = 60)
+	armor_type = /datum/armor/suit_radiation
 	flags_inv = HIDEJUMPSUIT|HIDETAIL|HIDEGLOVES|HIDESHOES
 
 	rad_resist = list(
@@ -135,6 +157,9 @@
 		RADIATION_BETA_PARTICLE = 17.6 MEGA ELECTRONVOLT,
 		RADIATION_HAWKING = 1 ELECTRONVOLT
 	)
+
+/datum/armor/suit_radiation
+	bio = 60
 
 /obj/item/clothing/suit/radiation/New()
 	..()

--- a/code/modules/clothing/suits/wiz_robe.dm
+++ b/code/modules/clothing/suits/wiz_robe.dm
@@ -76,17 +76,24 @@
 	item_state = "wizard"
 	gas_transfer_coefficient = 0.01 // IT'S MAGICAL OKAY JEEZ +1 TO NOT DIE
 	permeability_coefficient = 0.01
-	armor = list(melee = 30, bullet = 20, laser = 20,energy = 20, bomb = 20, bio = 20)
+	armor_type = /datum/armor/suit_wizard
 	allowed = list(/obj/item/teleportation_scroll)
 	siemens_coefficient = 0.8
 	wizard_garb = 1
+
+/datum/armor/suit_wizard
+	bio = 20
+	bomb = 20
+	bullet = 20
+	energy = 20
+	laser = 20
+	melee = 30
 
 /obj/item/clothing/suit/wizrobe/red
 	name = "red wizard robe"
 	desc = "A magnificant, red, gem-lined robe that seems to radiate power."
 	icon_state = "redwizard"
 	item_state = "redwizard"
-
 
 /obj/item/clothing/suit/wizrobe/marisa
 	name = "Witch Robe"
@@ -132,7 +139,6 @@
 	desc = "A rather dull, blue robe meant to mimick real wizard robes."
 	icon_state = "wizard-fake"
 	item_state = "wizard-fake"
-	armor = list(melee = 0, bullet = 0, laser = 0,energy = 0, bomb = 0, bio = 0)
 	siemens_coefficient = 1.0
 	wizard_garb = 0
 
@@ -140,7 +146,6 @@
 	name = "Witch Hat"
 	desc = "Strange-looking hat-wear, makes you want to cast fireballs."
 	icon_state = "marisa"
-	armor = list(melee = 0, bullet = 0, laser = 0,energy = 0, bomb = 0, bio = 0)
 	siemens_coefficient = 1.0
 	wizard_garb = 0
 
@@ -150,6 +155,5 @@
 	icon_state = "marisa"
 	item_state = "marisa"
 	body_parts_covered = UPPER_TORSO|LOWER_TORSO|ARMS|LEGS
-	armor = list(melee = 0, bullet = 0, laser = 0,energy = 0, bomb = 0, bio = 0)
 	siemens_coefficient = 1.0
 	wizard_garb = 0

--- a/code/modules/clothing/under/accessories/armor.dm
+++ b/code/modules/clothing/under/accessories/armor.dm
@@ -54,8 +54,15 @@
 	icon = 'icons/obj/clothing/modular_armor.dmi'
 	icon_state = "armor_light"
 	body_parts_covered = UPPER_TORSO|LOWER_TORSO
-	armor = list(melee = 25, bullet = 25, laser = 25, energy = 10, bomb = 25, bio = 0)
+	armor_type = /datum/armor/plate_light
 	slot = ACCESSORY_SLOT_ARMOR_C
+
+/datum/armor/plate_light
+	bomb = 25
+	bullet = 25
+	energy = 10
+	laser = 25
+	melee = 25
 
 /obj/item/clothing/accessory/armorplate/get_fibers()
 	return null	//plates do not shed
@@ -64,14 +71,28 @@
 	name = "medium armor plate"
 	desc = "A plasteel-reinforced synthetic armor plate, providing good protection. Attaches to a plate carrier."
 	icon_state = "armor_medium"
-	armor = list(melee = 35, bullet = 35, laser = 35, energy = 15, bomb = 30, bio = 0)
+	armor_type = /datum/armor/plate_medium
+
+/datum/armor/plate_medium
+	bomb = 30
+	bullet = 35
+	energy = 15
+	laser = 35
+	melee = 35
 
 /obj/item/clothing/accessory/armorplate/syndi
 	name = "heavy armor plate"
 	desc = "A ceramics-reinforced synthetic armor plate, providing state of of the art protection. Attaches to a plate carrier."
 	icon_state = "armor_merc"
-	armor = list(melee = 60, bullet = 60, laser = 60, energy = 35, bomb = 40, bio = 0)
+	armor_type = /datum/armor/plate_syndi
 	slowdown = 1
+
+/datum/armor/plate_syndi
+	bomb = 40
+	bullet = 60
+	energy = 35
+	laser = 60
+	melee = 60
 
 //Arm guards
 /obj/item/clothing/accessory/armguards
@@ -81,8 +102,15 @@
 	icon_state = "armguards"
 	gender = PLURAL
 	body_parts_covered = ARMS
-	armor = list(melee = 40, bullet = 40, laser = 40, energy = 15, bomb = 25, bio = 0)
+	armor_type = /datum/armor/armguards
 	slot = ACCESSORY_SLOT_ARMOR_A
+
+/datum/armor/armguards
+	bomb = 25
+	bullet = 40
+	energy = 15
+	laser = 40
+	melee = 40
 
 /obj/item/clothing/accessory/armguards/blue
 	desc = "A pair of blue arm pads reinforced with armor plating. Attaches to a plate carrier."
@@ -104,28 +132,55 @@
 	name = "heavy arm guards"
 	desc = "A pair of red-trimmed black arm pads reinforced with heavy armor plating. Attaches to a plate carrier."
 	icon_state = "armguards_merc"
-	armor = list(melee = 60, bullet = 60, laser = 60, energy = 40, bomb = 40, bio = 0)
+	armor_type = /datum/armor/armguards_syndi
+
+/datum/armor/armguards_syndi
+	bomb = 40
+	bullet = 60
+	energy = 40
+	laser = 60
+	melee = 60
 
 /obj/item/clothing/accessory/armguards/riot
 	name = "riot arm guards"
 	desc = "A pair of armored arm pads with heavy padding to protect against melee attacks."
 	icon_state = "armguards_riot"
-	armor = list(melee = 80, bullet = 35, laser = 35, energy = 15, bomb = 25, bio = 0)
+	armor_type = /datum/armor/armguards_riot
 	siemens_coefficient = 0.5
+
+/datum/armor/armguards_riot
+	bomb = 25
+	bullet = 35
+	energy = 15
+	laser = 35
+	melee = 80
 
 /obj/item/clothing/accessory/armguards/ballistic
 	name = "ballistic arm guards"
 	desc = "A pair of armored arm pads with heavy plates to protect against ballistic projectiles."
 	icon_state = "armguards_ballistic"
-	armor = list(melee = 35, bullet = 85, laser = 35, energy = 15, bomb = 25, bio = 0)
+	armor_type = /datum/armor/armguards_ballistic
 	siemens_coefficient = 0.7
+
+/datum/armor/armguards_ballistic
+	bomb = 25
+	bullet = 85
+	energy = 15
+	laser = 35
+	melee = 35
 
 /obj/item/clothing/accessory/armguards/ablative
 	name = "ablative arm guards"
 	desc = "A pair of armored arm pads with advanced shielding to protect against energy weapons."
 	icon_state = "armguards_ablative"
-	armor = list(melee = 35, bullet = 35, laser = 85, energy = 60, bomb = 0, bio = 0)
+	armor_type = /datum/armor/armguards_ablative
 	siemens_coefficient = 0
+
+/datum/armor/armguards_ablative
+	bullet = 35
+	energy = 60
+	laser = 85
+	melee = 35
 
 //Leg guards
 /obj/item/clothing/accessory/legguards
@@ -135,8 +190,15 @@
 	icon_state = "legguards"
 	gender = PLURAL
 	body_parts_covered = LEGS
-	armor = list(melee = 35, bullet = 35, laser = 35, energy = 15, bomb = 25, bio = 0)
+	armor_type = /datum/armor/legguards
 	slot = ACCESSORY_SLOT_ARMOR_L
+
+/datum/armor/legguards
+	bomb = 25
+	bullet = 35
+	energy = 15
+	laser = 35
+	melee = 35
 
 /obj/item/clothing/accessory/legguards/blue
 	desc = "A pair of armored leg pads in blue. Attaches to a plate carrier."
@@ -158,31 +220,59 @@
 	name = "heavy leg guards"
 	desc = "A pair of heavily armored leg pads in red-trimmed black. Attaches to a plate carrier."
 	icon_state = "legguards_merc"
-	armor = list(melee = 60, bullet = 60, laser = 60, energy = 35, bomb = 40, bio = 0)
+	armor_type = /datum/armor/legguards_syndi
+
+/datum/armor/legguards_syndi
+	bomb = 40
+	bullet = 60
+	energy = 35
+	laser = 60
+	melee = 60
 
 /obj/item/clothing/accessory/legguards/riot
 	name = "riot leg guards"
 	desc = "A pair of armored leg pads with heavy padding to protect against melee attacks. Looks like they might impair movement."
 	icon_state = "legguards_riot"
-	armor = list(melee = 80, bullet = 35, laser = 35, energy = 15, bomb = 25, bio = 0)
+	armor_type = /datum/armor/legguards_riot
 	siemens_coefficient = 0.5
 	slowdown = 1
+
+/datum/armor/legguards_riot
+	bomb = 25
+	bullet = 35
+	energy = 15
+	laser = 35
+	melee = 35
 
 /obj/item/clothing/accessory/legguards/ballistic
 	name = "ballistic leg guards"
 	desc = "A pair of armored leg pads with heavy plates to protect against ballistic projectiles. Looks like they might impair movement."
 	icon_state = "legguards_ballistic"
-	armor = list(melee = 35, bullet = 85, laser = 35, energy = 15, bomb = 25, bio = 0)
+	armor_type = /datum/armor/legguards_ballistic
 	siemens_coefficient = 0.7
 	slowdown = 1
+
+/datum/armor/legguards_ballistic
+	bomb = 25
+	bullet = 85
+	energy = 15
+	laser = 35
+	melee = 35
 
 /obj/item/clothing/accessory/legguards/ablative
 	name = "ablative leg guards"
 	desc = "A pair of armored leg pads with advanced shielding to protect against energy weapons. Looks like they might impair movement."
 	icon_state = "legguards_ablative"
-	armor = list(melee = 35, bullet = 35, laser = 85, energy = 60, bomb = 25, bio = 0)
+	armor_type = /datum/armor/legguards_ablative
 	siemens_coefficient = 0
 	slowdown = 1
+
+/datum/armor/legguards_ablative
+	bomb = 25
+	bullet = 35
+	energy = 60
+	laser = 85
+	melee = 35
 
 //Decorative attachments
 /obj/item/clothing/accessory/armor/tag

--- a/code/modules/clothing/under/jobs/civilian.dm
+++ b/code/modules/clothing/under/jobs/civilian.dm
@@ -95,8 +95,13 @@
 	desc = "It's the official uniform of the janitor. It has minor protection from biohazards."
 	name = "janitor's jumpsuit"
 	icon_state = "janitor"
-	armor = list(melee = 5, bullet = 5, laser = 5, energy = 0, bomb = 0, bio = 10)
+	armor_type = /datum/armor/under_janitor
 
+/datum/armor/under_janitor
+	bio = 10
+	bullet = 5
+	laser = 5
+	melee = 5
 
 /obj/item/clothing/under/lawyer
 	desc = "Slick threads."

--- a/code/modules/clothing/under/jobs/engineering.dm
+++ b/code/modules/clothing/under/jobs/engineering.dm
@@ -5,8 +5,14 @@
 	icon_state = "chiefengineer"
 	item_state = "g_suit"
 	worn_state = "chief"
-	armor = list(melee = 10, bullet = 5, laser = 5, energy = 0, bomb = 10, bio = 0)
+	armor_type = /datum/armor/under_ce
 	siemens_coefficient = 0.6
+
+/datum/armor/under_ce
+	bomb = 10
+	bullet = 5
+	laser = 5
+	melee = 10
 
 /obj/item/clothing/under/rank/atmospheric_technician
 	desc = "It's a jumpsuit worn by atmospheric technicians."
@@ -14,7 +20,13 @@
 	icon_state = "atmos"
 	item_state = "atmos_suit"
 	worn_state = "atmos"
-	armor = list(melee = 10, bullet = 5, laser = 5, energy = 0, bomb = 10, bio = 0)
+	armor_type = /datum/armor/under_atmos
+
+/datum/armor/under_atmos
+	bomb = 5
+	bullet = 5
+	laser = 5
+	melee = 10
 
 /obj/item/clothing/under/rank/engineer
 	desc = "It's an orange high visibility jumpsuit worn by engineers. It has minor radiation shielding."
@@ -22,8 +34,13 @@
 	icon_state = "engine"
 	item_state = "engi_suit"
 	worn_state = "engine"
-	armor = list(melee = 5, bullet = 5, laser = 5, energy = 0, bomb = 0, bio = 0)
+	armor_type = /datum/armor/under_engi
 	siemens_coefficient = 0.7
+
+/datum/armor/under_engi
+	bullet = 5
+	laser = 5
+	melee = 5
 
 /obj/item/clothing/under/rank/roboticist
 	desc = "It's a slimming black jumpsuit with reinforced seams; great for industrial work."

--- a/code/modules/clothing/under/jobs/medsci.dm
+++ b/code/modules/clothing/under/jobs/medsci.dm
@@ -5,7 +5,13 @@
 	desc = "It's a jumpsuit worn by those with the know-how to achieve the position of \"Research Director\". Its fabric provides minor protection from biological contaminants."
 	name = "research director's jumpsuit"
 	icon_state = "director"
-	armor = list(melee = 5, bullet = 5, laser = 5, energy = 0, bomb = 0, bio = 10)
+	armor_type = /datum/armor/under_rd
+
+/datum/armor/under_rd
+	bio = 10
+	bullet = 5
+	laser = 5
+	melee = 5
 
 /obj/item/clothing/under/rank/research_director/rdalt
 	desc = "A dress suit and slacks stained with hard work and dedication to science. Perhaps other things as well, but mostly hard work and dedication."
@@ -14,7 +20,6 @@
 	item_state_slots = list(
 		slot_hand_str = "director"
 		)
-	armor = list(melee = 5, bullet = 5, laser = 5, energy = 0, bomb = 0, bio = 10)
 
 /obj/item/clothing/under/rank/research_director/dress_rd
 	name = "research director dress uniform"
@@ -23,7 +28,6 @@
 	item_state_slots = list(
 		slot_hand_str = "director"
 		)
-	armor = list(melee = 5, bullet = 5, laser = 5, energy = 0, bomb = 0, bio = 10)
 	body_parts_covered = UPPER_TORSO|LOWER_TORSO|ARMS
 
 /obj/item/clothing/under/rank/scientist
@@ -34,7 +38,13 @@
 		slot_hand_str = "white"
 		)
 	permeability_coefficient = 0.50
-	armor = list(melee = 5, bullet = 5, laser = 5, energy = 0, bomb = 10, bio = 0)
+	armor_type = /datum/armor/under_science
+
+/datum/armor/under_science
+	bio = 10
+	bullet = 5
+	laser = 5
+	melee = 5
 
 /obj/item/clothing/under/rank/chemist
 	desc = "It's made of a special fiber that gives special protection against biohazards. It has a chemist rank stripe on it."
@@ -44,7 +54,13 @@
 		slot_hand_str = "white"
 		)
 	permeability_coefficient = 0.50
-	armor = list(melee = 5, bullet = 5, laser = 5, energy = 0, bomb = 0, bio = 10)
+	armor_type = /datum/armor/under_chem
+
+/datum/armor/under_chem
+	bio = 10
+	bullet = 5
+	laser = 5
+	melee = 5
 
 /*
  * Medical
@@ -57,7 +73,13 @@
 		slot_hand_str = "white"
 		)
 	permeability_coefficient = 0.50
-	armor = list(melee = 5, bullet = 5, laser = 5, energy = 0, bomb = 0, bio = 10)
+	armor_type = /datum/armor/under_ce
+
+/datum/armor/under_ce
+	bio = 10
+	bullet = 5
+	laser = 5
+	melee = 5
 
 /obj/item/clothing/under/rank/geneticist
 	desc = "It's made of a special fiber that gives special protection against biohazards. It has a genetics rank stripe on it."
@@ -67,7 +89,13 @@
 		slot_hand_str = "white"
 		)
 	permeability_coefficient = 0.50
-	armor = list(melee = 5, bullet = 5, laser = 5, energy = 0, bomb = 0, bio = 10)
+	armor_type = /datum/armor/under_gen
+
+/datum/armor/under_gen
+	bio = 10
+	bullet = 5
+	laser = 5
+	melee = 5
 
 /obj/item/clothing/under/rank/virologist
 	desc = "It's made of a special fiber that gives special protection against biohazards. It has a virologist rank stripe on it."
@@ -77,15 +105,27 @@
 		slot_hand_str = "white"
 		)
 	permeability_coefficient = 0.50
-	armor = list(melee = 5, bullet = 5, laser = 5, energy = 0, bomb = 0, bio = 10)
+	armor_type = /datum/armor/under_viro
+
+/datum/armor/under_viro
+	bio = 10
+	bullet = 5
+	laser = 5
+	melee = 5
 
 /obj/item/clothing/under/rank/nursesuit
 	desc = "It's a jumpsuit commonly worn by nursing staff in the medical department."
 	name = "nurse's suit"
 	icon_state = "nursesuit"
 	permeability_coefficient = 0.50
-	armor = list(melee = 5, bullet = 5, laser = 5, energy = 0, bomb = 0, bio = 10)
+	armor_type = /datum/armor/under_nursesuit
 	body_parts_covered = UPPER_TORSO|LOWER_TORSO
+
+/datum/armor/under_nursesuit
+	bio = 10
+	bullet = 5
+	laser = 5
+	melee = 5
 
 /obj/item/clothing/under/rank/nurse
 	desc = "A dress commonly worn by the nursing staff in the medical department."
@@ -95,8 +135,14 @@
 		slot_hand_str = "nursesuit"
 		)
 	permeability_coefficient = 0.50
-	armor = list(melee = 5, bullet = 5, laser = 5, energy = 0, bomb = 0, bio = 10)
+	armor_type = /datum/armor/under_nurse
 	body_parts_covered = UPPER_TORSO|LOWER_TORSO
+
+/datum/armor/under_nurse
+	bio = 10
+	bullet = 5
+	laser = 5
+	melee = 5
 
 /obj/item/clothing/under/rank/orderly
 	desc = "A white suit to be worn by medical attendants."
@@ -106,7 +152,13 @@
 		slot_hand_str = "nursesuit"
 		)
 	permeability_coefficient = 0.50
-	armor = list(melee = 5, bullet = 5, laser = 5, energy = 0, bomb = 0, bio = 10)
+	armor_type = /datum/armor/under_ordely
+
+/datum/armor/under_ordely
+	bio = 10
+	bullet = 5
+	laser = 5
+	melee = 5
 
 /obj/item/clothing/under/rank/medical
 	desc = "It's made of a special fiber that provides minor protection against biohazards. It has a cross on the chest denoting that the wearer is trained medical personnel."
@@ -116,7 +168,13 @@
 		slot_hand_str = "white"
 		)
 	permeability_coefficient = 0.50
-	armor = list(melee = 5, bullet = 5, laser = 5, energy = 0, bomb = 0, bio = 10)
+	armor_type = /datum/armor/under_medical
+
+/datum/armor/under_medical
+	bio = 10
+	bullet = 5
+	laser = 5
+	melee = 5
 
 /obj/item/clothing/under/rank/medical/paramedic
 	name = "short sleeve medical jumpsuit"

--- a/code/modules/clothing/under/jobs/security.dm
+++ b/code/modules/clothing/under/jobs/security.dm
@@ -15,8 +15,13 @@
 	item_state_slots = list(
 		slot_hand_str = "red"
 		)
-	armor = list(melee = 20, bullet = 20, laser = 20, energy = 0, bomb = 0, bio = 0)
+	armor_type = /datum/armor/under_warden
 	siemens_coefficient = 0.8
+
+/datum/armor/under_warden
+	bullet = 20
+	laser = 20
+	melee = 20
 
 /obj/item/clothing/under/rank/security
 	name = "security officer's jumpsuit"
@@ -25,8 +30,13 @@
 	item_state_slots = list(
 		slot_hand_str = "red"
 		)
-	armor = list(melee = 20, bullet = 20, laser = 20, energy = 0, bomb = 0, bio = 0)
+	armor_type = /datum/armor/under_security
 	siemens_coefficient = 0.8
+
+/datum/armor/under_security
+	bullet = 20
+	laser = 20
+	melee = 20
 
 /obj/item/clothing/under/rank/dispatch
 	name = "dispatcher's uniform"
@@ -35,9 +45,14 @@
 	item_state_slots = list(
 		slot_hand_str = "blue"
 		)
-	armor = list(melee = 10, bullet = 5, laser = 5, energy = 0, bomb = 0, bio = 0)
+	armor_type = /datum/armor/under_dispatch
 	body_parts_covered = UPPER_TORSO|LOWER_TORSO|LEGS
 	siemens_coefficient = 0.9
+
+/datum/armor/under_dispatch
+	bullet = 5
+	laser = 5
+	melee = 10
 
 /obj/item/clothing/under/rank/security/corp
 	icon_state = "sec_corp"
@@ -66,8 +81,13 @@
 	item_state_slots = list(
 		slot_hand_str = "black"
 		)
-	armor = list(melee = 10, bullet = 5, laser = 5,energy = 0, bomb = 0, bio = 0)
+	armor_type = /datum/armor/under_tactical
 	siemens_coefficient = 0.9
+
+/datum/armor/under_tactical
+	bullet = 5
+	laser = 5
+	melee = 10
 
 /*
  * Detective
@@ -76,9 +96,14 @@
 	name = "detective's suit"
 	desc = "A rumpled white dress shirt paired with well-worn grey slacks."
 	icon_state = "detective"
-	armor = list(melee = 10, bullet = 5, laser = 5, energy = 0, bomb = 0, bio = 0)
+	armor_type = /datum/armor/under_detective
 	siemens_coefficient = 0.9
 	starting_accessories = list(/obj/item/clothing/accessory/blue_clip)
+
+/datum/armor/under_detective
+	bullet = 5
+	laser = 5
+	melee = 10
 
 /obj/item/clothing/under/det/grey
 	icon_state = "det_grey"
@@ -106,8 +131,13 @@
 	item_state_slots = list(
 		slot_hand_str = "red"
 		)
-	armor = list(melee = 20, bullet = 25, laser = 25, energy = 0, bomb = 0, bio = 0)
+	armor_type = /datum/armor/under_hos
 	siemens_coefficient = 0.7
+
+/datum/armor/under_hos
+	bullet = 25
+	laser = 25
+	melee = 20
 
 /obj/item/clothing/under/rank/head_of_security/corp
 	icon_state = "hos_corp"
@@ -134,8 +164,13 @@
 	icon_state = "secpants"
 	gender = PLURAL
 	body_parts_covered = LOWER_TORSO|LEGS
-	armor = list(melee = 20, bullet = 20, laser = 20, energy = 0, bomb = 0, bio = 0)
+	armor_type = /datum/armor/under_secpants
 	siemens_coefficient = 0.9
+
+/datum/armor/under_secpants
+	bullet = 20
+	laser = 20
+	melee = 20
 
 /obj/item/clothing/under/security_pants/equipped // Preequipped w/ a shirt
 	starting_accessories = list(/obj/item/clothing/accessory/security_shirt)

--- a/code/modules/clothing/under/miscellaneous.dm
+++ b/code/modules/clothing/under/miscellaneous.dm
@@ -21,7 +21,11 @@
 	item_state_slots = list(
 		slot_hand_str = "black"
 		)
-	armor = list(melee = 15, bullet = 10, laser = 0, energy = 0, bomb = 0, bio = 0)
+	armor_type = /datum/armor/under_gorka
+
+/datum/armor/under_gorka
+	bullet = 10
+	melee = 15
 
 /obj/item/clothing/under/gorka/mob_can_equip(mob/user)
 	.=..()
@@ -34,8 +38,11 @@
 	name = "rosa dress"
 	icon_state = "rosa"
 	permeability_coefficient = 0.50
-	armor = list(melee = 0, bullet = 0, laser = 0, energy = 0, bomb = 0, bio = 10)
+	armor_type = /datum/armor/under_rose
 	body_parts_covered = UPPER_TORSO|LOWER_TORSO
+
+/datum/armor/under_rose
+	bio = 10
 
 /obj/item/clothing/under/captain_fly
 	name = "rogue's uniform"
@@ -108,8 +115,13 @@
 	item_state_slots = list(
 		slot_hand_str = "black"
 		)
-	armor = list(melee = 10, bullet = 5, laser = 5,energy = 0, bomb = 0, bio = 0)
+	armor_type = /datum/armor/under_ert
 	siemens_coefficient = 0.9
+
+/datum/armor/under_ert
+	bullet = 5
+	laser = 5
+	melee = 10
 
 /obj/item/clothing/under/space
 	name = "\improper NASA jumpsuit"
@@ -132,7 +144,7 @@
 	gas_transfer_coefficient = 0.01
 	permeability_coefficient = 0.01
 	body_parts_covered = UPPER_TORSO|LOWER_TORSO|LEGS|FEET|ARMS|HANDS
-	armor = list(melee = 100, bullet = 100, laser = 100,energy = 100, bomb = 100, bio = 100)
+	armor_type = /datum/armor/immune
 	cold_protection = UPPER_TORSO | LOWER_TORSO | LEGS | FEET | ARMS | HANDS
 	min_cold_protection_temperature = SPACE_SUIT_MIN_COLD_PROTECTION_TEMPERATURE
 	siemens_coefficient = 0
@@ -552,8 +564,11 @@
 	desc = "A high visibility jumpsuit made from heat and radiation resistant materials."
 	icon_state = "engine"
 	siemens_coefficient = 0.8
-	armor = list(melee = 0, bullet = 0, laser = 0,energy = 0, bomb = 20, bio = 0)
+	armor_type = /datum/armor/under_hazard
 	max_heat_protection_temperature = FIRESUIT_MAX_HEAT_PROTECTION_TEMPERATURE
+
+/datum/armor/under_hazard
+	bomb = 20
 
 /obj/item/clothing/under/sterile
 	name = "sterile jumpsuit"
@@ -563,7 +578,10 @@
 		slot_hand_str = "white"
 		)
 	permeability_coefficient = 0.50
-	armor = list(melee = 0, bullet = 0, laser = 0,energy = 0, bomb = 0, bio = 30)
+	armor_type = /datum/armor/under_sterile
+
+/datum/armor/under_sterile
+	bio = 30
 
 /obj/item/clothing/under/suit_jacket/charcoal
 	name = "charcoal suit"

--- a/code/modules/clothing/under/syndicate.dm
+++ b/code/modules/clothing/under/syndicate.dm
@@ -5,7 +5,6 @@
 	item_state = "bl_suit"
 	worn_state = "syndicate"
 	has_sensor = 0
-	armor = list(melee = 0, bullet = 0, laser = 0,energy = 0, bomb = 0, bio = 0)
 	siemens_coefficient = 0.9
 
 /obj/item/clothing/under/syndicate/combat
@@ -22,7 +21,6 @@
 	icon_state = "tactifool"
 	item_state = "bl_suit"
 	worn_state = "tactifool"
-	armor = list(melee = 0, bullet = 0, laser = 0,energy = 0, bomb = 0, bio = 0)
 	siemens_coefficient = 1
 	has_sensor = SUIT_HAS_SENSORS
 

--- a/code/modules/integrated_electronics/core/assemblies.dm
+++ b/code/modules/integrated_electronics/core/assemblies.dm
@@ -38,7 +38,7 @@
 
 	var/max_integrity = 50
 	pass_flags = 0
-	armor = list("melee" = 50, "bullet" = 70, "laser" = 70, "energy" = 100, "bomb" = 10, "bio" = 100, "rad" = 100, "fire" = 0, "acid" = 0)
+	armor_type = /datum/armor/intassembly
 	anchored = FALSE
 	var/can_anchor = TRUE
 	var/detail_color = COLOR_ASSEMBLY_BLACK
@@ -60,6 +60,14 @@
 		"blue" = COLOR_ASSEMBLY_BLUE,
 		"purple" = COLOR_ASSEMBLY_PURPLE
 		)
+
+/datum/armor/intassembly
+	bio = 100
+	bomb = 10
+	bullet = 70
+	energy = 100
+	laser = 70
+	melee = 50
 
 /obj/item/device/electronic_assembly/Initialize()
 	. = ..()

--- a/code/modules/mob/grab/normal/grab_normal.dm
+++ b/code/modules/mob/grab/normal/grab_normal.dm
@@ -277,7 +277,7 @@
 	var/obj/item/clothing/head/helmet = affecting.get_equipped_item(slot_head)
 	if(istype(helmet) && (helmet.body_parts_covered & HEAD) && (helmet.item_flags & ITEM_FLAG_STOPPRESSUREDAMAGE))
 		//we don't do an armor_check here because this is not an impact effect like a weapon swung with momentum, that either penetrates or glances off.
-		damage_mod = 1.0 - (helmet.armor["melee"]/100)
+		damage_mod = 1.0 - helmet.get_armor_rating(MELEE) / 100
 
 	var/total_damage = 0
 	var/damage_flags = W.damage_flags()

--- a/code/modules/mob/grab/normal/norm_aggressive.dm
+++ b/code/modules/mob/grab/normal/norm_aggressive.dm
@@ -42,7 +42,7 @@
 		return FALSE
 	var/obj/item/clothing/C = G.affecting.head
 	if(istype(C)) //powersuit helmets etc
-		if((C.item_flags & ITEM_FLAG_STOPPRESSUREDAMAGE) && C.armor["melee"] > 20)
+		if((C.item_flags & ITEM_FLAG_STOPPRESSUREDAMAGE) && C.get_armor_rating(MELEE) > 20)
 			to_chat(G.assailant, "<span class='warning'>\The [C] is in the way!</span>")
 			return FALSE
 	return TRUE

--- a/code/modules/mob/living/carbon/human/human_defense.dm
+++ b/code/modules/mob/living/carbon/human/human_defense.dm
@@ -184,11 +184,11 @@ meteor_act
 	var/list/protective_gear = list(head, wear_mask, wear_suit, w_uniform, gloves, shoes)
 	for(var/obj/item/clothing/gear in protective_gear)
 		if(gear.body_parts_covered & def_zone.body_part)
-			protection = add_armor(protection, gear.armor[type])
+			protection = add_armor(protection, gear.get_armor_rating(type))
 		if(gear.accessories.len)
 			for(var/obj/item/clothing/accessory/bling in gear.accessories)
 				if(bling.body_parts_covered & def_zone.body_part)
-					protection = add_armor(protection, bling.armor[type])
+					protection = add_armor(protection, bling.get_armor_rating(type))
 	return protection
 
 /mob/living/carbon/human/proc/check_head_coverage()

--- a/code/modules/mob/living/carbon/human/life.dm
+++ b/code/modules/mob/living/carbon/human/life.dm
@@ -576,8 +576,8 @@
 
 // Check if we should die.
 /mob/living/carbon/human/proc/handle_death_check()
-	var/obj/item/organ/internal/biostructure/BIO = locate() in contents
-	if(BIO && src.mind && src.mind.changeling)
+	var/obj/item/organ/internal/biostructure/struct = locate() in contents
+	if(struct && src.mind && src.mind.changeling)
 		return FALSE
 	if(should_have_organ(BP_BRAIN))
 		var/obj/item/organ/internal/brain/brain = internal_organs_by_name[BP_BRAIN]

--- a/code/modules/mob/living/simple_animal/bees.dm
+++ b/code/modules/mob/living/simple_animal/bees.dm
@@ -55,9 +55,9 @@
 	var/obj/item/clothing/worn_suit = M.wear_suit
 	var/obj/item/clothing/worn_helmet = M.head
 	if(worn_suit) // Are you wearing clothes?
-		sting_prob -= min(worn_suit.armor["bio"],70) // Is it sealed? I can't get to 70% of your body.
+		sting_prob -= min(worn_suit.get_armor_rating(BIO), 70) // Is it sealed? I can't get to 70% of your body.
 	if(worn_helmet)
-		sting_prob -= min(worn_helmet.armor["bio"],30) // Is your helmet sealed? I can't get to 30% of your body.
+		sting_prob -= min(worn_helmet.get_armor_rating(BIO), 30) // Is your helmet sealed? I can't get to 30% of your body.
 	if( prob(sting_prob) && (M.stat == CONSCIOUS || (M.stat == UNCONSCIOUS && prob(25))) ) // Try to sting! If you're not moving, think about stinging.
 		M.apply_damage(min(strength,2)+mut, BRUTE) // Stinging. The more mutated I am, the harder I sting.
 		M.apply_damage((round(feral/10,1)*(max((round(strength/20,1)),1)))+toxic, TOX) // Bee venom based on how angry I am and how many there are of me!

--- a/code/modules/mob/living/simple_animal/hostile/asteroid/goliath.dm
+++ b/code/modules/mob/living/simple_animal/hostile/asteroid/goliath.dm
@@ -139,14 +139,13 @@
 	if(proximity_flag)
 		if(istype(target, /obj/item/clothing/suit/space) || istype(target, /obj/item/clothing/head/helmet/space))
 			var/obj/item/clothing/suit/space/C = target
-			var/list/current_armor = C.armor
-			if(current_armor["melee"] < 80)
-				current_armor["melee"] = min(current_armor["melee"] + 10, 80)
+			if(C.get_armor().get_armor_rating(MELEE) < 80)
+				set_armor_rating(MELEE, min(C.get_armor().get_armor_rating(MELEE) + 10, 80))
 				C.breach_threshold = min(C.breach_threshold + 2, 24)
-				to_chat(user, "<span class='info'>You strengthen [target], improving its resistance against melee attacks.</span>")
+				to_chat(user, SPAN_INFO("You strengthen \the [target], improving its resistance against melee attacks."))
 				qdel(src)
 			else
-				to_chat(user, "<span class='warning'>You can't improve [C] any further!</span>")
+				to_chat(user, SPAN_WARNING("You can't improve \the [C] any further!"))
 				return
 		if(istype(target, /obj/mecha/working/ripley))
 			var/obj/mecha/working/ripley/D = target

--- a/code/modules/organs/external/_external.dm
+++ b/code/modules/organs/external/_external.dm
@@ -143,8 +143,8 @@
 
 	QDEL_NULL_LIST(children)
 
-	var/obj/item/organ/internal/biostructure/BIO = locate() in contents
-	BIO?.change_host(get_turf(src)) // Because we don't want biostructures to get wrecked so easily
+	var/obj/item/organ/internal/biostructure/struct = locate() in contents
+	struct?.change_host(get_turf(src)) // Because we don't want biostructures to get wrecked so easily
 
 	QDEL_NULL_LIST(internal_organs)
 

--- a/code/modules/virus2/helpers.dm
+++ b/code/modules/virus2/helpers.dm
@@ -18,7 +18,7 @@
 			var/obj/item/I = M.wear_mask
 			//masks provide a small bonus and can replace overall bio protection
 			if(I)
-				score = max(score, round(0.06*I.armor["bio"]))
+				score = max(score, round(0.06 * I.get_armor_rating(BIO)))
 				if (istype(I, /obj/item/clothing/mask))
 					score += 1 //this should be added after
 
@@ -126,7 +126,7 @@
 /mob/living/carbon/human/proc/can_spread_disease()
 	for(var/obj/item/clothing/gear in list(head, wear_mask))
 		if(istype(gear) && (gear.body_parts_covered & FACE))
-			if(gear.armor["bio"] > 0)
+			if(gear.get_armor_rating(BIO) > 0)
 				return FALSE
 	return TRUE
 

--- a/code/modules/xenoarcheaology/tools/equipment.dm
+++ b/code/modules/xenoarcheaology/tools/equipment.dm
@@ -3,29 +3,49 @@
 	desc = "A suit that protects against exotic alien energies and biological contamination."
 	icon_state = "bio_anom"
 	item_state = "bio_anom"
-	armor = list(melee = 0, bullet = 0, laser = 0, energy = 0, bomb = 0, bio = 100)
+	armor_type = /datum/armor/anomalyhood
+
+/datum/armor/anomalyhood
+	bio = 100
 
 /obj/item/clothing/head/bio_hood/anomaly
 	name = "Anomaly hood"
 	desc = "A hood that protects the head and face from exotic alien energies and biological contamination."
 	icon_state = "bio_anom"
 	item_state = "bio_anom"
-	armor = list(melee = 0, bullet = 0, laser = 0, energy = 0, bomb = 0, bio = 100)
+	armor_type = /datum/armor/anomalysuit
+
+/datum/armor/anomalysuit
+	bio = 100
 
 /obj/item/clothing/suit/space/void/excavation
 	name = "excavation voidsuit"
 	desc = "A specially shielded voidsuit that insulates against some exotic alien energies, as well as the more mundane dangers of excavation."
 	icon_state = "rig-excavation"
-	armor = list(melee = 30, bullet = 0, laser = 5,energy = 40, bomb = 35, bio = 100)
+	armor_type = /datum/armor/exvoidsuit
 	allowed = list(/obj/item/device/flashlight,/obj/item/tank,/obj/item/device/suit_cooling_unit,/obj/item/stack/flag,/obj/item/storage/excavation,/obj/item/pickaxe,/obj/item/device/healthanalyzer,/obj/item/device/measuring_tape,/obj/item/device/ano_scanner,/obj/item/device/depth_scanner,/obj/item/device/core_sampler,/obj/item/device/gps,/obj/item/pinpointer/radio,/obj/item/device/radio/beacon,/obj/item/pickaxe/archaeologist/hand,/obj/item/storage/bag/fossils)
+
+/datum/armor/exvoidsuit
+	bio = 100
+	bomb = 35
+	energy = 40
+	laser = 6
+	melee = 30
 
 /obj/item/clothing/head/helmet/space/void/excavation
 	name = "excavation voidsuit helmet"
 	desc = "A sophisticated voidsuit helmet, capable of protecting the wearer from many exotic alien energies."
 	icon_state = "rig0-excavation"
 	item_state = "excavation-helm"
-	armor = list(melee = 30, bullet = 0, laser = 5,energy = 40, bomb = 35, bio = 100)
+	armor_type = /datum/armor/exhelm
 	light_overlay = "hardhat_light"
+
+/datum/armor/exhelm
+	bio = 100
+	bomb = 35
+	energy = 40
+	laser = 5
+	melee = 30
 
 /obj/item/clothing/suit/space/void/excavation/prepared
 	helmet = /obj/item/clothing/head/helmet/space/void/excavation


### PR DESCRIPTION
Вольная интерпретация на основе наработок TG Station.

### Почему это хорошо?

- Кэширование, меньше дублирования объектов - меньше нагрузка на сервер.
- Избавление от дублирования в следствие переноса брони в атом.
  `var/list/damage_absorption` - `mecha.dm`
  `var/list/armor` - `var/list/armor`

### Задачи
- [x] Реализовать датум брони.
- [x] Реализовать функции для взаимодействия с броней через атом.
- [x] Заменить `armor = list(...)` для всей одежды на `armor_type = /datum/armor/...`
⁣
- [x] Pull Request полностью завершен, мне не нужна помощь чтобы его закончить.
- [x] Я внимательно прочитал все свои изменения и багов в них не нашел.
- [ ] Я запускал сервер со своими изменениями локально и все протестировал.
- [x] Я ознакомился c [Guide to Contribute](https://github.com/ChaoticOnyx/OnyxBay/blob/dev/docs/contributing.md).
