### PR TITLE
feat(monkeycube): simple mobs now gib after consuming monkey cube

### DIFF
--- a/code/modules/reagents/reagent_containers/food/unsorted.dm
+++ b/code/modules/reagents/reagent_containers/food/unsorted.dm
@@ -1237,6 +1237,7 @@
 		H.visible_message("<span class='warning'>A screeching creature bursts out of [M]'s chest!</span>")
 		var/obj/item/organ/external/organ = H.get_organ(BP_CHEST)
 		organ.take_external_damage(50, 0, 0, "Animal escaping the ribcage")
+	else M.gib()
 	Expand()
 
 /obj/item/reagent_containers/food/monkeycube/on_reagent_change()

--- a/code/modules/reagents/reagent_containers/food/unsorted.dm
+++ b/code/modules/reagents/reagent_containers/food/unsorted.dm
@@ -1237,7 +1237,7 @@
 		H.visible_message("<span class='warning'>A screeching creature bursts out of [M]'s chest!</span>")
 		var/obj/item/organ/external/organ = H.get_organ(BP_CHEST)
 		organ.take_external_damage(50, 0, 0, "Animal escaping the ribcage")
-	else M.gib()
+	else M.gib(do_gibs = TRUE)
 	Expand()
 
 /obj/item/reagent_containers/food/monkeycube/on_reagent_change()

--- a/code/modules/reagents/reagent_containers/food/unsorted.dm
+++ b/code/modules/reagents/reagent_containers/food/unsorted.dm
@@ -1234,10 +1234,14 @@
 /obj/item/reagent_containers/food/monkeycube/On_Consume(mob/M)
 	if(ishuman(M))
 		var/mob/living/carbon/human/H = M
-		H.visible_message("<span class='warning'>A screeching creature bursts out of [M]'s chest!</span>")
+		H.visible_message(SPAN("warning", "A screeching creature bursts out of [H]'s chest!"))
 		var/obj/item/organ/external/organ = H.get_organ(BP_CHEST)
 		organ.take_external_damage(50, 0, 0, "Animal escaping the ribcage")
-	else M.gib(do_gibs = TRUE)
+	else
+		M.visible_message(\
+			SPAN("warning", "A screeching creature bursts out of [M]!"),\
+			SPAN("warning", "You feel like your body is being torn apart from the inside!"))
+		M.gib(do_gibs = TRUE)
 	Expand()
 
 /obj/item/reagent_containers/food/monkeycube/on_reagent_change()


### PR DESCRIPTION
Как выяснилось, при поедании кубов страдают только люди, а остальные мобы не получают никакого урона, исправляю.

<details>
<summary>Чейнджлог</summary>

```yml
🆑
rscadd: простые мобы, не люди и или иные ксенорасы, теперь разрываются при вылуплении макаки из куба.
/🆑
```

</details>

- [x] Pull Request полностью завершен, мне не нужна помощь чтобы его закончить.
- [x] Я внимательно прочитал все свои изменения и багов в них не нашел.
- [ ] Я запускал сервер со своими изменениями локально и все протестировал.
- [x] Я ознакомился c [Guide to Contribute](https://github.com/ChaoticOnyx/OnyxBay/blob/dev/docs/contributing.md).
