### PR TITLE
Removes vampires' inability to perform Veil Step via RMB

### DIFF
--- a/baystation12.dme
+++ b/baystation12.dme
@@ -8,7 +8,6 @@
 // END_FILE_DIR
 // BEGIN_PREFERENCES
 #define DEBUG
-// #define TRACY_PROFILER
 // END_PREFERENCES
 // BEGIN_INCLUDE
 #include "code\__spaceman_dmm.dm"

--- a/baystation12.dme
+++ b/baystation12.dme
@@ -8,6 +8,7 @@
 // END_FILE_DIR
 // BEGIN_PREFERENCES
 #define DEBUG
+// #define TRACY_PROFILER
 // END_PREFERENCES
 // BEGIN_INCLUDE
 #include "code\__spaceman_dmm.dm"

--- a/code/game/gamemodes/vampire/powers/darkvision.dm
+++ b/code/game/gamemodes/vampire/powers/darkvision.dm
@@ -3,7 +3,7 @@
 /datum/vampire_power/toggled/darkvision
 	name = "Darkvision"
 	desc = "You're are able to see in the dark."
-	icon_state = "vamp_darksight_on"
+	icon_state = "vamp_darksight_off"
 	power_processing = FALSE
 	max_stat = UNCONSCIOUS
 

--- a/code/game/gamemodes/vampire/powers/veilstep.dm
+++ b/code/game/gamemodes/vampire/powers/veilstep.dm
@@ -26,6 +26,14 @@
 	set category = null
 	set name = "Veil Step (20)"
 	set desc = "For a moment, move through the Veil and emerge at a shadow of your choice."
+	if(ishuman(src)) // When used via the context menu the proc reparents to the mob, thank you lummox
+		var/mob/living/carbon/human/H = src
+		H.mind?.vampire?._vampire_veilstep(T)
+	else
+		_vampire_veilstep(T)
+	log_and_message_admins("activated veil step.")
+
+/datum/vampire/proc/_vampire_veilstep(turf/T)
 	var/blood_cost = 20
 
 	if (!T || T.density || T.contains_dense_objects())
@@ -68,7 +76,5 @@
 			G.affecting.forceMove(locate(T.x + rand(-1,1), T.y + rand(-1,1), T.z))
 		else
 			qdel(G)
-
-	log_and_message_admins("activated veil step.")
 
 	use_blood(blood_cost)


### PR DESCRIPTION

```yml
🆑
bugfix: Вампиры снова могут использовать Veil Step через ПКМ по тайлу, а не только через альт+клик.
bugfix: Исправлено отображение иконки у способности Darkvision вампиров.
/🆑
```

- [x] Pull Request полностью завершен, мне не нужна помощь чтобы его закончить.
- [x] Я внимательно прочитал все свои изменения и багов в них не нашел.
- [x] Я запускал сервер со своими изменениями локально и все протестировал.
- [x] Я ознакомился c [Guide to Contribute](https://github.com/ChaoticOnyx/OnyxBay/blob/dev/docs/contributing.md).
