### PR TITLE
Removes closet doors' inconsistency

### DIFF
--- a/code/game/objects/structures/crates_lockers/closets.dm
+++ b/code/game/objects/structures/crates_lockers/closets.dm
@@ -88,6 +88,10 @@
 
 	var/lockable = FALSE
 
+/obj/item/shield/closet/Initialize()
+	..()
+	update_icon()
+
 /obj/item/shield/closet/update_icon()
 	..()
 	if(isturf(loc))


### PR DESCRIPTION
тоби загрифонили стоячей дверкой

- Поворот спрайта у дверок от шкафчиков теперь работает надёжнее.
- При взрыве шкафчика дверка теперь может уничтожиться вместе с самим шкафчиком. При слабом взрыве - только отлетает, при среднем - 50/50, при сильном - гранатированно уничтожается.

---

- [x] Pull Request полностью завершен, мне не нужна помощь чтобы его закончить.
- [x] Я внимательно прочитал все свои изменения и багов в них не нашел.
- [x] Я запускал сервер со своими изменениями локально и все протестировал.
- [x] Я ознакомился c [Guide to Contribute](https://github.com/ChaoticOnyx/OnyxBay/blob/dev/docs/contributing.md).
