### PR TITLE
feat(mapvote): maked it start earlier, move allowed maps to config

### DIFF
--- a/code/controllers/evacuation/evacuation.dm
+++ b/code/controllers/evacuation/evacuation.dm
@@ -145,6 +145,7 @@ var/datum/evacuation_controller/evacuation_controller
 	else
 		SSannounce.play_announce(/datum/announce/shuttle_leaving_dock, "The Crew Transfer Shuttle has left the station. Estimate [round(get_eta()/60,1)] minute\s until the shuttle docks at [GLOB.using_map.dock_name].")
 
+	launch_map_vote()
 	return 1
 
 /datum/evacuation_controller/proc/finish_evacuation()
@@ -186,3 +187,19 @@ var/datum/evacuation_controller/evacuation_controller
 /datum/evacuation_controller/proc/toggle_emergency_light(state)
 	for(var/area/A in GLOB.hallway)
 		A.set_lighting_mode(LIGHTMODE_EVACUATION, state)
+
+/datum/evacuation_controller/proc/launch_map_vote()
+	if(config.game.map_switching && GLOB.all_maps.len > 1)
+		if (config.game.auto_map_vote)
+			SSvote.initiate_vote(new /datum/vote/map/end_game, forced = TRUE)
+		else if (config.game.auto_map_switching)
+			// Select random map exclude the current
+			var/datum/map/current_map = GLOB.using_map
+			var/datum/map/next_map = current_map
+
+			while (next_map.type == current_map.type)
+				next_map = GLOB.all_maps[pick(GLOB.all_maps)]
+
+			to_world("<span class='notice'>Map has been changed to: <b>[next_map.name]</b></span>")
+			fdel("data/use_map")
+			text2file("[next_map.type]", "data/use_map")

--- a/code/controllers/evacuation/evacuation_shuttle.dm
+++ b/code/controllers/evacuation/evacuation_shuttle.dm
@@ -35,6 +35,7 @@
 	if(autopilot && shuttle.moving_status == SHUTTLE_IDLE)
 		evac_arrival_time = world.time + (shuttle.move_time*10) + (shuttle.warmup_time*10)
 		shuttle.launch(src)
+	launch_map_vote()
 	// Announcements, state changes and such are handled by the shuttle itself to prevent desync.
 
 /datum/evacuation_controller/shuttle/finish_preparing_evac()

--- a/code/controllers/subsystems/ticker.dm
+++ b/code/controllers/subsystems/ticker.dm
@@ -126,20 +126,6 @@ SUBSYSTEM_DEF(ticker)
 		Master.SetRunLevel(RUNLEVEL_POSTGAME)
 		end_game_state = END_GAME_READY_TO_END
 		INVOKE_ASYNC(src, .proc/declare_completion)
-		if(config.game.map_switching && GLOB.all_maps.len > 1)
-			if (config.game.auto_map_vote)
-				SSvote.initiate_vote(/datum/vote/map/end_game, forced = 1)
-			else if (config.game.auto_map_switching)
-				// Select random map exclude the current
-				var/datum/map/current_map = GLOB.using_map
-				var/datum/map/next_map = current_map
-
-				while (next_map.type == current_map.type)
-					next_map = GLOB.all_maps[pick(GLOB.all_maps)]
-
-				to_world("<span class='notice'>Map has been changed to: <b>[next_map.name]</b></span>")
-				fdel("data/use_map")
-				text2file("[next_map.type]", "data/use_map")
 
 	else if(mode_finished && (end_game_state <= END_GAME_NOT_OVER))
 		end_game_state = END_GAME_MODE_FINISH_DONE

--- a/code/datums/configuration/mapping_section.dm
+++ b/code/datums/configuration/mapping_section.dm
@@ -4,11 +4,13 @@
 	var/preferable_engine = MAP_ENG_SINGULARITY
 	var/preferable_biodome = MAP_BIO_FOREST
 	var/preferable_bar = MAP_BAR_CLASSIC
+	var/list/allowed_maps = list()
 
 /datum/configuration_section/mapping/load_data(list/data)
 	CONFIG_LOAD_STR(preferable_engine,  data["preferable_engine"])
 	CONFIG_LOAD_STR(preferable_biodome, data["preferable_biodome"])
 	CONFIG_LOAD_STR(preferable_bar, 	data["preferable_bar"])
+	CONFIG_LOAD_LIST(allowed_maps, data["allowed_maps"])
 
 	if(!(preferable_engine in list(MAP_ENG_RANDOM, MAP_ENG_SINGULARITY, MAP_ENG_MATTER)))
 		preferable_engine = MAP_ENG_SINGULARITY

--- a/code/datums/vote/map.dm
+++ b/code/datums/vote/map.dm
@@ -27,13 +27,14 @@
 /datum/vote/map/end_game
 	name = "Round End Map Vote"
 
+/datum/vote/map/end_game/is_accessible_vote()
+	return FALSE
+
 /datum/vote/map/end_game/can_be_initiated(mob/by_who, forced)
 	. = ..()
 	if(!config.game.map_switching)
 		return FALSE
-	if(GAME_STATE !=  RUNLEVEL_POSTGAME)
-		return FALSE
-	if(!forced)
+	if(!isnull(by_who))
 		return FALSE
 
 /datum/vote/map/end_game/finalize_vote()

--- a/config/example/config.toml
+++ b/config/example/config.toml
@@ -553,6 +553,9 @@ preferable_bar = "classic"
 ## Pick one from: "random", "forest", "winter", "beach", "concert"
 preferable_biodome = "forest"
 
+[mapping.allowed_maps]
+Example = false
+
 [vote]
 ## Allow players to initiate a restart vote.
 allow_vote_restart = true

--- a/maps/~mapsystem/maps.dm
+++ b/maps/~mapsystem/maps.dm
@@ -12,6 +12,9 @@ var/const/MAP_HAS_RANK = 2		//Rank system, also togglable
 			M.setup_map()
 		else
 			M = new type
+		if(M.name in config.mapping.allowed_maps)
+			M.can_be_voted = config.mapping.allowed_maps[M.name]
+
 		if(!M.path)
 			log_error("Map '[M]' does not have a defined path, not adding to map list!")
 		else


### PR DESCRIPTION
1. Мапвоут теперь стартует при отбытии шатла, булат попросил
2. Карты для мапвоута вынесены в конфиг(если не указать, то будет использоваться стандартная переменная)

close #10976
<details>
<summary>Чейнджлог</summary>

```yml
🆑Lovla
tweak: Мапвоут теперь стартует при отбытии шатла
/🆑
```

</details>

- [x] Pull Request полностью завершен, мне не нужна помощь чтобы его закончить.
- [x] Я внимательно прочитал все свои изменения и багов в них не нашел.
- [x] Я запускал сервер со своими изменениями локально и все протестировал.
- [x] Я ознакомился c [Guide to Contribute](https://github.com/ChaoticOnyx/OnyxBay/blob/dev/docs/contributing.md).
