### PR TITLE
feat(eamc): peamc only block players with player age = 0

### DIFF
--- a/code/modules/admin/EAMS.dm
+++ b/code/modules/admin/EAMS.dm
@@ -261,9 +261,9 @@ SUBSYSTEM_DEF(eams)
 
 	if (C.eams_info.loaded)
 		if ((C.eams_info.ip_countryCode in __allowed_countries) && !C.eams_info.ip_proxy)
-			if(__panic)
+			if(__panic && get_player_age(C.ckey) > 0)
 				to_chat(C, SPAN_WARNING("You were blocked by EAMS! Please, contact Administrators."))
-				log_and_message_admins("Blocked by panic EAMS: [C.key] ([C.address]) connected from [C.eams_info.ip_country] ([C.eams_info.ip_countryCode])", 0)
+				log_and_message_admins("Blocked by panic EAMS: [C.key], age [get_player_age(C.ckey)], ([C.address]) connected from [C.eams_info.ip_country] ([C.eams_info.ip_countryCode])", 0)
 				return FALSE
 			return TRUE
 
@@ -292,6 +292,6 @@ SUBSYSTEM_DEF(eams)
 		return
 
 	var/eams_status = SSeams.Toggle()
-	if(eams_status && tgui_alert("Enable panic mode?",,"Yes","No") == "Yes")
+	if(eams_status && tgui_alert(src,"Enable panic mode?","Panic mode",list("Yes","No")) == "Yes")
 		SSeams.__panic = TRUE
 	log_and_message_admins("has [eams_status ? "enabled" : "disabled"] the Epic Anti-Multiaccount System [SSeams.__panic ? "with panic mode" : ""]!")

--- a/code/modules/admin/EAMS.dm
+++ b/code/modules/admin/EAMS.dm
@@ -261,7 +261,7 @@ SUBSYSTEM_DEF(eams)
 
 	if (C.eams_info.loaded)
 		if ((C.eams_info.ip_countryCode in __allowed_countries) && !C.eams_info.ip_proxy)
-			if(__panic && get_player_age(C.ckey) > 0)
+			if(__panic && get_player_age(C.ckey) == 0)
 				to_chat(C, SPAN_WARNING("You were blocked by EAMS! Please, contact Administrators."))
 				log_and_message_admins("Blocked by panic EAMS: [C.key], age [get_player_age(C.ckey)], ([C.address]) connected from [C.eams_info.ip_country] ([C.eams_info.ip_countryCode])", 0)
 				return FALSE


### PR DESCRIPTION
ЕАМС с паникбункером теперь не блокирует ВСЕХ, а только новичков.
<details>
<summary>Чейнджлог</summary>

```yml
🆑KreeperHLC
tweak: ЕАМС с паникбункером теперь не блокирует ВСЕХ, а только новичков.
/🆑
```

</details>

- [x] Pull Request полностью завершен, мне не нужна помощь чтобы его закончить.
- [x] Я внимательно прочитал все свои изменения и багов в них не нашел.
- [x] Я запускал сервер со своими изменениями локально и все протестировал.
- [x] Я ознакомился c [Guide to Contribute](https://github.com/ChaoticOnyx/OnyxBay/blob/dev/docs/contributing.md).
