### PR TITLE
refact(examinate): examinate proc

### DIFF
--- a/code/_onclick/click.dm
+++ b/code/_onclick/click.dm
@@ -269,7 +269,7 @@
 	A.ShiftClick(src)
 	return
 /atom/proc/ShiftClick(mob/user)
-	if(user.client && (src in view(user.client.eye)))
+	if(user.client)
 		user.examinate(src)
 
 	return

--- a/code/modules/examine/examine.dm
+++ b/code/modules/examine/examine.dm
@@ -70,7 +70,7 @@
 //override examinate verb to update description holders when things are examined
 /mob/examinate(atom/A)
 	if(..())
-		return 1
+		return TRUE
 
 	var/is_antag = ((mind && mind.special_role) || isghost(src)) //ghosts don't have minds
 	if(client)

--- a/code/modules/examine/examine.dm
+++ b/code/modules/examine/examine.dm
@@ -68,7 +68,7 @@
 			stat(null,"<font color='#8a0808'><b>[client.description_holders["antag"]]</b></font>") //Red, malicious antag-related text
 
 //override examinate verb to update description holders when things are examined
-/mob/examinate(atom/A as mob|obj|turf in view(src.client.eye))
+/mob/examinate(atom/A)
 	if(..())
 		return 1
 

--- a/code/modules/mob/living/parasite/meme.dm
+++ b/code/modules/mob/living/parasite/meme.dm
@@ -68,13 +68,10 @@ be able to influence the host through various commands.
 	set name = "Examine"
 	set category = "IC"
 
+	return examinate(A)
+
 /mob/living/parasite/meme/examinate(atom/A)
-	if(is_blind(host) || usr.stat)
-		to_chat(src,"Something is there but you can't see it.")
-		return TRUE
-
-	A.examine(src)
-
+	host.examinate(A)
 
 /mob/living/parasite/meme/New(mob/living/carbon/human/host)
 	..()

--- a/code/modules/mob/living/parasite/meme.dm
+++ b/code/modules/mob/living/parasite/meme.dm
@@ -64,13 +64,14 @@ be able to influence the host through various commands.
 	var/list/indoctrinated = list()
 
 
-/mob/living/parasite/meme/examinate(atom/A as mob|obj|turf in view(host))
+/mob/living/parasite/meme/examinate_verb(atom/A as mob|obj|turf in view(host))
 	set name = "Examine"
 	set category = "IC"
 
+/mob/living/parasite/meme/examinate(atom/A)
 	if(is_blind(host) || usr.stat)
 		to_chat(src,"Something is there but you can't see it.")
-		return 1
+		return TRUE
 
 	A.examine(src)
 

--- a/code/modules/mob/mob.dm
+++ b/code/modules/mob/mob.dm
@@ -276,13 +276,20 @@
 	return
 
 //mob verbs are faster than object verbs. See http://www.byond.com/forum/?post=1326139&page=2#comment8198716 for why this isn't atom/verb/_examine_text()
-/mob/verb/examinate(atom/A as mob|obj|turf in view(src.client.eye))
+/mob/verb/examinate_verb(atom/A as mob|obj|turf in view(src.client.eye))
 	set name = "Examine"
 	set category = "IC"
 
+	return examinate(A)
+
+/mob/proc/examinate(atom/A)
 	if((is_blind(src) || usr?.stat) && !isobserver(src))
-		to_chat(src, "<span class='notice'>Something is there but you can't see it.</span>")
-		return 1
+		to_chat(src, SPAN("notice", "Something is there but you can't see it."))
+		return TRUE
+
+	if(isturf(A) && !(sight & SEE_TURFS) && !(A in view(client ? client.view : world.view, src)))
+		// shift-click catcher may issue examinate() calls for out-of-sight turfs
+		return FALSE
 
 	var/examine_result
 

--- a/code/modules/mob/mob.dm
+++ b/code/modules/mob/mob.dm
@@ -283,7 +283,7 @@
 	return examinate(A)
 
 /mob/proc/examinate(atom/A)
-	if((is_blind(src) || usr?.stat) && !isobserver(src))
+	if((is_blind(src) || (usr?.stat != CONSCIOUS)) && !isobserver(src))
 		to_chat(src, SPAN("notice", "Something is there but you can't see it."))
 		return TRUE
 
@@ -300,7 +300,7 @@
 		if(fake)
 			examine_result = fake.examine(src)
 
-	if (isnull(examine_result))
+	if(isnull(examine_result))
 		examine_result = A.examine(src)
 
 	to_chat(usr, examine_result)

--- a/code/modules/mob/observer/freelook/eye.dm
+++ b/code/modules/mob/observer/freelook/eye.dm
@@ -40,7 +40,7 @@
 	set_dir(ndir)
 	return 1
 
-/mob/observer/eye/examinate()
+/mob/observer/eye/examinate_verb()
 	set popup_menu = 0
 	set src = usr.contents
 	return 0

--- a/code/modules/mob/observer/freelook/eye.dm
+++ b/code/modules/mob/observer/freelook/eye.dm
@@ -43,7 +43,7 @@
 /mob/observer/eye/examinate_verb()
 	set popup_menu = 0
 	set src = usr.contents
-	return 0
+	return FALSE
 
 /mob/observer/eye/pointed()
 	set popup_menu = 0


### PR DESCRIPTION
Отделил процедуру examinate от верба examinate, который теперь называется examinate_verb
Зачем это нужно?
Во-первых, теперь наконец-то стал возможным осмотр содержимого рюкзака и содержимого содержащихся в нём коробок. Также корректно стал работать осмотр в том случае, если моб находится в шкафу, мехе и тд.
Во-вторых, это не возвращает возможности нечестного examinate с помощью введения команды в чат по атомам, которых нет в поле зрения игрока, т.к. examinate_verb всё ещё требует от цели нахождения в пределах зрения.
В-третьих, это необходимо для осмотра мобов (и возможно в перспективе чего-нибудь ещё) в опенспейсах. (смотри #10284 )

<details>
<summary>Чейнджлог</summary>

```yml
🆑
bugfix: Вы снова можете осматривать содержимое рюкзака и содержимое содержащихся в нём контейнеров.
/🆑
```

</details>

- [x] Pull Request полностью завершен, мне не нужна помощь чтобы его закончить.
- [x] Я внимательно прочитал все свои изменения и багов в них не нашел.
- [x] Я запускал сервер со своими изменениями локально и все протестировал.
- [x] Я ознакомился c [Guide to Contribute](https://github.com/ChaoticOnyx/OnyxBay/blob/dev/docs/contributing.md).
