### PR TITLE
fix(launchers): fixing crossbow and pneumatic

### DIFF
--- a/code/game/atoms_movable.dm
+++ b/code/game/atoms_movable.dm
@@ -179,7 +179,7 @@
 	speed = round(speed)
 	var/impact_speed = speed
 	if(launched_mult)
-		impact_speed *= launched_mult
+		impact_speed /= launched_mult
 		pre_launched()
 	var/area/a = get_area(loc)
 

--- a/code/game/atoms_movable.dm
+++ b/code/game/atoms_movable.dm
@@ -148,7 +148,7 @@
 			if(A.density && !A.throwpass)	// **TODO: Better behaviour for windows which are dense, but shouldn't always stop movement
 				throw_impact(A, speed)
 
-/atom/movable/proc/throw_at(atom/target, range, speed = throw_speed, atom/thrower, thrown_with, target_zone, launched_mult)
+/atom/movable/proc/throw_at(atom/target, range, speed = throw_speed, atom/thrower, thrown_with, target_zone, launched_div)
 	set waitfor = FALSE
 
 	if(!target || QDELETED(src))
@@ -178,8 +178,8 @@
 	var/tiles_per_tick = speed
 	speed = round(speed)
 	var/impact_speed = speed
-	if(launched_mult)
-		impact_speed /= launched_mult
+	if(launched_div)
+		impact_speed /= launched_div
 		pre_launched()
 	var/area/a = get_area(loc)
 
@@ -257,7 +257,7 @@
 	if(isobj(src))
 		throw_impact(get_turf(src), impact_speed)
 
-	if(launched_mult)
+	if(launched_div)
 		post_launched()
 
 	thrown_to = null

--- a/code/game/objects/items/grenades/flashbang.dm
+++ b/code/game/objects/items/grenades/flashbang.dm
@@ -113,12 +113,14 @@
 			numspawned --
 
 	for(,numspawned > 0, numspawned--)
-		new /obj/item/grenade/flashbang/cluster(src.loc)//Launches flashbangs
-		playsound(src.loc, 'sound/weapons/armbomb.ogg', 75, 1, -3)
+		spawn(0)
+			new /obj/item/grenade/flashbang/cluster(src.loc)//Launches flashbangs
+			playsound(src.loc, 'sound/weapons/armbomb.ogg', 75, 1, -3)
 
 	for(,again > 0, again--)
-		new /obj/item/grenade/flashbang/clusterbang/segment(src.loc)//Creates a 'segment' that launches a few more flashbangs
-		playsound(src.loc, 'sound/weapons/armbomb.ogg', 75, 1, -3)
+		spawn(0)
+			new /obj/item/grenade/flashbang/clusterbang/segment(src.loc)//Creates a 'segment' that launches a few more flashbangs
+			playsound(src.loc, 'sound/weapons/armbomb.ogg', 75, 1, -3)
 	qdel(src)
 	return
 
@@ -147,8 +149,9 @@
 			numspawned --
 
 	for(,numspawned > 0, numspawned--)
-		new /obj/item/grenade/flashbang/cluster(src.loc)
-		playsound(src.loc, 'sound/weapons/armbomb.ogg', 75, 1, -3)
+		spawn(0)
+			new /obj/item/grenade/flashbang/cluster(src.loc)
+			playsound(src.loc, 'sound/weapons/armbomb.ogg', 75, 1, -3)
 	qdel(src)
 	return
 

--- a/code/game/objects/items/grenades/flashbang.dm
+++ b/code/game/objects/items/grenades/flashbang.dm
@@ -113,14 +113,12 @@
 			numspawned --
 
 	for(,numspawned > 0, numspawned--)
-		spawn(0)
-			new /obj/item/grenade/flashbang/cluster(src.loc)//Launches flashbangs
-			playsound(src.loc, 'sound/weapons/armbomb.ogg', 75, 1, -3)
+		new /obj/item/grenade/flashbang/cluster(src.loc)//Launches flashbangs
+		playsound(src.loc, 'sound/weapons/armbomb.ogg', 75, 1, -3)
 
 	for(,again > 0, again--)
-		spawn(0)
-			new /obj/item/grenade/flashbang/clusterbang/segment(src.loc)//Creates a 'segment' that launches a few more flashbangs
-			playsound(src.loc, 'sound/weapons/armbomb.ogg', 75, 1, -3)
+		new /obj/item/grenade/flashbang/clusterbang/segment(src.loc)//Creates a 'segment' that launches a few more flashbangs
+		playsound(src.loc, 'sound/weapons/armbomb.ogg', 75, 1, -3)
 	qdel(src)
 	return
 
@@ -149,9 +147,8 @@
 			numspawned --
 
 	for(,numspawned > 0, numspawned--)
-		spawn(0)
-			new /obj/item/grenade/flashbang/cluster(src.loc)
-			playsound(src.loc, 'sound/weapons/armbomb.ogg', 75, 1, -3)
+		new /obj/item/grenade/flashbang/cluster(src.loc)
+		playsound(src.loc, 'sound/weapons/armbomb.ogg', 75, 1, -3)
 	qdel(src)
 	return
 

--- a/code/modules/mob/living/carbon/human/human_defense.dm
+++ b/code/modules/mob/living/carbon/human/human_defense.dm
@@ -891,7 +891,7 @@ meteor_act
 		if(istype(O, /obj/item))
 			var/obj/item/I = O
 			mass = I.w_class / THROWNOBJ_KNOCKBACK_DIVISOR
-		var/momentum = speed * mass
+		var/momentum = (1 / speed) * mass
 
 		if(O.throw_source && momentum >= THROWNOBJ_KNOCKBACK_SPEED)
 			var/dir = get_dir(O.throw_source, src)

--- a/code/modules/projectiles/guns/launcher/crossbow.dm
+++ b/code/modules/projectiles/guns/launcher/crossbow.dm
@@ -91,11 +91,12 @@
 	var/obj/item/bolt
 	var/tension = 0                         // Current draw on the bow.
 	var/max_tension = 5                     // Highest possible tension.
+	var/force_multiplier = 2                // Multiplier of release force.
 	var/obj/item/cell/cell = null    // Used for firing superheated rods.
 	var/current_user                        // Used to check if the crossbow has changed hands since being drawn.
 
 /obj/item/gun/launcher/crossbow/update_release_force()
-	release_force = max(1, tension)
+	release_force = tension * force_multiplier
 
 /obj/item/gun/launcher/crossbow/consume_next_projectile(mob/user=null)
 	if(tension <= 0)

--- a/code/modules/projectiles/guns/launcher/syringe_gun.dm
+++ b/code/modules/projectiles/guns/launcher/syringe_gun.dm
@@ -62,7 +62,7 @@
 	if(syringe)
 		//check speed to see if we hit hard enough to trigger the rapid injection
 		//incidentally, this means syringe_cartridges can be used with the pneumatic launcher
-		if((speed >= 10 || speed <= 1) && isliving(hit_atom))
+		if((speed >= 10 || speed <= 0.9) && isliving(hit_atom))
 			var/mob/living/L = hit_atom
 			//unfortuately we don't know where the dart will actually hit, since that's done by the parent.
 			if(L.can_inject(null, ran_zone()) && syringe.reagents)

--- a/code/modules/projectiles/guns/launcher/syringe_gun.dm
+++ b/code/modules/projectiles/guns/launcher/syringe_gun.dm
@@ -62,7 +62,7 @@
 	if(syringe)
 		//check speed to see if we hit hard enough to trigger the rapid injection
 		//incidentally, this means syringe_cartridges can be used with the pneumatic launcher
-		if(speed >= 7 && isliving(hit_atom))
+		if(speed >= 10 && isliving(hit_atom))
 			var/mob/living/L = hit_atom
 			//unfortuately we don't know where the dart will actually hit, since that's done by the parent.
 			if(L.can_inject(null, ran_zone()) && syringe.reagents)
@@ -92,7 +92,7 @@
 	fire_sound = 'sound/weapons/empty.ogg'
 	fire_sound_text = "a metallic thunk"
 	screen_shake = 0
-	release_force = 10
+	release_force = 0.1
 	throw_distance = 10
 
 	var/list/darts = list()

--- a/code/modules/projectiles/guns/launcher/syringe_gun.dm
+++ b/code/modules/projectiles/guns/launcher/syringe_gun.dm
@@ -62,7 +62,7 @@
 	if(syringe)
 		//check speed to see if we hit hard enough to trigger the rapid injection
 		//incidentally, this means syringe_cartridges can be used with the pneumatic launcher
-		if(speed >= 10 && isliving(hit_atom))
+		if((speed >= 10 || speed <= 1) && isliving(hit_atom))
 			var/mob/living/L = hit_atom
 			//unfortuately we don't know where the dart will actually hit, since that's done by the parent.
 			if(L.can_inject(null, ran_zone()) && syringe.reagents)


### PR DESCRIPTION
Заменил умножение скорости и множителя на деление, и подкорректировал формулу на откидывание
Так же поменял циферки в стате у арбалета и шприцемёта, чтобы работало. Должно пофиксить пневму так же.

fix #9823 
fix #9329

<details>
<summary>Чейнджлог</summary>

```yml
🆑BaraBara
bugfix: Арбалеты и пневма снова наносят урон.
/🆑
```

</details>

- [x] Pull Request полностью завершен, мне не нужна помощь чтобы его закончить.
- [ ] Я внимательно прочитал все свои изменения и багов в них не нашел.
- [x] Я запускал сервер со своими изменениями локально и все протестировал.
- [x] Я ознакомился c [Guide to Contribute](https://github.com/ChaoticOnyx/OnyxBay/blob/dev/docs/contributing.md).
