### PR TITLE
feat(robot): add radial menu for hull selection

### DIFF
--- a/code/_helpers/global_access.dm
+++ b/code/_helpers/global_access.dm
@@ -679,8 +679,6 @@
 			return global.robot_hud_colours;
 		if("robot_inventory")
 			return global.robot_inventory;
-		if("robot_modules")
-			return global.robot_modules;
 		if("round_start_time")
 			return global.round_start_time;
 		if("roundstart_hour")
@@ -1548,8 +1546,6 @@
 			global.robot_hud_colours=newval;
 		if("robot_inventory")
 			global.robot_inventory=newval;
-		if("robot_modules")
-			global.robot_modules=newval;
 		if("round_start_time")
 			global.round_start_time=newval;
 		if("roundstart_hour")
@@ -2100,7 +2096,6 @@
 	"rkeys",
 	"robot_hud_colours",
 	"robot_inventory",
-	"robot_modules",
 	"round_start_time",
 	"roundstart_hour",
 	"rune_list",

--- a/code/datums/robot_hulls.dm
+++ b/code/datums/robot_hulls.dm
@@ -1,14 +1,12 @@
 /datum/robot_hull
-	var/icon_state = ""
-	var/footstep_sound = null
+	var/icon = 'icons/mob/robots.dmi'
+	var/icon_state = "robot"
+	var/footstep_sound = SFX_FOOTSTEP_ROBOT_SPIDER
 
-/datum/robot_hull/custom
-	var/icon
-
-/datum/robot_hull/custom/New(state = "robot", footstep = SFX_FOOTSTEP_ROBOT_SPIDER, cstm_icon = CUSTOM_ITEM_ROBOTS)
-	icon_state = state
-	footstep_sound = footstep
-	icon = cstm_icon
+/datum/robot_hull/New(icon, icon_state, footstep_sound)
+	src.icon = icon ? icon : initial(src.icon)
+	src.icon_state = icon_state ? icon_state : initial(src.icon_state)
+	src.footstep_sound = footstep_sound ? footstep_sound : initial(src.footstep_sound)
 
 /datum/robot_hull/spider
 	footstep_sound = SFX_FOOTSTEP_ROBOT_SPIDER

--- a/code/modules/mob/living/silicon/robot/login.dm
+++ b/code/modules/mob/living/silicon/robot/login.dm
@@ -11,7 +11,5 @@
 	else
 		winset(src, null, "mainwindow.macro=borgmacro hotkey_toggle.is-checked=false input.focus=true input.background-color=#d3b5b5")
 
-
-	// Forces synths to select an icon relevant to their module
-	if(!icon_selected)
-		choose_hull(icon_selection_tries, module_hulls)
+	if(!icon_chosen)
+		set_custom_sprite()

--- a/code/modules/mob/living/silicon/robot/login.dm
+++ b/code/modules/mob/living/silicon/robot/login.dm
@@ -12,4 +12,4 @@
 		winset(src, null, "mainwindow.macro=borgmacro hotkey_toggle.is-checked=false input.focus=true input.background-color=#d3b5b5")
 
 	if(!icon_chosen)
-		set_custom_sprite()
+		choose_hull(module_hulls)

--- a/code/modules/mob/living/silicon/robot/robot.dm
+++ b/code/modules/mob/living/silicon/robot/robot.dm
@@ -17,20 +17,23 @@
 	var/used_power_this_tick = 0
 	var/sight_mode = 0
 	var/custom_name = ""
-	var/custom_sprite = TRUE //Due to all the sprites involved, a var for our custom borgs may be best
-	var/original_icon = 'icons/mob/robots.dmi'
 	var/crisis //Admin-settable for combat module use.
 	var/crisis_override = 0
 	var/integrated_light_max_bright = 0.75
 	var/datum/wires/robot/wires
 
+	/// Whether this type of robot supports custom icons
+	var/custom_sprite = TRUE
+
 //Icon stuff
 
 	var/static/list/eye_overlays
-	var/icontype 				//Persistent icontype tracking allows for cleaner icon updates
-	var/module_hulls[0] 		//Used to store the associations between sprite names and hull datum.
-	var/icon_selected = 1		//If icon selection has been completed yet
-	var/icon_selection_tries = 0//Remaining attempts to select icon before a selection is forced
+	/// Key used to look up an appropriate hull datum in the `module_hulls`
+	var/icontype
+	/// Whether this mob've chosen a custom icon
+	var/icon_chosen = FALSE
+	/// List of avaliable robot hulls
+	var/datum/robot_hull/module_hulls[0]
 
 //Hud stuff
 
@@ -107,12 +110,12 @@
 		/mob/living/silicon/robot/proc/ResetSecurityCodes
 	)
 
-/mob/living/silicon/robot/New(loc,unfinished = 0)
+/mob/living/silicon/robot/New(loc, unfinished = 0)
 	spark_system = new /datum/effect/effect/system/spark_spread()
 	spark_system.set_up(5, 0, src)
 	spark_system.attach(src)
 
-	add_language("Robot Talk", 1)
+	add_language(LANGUAGE_ROBOT, 1)
 	add_language(LANGUAGE_EAL, 1)
 
 	wires = new(src)
@@ -121,11 +124,11 @@
 	robot_modules_background.icon = 'icons/hud/common/screen_storage.dmi'
 	robot_modules_background.icon_state = "block"
 	ident = random_id(/mob/living/silicon/robot, 1, 999)
+
 	module_hulls["Basic"] = new /datum/robot_hull/spider/robot
-	icontype = "Basic"
-	footstep_sound = module_hulls[icontype].footstep_sound
+	apply_hull("Basic")
+
 	updatename(modtype)
-	update_icon()
 
 	if(!scrambledcodes && !camera)
 		camera = new /obj/machinery/camera(src)
@@ -264,6 +267,24 @@
 	QDEL_NULL(cell)
 	return ..()
 
+/mob/living/silicon/robot/proc/apply_hull(new_icontype)
+	if(!(new_icontype in module_hulls))
+		return
+
+	var/datum/robot_hull/new_hull = module_hulls[new_icontype]
+	var/list/icon_states = icon_states(new_hull.icon)
+	if(!(new_hull.icon_state in icon_states))
+		return
+
+	icontype = new_icontype
+	icon = new_hull.icon
+	icon_state = new_hull.icon_state
+	footstep_sound = new_hull.footstep_sound
+
+	update_icon()
+
+	return TRUE
+
 /mob/living/silicon/robot/proc/set_module_hulls(list/new_sprites)
 	if(length(new_sprites))
 		module_hulls = new_sprites.Copy()
@@ -280,15 +301,7 @@
 					if(module_hulls[sprite_state])
 						qdel(module_hulls[sprite_state])
 						module_hulls[sprite_state] = null
-					module_hulls[sprite_state] = new /datum/robot_hull/custom(sprite_state, footstep, CUSTOM_ITEM_ROBOTS)
-		else
-			icontype = module_hulls[1]
-		if(!(icontype in module_hulls))
-			icontype = module_hulls[1]
-			icon = original_icon
-		icon_state = module_hulls[icontype].icon_state
-		footstep_sound = module_hulls[icontype].footstep_sound
-	update_icon()
+					module_hulls[sprite_state] = new /datum/robot_hull(CUSTOM_ITEM_ROBOTS, sprite_state, footstep)
 	return module_hulls
 
 /mob/living/silicon/robot/proc/choose_module()
@@ -301,7 +314,7 @@
 	if((crisis && security_state.current_security_level_is_same_or_higher_than(security_state.high_security_level)) || crisis_override) //Leaving this in until it's balanced appropriately.
 		to_chat(src, SPAN("warning", "Crisis mode active. Combat module available."))
 		modules += "Combat"
-	selected_module = input("Please, select a module!", "Robot module", null, null) as null|anything in modules
+	selected_module = tgui_input_list(src, "Please, select a module!", "Module Selection", modules)
 	if(!(selected_module in GLOB.robot_module_types))
 		return
 	setup_module()
@@ -339,7 +352,6 @@
 	else
 		braintype = "Cyborg"
 
-
 	var/changed_name = ""
 	if(custom_name)
 		changed_name = custom_name
@@ -358,9 +370,6 @@
 	//We also need to update name of internal camera.
 	if (camera)
 		camera.c_tag = changed_name
-
-	if(custom_sprite) //Check for custom sprite
-		set_custom_sprite()
 
 	//Flavour text.
 	if(client)
@@ -831,6 +840,12 @@
 				eye_overlays[eye_icon_state] = eye_overlay
 			overlays += eye_overlay
 
+		if(active_typing_indicator)
+			overlays |= active_typing_indicator
+
+		if(active_thinking_indicator)
+			overlays |= active_thinking_indicator
+
 	if(opened)
 		var/panelprefix = custom_sprite ? module_hulls[icontype] : "ov"
 		if(wiresexposed)
@@ -1088,40 +1103,33 @@
 
 	return
 
-/mob/living/silicon/robot/proc/choose_hull(triesleft, list/module_hulls)
-	if(!module_hulls.len)
-		to_chat(src, "Something is badly wrong with the sprite selection. Harass a coder.")
-		return
+/mob/living/silicon/robot/proc/choose_hull(list/module_hulls)
+	if(!length(module_hulls))
+		to_chat(src, FONT_HUGE("Something is badly wrong with the sprite selection. Please report this to local developer."))
+		return FALSE
+
+	icon_chosen = FALSE
+	set_custom_sprite()
+
 	set_module_hulls(module_hulls)
-	icon_selected = 0
-	src.icon_selection_tries = triesleft
-	if(module_hulls.len == 1 || !client)
-		if(!(icontype in module_hulls))
-			icontype = module_hulls[1]
-	else
-		icontype = input(src,"Select an icon! [triesleft ? "You have [triesleft] more chance\s." : "This is your last try."]", "Robot Icon", icontype) in module_hulls
-	footstep_sound = module_hulls[icontype].footstep_sound
-	icon_state = module_hulls[icontype].icon_state
-	if(istype(module_hulls[icontype], /datum/robot_hull/custom))
-		icon = module_hulls[icontype].icon
-		if(!icon)
-			icon = original_icon
-			icontype = module_hulls[1]
-	var/list/valid_states = icon_states(icon)
-	if(!(icon_state in valid_states))
-		icon = original_icon
-	update_icon()
 
-	if (module_hulls.len > 1 && triesleft >= 1 && client)
-		icon_selection_tries--
-		var/choice = input(src,"Look at your icon - is this what you want?") in list("Yes","No")
-		if(choice=="No")
-			choose_hull(icon_selection_tries, module_hulls)
-			return
+	if(!client || length(module_hulls) == 1)
+		apply_hull(module_hulls[1])
+		icon_chosen = TRUE
+		return TRUE
 
-	icon_selected = 1
-	icon_selection_tries = 0
-	to_chat(src, "Your icon has been set. You now require a module reset to change it.")
+	var/list/icontypes
+	for(var/hull_key as anything in module_hulls)
+		LAZYADDASSOC(icontypes, hull_key, image(module_hulls[hull_key].icon, module_hulls[hull_key].icon_state))
+
+	var/radius = 32 * (1 + 0.05 * clamp(length(icontypes), 0, 8))
+	var/new_icontype = show_radial_menu(src, src, icontypes, radius = radius)
+	apply_hull(new_icontype)
+	icon_chosen = TRUE
+
+	to_chat(src, SPAN_NOTICE("Your icon has been set. You now require a module reset to change it."))
+	return TRUE
+
 /mob/living/silicon/robot/proc/sensor_mode() //Medical/Security HUD controller for borgs
 	set name = "Set Sensor Augmentation"
 	set category = "Silicon Commands"

--- a/code/modules/mob/living/silicon/robot/robot.dm
+++ b/code/modules/mob/living/silicon/robot/robot.dm
@@ -840,12 +840,6 @@
 				eye_overlays[eye_icon_state] = eye_overlay
 			overlays += eye_overlay
 
-		if(active_typing_indicator)
-			overlays |= active_typing_indicator
-
-		if(active_thinking_indicator)
-			overlays |= active_thinking_indicator
-
 	if(opened)
 		var/panelprefix = custom_sprite ? module_hulls[icontype] : "ov"
 		if(wiresexposed)

--- a/code/modules/mob/living/silicon/robot/robot.dm
+++ b/code/modules/mob/living/silicon/robot/robot.dm
@@ -328,7 +328,7 @@
 	sensor_mode = 0
 	active_hud = null
 
-	var/module_type = robot_modules[modtype]
+	var/module_type = GLOB.robot_modules[modtype]
 	new module_type(src)
 	if(modtype != "Standard")
 		GLOB.robot_module_types.Remove(modtype)

--- a/code/modules/mob/living/silicon/robot/robot_modules.dm
+++ b/code/modules/mob/living/silicon/robot/robot_modules.dm
@@ -1,4 +1,4 @@
-var/global/list/robot_modules = list(
+GLOBAL_LIST_INIT(robot_modules, list(
 	"Standard"		= /obj/item/robot_module/standard,
 	"Service" 		= /obj/item/robot_module/service/butler,
 	"Research" 		= /obj/item/robot_module/research/general,
@@ -11,7 +11,7 @@ var/global/list/robot_modules = list(
 	"Advanced Medical"		= /obj/item/robot_module/medical/crisis_adv,
 	"Advanced Engineering"	= /obj/item/robot_module/engineering/adv,
 	"Advanced Miner"		= /obj/item/robot_module/miner/adv
-	)
+))
 
 /obj/item/robot_module
 	name = "robot module"

--- a/code/modules/mob/living/silicon/robot/robot_modules.dm
+++ b/code/modules/mob/living/silicon/robot/robot_modules.dm
@@ -55,6 +55,7 @@ var/global/list/robot_modules = list(
 	var/list/original_languages = list()
 	var/list/added_networks = list()
 	var/appointed_huds = list("Disable", "Security", "Medical")
+
 /obj/item/robot_module/New(mob/living/silicon/robot/R)
 	..()
 	if (!istype(R))
@@ -71,7 +72,7 @@ var/global/list/robot_modules = list(
 		R.silicon_radio.recalculateChannels()
 
 	R.set_module_hulls(hulls)
-	R.choose_hull(R.module_hulls.len + 1, R.module_hulls)
+	R.choose_hull(R.module_hulls)
 
 	for(var/obj/item/I in modules)
 		I.canremove = 0
@@ -84,7 +85,7 @@ var/global/list/robot_modules = list(
 
 	if(R.silicon_radio)
 		R.silicon_radio.recalculateChannels()
-	R.choose_hull(0, R.set_module_hulls(list(
+	R.choose_hull(R.set_module_hulls(list(
 		"Default" = new /datum/robot_hull/spider/robot
 		)))
 

--- a/code/modules/mob/living/silicon/robot/robot_upgrades.dm
+++ b/code/modules/mob/living/silicon/robot/robot_upgrades.dm
@@ -82,7 +82,7 @@
 			qdel(R.module)
 			R.module = null
 		R.drop_all_upgrades()
-		var/module_type = robot_modules[module]
+		var/module_type = GLOB.robot_modules[module]
 		new module_type(R)
 		R.modtype = module
 		R.hands.icon_state = lowertext(module)


### PR DESCRIPTION
- Добавлено радиальное меню выбора корпусов для роботов.
- Убрал примерку, так как она не нужна в условиях **визуальной** репрезентации спрайтов на экранах игроков, о чем было сказано еще в прошлой реализации.
- Кастомный спрайт применяется при первом заходе игрока в моба, если во время выбора модуля был выбран один из базовых корпусов, то он не перезаписывается насильно.
- Причесал код, отвечающий за применение корпусов на роботов. Добавил проверки на отсутствие иконок, убрал излишнее дублирование.
- Перенес выбор профессии роботов на TGUI input.

<details>
<summary>Демонстрация</summary>


![dreamseeker_MOb4Ryqxlt](https://github.com/ChaoticOnyx/OnyxBay/assets/118671019/082041e5-1cbc-4b45-92f1-72de2b61ad07)

![dreamseeker_1LgES0BtfG](https://github.com/ChaoticOnyx/OnyxBay/assets/118671019/5a3dff85-e041-4cac-a42c-abd4d4f93206)

![dreamseeker_0cuUckU0Lp](https://github.com/ChaoticOnyx/OnyxBay/assets/118671019/9a4c11c7-c8e1-4118-ab3c-33cc0b784447)


</details>

<details>
<summary>Чейнджлог</summary>

```yml
🆑
rscadd: меню выбора корпуса роботов теперь радиальное.
tweak: меню выбора профессии роботов переведено на TGUI input.
/🆑
```

</details>

close #8346

- [x] Pull Request полностью завершен, мне не нужна помощь чтобы его закончить.
- [x] Я внимательно прочитал все свои изменения и багов в них не нашел.
- [x] Я запускал сервер со своими изменениями локально и все протестировал.
- [x] Я ознакомился c [Guide to Contribute](https://github.com/ChaoticOnyx/OnyxBay/blob/dev/docs/contributing.md).
