### PR TITLE
balance(radiation) reducing the strength of the singularity radiation source

### DIFF
--- a/code/modules/radiation/radiation_presets.dm
+++ b/code/modules/radiation/radiation_presets.dm
@@ -14,14 +14,14 @@
 /datum/radiation/preset/singularity_beta
 	activity = 15 KILO CURIE
 	radiation_type = RADIATION_BETA_PARTICLE
-	energy = 4.2 MEGA ELECTRONVOLT
+	energy = 3.2 MEGA ELECTRONVOLT
 
 /datum/radiation/preset/hawking
-	activity = 1 MEGA CURIE
+	activity = 0.2 MEGA CURIE
 	radiation_type = RADIATION_HAWKING
-	energy = 122 MILLI ELECTRONVOLT
+	energy = 50 MILLI ELECTRONVOLT
 /datum/radiation/preset/gravitaty_generator
-	activity = 1 MEGA CURIE
+	activity = 0.1 MEGA CURIE
 	radiation_type = RADIATION_HAWKING
 	energy = 122 MILLI ELECTRONVOLT
 


### PR DESCRIPTION
Уменьшил силу радейки от синги. На локалке протестил, производит около ~8 МВт, не грея коллекторы, но я их не заполнял до предела. Если они и взорвутся, то точно не на первых минутах. 
<details>
<summary>Чейнджлог</summary>

```yml
🆑ilido
balance: Сингулярность теперь излучает меньше радиации и не должна взрывать коллекторы
/🆑
```
- [x] Pull Request полностью завершен, мне не нужна помощь чтобы его закончить.
- [x] Я внимательно прочитал все свои изменения и багов в них не нашел.
- [x] Я запускал сервер со своими изменениями локально и все протестировал.
- [x] Я ознакомился c [Guide to Contribute](https://github.com/ChaoticOnyx/OnyxBay/blob/dev/docs/contributing.md).
