### PR TITLE
fix(vessel flipping): bottles will no longer smash twice 

### DIFF
--- a/code/modules/reagents/reagent_containers/vessel/_vessel.dm
+++ b/code/modules/reagents/reagent_containers/vessel/_vessel.dm
@@ -411,7 +411,10 @@
 		if(!(MUTATION_BARTENDER in user.mutations) && prob(50))
 			var/turf/flip_turf = get_turf(flipping)
 			to_chat(user, SPAN_WARNING("Your fail to catch back \the [src]."))
-			smash(flip_turf, flip_turf)
+			if(brittle)
+				smash(flip_turf, flip_turf)
+			else
+				throw_impact(flip_turf, 1)
 		else
 			playsound(src, 'sound/effects/slap.ogg', 100, 1, -2)
 		QDEL_NULL(flipping)
@@ -472,7 +475,7 @@
 		if(flip_turf != get_turf(user))
 			to_chat(user, SPAN_WARNING("Your fail to catch back \the [src]."))
 			user.drop(src, flipping.loc, force = TRUE)
-			if(prob(50))
+			if(brittle && prob(50))
 				smash(flip_turf, flip_turf)
 			else
 				throw_impact(flip_turf, 1)
@@ -483,7 +486,10 @@
 			if(!(MUTATION_BARTENDER in user.mutations) && prob(50))
 				to_chat(user, SPAN_WARNING("Your fail to catch back \the [src]."))
 				user.drop(src, flipping.loc, force = TRUE)
-				smash(flip_turf, flip_turf)
+				if(brittle)
+					smash(flip_turf, flip_turf)
+				else
+					throw_impact(flip_turf, 1)
 			else
 				item_state = initial(item_state)
 				user.update_inv_l_hand()

--- a/code/modules/reagents/reagent_containers/vessel/_vessel.dm
+++ b/code/modules/reagents/reagent_containers/vessel/_vessel.dm
@@ -410,7 +410,6 @@
 		last_flipping = world.time
 		if(!(MUTATION_BARTENDER in user.mutations) && prob(50))
 			var/turf/flip_turf = get_turf(flipping)
-			to_chat(user, SPAN_WARNING("Your fail to catch back \the [src]."))
 			if(brittle)
 				smash(flip_turf, flip_turf)
 			else
@@ -475,10 +474,6 @@
 		if(flip_turf != get_turf(user))
 			to_chat(user, SPAN_WARNING("Your fail to catch back \the [src]."))
 			user.drop(src, flipping.loc, force = TRUE)
-			if(brittle && prob(50))
-				smash(flip_turf, flip_turf)
-			else
-				throw_impact(flip_turf, 1)
 			QDEL_NULL(flipping)
 			return
 
@@ -486,10 +481,6 @@
 			if(!(MUTATION_BARTENDER in user.mutations) && prob(50))
 				to_chat(user, SPAN_WARNING("Your fail to catch back \the [src]."))
 				user.drop(src, flipping.loc, force = TRUE)
-				if(brittle)
-					smash(flip_turf, flip_turf)
-				else
-					throw_impact(flip_turf, 1)
 			else
 				item_state = initial(item_state)
 				user.update_inv_l_hand()


### PR DESCRIPTION
<details>
<summary>Чейнджлог</summary>

```yml
🆑
bugfix: Исправил баг в результате которого разбившаяся бутылка дюпалась.
bugfix: Небьющуюся посуду типа фляжек и термосов больше нельзя разбить подкидыванием. 
/🆑
```

</details>

- [x] Pull Request полностью завершен, мне не нужна помощь чтобы его закончить.
- [x] Я внимательно прочитал все свои изменения и багов в них не нашел.
- [x] Я запускал сервер со своими изменениями локально и все протестировал.
- [x] Я ознакомился c [Guide to Contribute](https://github.com/ChaoticOnyx/OnyxBay/blob/dev/docs/contributing.md).
