### PR TITLE
Автоматическое открытие воут панели

### DIFF
--- a/code/controllers/subsystems/vote.dm
+++ b/code/controllers/subsystems/vote.dm
@@ -41,9 +41,6 @@ SUBSYSTEM_DEF(vote)
 			LAZYADD(old_votes, active_vote) // Store the datum for future reference.
 			reset()
 			return
-		if(VOTE_PROCESS_ONGOING)
-			for(var/client/C in voting)
-				show_panel(C.mob)
 
 /datum/controller/subsystem/vote/stat_entry()
 	..("Vote:[active_vote ? "[active_vote.name], [active_vote.time_remaining]" : "none"]")
@@ -78,6 +75,11 @@ SUBSYSTEM_DEF(vote)
 
 	active_vote = new_vote
 	last_started_time = world.time
+
+	if(new_vote.force_show_panel)
+		for(var/client/C in GLOB.clients)
+			show_panel(C.mob)
+
 	return TRUE
 
 /datum/controller/subsystem/vote/proc/interface(client/C)

--- a/code/datums/vote/map.dm
+++ b/code/datums/vote/map.dm
@@ -1,6 +1,8 @@
 /datum/vote/map
 	name = "map"
 
+	force_show_panel = TRUE
+
 /datum/vote/map/can_run(mob/creator, automatic)
 	if(!config.game.map_switching)
 		return FALSE

--- a/code/datums/vote/storyteller.dm
+++ b/code/datums/vote/storyteller.dm
@@ -1,6 +1,8 @@
 /datum/vote/storyteller
 	name = "storyteller"
 
+	force_show_panel = TRUE
+
 /datum/vote/storyteller/can_run(mob/creator, automatic)
 	if(!automatic && !is_admin(creator))
 		return FALSE // Must be an admin.

--- a/code/datums/vote/vote.dm
+++ b/code/datums/vote/vote.dm
@@ -23,6 +23,8 @@
 
 	var/manual_allowed = 1         // Whether humans can start it.
 
+	var/force_show_panel = FALSE   // принудительно открывать панель голосования при запуске самого голосования.
+
 //Expected to be run immediately after creation; a false return means that the vote could not be run and the datum will be deleted.
 /datum/vote/proc/setup(mob/creator, automatic)
 	if(!can_run(creator, automatic))
@@ -193,3 +195,4 @@
 		return // If the input was invalid, we don't continue recording the vote.
 
 	submit_vote(user, choice, priority)
+	SSvote.show_panel(user)


### PR DESCRIPTION
ааааааааааааа, один воут за фронтир при онлайне в 40 рыл заставил всех страдать, ну кто так делает

алсо убрал автоматическое обновление воут панели, ибо он реализовано через ебейшую жопу, и окошко создаётся для всех заново каждую ебаную секунду.


<details>
<summary>Чейнджлог</summary>

```yml
🆑
tweak: Голосования за карту и сторителлера теперь будут выскакивать принудительно.
/🆑
```

</details>


- [х] Pull Request полностью завершен, мне не нужна помощь чтобы его закончить.
- [х] Я внимательно прочитал все свои изменения и багов в них не нашел.
- [х] Я запускал сервер со своими изменениями локально и все протестировал.
- [х] Я ознакомился c [Guide to Contribute](https://github.com/ChaoticOnyx/OnyxBay/blob/dev/docs/contributing.md).
