### PR TITLE
fix(sleeper): forgotten Destroy()

### DIFF
--- a/code/game/machinery/Sleeper.dm
+++ b/code/game/machinery/Sleeper.dm
@@ -389,7 +389,10 @@
 		update_icon()
 
 /obj/machinery/sleeper/proc/go_out()
-	if(!occupant || locked)
+	if(!occupant)
+		return
+
+	if(locked)
 		return
 
 	if(occupant.client)

--- a/code/game/machinery/Sleeper.dm
+++ b/code/game/machinery/Sleeper.dm
@@ -67,7 +67,7 @@
 	if(stat & (NOPOWER|BROKEN))
 		return
 
-	if (!(occupant in src))
+	if(occupant && !(occupant in src))
 		go_out()
 
 	play_beep()
@@ -389,10 +389,9 @@
 		update_icon()
 
 /obj/machinery/sleeper/proc/go_out()
-	if(!occupant)
+	if(!occupant || locked)
 		return
-	if(locked)
-		return
+
 	if(occupant.client)
 		occupant.client.eye = occupant.client.mob
 		occupant.client.perspective = MOB_PERSPECTIVE
@@ -402,6 +401,7 @@
 	for(var/atom/movable/A in src) // In case an object was dropped inside or something
 		if(locate(A) in component_parts)
 			continue
+
 		A.dropInto(loc)
 	update_use_power(POWER_USE_IDLE)
 	update_icon()
@@ -430,3 +430,7 @@
 			to_chat(user, "The subject has too many chemicals.")
 	else
 		to_chat(user, "There's no suitable occupant in \the [src].")
+
+/obj/machinery/sleeper/Destroy()
+	go_out()
+	return ..()

--- a/code/game/machinery/atmoalter/clamp.dm
+++ b/code/game/machinery/atmoalter/clamp.dm
@@ -137,7 +137,7 @@
 /obj/machinery/clamp/proc/detach()
 	if(target?.clamp == src)
 		target.clamp = null
-	new/obj/item/clamp(loc)
+	new /obj/item/clamp(loc)
 	qdel(src)
 
 /obj/item/clamp


### PR DESCRIPTION
Fixes #10923

Кто-то нассал в океан мочи, но забыл добавить выкидывание моба из слипера в Destroy(). 

А еще починил говнокод который в процессинге слипера пытался выкинуть оккупанта, несмотря на то, что оккупанта вообще нет. 

<strike>
В идеале надо решить аналогичную проблему у бодисканнера, но я пока не готов нырять в этот кувшин билли джина 
</strike>


<details>
<summary>Чейнджлог</summary>

```yml
🆑
bugfix: Исправлено недоразумение в результате которого исчезал человек, находившийся в слипере в момент его уничтожения. 
/🆑
```

</details>


- [x] Pull Request полностью завершен, мне не нужна помощь чтобы его закончить.
- [x] Я внимательно прочитал все свои изменения и багов в них не нашел.
- [x] Я запускал сервер со своими изменениями локально и все протестировал.
- [x] Я ознакомился c [Guide to Contribute](https://github.com/ChaoticOnyx/OnyxBay/blob/dev/docs/contributing.md).
