### PR TITLE
tweak(radiation): atmos, eng & CE space suits rad resists

### DIFF
--- a/code/modules/clothing/spacesuits/rig/suits/station.dm
+++ b/code/modules/clothing/spacesuits/rig/suits/station.dm
@@ -140,6 +140,7 @@
 	offline_vision_restriction = TINT_HEAVY
 
 	helm_type = /obj/item/clothing/head/helmet/space/rig/ce
+	chest_type = /obj/item/clothing/suit/space/rig/ce
 	glove_type = /obj/item/clothing/gloves/rig/ce
 
 	allowed = list(/obj/item/gun,/obj/item/device/flashlight,/obj/item/tank,/obj/item/device/suit_cooling_unit,/obj/item/storage/ore,/obj/item/storage/toolbox,/obj/item/storage/briefcase/inflatable,/obj/item/inflatable_dispenser,/obj/item/device/t_scanner,/obj/item/pickaxe,/obj/item/rcd)
@@ -161,7 +162,19 @@
 		/obj/item/rig_module/cooling_unit
 		)
 
+/obj/item/clothing/suit/space/rig/ce
+	rad_resist = list(
+		RADIATION_ALPHA_PARTICLE = 533 MEGA ELECTRONVOLT,
+		RADIATION_BETA_PARTICLE = 400 MEGA ELECTRONVOLT,
+		RADIATION_HAWKING = 1 ELECTRONVOLT
+	)
+
 /obj/item/clothing/head/helmet/space/rig/ce
+	rad_resist = list(
+		RADIATION_ALPHA_PARTICLE = 533 MEGA ELECTRONVOLT,
+		RADIATION_BETA_PARTICLE = 400 MEGA ELECTRONVOLT,
+		RADIATION_HAWKING = 1 ELECTRONVOLT
+	)
 	camera = /obj/machinery/camera/network/engineering
 
 /obj/item/clothing/gloves/rig/ce

--- a/code/modules/clothing/spacesuits/void/atmos.dm
+++ b/code/modules/clothing/spacesuits/void/atmos.dm
@@ -12,6 +12,11 @@
 	armor = list(melee = 40, bullet = 5, laser = 20,energy = 5, bomb = 35, bio = 100)
 	max_heat_protection_temperature = FIRE_HELMET_MAX_HEAT_PROTECTION_TEMPERATURE
 	light_overlay = "helmet_light_dual_low"
+	rad_resist = list(
+		RADIATION_ALPHA_PARTICLE = 266 MEGA ELECTRONVOLT,
+		RADIATION_BETA_PARTICLE = 200 MEGA ELECTRONVOLT,
+		RADIATION_HAWKING = 1 ELECTRONVOLT
+	)
 
 /obj/item/clothing/suit/space/void/atmos
 	name = "atmos voidsuit"
@@ -24,6 +29,11 @@
 	armor = list(melee = 40, bullet = 5, laser = 20,energy = 5, bomb = 35, bio = 100)
 	max_heat_protection_temperature = FIRESUIT_MAX_HEAT_PROTECTION_TEMPERATURE
 	allowed = list(/obj/item/device/flashlight,/obj/item/tank,/obj/item/device/suit_cooling_unit,/obj/item/storage/toolbox,/obj/item/storage/briefcase/inflatable,/obj/item/device/t_scanner,/obj/item/rcd)
+	rad_resist = list(
+		RADIATION_ALPHA_PARTICLE = 266 MEGA ELECTRONVOLT,
+		RADIATION_BETA_PARTICLE = 200 MEGA ELECTRONVOLT,
+		RADIATION_HAWKING = 1 ELECTRONVOLT
+	)
 
 /obj/item/clothing/suit/space/void/atmos/prepared
 	helmet = /obj/item/clothing/head/helmet/space/void/atmos

--- a/code/modules/clothing/spacesuits/void/engineering.dm
+++ b/code/modules/clothing/spacesuits/void/engineering.dm
@@ -10,6 +10,11 @@
 		slot_r_hand_str = "eng_helm",
 		)
 	armor = list(melee = 40, bullet = 5, laser = 20,energy = 5, bomb = 35, bio = 100)
+	rad_resist = list(
+		RADIATION_ALPHA_PARTICLE = 400 MEGA ELECTRONVOLT,
+		RADIATION_BETA_PARTICLE = 300 MEGA ELECTRONVOLT,
+		RADIATION_HAWKING = 1 ELECTRONVOLT
+	)
 
 /obj/item/clothing/suit/space/void/engineering
 	name = "engineering voidsuit"
@@ -21,6 +26,11 @@
 	)
 	armor = list(melee = 40, bullet = 5, laser = 20,energy = 5, bomb = 35, bio = 100)
 	allowed = list(/obj/item/device/flashlight,/obj/item/tank,/obj/item/device/suit_cooling_unit,/obj/item/storage/toolbox,/obj/item/storage/briefcase/inflatable,/obj/item/device/t_scanner,/obj/item/rcd)
+	rad_resist = list(
+		RADIATION_ALPHA_PARTICLE = 400 MEGA ELECTRONVOLT,
+		RADIATION_BETA_PARTICLE = 300 MEGA ELECTRONVOLT,
+		RADIATION_HAWKING = 1 ELECTRONVOLT
+	)
 
 /obj/item/clothing/suit/space/void/engineering/New()
 	..()


### PR DESCRIPTION
Игроков загрифонила радейка

<details>
<summary>Чейнджлог</summary>

```yml
🆑
balance: Повышены рад резисты у рига CE, инженерных и атмос скафандров (в 1.5, 2 и 3 раза слабее чем у рад костюма соответственно).
/🆑
```

</details>

- [x] Pull Request полностью завершен, мне не нужна помощь чтобы его закончить.
- [x] Я внимательно прочитал все свои изменения и багов в них не нашел.
- [ ] Я запускал сервер со своими изменениями локально и все протестировал (игорьки потестят).
- [x] Я ознакомился c [Guide to Contribute](https://github.com/ChaoticOnyx/OnyxBay/blob/dev/docs/contributing.md).
