### PR TITLE
fix(mime): mime can now rename himself 

### DIFF
--- a/code/_helpers/unsorted.dm
+++ b/code/_helpers/unsorted.dm
@@ -344,6 +344,7 @@ Turf and target are seperate in case you want to teleport some distance from a t
 		if(!newname)	//we'll stick with the oldname then
 			return
 
+		log_and_message_admins("has renamed the [role] '[oldname]' to '[newname]'")
 		fully_replace_character_name(newname)
 
 

--- a/code/game/jobs/job/civilian.dm
+++ b/code/game/jobs/job/civilian.dm
@@ -210,6 +210,7 @@
 		return
 	if(.)
 		H.silent += 86400
+		H.rename_self("mime")
 
 	// Add "Invisible wall" spell
 	H.add_spell(new /datum/spell/aoe_turf/conjure/forcewall/mime, "grey_spell_ready")

--- a/code/game/jobs/job/civilian.dm
+++ b/code/game/jobs/job/civilian.dm
@@ -182,13 +182,6 @@
 	. = ..()
 	if(.)
 		H.mutations.Add(MUTATION_CLUMSY)
-		var/new_name = sanitizeSafe(input(src, "Enter new name, clown. Leave blank or as is to cancel and stay boring.", "[H.real_name] - Enter new HONKy name", H.real_name))
-		if(new_name && new_name != H.real_name)
-			log_and_message_admins("has renamed the clown '[H.real_name]' to '[new_name]'")
-			H.fully_replace_character_name(new_name)
-			H.dna.real_name = new_name
-			if(H.mind)
-				H.mind.name = new_name
 		H.rename_self("clown")
 
 /datum/job/mime
@@ -211,7 +204,6 @@
 	if(.)
 		H.silent += 86400
 		H.rename_self("mime")
-
 	// Add "Invisible wall" spell
 	H.add_spell(new /datum/spell/aoe_turf/conjure/forcewall/mime, "grey_spell_ready")
 


### PR DESCRIPTION
Был #2545 фиксящий #2514 да сплыл, коммит улетел в нуллспейс после хардресета

Параллельно починил легаси код говна. 
По какой-то причине код переименования клоуна был всрат чуть более чем полностью. 
log_and_message_admins вообще не отправлялся, а остальные удаленные строки дублировали прок rename_self. 
Теперь log_and_message_admins работает нормально. Правда, он уведомляет админов о смене имени как мима-клоуна, так и ИИ/боргов. Но разве это плохо, а?


<details>
<summary>Чейнджлог</summary>

```yml
🆑
bugfix: Пофикшен баг не позволявший миму переименовать себя. 
admin: Теперь переименование раундстарт ролей (мим, клоун, ИИ и борги) корректно логируется. 
/🆑
```

</details>

- [x] Pull Request полностью завершен, мне не нужна помощь чтобы его закончить.
- [x] Я внимательно прочитал все свои изменения и багов в них не нашел.
- [x] Я запускал сервер со своими изменениями локально и все протестировал.
- [x] Я ознакомился c [Guide to Contribute](https://github.com/ChaoticOnyx/OnyxBay/blob/dev/docs/contributing.md).
