### PR TITLE
tweak(throw): fix nullspace stuck

### DIFF
--- a/code/game/atoms_movable.dm
+++ b/code/game/atoms_movable.dm
@@ -238,6 +238,10 @@
 		src.loc = null
 		if (Move(previous))
 			Move(step)
+		if(!loc)
+			// we got into nullspace! abort!
+			loc = previous
+			break
 		hit_check(impact_speed)
 		dist_travelled++
 		dist_since_sleep += tiles_per_tick

--- a/code/game/objects/buckling.dm
+++ b/code/game/objects/buckling.dm
@@ -33,6 +33,9 @@
 		if(M != src && C.incapacitated())
 			return 0
 
+	if(M.throwing)
+		// can't throwing mob if it's buckled
+		M.throwing = 0
 	M.buckled = src
 	M.facing_dir = null
 	M.set_dir(buckle_dir ? buckle_dir : dir)


### PR DESCRIPTION
Теперь нельзя попасть в капкан и улететь в бекрумс ака нуллспейс.

<details>
<summary>Чейнджлог</summary>

```yml
🆑
bugfix: Теперь при броске нельзя застрять в нуллспейсе.
/🆑
```

</details>

- [x] Pull Request полностью завершен, мне не нужна помощь чтобы его закончить.
- [x] Я внимательно прочитал все свои изменения и багов в них не нашел.
- [x] Я запускал сервер со своими изменениями локально и все протестировал.
- [x] Я ознакомился c [Guide to Contribute](https://github.com/ChaoticOnyx/OnyxBay/blob/dev/docs/contributing.md).
