### PR TITLE
tweak(manifest_prediction) Predicts a crew manifest based on declares in lobby

### DIFF
--- a/code/modules/client/preference_setup/occupation/occupation.dm
+++ b/code/modules/client/preference_setup/occupation/occupation.dm
@@ -243,7 +243,6 @@
 		if(JOB_PRIORITY_HIGH)
 			pref.job_high = null
 		if(JOB_PRIORITY_MIDDLE)
-			pref.job_medium |= pref.job_high
 			pref.job_high = switched_job.title
 			pref.job_medium -= switched_job.title
 		if(JOB_PRIORITY_LOW)

--- a/code/modules/mob/new_player/new_player.dm
+++ b/code/modules/mob/new_player/new_player.dm
@@ -42,6 +42,7 @@
 	output += "<p><a href='byond://?src=\ref[src];show_settings=1'>Settings</a></p>"
 
 	if(GAME_STATE <= RUNLEVEL_LOBBY)
+		output += "<a href='byond://?src=\ref[src];predict_manifest=1'>View Crew Manifest Prediction</A><br><br>"
 		if(ready)
 			output += "<p>\[ <span class='linkOn'><b>Ready</b></span> | <a href='byond://?src=\ref[src];ready=0'>Not Ready</a> \]</p>"
 		else
@@ -199,6 +200,9 @@
 
 	if(href_list["manifest"])
 		ViewManifest()
+
+	if(href_list["predict_manifest"])
+		ViewManifestPrediction()
 
 	if(href_list["SelectedJob"])
 		var/datum/job/job = job_master.GetJob(href_list["SelectedJob"])
@@ -577,6 +581,16 @@
 	dat += html_crew_manifest(OOC = 1)
 	//show_browser(src, dat, "window=manifest;size=370x420;can_close=1")
 	var/datum/browser/popup = new(src, "Crew Manifest", "Crew Manifest", 370, 420, src)
+	popup.set_content(dat)
+	popup.open()
+
+/mob/new_player/proc/ViewManifestPrediction()
+	if(SSatoms.init_state < INITIALIZATION_INNEW_REGULAR)
+		to_chat(src, SPAN("notice", "Please, wait for the game to initialize!"))
+		return
+	var/dat = "<div align='center'>"
+	dat += manifest_prediction()
+	var/datum/browser/popup = new(src, "Crew Manifest Prediction", "Crew Manifest Prediction", 370, 420, src)
 	popup.set_content(dat)
 	popup.open()
 

--- a/code/modules/modular_computers/file_system/manifest.dm
+++ b/code/modules/modular_computers/file_system/manifest.dm
@@ -181,31 +181,35 @@ GLOBAL_LIST_EMPTY(dept_data)
 		//inserting non-head positions in GLOB.dept_data
 		for(var/list/J in preferenced_jobs)
 			var/list/jobs = J - GLOB.command_positions
-			if(length(jobs))
-				var/job = pick(jobs)
+			if(!length(jobs))
+				continue
 
-				if(job in list("AI", "Cyborg"))
-					silicon = TRUE
+			var/job = pick(jobs)
+			
+			if(job in list("AI", "Cyborg"))
+				silicon = TRUE
 
-				for(var/list/department in GLOB.dept_data)
-					var/flag = job_master.occupations_by_title[job].department_flag
+			for(var/list/department in GLOB.dept_data)
+				var/flag = job_master.occupations_by_title[job].department_flag
 
-					if(!silicon ? department["flag"]&flag : department["header"] == "Silicon")
-						department["all_jobs_in_dept"][job] += list(!silicon ? "[player_name]" : "\[Unknown\]" = player_prefs.player_alt_titles[job] ? player_prefs.player_alt_titles[job] : job)
-						break
-				break
+				if(!silicon ? department["flag"]&flag : department["header"] == "Silicon")
+					department["all_jobs_in_dept"][job] += list(!silicon ? "[player_name]" : "\[Unknown\]" = player_prefs.player_alt_titles[job] ? player_prefs.player_alt_titles[job] : job)
+					break
+			break
 
 	//building manifest page
 	for(var/list/department in GLOB.dept_data)
 		var/list/all_jobs = department["all_jobs_in_dept"]
-		if(length(all_jobs))
-			dat += "<tr><th colspan=3>[department["header"]]</th></tr>"
-			for(var/J in all_jobs)
-				var/list/job = all_jobs[J]
-				for(var/name in job)
-					var/job_slots = job_master.occupations_by_title[job[name]].spawn_positions
-					var/chance = job_slots == -1 ? 100 : clamp(job_slots/length(job)*100, 0, 100)
-					dat += "<tr class='candystripe'><td>[name]</td><td>[job[name]]</td><td>[chance]%</td></tr>"
+		if(!length(all_jobs))
+			continue
+
+		dat += "<tr><th colspan=3>[department["header"]]</th></tr>"
+		for(var/J in all_jobs)
+			var/list/job = all_jobs[J]
+			for(var/name in job)
+				var/job_slots = job_master.occupations_by_title[job[name]].spawn_positions
+				var/chance = job_slots == -1 ? 100 : clamp(job_slots/length(job)*100, 0, 100)
+				dat += "<tr class='candystripe'><td>[name]</td><td>[job[name]]</td><td>[chance]%</td></tr>"
 
 	dat += "</table>"
 	dat = replacetext(dat, "\n", "") // so it can be placed on paper correctly

--- a/code/modules/modular_computers/file_system/manifest.dm
+++ b/code/modules/modular_computers/file_system/manifest.dm
@@ -120,7 +120,6 @@ GLOBAL_LIST_EMPTY(dept_data)
 				var/datum/job/job = job_master.GetJob(command_position)
 				for(var/priority = JOB_PRIORITY_HIGH to JOB_PRIORITY_LOW)
 					if(player_prefs.IsJobPriority(job, priority))
-						//command_candidates["[command_position]"] += list("[priority]" = player_name)
 						if(!command_positions_with_candidates[command_position])
 							command_positions_with_candidates[command_position] = list(
 								JOB_PRIORITY_HIGH = list(),

--- a/code/modules/modular_computers/file_system/manifest.dm
+++ b/code/modules/modular_computers/file_system/manifest.dm
@@ -178,9 +178,9 @@ GLOBAL_LIST_EMPTY(dept_data)
 				player_prefs.job_low
 				)
 				
-		//inserting positions in GLOB.dept_data
+		//inserting non-head positions in GLOB.dept_data
 		for(var/list/J in preferenced_jobs)
-			var/list/jobs = J
+			var/list/jobs = J - GLOB.command_positions
 			if(length(jobs))
 				var/job = pick(jobs)
 

--- a/code/modules/modular_computers/file_system/manifest.dm
+++ b/code/modules/modular_computers/file_system/manifest.dm
@@ -157,7 +157,9 @@
 			for(var/J in all_jobs)
 				var/list/job = all_jobs[J]
 				for(var/name in job)
-					var/chance = clamp(abs(job_master.occupations_by_title[job[name]].spawn_positions/job.len*100), 0, 100)
+					var/job_slots = job_master.occupations_by_title[job[name]].spawn_positions
+					var/chance
+					job_slots == -1 ? (chance = 100) : (chance = clamp(job_slots/job.len*100, 0, 100))
 					dat += "<tr class='candystripe'><td>[name]</td><td>[job[name]]</td><td>[chance]%</td></tr>"
 
 	dat += "</table>"

--- a/code/modules/modular_computers/file_system/manifest.dm
+++ b/code/modules/modular_computers/file_system/manifest.dm
@@ -45,7 +45,7 @@ GLOBAL_LIST_EMPTY(dept_data)
 		if(isnull(department["flag"]))
 			bot = department["names"]
 
-	var/list/isactive = new()
+	var/list/isactive = list()
 	
 	// sort mobs
 	for(var/datum/computer_file/crew_record/CR in GLOB.all_crew_records)


### PR DESCRIPTION
Добавляет в лобби кнопку "View Crew Manifest Prediction".
Помните тот неудобный список декларов из вкладки lobby? Теперь есть его улучшенная версия в формате красивого крю манифеста!

<details>
<summary>Чейнджлог</summary>

```yml
🆑
tweak: В лобби до старта игры добавлен предсказатель списка персонала.
/🆑
```

</details>

- [x] Pull Request полностью завершен, мне не нужна помощь чтобы его закончить.
- [x] Я внимательно прочитал все свои изменения и багов в них не нашел.
- [x] Я запускал сервер со своими изменениями локально и все протестировал.
- [x] Я ознакомился c [Guide to Contribute](https://github.com/ChaoticOnyx/OnyxBay/blob/dev/docs/contributing.md).
