### PR TITLE
fix(extract): add duration for burning purple extract

### DIFF
--- a/code/modules/mob/living/carbon/xenobiological/crossbreeding/_status_effects.dm
+++ b/code/modules/mob/living/carbon/xenobiological/crossbreeding/_status_effects.dm
@@ -438,17 +438,17 @@
 	return ..()
 
 //Stabilized effects start below.
-/datum/modifier/status_effect/stabilized/grey
-	name = "stabilizedgrey"
-	colour = "grey"
+/datum/modifier/status_effect/stabilized/green
+	name = "stabilizedgreen"
+	colour = "green"
 
-/datum/modifier/status_effect/stabilized/grey/on_applied()
+/datum/modifier/status_effect/stabilized/green/on_applied()
 	set_next_think(world.time+1)
 
-/datum/modifier/status_effect/stabilized/grey/on_expire()
+/datum/modifier/status_effect/stabilized/green/on_expire()
 	set_next_think(0)
 
-/datum/modifier/status_effect/stabilized/grey/think()
+/datum/modifier/status_effect/stabilized/green/think()
 	for(var/mob/living/carbon/metroid/S in range(1, get_turf(holder)))
 		if(!(holder in S.Friends))
 			to_chat(holder, SPAN_NOTICE("[linked_extract] pulses gently as it communicates with [S]."))
@@ -793,13 +793,13 @@
 	set_next_think(0)
 	return ..()
 
-/datum/modifier/status_effect/stabilized/green
-	name = "stabilizedgreen"
-	colour = "green"
+/datum/modifier/status_effect/stabilized/grey
+	name = "stabilizedgrey"
+	colour = "grey"
 	var/datum/dna/originalDNA
 	var/originalname
 
-/datum/modifier/status_effect/stabilized/green/on_applied()
+/datum/modifier/status_effect/stabilized/grey/on_applied()
 	to_chat(holder, SPAN_WARNING("You feel different..."))
 	if(ishuman(holder))
 		var/mob/living/carbon/human/H = holder
@@ -815,12 +815,12 @@
 	return ..()
 
 // Only occasionally give examiners a warning.
-/datum/modifier/status_effect/stabilized/green/_examine_text()
+/datum/modifier/status_effect/stabilized/grey/_examine_text()
 	if(prob(50))
 		return SPAN_WARNING("[holder] look[holder] a bit green and gooey...")
 	return null
 
-/datum/modifier/status_effect/stabilized/green/on_expire()
+/datum/modifier/status_effect/stabilized/grey/on_expire()
 	to_chat(holder, SPAN_NOTICE("You feel more like yourself."))
 	if(ishuman(holder))
 		var/mob/living/carbon/human/H = holder
@@ -1034,3 +1034,15 @@
 	name = "adamantine"
 	incoming_brute_damage_percent = 0.75
 	duration = 1200
+
+/datum/modifier/status_effect/burningpurple
+	name = "burningpurple"
+	stacks = MODIFIER_STACK_EXTEND
+
+	duration = 1 MINUTE
+
+/datum/modifier/status_effect/burningpurple/on_applied()
+	ADD_TRAIT(holder, /datum/modifier/movespeed/lightpink)
+
+/datum/modifier/status_effect/burningpurple/on_expire()
+	REMOVE_TRAIT(holder, /datum/modifier/movespeed/lightpink)

--- a/code/modules/mob/living/carbon/xenobiological/crossbreeding/_status_effects.dm
+++ b/code/modules/mob/living/carbon/xenobiological/crossbreeding/_status_effects.dm
@@ -817,7 +817,7 @@
 // Only occasionally give examiners a warning.
 /datum/modifier/status_effect/stabilized/grey/_examine_text()
 	if(prob(50))
-		return SPAN_WARNING("[holder] look[holder] a bit green and gooey...")
+		return SPAN_WARNING("[holder] look[holder] a bit grey and gooey...")
 	return null
 
 /datum/modifier/status_effect/stabilized/grey/on_expire()

--- a/code/modules/mob/living/carbon/xenobiological/crossbreeding/burning.dm
+++ b/code/modules/mob/living/carbon/xenobiological/crossbreeding/burning.dm
@@ -87,8 +87,8 @@ Burning extracts:
 	new /obj/item/metroidcrossbeaker/autoinjector/metroidstimulant(get_turf(user))
 	if(isliving(user))
 		var/mob/living/L = user
-		L.add_modifier(/datum/modifier/movespeed/lightpink)
-	..()
+		ADD_TRAIT(L, /datum/modifier/status_effect/burningpurple)
+	return ..()
 
 /obj/item/metroidcross/burning/blue
 	colour = "blue"


### PR DESCRIPTION
Игроки сообщили о том, что фиолетовый экстракт дает перманентную скорость и это немного странно. Больше не дает!

<details>
<summary>Чейнджлог</summary>

```yml
🆑
bugfix: горящий фиолетовый экстракт больше не дает перманентную скорость.
/🆑
```

</details>

- [x] Pull Request полностью завершен, мне не нужна помощь чтобы его закончить.
- [x] Я внимательно прочитал все свои изменения и багов в них не нашел.
- [x] Я запускал сервер со своими изменениями локально и все протестировал.
- [x] Я ознакомился c [Guide to Contribute](https://github.com/ChaoticOnyx/OnyxBay/blob/dev/docs/contributing.md).
