### PR TITLE
fix(matchmaking): no more relationships with cyborgs

### DIFF
--- a/code/modules/client/preference_setup/matchmaking/matchmaking.dm
+++ b/code/modules/client/preference_setup/matchmaking/matchmaking.dm
@@ -17,7 +17,7 @@ var/global/datum/matchmaker/matchmaker = new()
 /datum/matchmaker/proc/do_matchmaking()
 	var/list/to_warn = list()
 	for(var/datum/relation/R in relations)
-		if(R.holder.current.isSynthetic())
+		if(!R.holder.current || R.holder.current.isSynthetic())
 			continue
 		if(!R.other)
 			R.find_match()

--- a/code/modules/client/preference_setup/matchmaking/matchmaking.dm
+++ b/code/modules/client/preference_setup/matchmaking/matchmaking.dm
@@ -17,6 +17,8 @@ var/global/datum/matchmaker/matchmaker = new()
 /datum/matchmaker/proc/do_matchmaking()
 	var/list/to_warn = list()
 	for(var/datum/relation/R in relations)
+		if(R.holder.current.isSynthetic())
+			continue
 		if(!R.other)
 			R.find_match()
 		if(R.other && !R.finalized)
@@ -69,6 +71,9 @@ var/global/datum/matchmaker/matchmaker = new()
 		return FALSE
 
 	if(!M.current)	//no extremely platonic relationships
+		return FALSE
+
+	if(M.current.isSynthetic()) // No relationships with robots
 		return FALSE
 
 	return TRUE


### PR DESCRIPTION
fix #10768

Этот ПР полностью отключает релейншипы с синтетиками. Теоретически, есть смысл оставить релейншипы по  типу "Served Together", но я не уверен что это нам нужно. 

<details>
<summary>Чейнджлог</summary>

```yml
🆑
bugfix: Отключены любые отношения с боргами.
/🆑
```

</details>


- [x] Pull Request полностью завершен, мне не нужна помощь чтобы его закончить.
- [x] Я внимательно прочитал все свои изменения и багов в них не нашел.
- [x] Я запускал сервер со своими изменениями локально и все протестировал.
- [x] Я ознакомился c [Guide to Contribute](https://github.com/ChaoticOnyx/OnyxBay/blob/dev/docs/contributing.md).
