### PR TITLE
fix[surgery]: fixed wrong message during mend_bones and saw steps

### DIFF
--- a/code/datums/surgery/steps/bone.dm
+++ b/code/datums/surgery/steps/bone.dm
@@ -69,23 +69,25 @@
 	return (..() && parent_organ.stage == 1)
 
 /datum/surgery_step/bone/mend_bone/initiate(obj/item/organ/external/parent_organ, obj/item/organ/target_organ, mob/living/carbon/human/target, obj/item/tool, mob/user)
+	var/bone = parent_organ.encased ? "[target]'s [parent_organ.encased]" : "bones in [target]'s [parent_organ]"
 	announce_preop(user,
-		"[user] is beginning to piece together [target]'s skull with \the [tool].",
-		"You are beginning to piece together [target]'s skull with \the [tool]."
+		"[user] is beginning to piece together [bone] with \the [tool].",
+		"You are beginning to piece together [bone] with \the [tool]."
 		)
 	return ..()
 
 /datum/surgery_step/bone/mend_bone/success(obj/item/organ/external/parent_organ, obj/item/organ/target_organ, mob/living/carbon/human/target, obj/item/tool, mob/user)
+	var/bone = parent_organ.encased ? "[target]'s [parent_organ.encased]" : "bones in [target]'s [parent_organ]"
 	announce_success(user,
-		"[user] sets [target]'s skull with \the [tool].",
-		"You set [target]'s skull with \the [tool]."
+		"[user] sets [bone] with \the [tool].",
+		"You set [bone] with \the [tool]."
 		)
 	parent_organ.stage = 2
 
 /datum/surgery_step/bone/mend_bone/failure(obj/item/organ/external/parent_organ, obj/item/organ/target_organ, mob/living/carbon/human/target, obj/item/tool, mob/user)
 	announce_failure(user,
-		"[user]'s hand slips, damaging [target]'s face with \the [tool]!",
-		"Your hand slips, damaging [target]'s face with \the [tool]!"
+		"[user]'s hand slips, damaging [target]'s [parent_organ.name] with \the [tool]!",
+		"Your hand slips, damaging [target]'s [parent_organ.name] with \the [tool]!"
 		)
 	parent_organ.take_external_damage(10, used_weapon = tool)
 	parent_organ.status |= ORGAN_DISFIGURED

--- a/code/datums/surgery/steps/generic.dm
+++ b/code/datums/surgery/steps/generic.dm
@@ -355,9 +355,10 @@
 	return (..() && parent_organ.open() == SURGERY_RETRACTED)
 
 /datum/surgery_step/generic/saw/initiate(obj/item/organ/external/parent_organ, obj/item/organ/target_organ, mob/living/carbon/human/target, obj/item/tool, mob/user)
+	var/bone = parent_organ.encased ? "[target]'s [parent_organ.encased]" : "bones in [target]'s [parent_organ]"
 	announce_preop(user,
-		"[user] begins to cut through [target]'s [parent_organ.encased] with \the [tool].",
-		"You begin to cut through [target]'s [parent_organ.encased] with \the [tool]."
+		"[user] begins to cut through [bone] with \the [tool].",
+		"You begin to cut through [bone] with \the [tool]."
 		)
 	target.custom_pain(
 		"Something hurts horribly in your [parent_organ]!",
@@ -367,16 +368,18 @@
 	return ..()
 
 /datum/surgery_step/generic/saw/success(obj/item/organ/external/parent_organ, obj/item/organ/target_organ, mob/living/carbon/human/target, obj/item/tool, mob/user)
+	var/bone = parent_organ.encased ? "[target]'s [parent_organ.encased]" : "bones in [target]'s [parent_organ]"
 	announce_success(user,
-		"[user] has cut [target]'s [parent_organ.encased] open with \the [tool].",
-		"You have cut [target]'s [parent_organ.encased] open with \the [tool]."
+		"[user] has cut [bone] open with \the [tool].",
+		"You have cut [bone] open with \the [tool]."
 		)
 	parent_organ.fracture()
 
 /datum/surgery_step/generic/saw/failure(obj/item/organ/external/parent_organ, obj/item/organ/target_organ, mob/living/carbon/human/target, obj/item/tool, mob/user)
+	var/bone = parent_organ.encased ? "[target]'s [parent_organ.encased]" : "bones in [target]'s [parent_organ]"
 	announce_failure(user,
-		"[user]'s hand slips, cracking [target]'s [parent_organ.encased] with \the [tool]!" ,
-		"Your hand slips, cracking [target]'s [parent_organ.encased] with \the [tool]!"
+		"[user]'s hand slips, cracking [bone] with \the [tool]!" ,
+		"Your hand slips, cracking [bone] with \the [tool]!"
 		)
 	parent_organ.take_external_damage(
 		15,


### PR DESCRIPTION
Fixes #10914

<details>
<summary>Чейнджлог</summary>

```yml
🆑
bugfix: Исправлено неправильное сообщение при операции по вправлению/распиливанию костей
/🆑
```

</details>

- [x] Pull Request полностью завершен, мне не нужна помощь чтобы его закончить.
- [x] Я внимательно прочитал все свои изменения и багов в них не нашел.
- [ ] Я запускал сервер со своими изменениями локально и все протестировал.
- [x] Я ознакомился c [Guide to Contribute](https://github.com/ChaoticOnyx/OnyxBay/blob/dev/docs/contributing.md).
