### PR TITLE
tweak(synths): fix meat organ present in body

### DIFF
--- a/code/modules/mob/living/silicon/robot/robot_parts.dm
+++ b/code/modules/mob/living/silicon/robot/robot_parts.dm
@@ -16,7 +16,7 @@
 
 /obj/item/robot_parts/New(newloc, model)
 	..(newloc)
-	if(model_info && model)
+	if(model_info)
 		if(isnull(model))
 			model = "Unbranded"
 		model_info = model

--- a/code/modules/organs/external/head.dm
+++ b/code/modules/organs/external/head.dm
@@ -87,7 +87,7 @@
 /obj/item/organ/external/head/robotize(company, skip_prosthetics = FALSE, keep_organs = FALSE, just_printed = FALSE)
 	if(company)
 		var/datum/robolimb/R = GLOB.all_robolimbs[company]
-		if(R)
+		if(istype(R))
 			can_intake_reagents = R.can_eat
 	. = ..(company, skip_prosthetics, 1)
 	has_lips = FALSE


### PR DESCRIPTION
~~Я сделал кринж в гитхабе и запушил бранч не на тот стрим, давайте замержим это и побыстрее избавимся от этой ветки.~~

Органы у синтетов точно убиваются, операции проводятся, все круто.

<details>
<summary>Чейнджлог</summary>

```yml
🆑
tweak: Теперь в синтетах при спавне не должно быть мясных органов.
/🆑
```

</details>

- [x] Pull Request полностью завершен, мне не нужна помощь чтобы его закончить.
- [x] Я внимательно прочитал все свои изменения и багов в них не нашел.
- [x] Я запускал сервер со своими изменениями локально и все протестировал.
- [x] Я ознакомился c [Guide to Contribute](https://github.com/ChaoticOnyx/OnyxBay/blob/dev/docs/contributing.md).
