### PR TITLE
bugfix(foreach): incorrect operand fix

### DIFF
--- a/code/modules/integrated_electronics/subtypes/lists.dm
+++ b/code/modules/integrated_electronics/subtypes/lists.dm
@@ -42,7 +42,7 @@
 	. = ..()
 	var/list/check_list = get_pin_data(IC_INPUT, 1)
 	var/check_mod = get_pin_data(IC_INPUT, 2)
-	if((input_list != check_list) && (check_mod != mode))
+	if((input_list != check_list) || (check_mod != mode))
 		step = 0
 
 /obj/item/integrated_circuit/lists/for_lists/do_work()


### PR DESCRIPTION
Тупанул, а никто не сказал (до этого дня)

<details>
<summary>Чейнджлог</summary>

```yml
🆑
bugfix: У интегрального компонента foreach list исправлена ошибка приводящая к невозможности забыть какой был индекс перехода у списка при смене этого списка. 
/🆑
```

</details>

- [x] Pull Request полностью завершен, мне не нужна помощь чтобы его закончить.
- [x] Я внимательно прочитал все свои изменения и багов в них не нашел.
- [ ] Я запускал сервер со своими изменениями локально и все протестировал.
- [x] Я ознакомился c [Guide to Contribute](https://github.com/ChaoticOnyx/OnyxBay/blob/dev/docs/contributing.md).
