### PR TITLE
tweak(announcers): remove patron tier requirement

### DIFF
--- a/code/datums/announcer/announcer.dm
+++ b/code/datums/announcer/announcer.dm
@@ -73,7 +73,7 @@
 	)
 
 /datum/announcer/vgstation
-	required_tier = PATREON_CARGO
+	required_tier = PATREON_NONE
 
 	sounds = list(
 		/datum/announce/command_report 			= 'sound/announcer/vgstation/command_report.ogg',
@@ -86,7 +86,7 @@
 	)
 
 /datum/announcer/baystation12
-	required_tier = PATREON_CARGO
+	required_tier = PATREON_NONE
 
 	sounds = list(
 		/datum/announce/command_report 				= 'sound/announcer/baystation12/command_report.ogg',
@@ -106,7 +106,7 @@
 
 
 /datum/announcer/baystation12_torch
-	required_tier = PATREON_CARGO
+	required_tier = PATREON_NONE
 
 	sounds = list(
 		/datum/announce/command_report 			= 'sound/announcer/baystation12-torch/command_report.ogg',
@@ -120,7 +120,7 @@
 	)
 
 /datum/announcer/tgstation
-	required_tier = PATREON_CARGO
+	required_tier = PATREON_NONE
 
 	sounds = list(
 		/datum/announce/command_report 				= 'sound/announcer/tgstation/command_report.ogg',


### PR DESCRIPTION
Почему бы и нет

<details>
<summary>Чейнджлог</summary>

```yml
🆑
tweak: Убраны требования по тиру у существующих на данный момент анонсеров.
/🆑
```

</details>

- [x] Pull Request полностью завершен, мне не нужна помощь чтобы его закончить.
- [x] Я внимательно прочитал все свои изменения и багов в них не нашел.
- [ ] Я запускал сервер со своими изменениями локально и все протестировал.
- [x] Я ознакомился c [Guide to Contribute](https://github.com/ChaoticOnyx/OnyxBay/blob/dev/docs/contributing.md).
