### PR TITLE
fix(commanded): fixed bugs in simple_animal/hostile/commanded

### DIFF
--- a/code/modules/mob/living/simple_animal/hostile/commanded/commanded.dm
+++ b/code/modules/mob/living/simple_animal/hostile/commanded/commanded.dm
@@ -53,11 +53,13 @@
 			continue
 		if(isliving(A))
 			M = A
-		if(istype(A,/obj/mecha))
+		else if(istype(A,/obj/mecha))
 			var/obj/mecha/mecha = A
 			if(!mecha.occupant)
 				continue
 			M = mecha.occupant
+		else // If it is not living and not /obj/mecha/, then we have something strange going on.
+			continue
 		if(M && M.stat)
 			continue
 		if(mode == "specific")
@@ -190,3 +192,8 @@
 		stance = HOSTILE_STANCE_ATTACK
 		if(weakref(M) in friends)
 			friends -= weakref(M)
+
+/mob/living/simple_animal/hostile/commanded/AttackingTarget()
+	if(!client && target_mob == master) // we don't want mob attacking its master
+		return
+	. = ..()


### PR DESCRIPTION
В проке find_target() идет поиск целей через hearers(src, vision_range) - это добавляет в список лишних мобов, а проверка это не учитывала. 

Плюс призванный медведь по команде "follow me" начинал следовать за магом. Правда следование там идет через follow_command, который вызывает set_target_mob - что делало мага целью для атаки. Воткнул заглушку и на это. 

fixes #10796

<details>
<summary>Чейнджлог</summary>

```yml
🆑
bugfix: Теперь медведи мага должны корректно атаковать цели.
/🆑
```

</details>



- [x] Pull Request полностью завершен, мне не нужна помощь чтобы его закончить.
- [x] Я внимательно прочитал все свои изменения и багов в них не нашел.
- [x] Я запускал сервер со своими изменениями локально и все протестировал.
- [x] Я ознакомился c [Guide to Contribute](https://github.com/ChaoticOnyx/OnyxBay/blob/dev/docs/contributing.md).
