### PR TITLE
feat(borer&logs): added some logs to borer

### DIFF
--- a/code/modules/mob/living/simple_animal/borer/borer_powers.dm
+++ b/code/modules/mob/living/simple_animal/borer/borer_powers.dm
@@ -126,7 +126,7 @@ BORER_STATUS_HUSK = list(\
 
 	if(H in view(1, src))
 		to_chat(src, "You wiggle into [H]'s ear.")
-		log_and_message_admins("infested ([host]).")
+		log_and_message_admins("infested ([H]).")
 		if(!H.stat)
 			to_chat(H, "Something disgusting and slimy wiggles into your ear!")
 
@@ -183,7 +183,7 @@ BORER_STATUS_HUSK = list(\
 		return
 
 	to_chat(src, SPAN("danger", "It only takes a few moments to render the dead host brain down into a nutrient-rich slurry..."))
-	log_and_message_admins("assumed dirrect control on a dead host([host]).")
+	log_and_message_admins("assumed dirrect control of a dead host([host]).")
 	replace_brain()
 
 /mob/living/simple_animal/borer/proc/replace_brain()
@@ -316,7 +316,7 @@ BORER_STATUS_HUSK = list(\
 
 		to_chat(src, SPAN("danger", "You plunge your probosci deep into the cortex of the host brain, interfacing directly with their nervous system."))
 		to_chat(host, SPAN("danger", "You feel a strange shifting sensation behind your eyes as an alien consciousness displaces yours."))
-		log_and_message_admins("assumed dirrect control on host([host]).")
+		log_and_message_admins("assumed dirrect control of host([host]).")
 		host.add_language("Cortical Link")
 
 		// host -> brain

--- a/code/modules/mob/living/simple_animal/borer/borer_powers.dm
+++ b/code/modules/mob/living/simple_animal/borer/borer_powers.dm
@@ -59,6 +59,7 @@ BORER_STATUS_HUSK = list(\
 				to_chat(host, SPAN("danger", "Something slimy wiggles out of your ear and plops to the ground!"))
 			else
 				to_chat(host, SPAN("danger", "As though waking from a dream, you shake off the insidious mind control of the brain worm. Your thoughts are your own again."))
+		log_and_message_admins("released host([host]).")
 		detatch()
 		leave_host()
 		update_abilities()
@@ -125,6 +126,7 @@ BORER_STATUS_HUSK = list(\
 
 	if(H in view(1, src))
 		to_chat(src, "You wiggle into [H]'s ear.")
+		log_and_message_admins("infested ([host]).")
 		if(!H.stat)
 			to_chat(H, "Something disgusting and slimy wiggles into your ear!")
 
@@ -181,6 +183,7 @@ BORER_STATUS_HUSK = list(\
 		return
 
 	to_chat(src, SPAN("danger", "It only takes a few moments to render the dead host brain down into a nutrient-rich slurry..."))
+	log_and_message_admins("assumed dirrect control on a dead host([host]).")
 	replace_brain()
 
 /mob/living/simple_animal/borer/proc/replace_brain()
@@ -313,6 +316,7 @@ BORER_STATUS_HUSK = list(\
 
 		to_chat(src, SPAN("danger", "You plunge your probosci deep into the cortex of the host brain, interfacing directly with their nervous system."))
 		to_chat(host, SPAN("danger", "You feel a strange shifting sensation behind your eyes as an alien consciousness displaces yours."))
+		log_and_message_admins("assumed dirrect control on host([host]).")
 		host.add_language("Cortical Link")
 
 		// host -> brain
@@ -432,7 +436,7 @@ BORER_STATUS_HUSK = list(\
 		return
 
 	visible_message(SPAN("warning", "With a hideous, rattling moan, [src] shudders back to life!"))
-
+	log_and_message_admins("revived host([host]).")
 	revive()
 	update_canmove()
 

--- a/code/modules/mob/living/simple_animal/borer/say.dm
+++ b/code/modules/mob/living/simple_animal/borer/say.dm
@@ -35,6 +35,7 @@
 	to_chat(src, "You drop words into [host]'s mind: \"[message]\"")
 	to_chat(host, "Your own thoughts speak: \"[message]\"")
 
+	log_say("\[BORER\] [name]([key])->[host.name]([host.key]): \"[message]\"")
 	for (var/mob/M in GLOB.player_list)
 		if (istype(M, /mob/new_player))
 			continue


### PR DESCRIPTION
БОРЕР ТЕПЕРЬ ЛОГИРУЕТСЯ!
А часть абилок теперь ещё и педалей уведомляет об использовании.

<details>
<summary>Чейнджлог</summary>

```yml
🆑Lovla
admin: Борер теперь логгируется.
/🆑
```

</details>


Далее честно заполняем галочки. Чем больше галочек, тем быстрее проверять Pull Request, соответственно он быстрее будет принят. Чтобы отметить - ставим x внутри квадратных скобочек вот так: `- [x] ...`. Галочки можно доставлять позже по мере окончания работы над ПРом. ЭТУ СТРОЧКУ НУЖНО УДАЛИТЬ.

- [x] Pull Request полностью завершен, мне не нужна помощь чтобы его закончить.
- [x] Я внимательно прочитал все свои изменения и багов в них не нашел.
- [x] Я запускал сервер со своими изменениями локально и все протестировал.
- [x] Я ознакомился c [Guide to Contribute](https://github.com/ChaoticOnyx/OnyxBay/blob/dev/docs/contributing.md).
