### PR TITLE
fix(clothing.dm): correct body_parts_covered for some clothing

### DIFF
--- a/code/__defines/items_clothing.dm
+++ b/code/__defines/items_clothing.dm
@@ -106,24 +106,25 @@
 #define slot_hidden_str     "slot_hidden"
 
 // Bitflags for clothing parts.
-#define HEAD        0x1
-#define FACE        0x2
-#define EYES        0x4
-#define UPPER_TORSO 0x8
-#define LOWER_TORSO 0x10
-#define LEG_LEFT    0x20
-#define LEG_RIGHT   0x40
-#define LEGS        0x60   //  LEG_LEFT | LEG_RIGHT
-#define FOOT_LEFT   0x80
-#define FOOT_RIGHT  0x100
-#define FEET        0x180  // FOOT_LEFT | FOOT_RIGHT
-#define ARM_LEFT    0x200
-#define ARM_RIGHT   0x400
-#define ARMS        0x600 //  ARM_LEFT | ARM_RIGHT
-#define HAND_LEFT   0x800
-#define HAND_RIGHT  0x1000
-#define HANDS       0x1800 // HAND_LEFT | HAND_RIGHT
-#define FULL_BODY   0xFFFF
+#define NO_BODYPARTS	0x0
+#define HEAD			0x1
+#define FACE			0x2
+#define EYES			0x4
+#define UPPER_TORSO		0x8
+#define LOWER_TORSO		0x10
+#define LEG_LEFT		0x20
+#define LEG_RIGHT		0x40
+#define LEGS			0x60	//  LEG_LEFT | LEG_RIGHT
+#define FOOT_LEFT		0x80
+#define FOOT_RIGHT		0x100
+#define FEET			0x180	// FOOT_LEFT | FOOT_RIGHT
+#define ARM_LEFT		0x200
+#define ARM_RIGHT		0x400
+#define ARMS			0x600	//  ARM_LEFT | ARM_RIGHT
+#define HAND_LEFT		0x800
+#define HAND_RIGHT		0x1000
+#define HANDS			0x1800	// HAND_LEFT | HAND_RIGHT
+#define FULL_BODY		0xFFFF
 
 // Bitflags for the percentual amount of protection a piece of clothing which covers the body part offers.
 // Used with human/proc/get_heat_protection() and human/proc/get_cold_protection().

--- a/code/game/antagonist/outsider/abductor/equipment/abductors_gear.dm
+++ b/code/game/antagonist/outsider/abductor/equipment/abductors_gear.dm
@@ -688,7 +688,7 @@ Congratulations! You are now trained for invasive xenobiology research!"}
 	species_restricted = list(SPECIES_ABDUCTOR)
 	flags_inv = HIDEMASK|HIDEEARS|HIDEEYES|BLOCKHAIR
 	body_parts_covered = HEAD|FACE|EYES
-	visor_body_parts_covered = 0
+	visor_body_parts_covered = NO_BODYPARTS
 
 // Operating Table / Beds / Lockers
 /obj/structure/bed/abductor

--- a/code/game/antagonist/outsider/abductor/equipment/abductors_gear.dm
+++ b/code/game/antagonist/outsider/abductor/equipment/abductors_gear.dm
@@ -687,6 +687,8 @@ Congratulations! You are now trained for invasive xenobiology research!"}
 	item_state = "alienhelmet"
 	species_restricted = list(SPECIES_ABDUCTOR)
 	flags_inv = HIDEMASK|HIDEEARS|HIDEEYES|BLOCKHAIR
+	body_parts_covered = HEAD|FACE|EYES
+	visor_body_parts_covered = 0
 
 // Operating Table / Beds / Lockers
 /obj/structure/bed/abductor

--- a/code/game/gamemodes/events/holidays/Christmas.dm
+++ b/code/game/gamemodes/events/holidays/Christmas.dm
@@ -61,5 +61,5 @@
 	icon_state = "xmashat"
 	desc = "A crappy paper hat that you are REQUIRED to wear."
 	flags_inv = 0
-	body_parts_covered = 0
+	body_parts_covered = NO_BODYPARTS
 	armor = list(melee = 0, bullet = 0, laser = 0,energy = 0, bomb = 0, bio = 0)

--- a/code/game/objects/items.dm
+++ b/code/game/objects/items.dm
@@ -50,7 +50,7 @@
 	//This flag is used to determine when items in someone's inventory cover others. IE helmets making it so you can't see glasses, etc.
 	//It should be used purely for appearance. For gameplay effects caused by items covering body parts, use body_parts_covered.
 	var/flags_inv = 0
-	var/body_parts_covered = 0 //see code/__defines/items_clothing.dm for appropriate bit flags
+	var/body_parts_covered = NO_BODYPARTS //see code/__defines/items_clothing.dm for appropriate bit flags
 
 	var/item_flags = 0 //Miscellaneous flags pertaining to equippable objects.
 

--- a/code/game/objects/items/smokables/smokables.dm
+++ b/code/game/objects/items/smokables/smokables.dm
@@ -4,7 +4,7 @@
 /obj/item/clothing/mask/smokable
 	name = "smokable item"
 	desc = "You're not sure what this is. You should probably ahelp it."
-	body_parts_covered = 0
+	body_parts_covered = NO_BODYPARTS
 	icon = 'icons/obj/cigarettes.dmi'
 	var/lit = 0
 	var/ever_lit = FALSE // Has it ever been lit
@@ -76,7 +76,7 @@
 							  SPAN("danger", "[src] ignites \the [H.head] on your head. You are on fire!"))
 			H.adjust_fire_stacks(1)
 			H.IgniteMob()
-	
+
 	set_next_think(world.time + 1 SECOND)
 
 /obj/item/clothing/mask/smokable/update_icon()

--- a/code/game/objects/items/weapons/ecigs.dm
+++ b/code/game/objects/items/weapons/ecigs.dm
@@ -10,7 +10,7 @@
 	w_class = ITEM_SIZE_TINY
 	slot_flags = SLOT_EARS | SLOT_MASK
 	attack_verb = list("attacked", "poked", "battered")
-	body_parts_covered = 0
+	body_parts_covered = NO_BODYPARTS
 	var/brightness_on = 1
 	chem_volume = 0 //ecig has no storage on its own but has reagent container created by parent obj
 	item_state = "ecigoff"

--- a/code/modules/clothing/chameleon.dm
+++ b/code/modules/clothing/chameleon.dm
@@ -107,7 +107,7 @@
 	icon_state = "greysoft"
 	desc = "It looks like a plain hat, but upon closer inspection, there's an advanced holographic array installed inside. It seems to have a small dial inside."
 	origin_tech = list(TECH_ILLEGAL = 3)
-	body_parts_covered = 0
+	body_parts_covered = NO_BODYPARTS
 	var/global/list/clothing_choices
 
 /obj/item/clothing/head/chameleon/New()

--- a/code/modules/clothing/clothing.dm
+++ b/code/modules/clothing/clothing.dm
@@ -499,7 +499,7 @@ BLIND     // can't see anything
 	var/list/say_messages
 	var/list/say_verbs
 	var/down_gas_transfer_coefficient = 0
-	var/down_body_parts_covered = 0
+	var/down_body_parts_covered = NO_BODYPARTS
 	var/down_icon_state = 0
 	var/down_item_flags = 0
 	var/down_flags_inv = 0

--- a/code/modules/clothing/custom_clothing.dm
+++ b/code/modules/clothing/custom_clothing.dm
@@ -33,6 +33,7 @@
 	icon_state = "helmet_police"
 	valid_accessory_slots = null
 	body_parts_covered = HEAD|FACE|EYES //face shield
+	visor_body_parts_covered = FACE|EYES
 	armor = list(melee = 55, bullet = 55, laser = 55, energy = 25, bomb = 35, bio = 5)
 	siemens_coefficient = 0.6
 	action_button_name = "Toggle Visor"
@@ -68,9 +69,9 @@
 	icon_state = "wehrhelm"
 	valid_accessory_slots = null
 	body_parts_covered = HEAD
+	visor_body_parts_covered = 0
 	armor = list(melee = 45, bullet = 60, laser = 45,energy = 10, bomb = 40, bio = 2)
 	siemens_coefficient = 1
-	has_visor = 0
 
 //Schutze88
 

--- a/code/modules/clothing/custom_clothing.dm
+++ b/code/modules/clothing/custom_clothing.dm
@@ -69,7 +69,7 @@
 	icon_state = "wehrhelm"
 	valid_accessory_slots = null
 	body_parts_covered = HEAD
-	visor_body_parts_covered = 0
+	visor_body_parts_covered = NO_BODYPARTS
 	armor = list(melee = 45, bullet = 60, laser = 45,energy = 10, bomb = 40, bio = 2)
 	siemens_coefficient = 1
 

--- a/code/modules/clothing/glasses/glasses.dm
+++ b/code/modules/clothing/glasses/glasses.dm
@@ -70,7 +70,7 @@
 		slot_l_hand_str = "blindfold", // Looks kinda close ngl
 		slot_r_hand_str = "blindfold"
 		)
-	body_parts_covered = 0
+	body_parts_covered = NO_BODYPARTS
 	one_eyed = TRUE
 	var/flipped = FALSE // Indicates left or right eye; 0 = on the right
 
@@ -98,7 +98,7 @@
 		slot_l_hand_str = "headset",
 		slot_r_hand_str = "headset"
 		)
-	body_parts_covered = 0
+	body_parts_covered = NO_BODYPARTS
 	one_eyed = TRUE
 
 /obj/item/clothing/glasses/regular
@@ -106,7 +106,7 @@
 	desc = "Made by Nerd. Co."
 	icon_state = "glasses"
 	prescription = 7
-	body_parts_covered = 0
+	body_parts_covered = NO_BODYPARTS
 
 /obj/item/clothing/glasses/regular/scanners
 	name = "scanning goggles"
@@ -124,19 +124,19 @@
 	name = "3D glasses"
 	desc = "A long time ago, people used these glasses to makes images from screens threedimensional."
 	icon_state = "3d"
-	body_parts_covered = 0
+	body_parts_covered = NO_BODYPARTS
 
 /obj/item/clothing/glasses/gglasses
 	name = "green glasses"
 	desc = "Forest green glasses, like the kind you'd wear when hatching a nasty scheme."
 	icon_state = "gglasses"
-	body_parts_covered = 0
+	body_parts_covered = NO_BODYPARTS
 
 /obj/item/clothing/glasses/rglasses
 	name = "red glasses"
 	desc = "They make you look like a wannabe elite agent."
 	icon_state = "bigredglasses"
-	body_parts_covered = 0
+	body_parts_covered = NO_BODYPARTS
 
 /obj/item/clothing/glasses/sunglasses
 	name = "sunglasses"

--- a/code/modules/clothing/glasses/hud.dm
+++ b/code/modules/clothing/glasses/hud.dm
@@ -435,7 +435,7 @@
 
 /obj/item/clothing/glasses/hud/one_eyed
 	one_eyed = TRUE
-	body_parts_covered = 0 // Covering one eye isn't enough to protect you from eye-forking
+	body_parts_covered = NO_BODYPARTS // Covering one eye isn't enough to protect you from eye-forking
 	var/flipped = FALSE // Indicates left or right eye; FALSE = on the left
 
 /obj/item/clothing/glasses/hud/one_eyed/verb/flip_patch()

--- a/code/modules/clothing/glasses/hud_presets.dm
+++ b/code/modules/clothing/glasses/hud_presets.dm
@@ -104,7 +104,7 @@
 	icon_state = "thermoncle"
 	item_state = "thermoncle"
 	matrix = /obj/item/device/hudmatrix/thermal
-	body_parts_covered = 0 //doesn't protect eyes because it's a monocle, duh
+	body_parts_covered = NO_BODYPARTS //doesn't protect eyes because it's a monocle, duh
 
 /obj/item/clothing/glasses/hud/plain/thermal/jensen
 	name = "optical thermal implants"
@@ -117,4 +117,4 @@
 		slot_r_hand_str = "syringe_kit"
 		)
 	matrix = /obj/item/device/hudmatrix/thermal
-	body_parts_covered = 0 //don't protect eyes because, well, contacts
+	body_parts_covered = NO_BODYPARTS //don't protect eyes because, well, contacts

--- a/code/modules/clothing/gloves/color.dm
+++ b/code/modules/clothing/gloves/color.dm
@@ -27,7 +27,7 @@
 	name = "fingerless gloves"
 	desc = "A pair of fingerless gloves, they look like they belong to a soul hungry for rebellion."
 	icon_state = "color_fingerless"
-	body_parts_covered = 0	//fingerless gloves don't prevent from leaving fingerprints
+	body_parts_covered = NO_BODYPARTS	//fingerless gloves don't prevent from leaving fingerprints
 	clipped = TRUE
 	species_restricted = list("exclude", SPECIES_NABBER, SPECIES_VOX)
 

--- a/code/modules/clothing/gloves/color.dm
+++ b/code/modules/clothing/gloves/color.dm
@@ -27,6 +27,7 @@
 	name = "fingerless gloves"
 	desc = "A pair of fingerless gloves, they look like they belong to a soul hungry for rebellion."
 	icon_state = "color_fingerless"
+	body_parts_covered = 0	//fingerless gloves don't prevent from leaving fingerprints
 	armor = list(melee = 5, bullet = 5, laser = 5, energy = 0, bomb = 0, bio = 0)
 
 /obj/item/clothing/gloves/rainbow/modified

--- a/code/modules/clothing/gloves/color.dm
+++ b/code/modules/clothing/gloves/color.dm
@@ -28,7 +28,8 @@
 	desc = "A pair of fingerless gloves, they look like they belong to a soul hungry for rebellion."
 	icon_state = "color_fingerless"
 	body_parts_covered = 0	//fingerless gloves don't prevent from leaving fingerprints
-	armor = list(melee = 5, bullet = 5, laser = 5, energy = 0, bomb = 0, bio = 0)
+	clipped = TRUE
+	species_restricted = list("exclude", SPECIES_NABBER, SPECIES_VOX)
 
 /obj/item/clothing/gloves/rainbow/modified
 	item_flags = ITEM_FLAG_PREMODIFIED

--- a/code/modules/clothing/head/collectable.dm
+++ b/code/modules/clothing/head/collectable.dm
@@ -14,7 +14,7 @@
 	name = "collectable slime cap!"
 	desc = "It just latches right in place!"
 	icon_state = "slime"
-	body_parts_covered = 0
+	body_parts_covered = NO_BODYPARTS
 
 /obj/item/clothing/head/collectable/xenom
 	name = "collectable alien monster helmet!"
@@ -37,14 +37,14 @@
 	desc = "What looks like an ordinary paper hat, is actually a rare and valuable collector's edition paper hat. Keep away from water, fire and Librarians."
 	icon_state = "paper"
 	item_state = "paper"
-	body_parts_covered = 0
+	body_parts_covered = NO_BODYPARTS
 
 /obj/item/clothing/head/collectable/tophat
 	name = "collectable top hat"
 	desc = "A top hat worn by only the most prestigious hat collectors."
 	icon_state = "tophat"
 	item_state = "tophat"
-	body_parts_covered = 0
+	body_parts_covered = NO_BODYPARTS
 
 /obj/item/clothing/head/collectable/captain
 	name = "collectable captain's hat"
@@ -54,19 +54,19 @@
 		slot_l_hand_str = "caphat",
 		slot_r_hand_str = "caphat",
 		)
-	body_parts_covered = 0
+	body_parts_covered = NO_BODYPARTS
 
 /obj/item/clothing/head/collectable/police
 	name = "collectable police officer's hat"
 	desc = "A Collectable Police Officer's Hat. This hat emphasizes that you are THE LAW."
 	icon_state = "policehelm"
-	body_parts_covered = 0
+	body_parts_covered = NO_BODYPARTS
 
 /obj/item/clothing/head/collectable/beret
 	name = "collectable beret"
 	desc = "A Collectable red Beret. It smells faintly of Garlic."
 	icon_state = "beret"
-	body_parts_covered = 0
+	body_parts_covered = NO_BODYPARTS
 
 /obj/item/clothing/head/collectable/welding
 	name = "collectable welding helmet"
@@ -94,13 +94,13 @@
 	name = "collectable pirate hat"
 	desc = "You'd make a great Dread Syndie Roberts!"
 	icon_state = "pirate"
-	body_parts_covered = 0
+	body_parts_covered = NO_BODYPARTS
 
 /obj/item/clothing/head/collectable/kitty
 	name = "collectable kitty ears"
 	desc = "The fur feels.....a bit too realistic."
 	icon_state = "kitty"
-	body_parts_covered = 0
+	body_parts_covered = NO_BODYPARTS
 
 /obj/item/clothing/head/collectable/kitty/equipped(mob/living/carbon/human/user, slot)
 	. = ..()
@@ -117,7 +117,7 @@
 	name = "collectable rabbit ears"
 	desc = "Not as lucky as the feet!"
 	icon_state = "bunny"
-	body_parts_covered = 0
+	body_parts_covered = NO_BODYPARTS
 
 /obj/item/clothing/head/collectable/wizard
 	name = "collectable wizard's hat"
@@ -129,13 +129,13 @@
 	desc = "WARNING! Offers no real protection, or luminosity, but it is damn fancy!"
 	icon_state = "hardhat0_yellow"
 	w_class = ITEM_SIZE_NORMAL
-	body_parts_covered = 0
+	body_parts_covered = NO_BODYPARTS
 
 /obj/item/clothing/head/collectable/HoS
 	name = "collectable HoS hat"
 	desc = "Now you can beat prisoners, set silly sentences and arrest for no reason too!"
 	icon_state = "hoscap"
-	body_parts_covered = 0
+	body_parts_covered = NO_BODYPARTS
 
 /obj/item/clothing/head/collectable/thunderdome
 	name = "collectable Thunderdome helmet"

--- a/code/modules/clothing/head/helmet.dm
+++ b/code/modules/clothing/head/helmet.dm
@@ -85,7 +85,7 @@
 	valid_accessory_slots = null
 	flags_inv = HIDEMASK|HIDEEARS|HIDEEYES|BLOCKHAIR
 	body_parts_covered = HEAD|FACE
-	visor_body_parts_covered = 0
+	visor_body_parts_covered = NO_BODYPARTS
 	siemens_coefficient = 1
 
 /obj/item/clothing/head/helmet/captain
@@ -94,7 +94,7 @@
 	item_state = "caphelmet"
 	desc = "A special extra-durable helmet designed for the most fashionable of military figureheads."
 	body_parts_covered = HEAD|EYES
-	visor_body_parts_covered = 0
+	visor_body_parts_covered = NO_BODYPARTS
 	flags_inv = HIDEFACE|BLOCKHAIR
 	armor = list(melee = 65, bullet = 65, laser = 65,energy = 35, bomb = 45, bio = 10)
 	siemens_coefficient = 0.5
@@ -106,7 +106,7 @@
 	desc = "An in-atmosphere helmet worn by NanoTrasen's elite Emergency Response Teams. Has blue highlights."
 	icon_state = "erthelmet_cmd"
 	body_parts_covered = HEAD|EYES
-	visor_body_parts_covered = 0
+	visor_body_parts_covered = NO_BODYPARTS
 	valid_accessory_slots = null
 	item_state_slots = list(
 		slot_l_hand_str = "syndicate-helm-green",
@@ -139,7 +139,7 @@
 	desc = "They're often used by highly trained SWAT Members."
 	icon_state = "swat"
 	body_parts_covered = HEAD|EYES
-	visor_body_parts_covered = 0
+	visor_body_parts_covered = NO_BODYPARTS
 	armor = list(melee = 85, bullet = 85, laser = 85,energy = 55, bomb = 50, bio = 50)
 	cold_protection = HEAD
 	min_cold_protection_temperature = SPACE_HELMET_MIN_COLD_PROTECTION_TEMPERATURE
@@ -153,7 +153,7 @@
 	armor = list(melee = 70, bullet = 60, laser = 50,energy = 25, bomb = 50, bio = 10)
 	flags_inv = HIDEEARS|HIDEEYES
 	body_parts_covered = HEAD|EYES|BLOCKHEADHAIR
-	visor_body_parts_covered = 0
+	visor_body_parts_covered = NO_BODYPARTS
 	cold_protection = HEAD
 	min_cold_protection_temperature = SPACE_HELMET_MIN_COLD_PROTECTION_TEMPERATURE
 	siemens_coefficient = 0.4
@@ -172,7 +172,7 @@
 	desc = "<i>'Let the battle commence!'</i>"
 	icon_state = "thunderdome"
 	body_parts_covered = HEAD
-	visor_body_parts_covered = 0
+	visor_body_parts_covered = NO_BODYPARTS
 	valid_accessory_slots = null
 	armor = list(melee = 80, bullet = 60, laser = 50,energy = 10, bomb = 25, bio = 10)
 	cold_protection = HEAD

--- a/code/modules/clothing/head/helmet.dm
+++ b/code/modules/clothing/head/helmet.dm
@@ -9,7 +9,7 @@
 	valid_accessory_slots = list(ACCESSORY_SLOT_HELM_C)
 	restricted_accessory_slots = list(ACCESSORY_SLOT_HELM_C)
 	item_flags = ITEM_FLAG_THICKMATERIAL
-	body_parts_covered = HEAD
+	body_parts_covered = HEAD|EYES
 	armor = list(melee = 50, bullet = 50, laser = 50, energy = 25, bomb = 35, bio = 0)
 	flags_inv = HIDEEARS|BLOCKHEADHAIR
 	cold_protection = HEAD
@@ -18,7 +18,7 @@
 	max_heat_protection_temperature = HELMET_MAX_HEAT_PROTECTION_TEMPERATURE
 	siemens_coefficient = 0.6
 	w_class = ITEM_SIZE_NORMAL
-	var/has_visor = 1
+	var/visor_body_parts_covered = EYES //body parts covered by visor, switches them if you switch visor
 	ear_protection = 1
 	rad_resist = list(
 		RADIATION_ALPHA_PARTICLE = 25 MEGA ELECTRONVOLT,
@@ -27,18 +27,20 @@
 	)
 
 /obj/item/clothing/head/helmet/attack_self(mob/user)
-	if(has_visor)
+	if(visor_body_parts_covered)
 		togglevisor(user)
 	else
 		..()
 
 /obj/item/clothing/head/helmet/proc/togglevisor(mob/user)
 	if(icon_state == initial(icon_state))
-		src.icon_state = "[icon_state]_up"
-		to_chat(user, "You raise the visor on the [src].")
+		icon_state = "[icon_state]_up"
+		to_chat(user, "You raise the visor on \the [src].")
+		body_parts_covered &= ~visor_body_parts_covered
 	else
 		icon_state = initial(icon_state)
-		to_chat(user, "You lower the visor on the [src].")
+		to_chat(user, "You lower the visor on \the [src].")
+		body_parts_covered |= visor_body_parts_covered
 	add_fingerprint(user)
 	update_clothing_icon()
 
@@ -51,6 +53,7 @@
 	icon_state = "helmet_riot"
 	valid_accessory_slots = null
 	body_parts_covered = HEAD|FACE|EYES //face shield
+	visor_body_parts_covered = FACE|EYES
 	armor = list(melee = 85, bullet = 50, laser = 50, energy = 25, bomb = 35, bio = 5)
 	siemens_coefficient = 0.5
 	action_button_name = "Toggle Visor"
@@ -60,6 +63,8 @@
 	desc = "A helmet made from advanced materials which protects against concentrated energy weapons."
 	icon_state = "helmet_reflect"
 	valid_accessory_slots = null
+	body_parts_covered = HEAD|EYES
+	visor_body_parts_covered = EYES
 	armor = list(melee = 50, bullet = 50, laser = 90, energy = 60, bomb = 35, bio = 2)
 	siemens_coefficient = 0
 
@@ -68,6 +73,8 @@
 	desc = "A helmet with reinforced plating to protect against ballistic projectiles."
 	icon_state = "helmet_bulletproof"
 	valid_accessory_slots = null
+	body_parts_covered = HEAD|EYES
+	visor_body_parts_covered = EYES
 	armor = list(melee = 50, bullet = 90, laser = 50, energy = 5, bomb = 35, bio = 2)
 	siemens_coefficient = 0.6
 
@@ -78,18 +85,19 @@
 	valid_accessory_slots = null
 	flags_inv = HIDEMASK|HIDEEARS|HIDEEYES|BLOCKHAIR
 	body_parts_covered = HEAD|FACE
+	visor_body_parts_covered = 0
 	siemens_coefficient = 1
-	has_visor = 0
 
 /obj/item/clothing/head/helmet/captain
 	name = "captain's helmet"
 	icon_state = "caphelmet"
 	item_state = "caphelmet"
 	desc = "A special extra-durable helmet designed for the most fashionable of military figureheads."
+	body_parts_covered = HEAD|EYES
+	visor_body_parts_covered = 0
 	flags_inv = HIDEFACE|BLOCKHAIR
 	armor = list(melee = 65, bullet = 65, laser = 65,energy = 35, bomb = 45, bio = 10)
 	siemens_coefficient = 0.5
-	has_visor = 0
 
 //Non-powersuit ERT helmets.
 //Commander
@@ -97,6 +105,8 @@
 	name = "ERT commander helmet"
 	desc = "An in-atmosphere helmet worn by NanoTrasen's elite Emergency Response Teams. Has blue highlights."
 	icon_state = "erthelmet_cmd"
+	body_parts_covered = HEAD|EYES
+	visor_body_parts_covered = 0
 	valid_accessory_slots = null
 	item_state_slots = list(
 		slot_l_hand_str = "syndicate-helm-green",
@@ -104,7 +114,6 @@
 		)
 	armor = list(melee = 62, bullet = 50, laser = 50,energy = 35, bomb = 10, bio = 2)
 	siemens_coefficient = 0.5
-	has_visor = 0
 
 //Security
 /obj/item/clothing/head/helmet/ert/security
@@ -129,11 +138,12 @@
 	name = "\improper SWAT helmet"
 	desc = "They're often used by highly trained SWAT Members."
 	icon_state = "swat"
+	body_parts_covered = HEAD|EYES
+	visor_body_parts_covered = 0
 	armor = list(melee = 85, bullet = 85, laser = 85,energy = 55, bomb = 50, bio = 50)
 	cold_protection = HEAD
 	min_cold_protection_temperature = SPACE_HELMET_MIN_COLD_PROTECTION_TEMPERATURE
 	siemens_coefficient = 0.3
-	has_visor = 0
 
 /obj/item/clothing/head/helmet/augment
 	name = "Augment Array"
@@ -143,15 +153,17 @@
 	armor = list(melee = 70, bullet = 60, laser = 50,energy = 25, bomb = 50, bio = 10)
 	flags_inv = HIDEEARS|HIDEEYES
 	body_parts_covered = HEAD|EYES|BLOCKHEADHAIR
+	visor_body_parts_covered = 0
 	cold_protection = HEAD
 	min_cold_protection_temperature = SPACE_HELMET_MIN_COLD_PROTECTION_TEMPERATURE
 	siemens_coefficient = 0.4
-	has_visor = 0
 
 /obj/item/clothing/head/helmet/syndi
 	name = "heavy helmet"
 	desc = "A heavily reinforced helmet painted with red markings. Feels like it could take a lot of punishment."
 	icon_state = "helmet_merc"
+	body_parts_covered = HEAD|EYES
+	visor_body_parts_covered = EYES
 	armor = list(melee = 75, bullet = 75, laser = 75, energy = 50, bomb = 50, bio = 50)
 	siemens_coefficient = 0.4
 
@@ -159,9 +171,10 @@
 	name = "\improper Thunderdome helmet"
 	desc = "<i>'Let the battle commence!'</i>"
 	icon_state = "thunderdome"
+	body_parts_covered = HEAD
+	visor_body_parts_covered = 0
 	valid_accessory_slots = null
 	armor = list(melee = 80, bullet = 60, laser = 50,energy = 10, bomb = 25, bio = 10)
 	cold_protection = HEAD
 	min_cold_protection_temperature = SPACE_HELMET_MIN_COLD_PROTECTION_TEMPERATURE
 	siemens_coefficient = 1
-	has_visor = 0

--- a/code/modules/clothing/head/jobs.dm
+++ b/code/modules/clothing/head/jobs.dm
@@ -101,7 +101,7 @@
 	name = "beret"
 	desc = "A beret, an artists favorite headwear."
 	icon_state = "beret"
-	body_parts_covered = 0
+	body_parts_covered = NO_BODYPARTS
 	armor = list(melee = 5, bullet = 5, laser = 5,energy = 0, bomb = 0, bio = 0)
 
 /obj/item/clothing/head/beret/sec

--- a/code/modules/clothing/head/jobs.dm
+++ b/code/modules/clothing/head/jobs.dm
@@ -225,7 +225,7 @@
 	name = "warden's hat"
 	desc = "It's a special helmet issued to the Warden of a securiy force."
 	icon_state = "policehelm"
-	body_parts_covered = 0
+	body_parts_covered = NO_BODYPARTS
 
 /obj/item/clothing/head/warden/drill
 	name = "warden's drill hat"

--- a/code/modules/clothing/head/misc.dm
+++ b/code/modules/clothing/head/misc.dm
@@ -359,9 +359,9 @@
 	tint = TINT_BLIND
 	flags_inv = HIDEMASK|HIDEEARS|HIDEEYES|HIDEFACE|BLOCKHAIR
 	body_parts_covered = HEAD|FACE|EYES
+	visor_body_parts_covered = 0
 	flash_protection = FLASH_PROTECTION_MAJOR
 	armor = list(melee = 20, bullet = 10, laser = 10,energy = 5, bomb = 5, bio = 0)
-	has_visor = 0
 
 /obj/item/clothing/head/rasta
 	name = "rasta hat"

--- a/code/modules/clothing/head/misc.dm
+++ b/code/modules/clothing/head/misc.dm
@@ -9,7 +9,7 @@
 		)
 	desc = "It's good to be emperor."
 	siemens_coefficient = 0.9
-	body_parts_covered = 0
+	body_parts_covered = NO_BODYPARTS
 	armor = list(melee = 10, bullet = 5, laser = 5,energy = 0, bomb = 0, bio = 0)
 
 /obj/item/clothing/head/hairflower
@@ -17,7 +17,7 @@
 	icon_state = "hairflower"
 	desc = "Smells nice."
 	slot_flags = SLOT_HEAD | SLOT_EARS
-	body_parts_covered = 0
+	body_parts_covered = NO_BODYPARTS
 
 /obj/item/clothing/head/hairflower/blue
 	icon_state = "hairflower_blue"
@@ -57,21 +57,21 @@
 	icon_state = "tophat"
 	item_state = "tophat"
 	siemens_coefficient = 0.9
-	body_parts_covered = 0
+	body_parts_covered = NO_BODYPARTS
 	armor = list(melee = 5, bullet = 5, laser = 5,energy = 0, bomb = 0, bio = 0)
 
 /obj/item/clothing/head/redcoat
 	name = "redcoat's hat"
 	icon_state = "redcoat"
 	desc = "<i>'I guess it's a redhead.'</i>"
-	body_parts_covered = 0
+	body_parts_covered = NO_BODYPARTS
 	armor = list(melee = 10, bullet = 5, laser = 5,energy = 0, bomb = 0, bio = 0)
 
 /obj/item/clothing/head/mailman
 	name = "mail cap"
 	icon_state = "mailman"
 	desc = "<i>Choo-choo</i>!"
-	body_parts_covered = 0
+	body_parts_covered = NO_BODYPARTS
 
 /obj/item/clothing/head/plaguedoctorhat
 	name = "plague doctor's hat"
@@ -79,7 +79,7 @@
 	icon_state = "plaguedoctor"
 	permeability_coefficient = 0.01
 	siemens_coefficient = 0.9
-	body_parts_covered = 0
+	body_parts_covered = NO_BODYPARTS
 	armor = list(melee = 5, bullet = 5, laser = 5,energy = 0, bomb = 0, bio = 0)
 
 /obj/item/clothing/head/hasturhood
@@ -94,7 +94,7 @@
 	desc = "It allows quick identification of trained medical personnel."
 	icon_state = "nursehat"
 	siemens_coefficient = 0.9
-	body_parts_covered = 0
+	body_parts_covered = NO_BODYPARTS
 
 /obj/item/clothing/head/syndicatefake
 	name = "red space-helmet replica"
@@ -154,7 +154,7 @@
 	name = "rabbit ears"
 	desc = "Wearing these makes you looks useless, and only good for your sex appeal."
 	icon_state = "bunny"
-	body_parts_covered = 0
+	body_parts_covered = NO_BODYPARTS
 
 /obj/item/clothing/head/flatcap
 	name = "flat cap"
@@ -171,21 +171,21 @@
 	name = "pirate hat"
 	desc = "Yarr."
 	icon_state = "pirate"
-	body_parts_covered = 0
+	body_parts_covered = NO_BODYPARTS
 	armor = list(melee = 5, bullet = 5, laser = 5,energy = 0, bomb = 0, bio = 0)
 
 /obj/item/clothing/head/hgpiratecap
 	name = "pirate hat"
 	desc = "Yarr."
 	icon_state = "hgpiratecap"
-	body_parts_covered = 0
+	body_parts_covered = NO_BODYPARTS
 	armor = list(melee = 10, bullet = 5, laser = 5,energy = 0, bomb = 0, bio = 0)
 
 /obj/item/clothing/head/bandana
 	name = "pirate bandana"
 	desc = "Yarr."
 	icon_state = "bandana"
-	body_parts_covered = 0
+	body_parts_covered = NO_BODYPARTS
 	armor = list(melee = 5, bullet = 0, laser = 0,energy = 0, bomb = 0, bio = 0)
 
 /obj/item/clothing/head/bandana/green
@@ -203,7 +203,7 @@
 	name = "bowler-hat"
 	desc = "Gentleman, elite aboard!"
 	icon_state = "bowler"
-	body_parts_covered = 0
+	body_parts_covered = NO_BODYPARTS
 	armor = list(melee = 5, bullet = 5, laser = 5,energy = 0, bomb = 0, bio = 0)
 
 //stylish bs12 hats
@@ -212,7 +212,7 @@
 	name = "bowler hat"
 	icon_state = "bowler_hat"
 	desc = "For the gentleman of distinction."
-	body_parts_covered = 0
+	body_parts_covered = NO_BODYPARTS
 	armor = list(melee = 5, bullet = 5, laser = 5,energy = 0, bomb = 0, bio = 0)
 
 /obj/item/clothing/head/beaverhat
@@ -298,7 +298,7 @@
 		slot_r_hand_str = "pwig",
 		)
 	flags_inv = BLOCKHAIR
-	body_parts_covered = 0
+	body_parts_covered = NO_BODYPARTS
 	armor = list(melee = 5, bullet = 5, laser = 0,energy = 0, bomb = 0, bio = 0)
 
 /obj/item/clothing/head/hijab
@@ -312,14 +312,14 @@
 	name = "kippa"
 	desc = "A small, brimless cap."
 	icon_state = "kippa"
-	body_parts_covered = 0
+	body_parts_covered = NO_BODYPARTS
 	armor = list(melee = 5, bullet = 0, laser = 0,energy = 0, bomb = 0, bio = 0)
 
 /obj/item/clothing/head/turban
 	name = "turban"
 	desc = "A sturdy cloth, worn around the head."
 	icon_state = "turban"
-	body_parts_covered = 0
+	body_parts_covered = NO_BODYPARTS
 	flags_inv = BLOCKHEADHAIR //Shows beards!
 	armor = list(melee = 10, bullet = 5, laser = 5,energy = 0, bomb = 0, bio = 0)
 
@@ -335,7 +335,7 @@
 	desc = "A short, rounded skullcap usually worn for religious purposes."
 	icon_state = "taqiyah"
 	item_state = "taqiyah"
-	body_parts_covered = 0
+	body_parts_covered = NO_BODYPARTS
 	armor = list(melee = 5, bullet = 0, laser = 0,energy = 0, bomb = 0, bio = 0)
 
 /obj/item/clothing/head/tank
@@ -359,7 +359,7 @@
 	tint = TINT_BLIND
 	flags_inv = HIDEMASK|HIDEEARS|HIDEEYES|HIDEFACE|BLOCKHAIR
 	body_parts_covered = HEAD|FACE|EYES
-	visor_body_parts_covered = 0
+	visor_body_parts_covered = NO_BODYPARTS
 	flash_protection = FLASH_PROTECTION_MAJOR
 	armor = list(melee = 20, bullet = 10, laser = 10,energy = 5, bomb = 5, bio = 0)
 

--- a/code/modules/clothing/head/misc_special.dm
+++ b/code/modules/clothing/head/misc_special.dm
@@ -236,7 +236,7 @@
 	desc = "A pair of kitty ears. Meow!"
 	icon_state = "kitty"
 	slot_flags = SLOT_HEAD | SLOT_EARS
-	body_parts_covered = 0
+	body_parts_covered = NO_BODYPARTS
 	siemens_coefficient = 1.5
 	item_icons = list()
 
@@ -265,7 +265,7 @@
 	name = "Tinfoil hat"
 	desc = "Big brother is watching you!"
 	icon_state = "foilhat"
-	body_parts_covered = 0
+	body_parts_covered = NO_BODYPARTS
 	armor = list(melee = 0, bullet = 0, laser = 5, energy = 5, bomb = 0, bio = 0)
 	rad_resist = list(
 		RADIATION_ALPHA_PARTICLE = 30 MEGA ELECTRONVOLT,

--- a/code/modules/clothing/masks/gasmask.dm
+++ b/code/modules/clothing/masks/gasmask.dm
@@ -111,7 +111,7 @@
 /obj/item/clothing/mask/gas/swat/vox
 	name = "alien mask"
 	desc = "Clearly not designed for a human face."
-	body_parts_covered = 0 //Hack to allow vox to eat while wearing this mask.
+	body_parts_covered = NO_BODYPARTS //Hack to allow vox to eat while wearing this mask.
 	species_restricted = list(SPECIES_VOX)
 
 /obj/item/clothing/mask/gas/syndicate
@@ -187,7 +187,7 @@
 	icon_state = "respirator"
 	istinted = 0
 	flags_inv = 0
-	body_parts_covered = 0
+	body_parts_covered = NO_BODYPARTS
 	species_restricted = list(SPECIES_VOX)
 	filtered_gases = list("plasma", "sleeping_agent", "oxygen")
 

--- a/code/modules/clothing/masks/miscellaneous.dm
+++ b/code/modules/clothing/masks/miscellaneous.dm
@@ -60,7 +60,7 @@
 	desc = "Warning: moustache is fake."
 	icon_state = "fake-moustache"
 	flags_inv = HIDEFACE
-	body_parts_covered = 0
+	body_parts_covered = NO_BODYPARTS
 	visible_name = "Scoundrel"
 
 /obj/item/clothing/mask/snorkel
@@ -68,14 +68,14 @@
 	desc = "For the Swimming Savant."
 	icon_state = "snorkel"
 	flags_inv = HIDEFACE
-	body_parts_covered = 0
+	body_parts_covered = NO_BODYPARTS
 
 /obj/item/clothing/mask/bluescarf
 	name = "blue neck scarf"
 	desc = "A blue neck scarf."
 	icon_state = "blueneckscarf"
 	item_state = "blueneckscarf"
-	body_parts_covered = 0
+	body_parts_covered = NO_BODYPARTS
 	item_flags = 0
 	w_class = ITEM_SIZE_SMALL
 
@@ -84,7 +84,7 @@
 	desc = "Weaboo mask."
 	icon_state = "uwu"
 	item_state = "uwu"
-	body_parts_covered = 0
+	body_parts_covered = NO_BODYPARTS
 	item_flags = 0
 	w_class = ITEM_SIZE_SMALL
 
@@ -93,7 +93,7 @@
 	desc = "A red and white checkered neck scarf."
 	icon_state = "redwhite_scarf"
 	item_state = "redwhite_scarf"
-	body_parts_covered = 0
+	body_parts_covered = NO_BODYPARTS
 	item_flags = 0
 	w_class = ITEM_SIZE_SMALL
 
@@ -102,7 +102,7 @@
 	desc = "A green neck scarf."
 	icon_state = "green_scarf"
 	item_state = "green_scarf"
-	body_parts_covered = 0
+	body_parts_covered = NO_BODYPARTS
 	w_class = ITEM_SIZE_SMALL
 
 /obj/item/clothing/mask/ninjascarf
@@ -110,7 +110,7 @@
 	desc = "A stealthy, dark scarf."
 	icon_state = "ninja_scarf"
 	item_state = "ninja_scarf"
-	body_parts_covered = 0
+	body_parts_covered = NO_BODYPARTS
 	w_class = ITEM_SIZE_SMALL
 
 /obj/item/clothing/mask/sbluescarf
@@ -118,7 +118,7 @@
 	desc = "A stripped blue neck scarf."
 	icon_state = "sblue_scarf"
 	item_state = "sblue_scarf"
-	body_parts_covered = 0
+	body_parts_covered = NO_BODYPARTS
 	w_class = ITEM_SIZE_SMALL
 
 /obj/item/clothing/mask/sgreenscarf
@@ -126,7 +126,7 @@
 	desc = "A stripped green neck scarf."
 	icon_state = "sgreen_scarf"
 	item_state = "sgreen_scarf"
-	body_parts_covered = 0
+	body_parts_covered = NO_BODYPARTS
 	w_class = ITEM_SIZE_SMALL
 
 /obj/item/clothing/mask/sredscarf
@@ -134,7 +134,7 @@
 	desc = "A stripped red neck scarf."
 	icon_state = "sred_scarf"
 	item_state = "sred_scarf"
-	body_parts_covered = 0
+	body_parts_covered = NO_BODYPARTS
 	w_class = ITEM_SIZE_SMALL
 
 /obj/item/clothing/mask/redscarf

--- a/code/modules/clothing/masks/miscellaneous.dm
+++ b/code/modules/clothing/masks/miscellaneous.dm
@@ -142,7 +142,7 @@
 	desc = "A red neck scarf."
 	icon_state = "red_scarf"
 	item_state = "red_scarf"
-	body_parts_covered = 0
+	body_parts_covered = NO_BODYPARTS
 	w_class = ITEM_SIZE_SMALL
 
 /obj/item/clothing/mask/ai

--- a/code/modules/clothing/shoes/miscellaneous.dm
+++ b/code/modules/clothing/shoes/miscellaneous.dm
@@ -51,7 +51,7 @@
 	name = "sandals"
 	icon_state = "wizard"
 	species_restricted = null
-	body_parts_covered = 0
+	body_parts_covered = NO_BODYPARTS
 	siemens_coefficient = 1.0
 
 	wizard_garb = 1

--- a/code/modules/clothing/spacesuits/miscellaneous.dm
+++ b/code/modules/clothing/spacesuits/miscellaneous.dm
@@ -25,7 +25,7 @@
 	armor = list(melee = 60, bullet = 50, laser = 30,energy = 15, bomb = 30, bio = 30)
 	flags_inv = BLOCKHAIR
 	body_parts_covered = HEAD
-	visor_body_parts_covered = 0
+	visor_body_parts_covered = NO_BODYPARTS
 	siemens_coefficient = 0.9
 
 /obj/item/clothing/suit/space/pirate

--- a/code/modules/clothing/spacesuits/miscellaneous.dm
+++ b/code/modules/clothing/spacesuits/miscellaneous.dm
@@ -24,9 +24,9 @@
 	item_state = "pirate"
 	armor = list(melee = 60, bullet = 50, laser = 30,energy = 15, bomb = 30, bio = 30)
 	flags_inv = BLOCKHAIR
-	body_parts_covered = 0
+	body_parts_covered = HEAD
+	visor_body_parts_covered = 0
 	siemens_coefficient = 0.9
-	has_visor = 0
 
 /obj/item/clothing/suit/space/pirate
 	name = "pirate coat"

--- a/code/modules/clothing/spacesuits/rig/rig_pieces.dm
+++ b/code/modules/clothing/spacesuits/rig/rig_pieces.dm
@@ -11,7 +11,6 @@
 	cold_protection =    HEAD|FACE|EYES
 	brightness_on = 4
 	species_restricted = null
-	has_visor = 0
 
 	rad_resist = list(
 		RADIATION_ALPHA_PARTICLE = 80.9 MEGA ELECTRONVOLT,

--- a/code/modules/clothing/spacesuits/spacesuits.dm
+++ b/code/modules/clothing/spacesuits/spacesuits.dm
@@ -16,7 +16,7 @@
 	armor = list(melee = 0, bullet = 0, laser = 0,energy = 0, bomb = 0, bio = 100)
 	flags_inv = HIDEMASK|HIDEEARS|HIDEEYES|HIDEFACE|BLOCKHAIR
 	body_parts_covered = HEAD|FACE|EYES
-	visor_body_parts_covered = 0
+	visor_body_parts_covered = NO_BODYPARTS
 	cold_protection = HEAD
 	min_cold_protection_temperature = SPACE_HELMET_MIN_COLD_PROTECTION_TEMPERATURE
 	siemens_coefficient = 0.9

--- a/code/modules/clothing/spacesuits/spacesuits.dm
+++ b/code/modules/clothing/spacesuits/spacesuits.dm
@@ -16,6 +16,7 @@
 	armor = list(melee = 0, bullet = 0, laser = 0,energy = 0, bomb = 0, bio = 100)
 	flags_inv = HIDEMASK|HIDEEARS|HIDEEYES|HIDEFACE|BLOCKHAIR
 	body_parts_covered = HEAD|FACE|EYES
+	visor_body_parts_covered = 0
 	cold_protection = HEAD
 	min_cold_protection_temperature = SPACE_HELMET_MIN_COLD_PROTECTION_TEMPERATURE
 	siemens_coefficient = 0.9
@@ -23,7 +24,6 @@
 	randpixel = 0
 	species_restricted = list("exclude", SPECIES_NABBER, SPECIES_DIONA, "Xenomorph")
 	flash_protection = FLASH_PROTECTION_MAJOR
-	has_visor = 0
 
 	var/obj/machinery/camera/camera
 

--- a/code/modules/clothing/suits/jobs.dm
+++ b/code/modules/clothing/suits/jobs.dm
@@ -9,7 +9,7 @@
 	icon_state = "apron"
 	item_state = "apron"
 	blood_overlay_type = "armorblood"
-	body_parts_covered = 0
+	body_parts_covered = NO_BODYPARTS
 	allowed = list (/obj/item/reagent_containers/spray/plantbgone,/obj/item/device/analyzer/plant_analyzer,/obj/item/seeds,/obj/item/reagent_containers/vessel/bottle/chemical,/obj/item/material/minihoe)
 
 //Captain
@@ -72,7 +72,7 @@
 	icon_state = "apronchef"
 	item_state = "apronchef"
 	blood_overlay_type = "armorblood"
-	body_parts_covered = 0
+	body_parts_covered = NO_BODYPARTS
 
 //Security
 /obj/item/clothing/suit/security/navyofficer

--- a/code/modules/clothing/suits/miscellaneous.dm
+++ b/code/modules/clothing/suits/miscellaneous.dm
@@ -230,7 +230,7 @@
 
 //stripper
 /obj/item/clothing/under/stripper
-	body_parts_covered = 0
+	body_parts_covered = NO_BODYPARTS
 
 /obj/item/clothing/under/stripper/stripper_pink
 	name = "pink swimsuit"
@@ -277,7 +277,7 @@
 //swimsuit
 /obj/item/clothing/under/swimsuit/
 	siemens_coefficient = 1
-	body_parts_covered = 0
+	body_parts_covered = NO_BODYPARTS
 
 /obj/item/clothing/under/swimsuit/black
 	name = "black swimsuit"

--- a/code/modules/clothing/suits/wiz_robe.dm
+++ b/code/modules/clothing/suits/wiz_robe.dm
@@ -8,7 +8,7 @@
 		)
 	//Not given any special protective value since the magic robes are full-body protection --NEO
 	siemens_coefficient = 0.8
-	body_parts_covered = 0
+	body_parts_covered = NO_BODYPARTS
 	wizard_garb = 1
 
 /obj/item/clothing/head/wizard/red

--- a/code/modules/clothing/under/miscellaneous.dm
+++ b/code/modules/clothing/under/miscellaneous.dm
@@ -624,7 +624,7 @@
 	icon_state = "gear_harness"
 	worn_state = "gear_harness"
 	species_restricted = null
-	body_parts_covered = 0
+	body_parts_covered = NO_BODYPARTS
 
 /obj/item/clothing/under/grayson
 	name = "\improper Grayson overalls"


### PR DESCRIPTION
- Беспальцевые перчатки больше не предотвращают от оставления отпечатков. (Из-за этого пришлось пожертвовать наличием брони). Ксеносам больше не нужно их обрезать, чтобы надеть.
- Поправил шляпу пирата, которая раньше не закрывала ни одну часть тела. Теперь она закрывает голову.
- Исправил пропадающие спрайты у шлема абдуктора из-за невыпиленной возможности переключить забрало.
- Теперь шлема закрывают части тела соответственно спрайту. Таким образом, шлем с опущенным забралом защищает от удара отвёрткой в глаза и не защищает, если забрало поднято. Точно так же омоновский шлем закрывает или не закрывает всё лицо.

fix #3316 

<details>
<summary>Чейнджлог</summary>

```yml
🆑
bugfix: Руки в беспальцевых перчатках теперь оставляют отпечатки.
bugfix: Шляпа пирата теперь защищает голову своего носителя.
bugfix: Спрайт шлема абдуктора больше не пропадает.
bugfix: Шлемы с опущенным забралом теперь защищают от ударов в глаза.
bugfix: Шлем для разгона демонстраций больше не защищает глаза и лицо, если забрало поднято.
/🆑
```

</details>

- [x] Pull Request полностью завершен, мне не нужна помощь чтобы его закончить.
- [x] Я внимательно прочитал все свои изменения и багов в них не нашел.
- [x] Я запускал сервер со своими изменениями локально и все протестировал.
- [x] Я ознакомился c [Guide to Contribute](https://github.com/ChaoticOnyx/OnyxBay/blob/dev/docs/contributing.md).
