### PR TITLE
fix(votes): fixed ability to nonadmins start round end vote

### DIFF
--- a/code/datums/vote/end.dm
+++ b/code/datums/vote/end.dm
@@ -3,11 +3,11 @@
 	default_choices = list("End the Round", "Continue Playing")
 
 /datum/vote/end_round/can_be_initiated(mob/by_who, forced)
-	. = ..()
 	if(GAME_STATE !=  RUNLEVEL_GAME)
 		return FALSE
-	if(forced || check_rights(R_SERVER, FALSE, by_who))
-		return TRUE
+	if(!forced && !check_rights(R_SERVER, FALSE, by_who))
+		return FALSE
+	return ..()
 
 /datum/vote/end_round/finalize_vote(winning_option)
 	if(..())

--- a/code/datums/vote/storyteller.dm
+++ b/code/datums/vote/storyteller.dm
@@ -21,7 +21,7 @@
 		return TRUE
 
 	if(winning_option == "Random")
-		SSstoryteller.character = pick(choices - "Random")
+		SSstoryteller.character = GLOB.all_storytellers[pick(default_choices - "Random")]
 		log_and_message_admins("Storyteller's character was changed to [SSstoryteller.character.name].")
 		return
 	SSstoryteller.character = GLOB.all_storytellers[winning_option]


### PR DESCRIPTION


<details>
<summary>Чейнджлог</summary>

```yml
🆑
bugfix: Раундэнд воут больше нельзя запустить не админам
/🆑
```

</details>


- [x] Pull Request полностью завершен, мне не нужна помощь чтобы его закончить.
- [x] Я внимательно прочитал все свои изменения и багов в них не нашел.
- [x] Я запускал сервер со своими изменениями локально и все протестировал.
- [x] Я ознакомился c [Guide to Contribute](https://github.com/ChaoticOnyx/OnyxBay/blob/dev/docs/contributing.md).
