### PR TITLE
fix(muzzled_say)

### DIFF
--- a/code/modules/mob/living/carbon/human/say.dm
+++ b/code/modules/mob/living/carbon/human/say.dm
@@ -150,10 +150,20 @@
 	if(silent || (sdisabilities & MUTE))
 		message_data["message"] = ""
 		. = TRUE
-
-	else if(istype(wear_mask, /obj/item/clothing/mask))
+	else if(wear_mask)
 		var/obj/item/clothing/mask/M = wear_mask
-		if(M.voicechange)
+		if(is_muzzled() && !(message_data["language"]?.flags & (NONVERBAL|SIGNLANG)))
+			if(istype(M, /obj/item/clothing/mask))
+				if(M.say_messages)
+					message_data["message"] = pick(M.say_messages)
+				if(M.say_verbs)
+					message_data["verb"] = pick(M.say_verbs)
+				. = TRUE
+			else
+				message_data["message"] = pick("Mmfph!", "Mmmf mrrfff!", "Mmmf mnnf!")
+				message_data["verb"] = pick("mumbles", "says")
+				. = TRUE
+		else if(istype(M, /obj/item/clothing/mask) && M.voicechange)
 			message_data["message"] = pick(M.say_messages)
 			message_data["verb"] = pick(M.say_verbs)
 			. = TRUE

--- a/code/modules/mob/living/say.dm
+++ b/code/modules/mob/living/say.dm
@@ -169,9 +169,6 @@ var/list/channel_to_radio_key = new
 
 	say_get_alt_name(message_data)
 
-	if(!say_check_special(message_data))
-		return message_data["say_result"]
-
 	client?.spellcheck(message_data["message"])
 
 	// This is broadcast to all mobs with the language,
@@ -243,13 +240,6 @@ var/list/channel_to_radio_key = new
 		return FALSE
 	if(prefix == get_prefix_key(/decl/prefix/visible_emote))
 		message_data["say_result"] = custom_emote(1, copytext_char(message_data["message"], 2))
-		return FALSE
-	return TRUE
-
-/mob/living/proc/say_check_special(list/message_data)
-	if(is_muzzled() && !(message_data["language"]?.flags & (NONVERBAL|SIGNLANG)))
-		to_chat(src, SPAN("danger", "You're muzzled and cannot speak!"))
-		message_data["say_result"] = FALSE
 		return FALSE
 	return TRUE
 


### PR DESCRIPTION
Теперь с различного рода кляпами фразы снова заменяются на мычания "Mmfph!".

<details>
<summary>Чейнджлог</summary>

```yml
🆑
bugfix: Кляпы снова меняют сейлоги на мычание.
/🆑
```

</details>

- [x] Pull Request полностью завершен, мне не нужна помощь чтобы его закончить.
- [x] Я внимательно прочитал все свои изменения и багов в них не нашел.
- [x] Я запускал сервер со своими изменениями локально и все протестировал.
- [x] Я ознакомился c [Guide to Contribute](https://github.com/ChaoticOnyx/OnyxBay/blob/dev/docs/contributing.md).