### PR TITLE
fix(metabolism): qdel cleanup

### DIFF
--- a/code/modules/reagents/Chemistry-Metabolism.dm
+++ b/code/modules/reagents/Chemistry-Metabolism.dm
@@ -9,6 +9,10 @@
 	if(istype(parent_mob))
 		parent = parent_mob
 
+/datum/reagents/metabolism/Destroy()
+	parent = null
+	. = ..()
+
 /datum/reagents/metabolism/proc/metabolize()
 
 	var/metabolism_type = 0 //non-human mobs


### PR DESCRIPTION
Зануляем рефы при удалении
<details>
<summary>Чейнджлог</summary>

```yml
🆑
bugfix: Метаболизм теперь зануляет реф при удалении.
/🆑
```

</details>

- [x] Pull Request полностью завершен, мне не нужна помощь чтобы его закончить.
- [x] Я внимательно прочитал все свои изменения и багов в них не нашел.
- [ ] Я запускал сервер со своими изменениями локально и все протестировал.
- [x] Я ознакомился c [Guide to Contribute](https://github.com/ChaoticOnyx/OnyxBay/blob/dev/docs/contributing.md).
