### PR TITLE
Огнестрел опасен для здоровья

### DIFF
--- a/code/modules/mob/living/carbon/human/human_defense.dm
+++ b/code/modules/mob/living/carbon/human/human_defense.dm
@@ -41,7 +41,7 @@ meteor_act
 
 	//Internal damage
 	var/penetrating_damage = ((P.damage + P.armor_penetration) * P.penetration_modifier) - blocked
-	var/internal_damage_prob = 70 + max(penetrating_damage, -30) // The minimal chance to deal internal damage is 40%, armor is more about blocking damage itself
+	var/internal_damage_prob = 110 + max(penetrating_damage, -20) // The minimal chance to deal internal damage is 40%, armor is more about blocking damage itself
 
 	var/overkill_value = 1
 	if(organ.damage > organ.max_damage) // Overkill stuff; if our bodypart is a pile of shredded meat then it doesn't protect organs well
@@ -52,13 +52,13 @@ meteor_act
 		if(blocked >= P.damage) // Armor has absorbed the penetrational power
 			damage_amt = sqrt(damage_amt)
 		if(organ.encased && !(organ.status & ORGAN_BROKEN)) //ribs and skulls somewhat protect
-			overkill_value *= 0.75
+			overkill_value *= 0.85
 		damage_amt *= overkill_value
 		if(damage_amt > 0)
 			var/list/victims = list()
 			var/list/possible_victims = shuffle(organ.internal_organs.Copy())
 			for(var/obj/item/organ/internal/I in possible_victims)
-				if(I.damage < I.max_damage && (prob((sqrt(I.relative_size) * 10) * (1 / max(1, victims.len)))))
+				if(I.damage < I.max_damage && (prob((sqrt(I.relative_size) * 20) * (2 / max(2, victims.len)))))
 					victims += I
 			if(victims.len)
 				for(var/obj/item/organ/internal/victim in victims)

--- a/code/modules/organs/external/_external_damage.dm
+++ b/code/modules/organs/external/_external_damage.dm
@@ -103,14 +103,14 @@ obj/item/organ/external/take_general_damage(amount, silent = FALSE)
 			cur_damage += burn_dam
 		var/organ_damage_threshold = 5
 		if(sharp)
-			organ_damage_threshold *= 0.5
+			organ_damage_threshold *= 0.75
 		var/organ_damage_prob = 6.25 * damage_amt/organ_damage_threshold //more damage, higher chance to damage
 		if(sharp)
 			organ_damage_prob *= 1.5
 		if(cur_damage >= 15)
 			organ_damage_prob *= cur_damage/15
 		if(encased && !(status & ORGAN_BROKEN)) //ribs and skulls protect
-			organ_damage_prob *= 0.5
+			organ_damage_prob *= 0.75
 		if(internal_organs && internal_organs.len && (cur_damage + damage_amt >= max_damage || damage_amt >= organ_damage_threshold) && prob(organ_damage_prob))
 			// Damage an internal organ
 			var/list/victims = list()
@@ -123,7 +123,7 @@ obj/item/organ/external/take_general_damage(amount, silent = FALSE)
 				brute /= 2
 				if(laser)
 					burn /= 3
-				damage_amt /= 2
+				damage_amt /= 1.5
 				victim.take_internal_damage(damage_amt)
 
 	if(status & ORGAN_BROKEN && brute)

--- a/code/modules/organs/external/head.dm
+++ b/code/modules/organs/external/head.dm
@@ -4,7 +4,7 @@
 	icon_name = "head"
 	name = "head"
 	slot_flags = SLOT_BELT
-	max_damage = 75
+	max_damage = 60
 	min_broken_damage = 40
 	w_class = ITEM_SIZE_NORMAL
 	body_part = HEAD
@@ -16,7 +16,7 @@
 	cavity_name = "cranial"
 	limb_flags = ORGAN_FLAG_CAN_AMPUTATE | ORGAN_FLAG_GENDERED_ICON | ORGAN_FLAG_HEALS_OVERKILL | ORGAN_FLAG_CAN_BREAK
 
-	internal_organs_size = 3
+	internal_organs_size = 4
 
 	var/can_intake_reagents = 1
 

--- a/code/modules/organs/external/standard.dm
+++ b/code/modules/organs/external/standard.dm
@@ -8,7 +8,7 @@
 	name = "upper body"
 	organ_tag = BP_CHEST
 	icon_name = "torso"
-	max_damage = 110
+	max_damage = 115
 	min_broken_damage = 45
 	w_class = ITEM_SIZE_HUGE //Used for dismembering thresholds, in addition to storage. Humans are w_class 6, so it makes sense that chest is w_class 5.
 	body_part = UPPER_TORSO

--- a/code/modules/organs/internal/brain.dm
+++ b/code/modules/organs/internal/brain.dm
@@ -14,7 +14,7 @@
 
 	max_damage = isnull(holder?.species) ? 100 : species.total_health
 	min_bruised_damage = max_damage * 0.25
-	min_broken_damage = max_damage * 0.75
+	min_broken_damage = max_damage * 0.50
 
 	damage_threshold_value = round(max_damage / BRAIN_DAMAGE_THRESHOLD)
 


### PR DESCRIPTION
_Экспериментальная хрень_ 

Мне кажется, что с более хрупкими куклами играть станет интереснее. Ну нужно тестить. Из примеров: .357-ой револьвер в упор в голову кладёт спать, матеба чаще гибает, 9мм пистолетик убивает в голову с 2-3 выстрелов. 

- Шанс нанести урон внутреннем органам повышен
- Череп и рёбра слабее защищают органы
- Внутренние органы получают больше дамага
- Нёрф башки (-15 максимального дамага)
- Небольшой совсем бафф торса (+5 к максимальному дамагу)
- Увеличен размер органов в голове на 1 единицу (чтобы легче было продамажить)
- Мозг чуть легче ломается

<details>
<summary>Чейнджлог</summary>

```yml
🆑Armolitskiy
balance: Огнестрельное становится ещё более опасным.
/🆑
```

</details>

- [x] Pull Request полностью завершен, мне не нужна помощь чтобы его закончить.
- [x] Я внимательно прочитал все свои изменения и багов в них не нашел.
- [x] Я запускал сервер со своими изменениями локально и все протестировал.
- [x] Я ознакомился c [Guide to Contribute](https://github.com/ChaoticOnyx/OnyxBay/blob/dev/docs/contributing.md).
