### PR TITLE
Removes simple_animals' ultimate anti-taser defence

### DIFF
--- a/code/modules/mob/living/simple_animal/simple_animal.dm
+++ b/code/modules/mob/living/simple_animal/simple_animal.dm
@@ -184,12 +184,12 @@
 	..(icon_gib, do_gibs)
 
 /mob/living/simple_animal/bullet_act(obj/item/projectile/Proj)
-	if(!Proj || Proj.nodamage)
+	if(!Proj)
 		return
 
 	var/damage = Proj.damage * ((100 - armor_projectile) / 100)
-	if(Proj.damtype == STUN)
-		damage = (Proj.damage / 8)
+	if(Proj.damtype == STUN || Proj.damtype == PAIN)
+		damage = (Proj.damage / 8) + (Proj.agony / 8)
 
 	adjustBruteLoss(damage)
 	return 0


### PR DESCRIPTION
тоби-турель загриферили мыши

- Простые животные теперь получают небольшой урон от всяких тазеров и станпуль ((урон+агония)/8).

```yml
🆑
bugfix: Исправлена ошибка, из-за которой простые животные не получали урон от всяких тазеров и станпулек.
/🆑
```

по идее не гейдизайн, это было впилено ещё несколько лет назад, но всё обосралось об смешную проверочку на Proj.nodamage из-за переделки тазеров

- [x] Pull Request полностью завершен, мне не нужна помощь чтобы его закончить.
- [x] Я внимательно прочитал все свои изменения и багов в них не нашел.
- [x] Я запускал сервер со своими изменениями локально и все протестировал.
- [x] Я ознакомился c [Guide to Contribute](https://github.com/ChaoticOnyx/OnyxBay/blob/dev/docs/contributing.md).
