### PR TITLE
Removes the revert of the removal of poise damage inflicted by projectiles

### DIFF
--- a/code/modules/mob/living/carbon/human/human_defense.dm
+++ b/code/modules/mob/living/carbon/human/human_defense.dm
@@ -76,6 +76,7 @@ meteor_act
 				SP.loc = organ
 				organ.embed(SP)
 
+	projectile_affect_poise(P, P.poisedamage * blocked_mult(blocked), def_zone)
 	projectile_hit_bloody(P, P.damage*blocked_mult(blocked), def_zone)
 
 	return blocked
@@ -747,6 +748,30 @@ meteor_act
 					update_inv_glasses(0)
 			if(BP_CHEST)
 				bloody_body(src)
+
+/mob/living/carbon/human/proc/projectile_affect_poise(obj/item/projectile/P, poisedamage, hit_zone)
+	if(!poisedamage)
+		return 0 //save a couple of nanoseconds
+
+	if(status_flags & GODMODE)
+		return 0 //godmode
+
+	var/pd_mult = 1.0
+	switch(hit_zone)
+		if(BP_HEAD)
+			pd_mult = 1.35
+		if(BP_CHEST)
+			pd_mult = 1.0
+		if(BP_GROIN)
+			pd_mult = 1.15
+		else
+			pd_mult = 0.75
+
+	damage_poise(poisedamage * pd_mult)
+	if(poise <= 25 && !prob(poise * 3))
+		apply_effect(max(3, (poisedamage * pd_mult / 4)), WEAKEN)
+		if(!lying)
+			visible_message(SPAN("danger", "[src] goes down under the impact of \the [P]!"))
 
 /mob/living/carbon/human/proc/attack_joint(obj/item/organ/external/organ, obj/item/W, effective_force, dislocate_mult, blocked)
 	if(!organ || (organ.dislocated == 2) || (organ.dislocated == -1) || blocked >= 100)

--- a/code/modules/projectiles/gun.dm
+++ b/code/modules/projectiles/gun.dm
@@ -385,6 +385,8 @@
 		for(var/obj/item/grab/G in H.grabbed_by)
 			if(G.point_blank_mult() > max_mult)
 				max_mult = G.point_blank_mult()
+		if(H.lying)
+			max_mult *= 1.5
 	P.damage *= max_mult
 	P.accuracy += 4
 

--- a/code/modules/projectiles/projectile.dm
+++ b/code/modules/projectiles/projectile.dm
@@ -52,6 +52,7 @@
 	var/embed = 0 // whether or not the projectile can embed itself in the mob
 	var/penetration_modifier = 0.2 //How much internal damage this projectile can deal, as a multiplier.
 	var/tasing = 0 //Whether or not it will stun the target once they reach the pain limit
+	var/poisedamage = 0 //Kinda self-decriptive
 
 
 	// effect types to be used

--- a/code/modules/projectiles/projectile/bullets.dm
+++ b/code/modules/projectiles/projectile/bullets.dm
@@ -8,6 +8,7 @@
 	embed = 1
 	sharp = 1
 	penetration_modifier = 1.0
+	poisedamage = 5.0
 	var/mob_passthrough_check = 0
 
 	muzzle_type = /obj/effect/projectile/muzzle/bullet
@@ -67,6 +68,7 @@
 /obj/item/projectile/bullet/pellet
 	name = "shrapnel" //'shrapnel' sounds more dangerous (i.e. cooler) than 'pellet'
 	damage = 22.5
+	poisedamage = 10.0
 	//icon_state = "bullet" //TODO: would be nice to have it's own icon state
 	var/pellets = 4			//number of pellets
 	var/range_step = 2		//projectile will lose a fragment each time it travels this distance. Can be a non-integer.
@@ -130,34 +132,41 @@
 /obj/item/projectile/bullet/pistol
 	damage = 27.5 //9mm, .38, etc
 	armor_penetration = 13.5
+	poisedamage = 5.0
 
 /obj/item/projectile/bullet/pistol/medium
 	damage = 30 //.45
 	armor_penetration = 14.5
+	poisedamage = 7.5
 
 /obj/item/projectile/bullet/pistol/medium/smg
 	damage = 32.5 //10mm
 	armor_penetration = 19.5
+	poisedamage = 6.0
 
 /obj/item/projectile/bullet/pistol/medium/revolver
 	fire_sound = 'sound/effects/weapons/gun/fire_revolver44.ogg'
 	damage = 37.5 //.44 magnum or something
 	armor_penetration = 20
+	poisedamage = 12.5
 
 /obj/item/projectile/bullet/pistol/strong //matebas
 	fire_sound = 'sound/effects/weapons/gun/fire_mateba.ogg'
 	damage = 60 //.50AE
 	armor_penetration = 30
+	poisedamage = 20.0
 
 /obj/item/projectile/bullet/pistol/strong/revolver //revolvers
 	damage = 50 //Revolvers get snowflake bullets, to keep them relevant
 	armor_penetration = 20
+	poisedamage = 20.0
 
 // for rapid-fire mode (lawgiver)
 /obj/item/projectile/bullet/pistol/lawgiver
 	damage = 18.5
 	armor_penetration = 10
 	fire_sound = 'sound/effects/weapons/gun/fire1.ogg'
+	poisedamage = 3.0
 
 /obj/item/projectile/bullet/pistol/rubber //"rubber" bullets
 	name = "rubber bullet"
@@ -168,6 +177,7 @@
 	sharp = 0
 	armor_penetration = 2.5
 	penetration_modifier = 0.2
+	poisedamage = 10.0
 
 /obj/item/projectile/bullet/pistol/rubber/c44
 	name = "rubber bullet"
@@ -177,12 +187,14 @@
 	embed = 0
 	sharp = 0
 	fire_sound = 'sound/effects/weapons/gun/fire_revolver44.ogg'
+	poisedamage = 13.5
 
 /obj/item/projectile/bullet/pistol/accelerated/c38
 	name = "accelerated bullet"
 	damage = 35.0 // .38 + gauss
 	armor_penetration = 35
 	fire_sound = 'sound/effects/weapons/gun/fire_revolver44.ogg' // Gauss .38 should sound like a badass
+	poisedamage = 12.5
 
 
 /* shotgun projectiles */
@@ -191,6 +203,7 @@
 	name = "slug"
 	damage = 55
 	armor_penetration = 20
+	poisedamage = 20.0
 
 /obj/item/projectile/bullet/shotgun/beanbag		//because beanbags are not bullets
 	name = "beanbag"
@@ -201,6 +214,7 @@
 	sharp = 0
 	penetration_modifier = 0.2
 	can_ricochet = FALSE // Too soft
+	poisedamage = 20.0
 
 //Should do about 80 damage at 1 tile distance (adjacent), and 50 damage at 3 tiles distance.
 //Overall less damage than slugs in exchange for more damage at very close range and more embedding
@@ -211,6 +225,7 @@
 	range_step = 1
 	spread_step = 10
 	penetration_modifier = 1.2 // A bit more internal damage since we don't have armor penetration anyway
+	poisedamage = 12.5
 
 /obj/item/projectile/bullet/pellet/scattershot // Used by *heavy* shotguns, i.e. LBX AC 10 "Scattershot"
 	name = "shrapnel"
@@ -220,6 +235,7 @@
 	range_step = 2
 	spread_step = 15
 	penetration_modifier = 1.2
+	poisedamage = 17.5
 
 /obj/item/projectile/bullet/pellet/accelerated
 	name = "accelerated particles"
@@ -233,15 +249,18 @@
 	spread_step = 5
 	penetration_modifier = 1.1
 	muzzle_type = /obj/effect/projectile/muzzle/accel
+	poisedamage = 15.0
 
 /obj/item/projectile/bullet/pellet/accelerated/lesser
 	damage = 20
+	poisedamage = 12.5
 
 /* "Rifle" rounds */
 
 /obj/item/projectile/bullet/rifle
 	armor_penetration = 25
 	penetrating = 1
+	poisedamage = 7.0
 
 /obj/item/projectile/bullet/rifle/a556
 	damage = 27.5
@@ -258,6 +277,7 @@
 	armor_penetration = 80
 	hitscan = 1 //so the PTR isn't useless as a sniper weapon
 	penetration_modifier = 1.25
+	poisedamage = 125.0 //you can't withstand a knuckle-sized chunk of metal with borderline escape velocity
 
 /obj/item/projectile/bullet/rifle/a145/apds
 	damage = 75
@@ -302,13 +322,16 @@
 
 /obj/item/projectile/bullet/pistol/practice
 	damage = 5
+	poisedamage = 3.0
 
 /obj/item/projectile/bullet/rifle/a762/practice
 	damage = 5
+	poisedamage = 3.0
 
 /obj/item/projectile/bullet/shotgun/practice
 	name = "practice"
 	damage = 5
+	poisedamage = 3.0
 
 /obj/item/projectile/bullet/pistol/cap
 	name = "cap"
@@ -319,6 +342,7 @@
 	nodamage = 1
 	embed = 0
 	sharp = 0
+	poisedamage = 0.0
 
 /obj/item/projectile/bullet/pistol/cap/Process()
 	loc = null
@@ -330,6 +354,7 @@
 	damage = 40
 	armor_penetration = 25
 	kill_count = 255
+	poisedamage = 255 // SLAM JAM
 
 /obj/item/projectile/bullet/rock/New()
 	icon_state = "rock[rand(1,3)]"

--- a/code/modules/projectiles/projectile/energy.dm
+++ b/code/modules/projectiles/projectile/energy.dm
@@ -213,6 +213,7 @@
 	agony = 70
 	damage_type = BURN
 	vacuum_traversal = 0
+	poisedamage = 20.0
 
 /obj/item/projectile/energy/plasmastun/proc/bang(mob/living/carbon/M)
 

--- a/code/modules/projectiles/projectile/force.dm
+++ b/code/modules/projectiles/projectile/force.dm
@@ -4,6 +4,7 @@
 	icon_state = "ice_1"
 	damage = 20
 	check_armour = "energy"
+	poisedamage = 35.0 // well, itsa FORCE bolt right?
 
 /obj/item/projectile/forcebolt/strong
 	name = "force bolt"

--- a/code/modules/projectiles/projectile/special.dm
+++ b/code/modules/projectiles/projectile/special.dm
@@ -72,6 +72,7 @@
 	nodamage = 1
 	check_armour = "bullet"
 	blockable = FALSE
+	poisedamage = 255 // slammy jammy
 
 /obj/item/projectile/meteor/Bump(atom/A, forced = FALSE)
 	if(A == firer)


### PR DESCRIPTION
тоби загрифонили отсутствием пойздамага у пулек

https://github.com/ChaoticOnyx/OnyxBay/pull/653 но занёрфленный
---
```yml
🆑
tweak: Возвращён пойздамаг от выстрелов, но в ослабленном виде. Резиновые пули и бинбэги снова полезные, ПТР снова вызывает ПТСР.
tweak: Возвращён дополнительный урон от выстрелов в упор по лежачим целям.
/🆑
```
---

Всё как раньше, но шанс опрокидывания ниже, урон по пойзу ниже, множитель урона от добивания понижен с 250% до 150%.

---

- [x] Pull Request полностью завершен, мне не нужна помощь чтобы его закончить.
- [x] Я внимательно прочитал все свои изменения и багов в них не нашел.
- [x] Я запускал сервер со своими изменениями локально и все протестировал.
- [x] Я ознакомился c [Guide to Contribute](https://github.com/ChaoticOnyx/OnyxBay/blob/dev/docs/contributing.md).
