### PR TITLE
fix(hud): fix adding qdeleted actions to the HUD

### DIFF
--- a/code/modules/mob/living/living_defense.dm
+++ b/code/modules/mob/living/living_defense.dm
@@ -413,6 +413,9 @@
 
 	var/button_number = 0
 	for(var/datum/action/A in actions)
+		if(QDELETED(A))
+			continue
+
 		button_number++
 		if(A.button == null)
 			var/obj/screen/movable/action_button/N = new(hud_used)


### PR DESCRIPTION
Больше удалённые экшены не будут добавляться на ХУД, что приводило к хардделу.
<details>
<summary>Чейнджлог</summary>

```yml
🆑
bugfix: Добавлена проверка на удалённый экшен, что чутка оптимизировало возможные последствия такого.
/🆑
```

</details>

- [x] Pull Request полностью завершен, мне не нужна помощь чтобы его закончить.
- [x] Я внимательно прочитал все свои изменения и багов в них не нашел.
- [ ] Я запускал сервер со своими изменениями локально и все протестировал.
- [x] Я ознакомился c [Guide to Contribute](https://github.com/ChaoticOnyx/OnyxBay/blob/dev/docs/contributing.md).
