### PR TITLE
fix[surgery]: operations with hookah no more

### DIFF
--- a/code/datums/surgery/surgery_step.dm
+++ b/code/datums/surgery/surgery_step.dm
@@ -67,14 +67,14 @@
 	if(!check_zone(target, parent_zone))
 		return FALSE
 
-	if(needs_uncovered_organ && !check_clothing(target, target_zone))
-		to_chat(user, SPAN_DANGER("Clothing on [target]'s [organ_name_by_zone(target, target_zone)] blocks surgery!"))
-		return SURGERY_FAILURE
-
 	var/obj/item/organ/parent_organ = target.get_organ(parent_zone)
 	var/parent_status = check_parent_organ(parent_organ, target, tool, user)
 	if(!parent_status || parent_status == SURGERY_FAILURE)
 		return parent_status
+
+	if(needs_uncovered_organ && !check_clothing(target, target_zone))
+		to_chat(user, SPAN_DANGER("Clothing on [target]'s [organ_name_by_zone(target, target_zone)] blocks surgery!"))
+		return SURGERY_FAILURE
 
 	var/obj/item/organ/target_organ = pick_target_organ(user, target, target_zone)
 

--- a/code/modules/mob/living/carbon/human/human_helpers.dm
+++ b/code/modules/mob/living/carbon/human/human_helpers.dm
@@ -44,15 +44,14 @@
 /// Check whether mob is lying down on something we can operate him on.
 /mob/living/carbon/human/proc/can_operate(mob/user)
 	var/turf/T = get_turf(src)
-	if(locate(/obj/machinery/optable, T))
+	if(lying && locate(/obj/structure/table, T))
 		. = TRUE
-	if(locate(/obj/structure/bed, T))
+	if(lying && locate(/obj/machinery/optable, T))
 		. = TRUE
-	if(locate(/obj/structure/table, T))
+	if(lying && locate(/obj/effect/rune/, T))
 		. = TRUE
-	if(locate(/obj/effect/rune/, T))
+	if(buckled && istype(buckled, /obj/structure/bed))
 		. = TRUE
-
 
 	if(src == user)
 		var/mob/living/carbon/human/H = user // No way it can't be human at this point.


### PR DESCRIPTION
Fixes #10967 #10891 #10889 #10980 #1743
<details>
<summary>Чейнджлог</summary>

```yml
🆑
bugfix: Исправлена ошибка при которой начиналась операция пиццей, кальяном и другими предметами. 
bugfix: Исправлена баг, позволявший проводить операцию если моб просто стоит на тайле с кроватью, но не пристегнут к ней.
/🆑
```



</details>

- [x] Pull Request полностью завершен, мне не нужна помощь чтобы его закончить.
- [x] Я внимательно прочитал все свои изменения и багов в них не нашел, но что-то все равно сломается к хуям.
- [x] Я запускал сервер со своими изменениями локально и потыкал палкой, вроде бы работает.
- [x] Я ознакомился c [Guide to Contribute](https://github.com/ChaoticOnyx/OnyxBay/blob/dev/docs/contributing.md).
