### PR TITLE
fix(extract): add ability to feed from a bag & fix description

### DIFF
--- a/code/modules/mob/living/carbon/xenobiological/crossbreeding/_corecross.dm
+++ b/code/modules/mob/living/carbon/xenobiological/crossbreeding/_corecross.dm
@@ -90,7 +90,7 @@ To add a crossbreed:
 /obj/item/metroidcross/_examine_text(mob/user)
 	. = ..()
 	if(effect_desc)
-		. += SPAN_NOTICE("[effect_desc]")
+		. += SPAN_NOTICE("\n[effect_desc]")
 
 /obj/item/metroidcross/Initialize(mapload)
 	. = ..()


### PR DESCRIPTION
Судя по описанию, репродуктивный экстракт должен кормиться из сумки, тем не менее делать это было нельзя. Теперь можно! 

Еще поправил описания экстрактов, теперь там есть ньюлайн и текст не перемешивается, ВАУ!

Кулдаун экстракта был снижен с 5 до 3 секунд по заявкам игроков.

<details>
<summary>Чейнджлог</summary>

```yml
🆑
bugfix: описания эктрактов больше не сливаются в одну длинную строчку.
rscadd: репродуктивный экстракт можно кормить из сумки.
tweak: кулдаун экстракта уменьшен с 5 до 3 секунд по просьбам игроков.
/🆑
```

</details>

- [x] Pull Request полностью завершен, мне не нужна помощь чтобы его закончить.
- [x] Я внимательно прочитал все свои изменения и багов в них не нашел.
- [x] Я запускал сервер со своими изменениями локально и все протестировал.
- [x] Я ознакомился c [Guide to Contribute](https://github.com/ChaoticOnyx/OnyxBay/blob/dev/docs/contributing.md).
