### PR TITLE
fix(storyteller): possible fix of runtime

### DIFF
--- a/code/game/antagonist/antagonist_add.dm
+++ b/code/game/antagonist/antagonist_add.dm
@@ -8,15 +8,15 @@
 		player.assigned_role = role_text
 	player.special_role = role_text
 
-	if(player.current)
-		BITSET(player.current.hud_updateflag, SPECIALROLE_HUD)
-
 	if(isghostmind(player) || isnewplayer(player.current))
 		create_default(player.current, team)
 	else
 		create_antagonist(player, move_to_spawn, do_not_announce, preserve_appearance, team)
 		if(!do_not_equip)
 			equip(player.current)
+
+	if(player.current)
+		BITSET(player.current.hud_updateflag, SPECIALROLE_HUD)
 
 	player.current.faction = faction
 	return TRUE


### PR DESCRIPTION
Проблема следующая - игрок сидит в лобби, ему предлагает рольку. Он жмет YES, в чат выводится текст про амбиции, добавляется AOOC, но ничего не происходит. Игрок как сидит в лобби, так и сидит. Вылетает следующий рантайм:

[15:22:22] Runtime in antagonist_add.dm, line 12: undefined variable /mob/observer/ghost/var/hud_updateflag

Теоретически поставив битсет после создания моба для антага должно это пофиксить. 

Как это тестить на локалке - я не знаю. 

Fixes #10696 #10530

<details>
<summary>Чейнджлог</summary>

```yml
🆑
bugfix: Фикс выдачи мидраунд антагов гостам.
/🆑
```

</details>

- [x] Pull Request полностью завершен, мне не нужна помощь чтобы его закончить.
- [x] Я внимательно прочитал все свои изменения и багов в них не нашел.
- [x] Я запускал сервер со своими изменениями локально и все протестировал.
- [x] Я ознакомился c [Guide to Contribute](https://github.com/ChaoticOnyx/OnyxBay/blob/dev/docs/contributing.md).
