### PR TITLE
Призраки видят сообщения по ПДА от преференса Ghost Radio вместо Ghost Ears

### DIFF
--- a/code/game/objects/items/devices/PDA/PDA.dm
+++ b/code/game/objects/items/devices/PDA/PDA.dm
@@ -1025,7 +1025,7 @@ var/global/list/obj/item/device/pda/PDAs = list()
 		P.tnote.Add(list(list("sent" = 0, "owner" = "[owner]", "job" = "[ownjob]", "message" = "[utf_message]", "timestamp" = stationtime2text(), "target" = "\ref[src]")))
 
 		for(var/mob/M in GLOB.player_list)
-			if(M.is_ooc_dead() && M.get_preference_value(/datum/client_preference/ghost_ears) == GLOB.PREF_ALL_SPEECH) // src.client is so that ghosts don't have to listen to mice
+			if(M.is_ooc_dead() && M.get_preference_value(/datum/client_preference/ghost_radio) == GLOB.PREF_ALL_CHATTER) // src.client is so that ghosts don't have to listen to mice
 				if(istype(M, /mob/new_player))
 					continue
 				M.show_message("<span class='game say'>PDA Message - <span class='name'>[owner]</span> -> <span class='name'>[P.owner]</span>: <span class='message'>[message]</span></span>")


### PR DESCRIPTION
Сук, почему я обязан слушать сейлоги вообще всей станции, ради того чтобы читать переписки? Да и сообщения ПДА ближе к рации, чем к устной речи.

- Сообщения по ПДА будут показываться призраку при установленном на всеслышимость преференсе Ghost Radio, а не Ghost Ears.

<details>
<summary>Чейнджлог</summary>

```yml
🆑TheUnknownOne
tweak: Призраки теперь видят или не видят сообщения по ПДА в зависимости от значения преференса Ghost Radio, а не Ghost Ears.
/🆑
```

</details>

- [x] Pull Request полностью завершен, мне не нужна помощь чтобы его закончить.
- [x] Я внимательно прочитал все свои изменения и багов в них не нашел.
- [ ] Я запускал сервер со своими изменениями локально и все протестировал.
- [x] Я ознакомился c [Guide to Contribute](https://github.com/ChaoticOnyx/OnyxBay/blob/dev/docs/contributing.md).