### PR TITLE
fix(typing_indicator): update typing indicator logic & fix ghost overlays

### DIFF
--- a/code/modules/mob/mob_defines.dm
+++ b/code/modules/mob/mob_defines.dm
@@ -206,3 +206,12 @@
 	var/list/alerts = list()
 
 	var/is_view_shifted = FALSE
+
+	/// Icon state name for speech bubble
+	var/bubble_icon = "default"
+	/// Icon used for the typing indicator's bubble
+	var/active_typing_indicator
+	/// Icon used for the thinking inicator's bubble
+	var/active_thinking_indicator
+	/// Is user typing in character
+	var/thinking_IC = FALSE

--- a/code/modules/mob/mob_defines.dm
+++ b/code/modules/mob/mob_defines.dm
@@ -215,3 +215,5 @@
 	var/active_thinking_indicator
 	/// Is user typing in character
 	var/thinking_IC = FALSE
+	/// Whether typing indicator sould be shown
+	var/thinking_silent = FALSE

--- a/code/modules/mob/observer/ghost/ghost.dm
+++ b/code/modules/mob/observer/ghost/ghost.dm
@@ -688,6 +688,10 @@ This is the proc mobs get to turn into a ghost. Forked from ghostize due to comp
 	plane = pre_plane
 	layer = pre_layer
 	opacity = pre_opacity
+
+	overlays -= target.active_typing_indicator
+	overlays -= target.active_thinking_indicator
+
 	set_invisibility(pre_invis)
 	ClearTransform()	//make goast stand up
 

--- a/code/modules/mob/typing_indicator.dm
+++ b/code/modules/mob/typing_indicator.dm
@@ -1,20 +1,20 @@
-// Adds a typing indicator over the mob.
+/// Adds a typing indicator over the mob.
 /mob/proc/create_typing_indicator()
 	return
 
-// Removes the typing indicator over the mob.
+/// Removes the typing indicator over the mob.
 /mob/proc/remove_typing_indicator()
 	return
 
-// Adds a thinking indicator over the mob.
+/// Adds a thinking indicator over the mob.
 /mob/proc/create_thinking_indicator()
 	return
 
-// Removes the thinking indicator over the mob.
+/// Removes the thinking indicator over the mob.
 /mob/proc/remove_thinking_indicator()
 	return
 
-// Removes all indicators and marks mob as not speaking IC.
+/// Removes all indicators and marks mob as not speaking IC.
 /mob/proc/remove_all_indicators()
 	return
 

--- a/code/modules/mob/typing_indicator.dm
+++ b/code/modules/mob/typing_indicator.dm
@@ -1,3 +1,7 @@
+/// Checks whether a typing indicator should be created, 'FALSE' by default
+/mob/proc/should_show_typing_indicator()
+	return FALSE
+
 /// Adds a typing indicator over the mob.
 /mob/proc/create_typing_indicator()
 	return
@@ -33,6 +37,7 @@
 	if (return_content)
 		. = winget(src, "saywindow.saywindow-input", "text")
 	winset(src, "saywindow.saywindow-input", "text=\"\"")
+	mob.thinking_silent = FALSE
 	mob.remove_speech_bubble()
 
 /mob/verb/add_speech_bubble(is_sayinput as num|null)
@@ -40,6 +45,8 @@
 	set hidden = TRUE
 
 	ASSERT(client && src == usr)
+
+	thinking_silent = should_show_typing_indicator()
 
 	if(is_sayinput)
 		thinking_IC = TRUE
@@ -83,14 +90,9 @@
 	if(message)
 		me_verb(message)
 
-/mob/proc/should_show_indicator()
-	if(!client)
-		return FALSE
-	return (get_preference_value(/datum/client_preference/show_typing_indicator) == GLOB.PREF_SHOW) == (client.shift_released_at <= world.time - 2)
-
 /mob/proc/start_typing()
 	remove_thinking_indicator()
-	if(!thinking_IC || !should_show_indicator())
+	if(!thinking_IC || thinking_silent)
 		return FALSE
 	create_typing_indicator()
 
@@ -98,9 +100,15 @@
 	if(!src)
 		return FALSE
 	remove_typing_indicator()
-	if(!thinking_IC || !should_show_indicator())
+	if(!thinking_IC || thinking_silent)
 		return FALSE
 	create_thinking_indicator()
+
+/mob/living/should_show_typing_indicator()
+	if(!client)
+		return FALSE
+	var/pref = cmptext(get_preference_value("SHOW_TYPING"), GLOB.PREF_SHOW)
+	return client.shift_released_at <= world.time - 2 ? !pref : pref
 
 /mob/living/create_thinking_indicator()
 	if(active_thinking_indicator || active_typing_indicator || !thinking_IC || stat != CONSCIOUS)

--- a/code/modules/mob/typing_indicator.dm
+++ b/code/modules/mob/typing_indicator.dm
@@ -50,8 +50,7 @@
 	if(findtext(text, "Say ", 1, 5))
 		thinking_IC = TRUE
 		start_typing()
-	else
-		remove_all_indicators()
+		return
 
 /mob/verb/remove_speech_bubble()
 	set name = ".remove_speech_bubble"
@@ -59,7 +58,19 @@
 
 	ASSERT(client && src == usr)
 
-	stop_typing()
+	var/visible = winget(usr, "saywindow", "is-visible")
+	if(cmptext(visible, "true"))
+		stop_typing()
+		return
+
+	var/focus = winget(usr, ":input", "focus")
+	if(cmptext(focus, "false"))
+		var/text = winget(usr, ":input", "text")
+		if(findtext(text, "Say ", 1, 5) && length(text) > 5)
+			stop_typing()
+			return
+
+	remove_all_indicators()
 
 /mob/verb/me_wrapper()
 	set name = ".Me"

--- a/code/modules/mob/typing_indicator.dm
+++ b/code/modules/mob/typing_indicator.dm
@@ -1,16 +1,3 @@
-// TO-DO: move all mob variables to one file 'cause it's cringe. - N
-/mob
-	// Icon state name for speech bubble.
-	var/bubble_icon = "default"
-
-	// Icon used for the typing indicator's bubble.
-	var/active_typing_indicator
-	// Icon used for the thinking inicator's bubble.
-	var/active_thinking_indicator
-
-	// Is user typing in character.
-	var/thinking_IC = FALSE
-
 // Adds a typing indicator over the mob.
 /mob/proc/create_typing_indicator()
 	return

--- a/code/modules/mob/typing_indicator.dm
+++ b/code/modules/mob/typing_indicator.dm
@@ -37,7 +37,6 @@
 	if (return_content)
 		. = winget(src, "saywindow.saywindow-input", "text")
 	winset(src, "saywindow.saywindow-input", "text=\"\"")
-	mob.thinking_silent = FALSE
 	mob.remove_speech_bubble()
 
 /mob/verb/add_speech_bubble(is_sayinput as num|null)

--- a/code/modules/mob/typing_indicator.dm
+++ b/code/modules/mob/typing_indicator.dm
@@ -33,7 +33,7 @@
 	if (return_content)
 		. = winget(src, "saywindow.saywindow-input", "text")
 	winset(src, "saywindow.saywindow-input", "text=\"\"")
-	mob.remove_all_indicators()
+	mob.remove_speech_bubble()
 
 /mob/verb/add_speech_bubble(is_sayinput as num|null)
 	set name = ".add_speech_bubble"


### PR DESCRIPTION
Переписал логику работы облачков, так как старый код перестал правильно работать в новых условиях. 
- Индикатор появляется, когда строка ввода в фокусе и пропадает при расфокусе, если в строке нет сообщения т.е просто `Say "`.
- Если во время ввода сообщения через строку было использовано окно, то при выполнении условия выше индикатор не пропадет.
- Индикатор ввода не появляется, если до переключения фокуса на окно была нажата кнопка `Shift`.

Исправил перенос облачков на призраков при внезапной смерти или использовании "aghost".

<details>
<summary>Чейнджлог</summary>

```yml
🆑
tweak: облачко появляется, когда строка ввода в фокусе и пропадает при расфокусе, если в строке нет сообщения т.е просто `Say "`.
tweak: тихий ввод теперь возможен через строку ввода, для этого нужно нажать "Shift" перед ее выбором.
bugfix: исправлен перенос облачка на призрака при использовании "aghost" или внезапной смерти.
/🆑
```

</details>

- [x] Pull Request полностью завершен, мне не нужна помощь чтобы его закончить.
- [x] Я внимательно прочитал все свои изменения и багов в них не нашел.
- [x] Я запускал сервер со своими изменениями локально и все протестировал.
- [x] Я ознакомился c [Guide to Contribute](https://github.com/ChaoticOnyx/OnyxBay/blob/dev/docs/contributing.md).
