### PR TITLE
fix(events): null ref to apc when electrical storm ends

### DIFF
--- a/code/datums/events/electrical_storm.dm
+++ b/code/datums/events/electrical_storm.dm
@@ -92,7 +92,7 @@
 	set_next_think(world.time + 3 SECONDS)
 
 /datum/event/electrical_storm/proc/end()
-	valid_apcs = list()
+	valid_apcs.Cut()
 	SSannounce.play_station_announce(/datum/announce/electrical_storm_clear)
 	SSevents.evars["electrical_storm_running"] = FALSE
 

--- a/code/datums/events/electrical_storm.dm
+++ b/code/datums/events/electrical_storm.dm
@@ -92,7 +92,7 @@
 	set_next_think(world.time + 3 SECONDS)
 
 /datum/event/electrical_storm/proc/end()
-	valid_apcs = null
+	valid_apcs = list()
 	SSannounce.play_station_announce(/datum/announce/electrical_storm_clear)
 	SSevents.evars["electrical_storm_running"] = FALSE
 

--- a/code/datums/events/electrical_storm.dm
+++ b/code/datums/events/electrical_storm.dm
@@ -92,6 +92,7 @@
 	set_next_think(world.time + 3 SECONDS)
 
 /datum/event/electrical_storm/proc/end()
+	valid_apcs = null
 	SSannounce.play_station_announce(/datum/announce/electrical_storm_clear)
 	SSevents.evars["electrical_storm_running"] = FALSE
 


### PR DESCRIPTION
Занулять рефы круто
<details>
<summary>Чейнджлог</summary>

```yml
🆑
bugfix: Рефы к АПЦ зануляются после конца электрического шторма.
/🆑
```

</details>

- [x] Pull Request полностью завершен, мне не нужна помощь чтобы его закончить.
- [x] Я внимательно прочитал все свои изменения и багов в них не нашел.
- [ ] Я запускал сервер со своими изменениями локально и все протестировал.
- [x] Я ознакомился c [Guide to Contribute](https://github.com/ChaoticOnyx/OnyxBay/blob/dev/docs/contributing.md).
