### PR TITLE
fix(typing-indicator): add necessary checks to prevent 'bad client' runtime

### DIFF
--- a/code/modules/mob/typing_indicator.dm
+++ b/code/modules/mob/typing_indicator.dm
@@ -64,6 +64,9 @@
 
 	ASSERT(client && src == usr)
 
+	if(QDELETED(usr))
+		return
+
 	var/visible = winget(usr, "saywindow", "is-visible")
 	if(cmptext(visible, "true"))
 		stop_typing()

--- a/code/modules/mob/typing_indicator.dm
+++ b/code/modules/mob/typing_indicator.dm
@@ -62,7 +62,7 @@
 	set name = ".remove_speech_bubble"
 	set hidden = TRUE
 
-	ASSERT(client && src == usr)
+	ASSERT(src == usr)
 
 	if(QDELETED(usr))
 		return


### PR DESCRIPTION
В некоторых случаях индикатор может удаляться у моба, который стоит в очереди на удаление, к примеру, на БС техе, который прожал "teleport out". Добавил проверку, дабы не вингеты не делались на удаляющемся мобе.

Надеюсь, это первый и последний рантайм с ними.

- [x] Pull Request полностью завершен, мне не нужна помощь чтобы его закончить.
- [x] Я внимательно прочитал все свои изменения и багов в них не нашел.
- [x] Я запускал сервер со своими изменениями локально и все протестировал.
- [x] Я ознакомился c [Guide to Contribute](https://github.com/ChaoticOnyx/OnyxBay/blob/dev/docs/contributing.md).
