### PR TITLE
tweak(interaction): add case for anchored items

### DIFF
--- a/code/modules/tables/interactions.dm
+++ b/code/modules/tables/interactions.dm
@@ -195,6 +195,9 @@ Note: This proc can be overwritten to allow for different types of auto-alignmen
 */
 /obj/item/var/center_of_mass = "x=16;y=16" //can be null for no exact placement behaviour
 /obj/structure/table/proc/auto_align(obj/item/W, click_params)
+	// If item is anchored, we can't move it.
+	if(W.anchored)
+		return
 	if (!W.center_of_mass) // Clothing, material stacks, generally items with large sprites where exact placement would be unhandy.
 		W.pixel_x = rand(-W.randpixel, W.randpixel)
 		W.pixel_y = rand(-W.randpixel, W.randpixel)


### PR DESCRIPTION
Положился на код 7 летней давности, невер агейн.


https://github.com/ChaoticOnyx/OnyxBay/assets/63081538/01d11509-7e2b-4581-b143-5e72ac36b9ff



close #10374 

<details>
<summary>Чейнджлог</summary>

```yml
🆑
bugfix: Теперь интерком и другие прикрепленные предметы нельзя перемещать по столу.
/🆑
```

</details>

- [x] Pull Request полностью завершен, мне не нужна помощь чтобы его закончить.
- [x] Я внимательно прочитал все свои изменения и багов в них не нашел.
- [x] Я запускал сервер со своими изменениями локально и все протестировал.
- [x] Я ознакомился c [Guide to Contribute](https://github.com/ChaoticOnyx/OnyxBay/blob/dev/docs/contributing.md).
