### PR TITLE
feat(signals): add examined signal

### DIFF
--- a/code/__defines/ces/signals_atom.dm
+++ b/code/__defines/ces/signals_atom.dm
@@ -24,3 +24,6 @@
 
 /// From base of atom/proc/Initialize(): sent any time a new atom is created in this atom
 #define SIGNAL_ATOM_INITIALIZED_ON "atom_initialized_on"
+
+/// Called on 'atom/examine' (/mob, list/examine_texts)
+#define SIGNAL_ATOM_EXAMINED "atom_examined"

--- a/code/__defines/ces/signals_atom.dm
+++ b/code/__defines/ces/signals_atom.dm
@@ -25,5 +25,5 @@
 /// From base of atom/proc/Initialize(): sent any time a new atom is created in this atom
 #define SIGNAL_ATOM_INITIALIZED_ON "atom_initialized_on"
 
-/// Called on 'atom/examine' (/mob, list/examine_texts)
+/// Called on 'atom/proc/examine' (/mob, list/examine_texts)
 #define SIGNAL_ATOM_EXAMINED "atom_examined"

--- a/code/game/atoms.dm
+++ b/code/game/atoms.dm
@@ -304,15 +304,16 @@ its easier to just keep the beam vertical.
 
 	return
 
-/atom/proc/examine(...)
+/atom/proc/examine(mob/user)
 	SHOULD_NOT_OVERRIDE(TRUE)
 
-	var/content = "<div class='Examine'>"
+	var/list/content
 
-	content += _examine_text(arglist(args))
-	content += "</div>"
+	LAZYADD(content, _examine_text(user))
 
-	return content
+	SEND_SIGNAL(src, SIGNAL_ATOM_EXAMINED, user, content)
+
+	return EXAMINE_BLOCK(content.Join())
 
 // called by mobs when e.g. having the atom as their machine, pulledby, loc (AKA mob being inside the atom) or buckled var set.
 // see code/modules/mob/mob_movement.dm for more.


### PR DESCRIPTION
Добавлен сигнал `SIGNAL_ATOM_EXAMINED`, который вызывается в `atom/proc/examine`. Сигнал позволяет компонентам подписываться на событие осмотра атома и дополнять описание, если потребуется.

<details>
<summary>Проверка</summary>

![dreamseeker_7NaUqIYx00](https://github.com/ChaoticOnyx/OnyxBay/assets/118671019/fa60c105-aa6d-4d47-866f-760f3b2e7a34)

</details>

- [x] Pull Request полностью завершен, мне не нужна помощь чтобы его закончить.
- [x] Я внимательно прочитал все свои изменения и багов в них не нашел.
- [x] Я запускал сервер со своими изменениями локально и все протестировал.
- [x] Я ознакомился c [Guide to Contribute](https://github.com/ChaoticOnyx/OnyxBay/blob/dev/docs/contributing.md).
