### PR TITLE
feat(prefs): add become midround antag pref

### DIFF
--- a/code/game/antagonist/antagonist.dm
+++ b/code/game/antagonist/antagonist.dm
@@ -143,7 +143,7 @@
 		log_debug_verbose("[key_name(player)] is not eligible to become a [role_text]: Is only [player.current.client.player_age] day\s old, has to be [min_player_age] day\s!")
 		return FALSE
 	if(player.current.client.get_preference_value(/datum/client_preference/become_midround_antag) != GLOB.PREF_YES && GAME_STATE >= RUNLEVEL_GAME)
-		log_debug("[key_name(player)] set their preference to disable becoming midround antag!")
+		log_debug_verbose("[key_name(player)] set their preference to disable becoming midround antag!")
 		switch(player.current.client.get_preference_value(/datum/client_preference/become_midround_antag))
 			if(GLOB.PREF_NO)
 				return FALSE

--- a/code/game/antagonist/antagonist.dm
+++ b/code/game/antagonist/antagonist.dm
@@ -142,6 +142,17 @@
 	if(config.game.use_age_restriction_for_antags && player.current.client.player_age < min_player_age)
 		log_debug_verbose("[key_name(player)] is not eligible to become a [role_text]: Is only [player.current.client.player_age] day\s old, has to be [min_player_age] day\s!")
 		return FALSE
+	if(player.current.client.get_preference_value(/datum/client_preference/become_midround_antag) != GLOB.PREF_YES && GAME_STATE >= RUNLEVEL_GAME)
+		log_debug("[key_name(player)] set their preference to disable becoming midround antag!")
+		switch(player.current.client.get_preference_value(/datum/client_preference/become_midround_antag))
+			if(GLOB.PREF_NO)
+				return FALSE
+			if(GLOB.PREF_AS_GHOST)
+				if(!isghostmind(player))
+					return FALSE
+			if(GLOB.PREF_AS_LIVING)
+				if(isghostmind(player))
+					return FALSE
 	if(player.special_role)
 		log_debug_verbose("[key_name(player)] is not eligible to become a [role_text]: They already have a special role ([player.special_role])!")
 		return FALSE

--- a/code/modules/client/preference_setup/global/preferences.dm
+++ b/code/modules/client/preference_setup/global/preferences.dm
@@ -28,6 +28,8 @@ GLOBAL_VAR_CONST(PREF_DARK, "Dark")
 GLOBAL_VAR_CONST(PREF_LOW, "Low")
 GLOBAL_VAR_CONST(PREF_MED, "Medium")
 GLOBAL_VAR_CONST(PREF_HIGH, "High")
+GLOBAL_VAR_CONST(PREF_AS_GHOST, "Only as ghost")
+GLOBAL_VAR_CONST(PREF_AS_LIVING, "Only when alive")
 
 var/global/list/_client_preferences
 var/global/list/_client_preferences_by_key
@@ -93,6 +95,13 @@ var/global/list/_client_preferences_by_type
 /*********************
 * Player Preferences *
 *********************/
+
+/datum/client_preference/become_midround_antag
+	description = "Become Midround Antag"
+	key = "GAME_MIDROUND_ANTAG"
+	options = list(GLOB.PREF_YES, GLOB.PREF_NO, GLOB.PREF_AS_GHOST, GLOB.PREF_AS_LIVING)
+	default_value = GLOB.PREF_YES
+
 /datum/client_preference/runechat
 	description = "Show Runechat (Above-Head-Speech)"
 	key = "CHAT_RUNECHAT"


### PR DESCRIPTION
Я заебался смотреть на предложения "вы хотите стать борером" в гостах, поэтому исходя из иссуя и предложения в оном Голиафа - впиливаю преф, который позволяет включить/выключить становление мидраунд антагом будучи живым или в гостоте.

close #11008

<details>
<summary>Чейнджлог</summary>

```yml
🆑
rscadd: Добавлен новый преф, позволяющий указать, желает ли игрок становиться мидраунд антагом.
/🆑
```

</details>

- [x] Pull Request полностью завершен, мне не нужна помощь чтобы его закончить.
- [x] Я внимательно прочитал все свои изменения и багов в них не нашел.
- [x] Я запускал сервер со своими изменениями локально и все протестировал.
- [x] Я ознакомился c [Guide to Contribute](https://github.com/ChaoticOnyx/OnyxBay/blob/dev/docs/contributing.md).
