### PR TITLE
Removes inability to craft balloon animals

### DIFF
--- a/code/game/objects/items/balloons.dm
+++ b/code/game/objects/items/balloons.dm
@@ -178,8 +178,16 @@
 	name = "burst balloon"
 	desc = "Ow... Not much can be done with this now."
 	icon_state = "burst"
-	layer = BELOW_TABLE_LAYER
+	item_state = null
+	force = 0.0
+	throwforce = 0.0
 	throw_range = 7
+	w_class = ITEM_SIZE_TINY
+	layer = BELOW_TABLE_LAYER
+
+	item_icons = list()
+	update_held_icon()
+
 	playsound(get_turf(src), 'sound/effects/snap.ogg', 100, 1)
 
 /obj/item/balloon/verb/deflate()
@@ -348,8 +356,11 @@
 	name = "burst balloon"
 	desc = "Ow... Not much can be done with this now."
 	icon_state = "burst"
-	layer = BELOW_TABLE_LAYER
+	force = 0.0
+	throwforce = 0.0
 	throw_range = 7
+	w_class = ITEM_SIZE_TINY
+	layer = BELOW_TABLE_LAYER
 	balloon_type = BALLOON_BURST
 
 #undef BALLOON_FORBIDDEN

--- a/code/game/objects/items/balloons.dm
+++ b/code/game/objects/items/balloons.dm
@@ -245,31 +245,37 @@
 	desc = "It's an inflatable crab!"
 	icon_state = "crab"
 	type_desc = "Animal (Crab)"
+	balloon_type = BALLOON_ADVANCED
 
 /obj/item/balloon/animal/corgi
 	desc = "It's an inflatable corgi! HoP's favourite!"
 	icon_state = "corgi"
 	type_desc = "Animal (Corgi)"
+	balloon_type = BALLOON_ADVANCED
 
 /obj/item/balloon/animal/cat
 	desc = "It's an inflatable cat! CMO's favourite!"
 	icon_state = "cat"
 	type_desc = "Animal (Cat)"
+	balloon_type = BALLOON_ADVANCED
 
 /obj/item/balloon/animal/mouse
 	desc = "It's an inflatable mouse! Hope it doesn't bite your foot."
 	icon_state = "mouse"
 	type_desc = "Animal (Mouse)"
+	balloon_type = BALLOON_ADVANCED
 
 /obj/item/balloon/animal/carp
 	desc = "It's an inflatable carp! Hope it doesn't knock you down."
 	icon_state = "carp"
 	type_desc = "Animal (Carp)"
+	balloon_type = BALLOON_ADVANCED
 
 /obj/item/balloon/animal/pig
 	desc = "It's an inflatable pig! Does it even oink?.."
 	icon_state = "pig"
 	type_desc = "Animal (Pig)"
+	balloon_type = BALLOON_ADVANCED
 
 /obj/item/balloon/item
 	name = "inflatable item"


### PR DESCRIPTION
```yml
🆑
bugfix: Исправлена ошибка, из-за которой мим не мог надувать шарики в виде животных.
bugfix: Лопнувшие шарики теперь не отображаются в руках как надутые и не занимают столько места в инвентаре.
/🆑
```

- [x] Pull Request полностью завершен, мне не нужна помощь чтобы его закончить.
- [x] Я внимательно прочитал все свои изменения и багов в них не нашел.
- [x] Я запускал сервер со своими изменениями локально и все протестировал.
- [x] Я ознакомился c [Guide to Contribute](https://github.com/ChaoticOnyx/OnyxBay/blob/dev/docs/contributing.md).
