### PR TITLE
fix(antaghud): correct path to co-antagonist icons

### DIFF
--- a/code/game/antagonist/antagonist_update.dm
+++ b/code/game/antagonist/antagonist_update.dm
@@ -31,7 +31,7 @@
 	if(!antag_indicator || !other.current || !recipient.current)
 		return
 	var/indicator = (faction_indicator && (other in faction_members)) ? faction_indicator : antag_indicator
-	return image('icons/mob/huds/hud.dmi', loc = other.current, icon_state = indicator, layer = ABOVE_HUMAN_LAYER)
+	return image('icons/mob/huds/antag_hud.dmi', loc = other.current, icon_state = indicator, layer = ABOVE_HUMAN_LAYER)
 
 /datum/antagonist/proc/update_all_icons()
 	if(!antag_indicator)


### PR DESCRIPTION
Во время дебаг сессии ХУДов мною был замечен следующий баг - исправляю.

![dreamseeker_pzp92ZKYuw](https://github.com/ChaoticOnyx/OnyxBay/assets/118671019/877a6412-119c-41f3-b2cc-bcc537e16c81)

close #10331

- [x] Pull Request полностью завершен, мне не нужна помощь чтобы его закончить.
- [x] Я внимательно прочитал все свои изменения и багов в них не нашел.
- [x] Я запускал сервер со своими изменениями локально и все протестировал.
- [x] Я ознакомился c [Guide to Contribute](https://github.com/ChaoticOnyx/OnyxBay/blob/dev/docs/contributing.md).
