### PR TITLE
fix(obj): pbag can be flipped back

### DIFF
--- a/code/modules/clothing/masks/miscellaneous.dm
+++ b/code/modules/clothing/masks/miscellaneous.dm
@@ -391,6 +391,9 @@
 	body_parts_covered = HEAD|FACE|EYES
 	tint = TINT_BLIND
 
+/obj/item/clothing/mask/plasticbag/attack_self(mob/user)
+	user.replace_item(src, new /obj/item/storage/bag/plasticbag, TRUE, TRUE)
+
 /obj/item/clothing/mask/plasticbag/attackby(obj/item/W, mob/user)
 	if(istype(W, /obj/item/tape_roll))
 		to_chat(user, "You attach a piece of [W] to [src]!")


### PR DESCRIPTION
Фикс в две строки. Добавил аттакселф идентичный самому пакету контейнеру. 

close #11108

<details>
<summary>Чейнджлог</summary>

```yml
🆑
bugfix: Пакет можно развернуть обратно в пакет.
/🆑
```

</details>

- [x] Pull Request полностью завершен, мне не нужна помощь чтобы его закончить.
- [x] Я внимательно прочитал все свои изменения и багов в них не нашел.
- [x] Я запускал сервер со своими изменениями локально и все протестировал.
- [x] Я ознакомился c [Guide to Contribute](https://github.com/ChaoticOnyx/OnyxBay/blob/dev/docs/contributing.md).
