### PR TITLE
Removes absence of crew photos

### DIFF
--- a/code/_helpers/icons.dm
+++ b/code/_helpers/icons.dm
@@ -769,7 +769,7 @@
 	cap.Blend("#000", ICON_OVERLAY)
 	for(var/atom/A in atoms)
 		if(A)
-			var/icon/img = getFlatIcon(A, no_anim = TRUE)
+			var/icon/img = ishuman(A) ? A.get_flat_icon(user) : getFlatIcon(A, no_anim = TRUE)
 			if(istype(img, /icon))
 				if(istype(A, /mob/living) && A:lying)
 					img.BecomeLying()
@@ -941,3 +941,101 @@
 		flat.Blend(rgb(255, 255, 255, alpha), ICON_MULTIPLY)
 
 	return icon(flat, "", SOUTH)
+
+// Returns a flattened icon of an atom with emissive blockers stripped.
+// The icon gets rendered on 'caller's side. If there's no 'caller' provided or the 'caller' has no client,
+// the icon will be rendered on a random client's side (unless 'allow_ratty_rendering = FALSE', in this case we give up).
+// 'dir' accepts either a single dir, uses 'src.dir' if not provided.
+// I'm not completely sure how ethical the 'allow_ratty_rendering' usage is, since it's basically lowkey cryptomining, but who fucking cares?
+/atom/proc/get_flat_icon(mob/caller, dir, allow_ratty_rendering = TRUE)
+	var/client/rendering_client
+	if(caller?.client)
+		rendering_client = caller.client // We are good, let the caller deal with their own stuff.
+	else if(allow_ratty_rendering)
+		for(var/mob/prey in shuffle(GLOB.player_list)) // We are not that good, randomly choosing a poor being to deal with rendering.
+			if(prey?.client)
+				rendering_client = prey.client
+				break
+
+	if(!rendering_client)
+		return null // Everything's broken somehow, giving up.
+
+	if(!dir)
+		dir = src.dir
+
+	var/obj/dummy = new
+	dummy.icon = icon
+	dummy.icon_state = icon_state
+	dummy.alpha = alpha
+	dummy.color = color
+	dummy.transform = transform
+	dummy.set_dir(dir)
+
+	for(var/I in underlays)
+		var/image/image = image(I)
+		if(image.plane == EMISSIVE_PLANE)
+			continue
+		image.dir = dir
+		dummy.underlays += image
+
+	for(var/I in overlays)
+		var/image/image = image(I)
+		if(image.plane == EMISSIVE_PLANE)
+			continue
+		image.dir = dir
+		dummy.overlays += image
+
+	qdel(dummy)
+	return icon(rendering_client.RenderIcon(dummy))
+
+// Extended version of the above. It can accept 'dirs' as a list, and returns a list populated with rendered icons.
+// It's cheaper than calling 'get_flat_icon' multiple times, but for some reason beyond my understanding, it sometimes just gives
+// up and returns a list of same-directioned icons. Still may come in handy.
+/atom/proc/get_flat_icons_list(mob/caller, dirs = SOUTH, allow_ratty_rendering = TRUE)
+	var/client/rendering_client
+	if(caller?.client)
+		rendering_client = caller.client // We are good, let the caller deal with their own stuff.
+	else if(allow_ratty_rendering)
+		for(var/mob/prey in shuffle(GLOB.player_list)) // We are not that good, randomly choosing a poor being to deal with rendering.
+			if(prey?.client)
+				rendering_client = prey.client
+				break
+
+	if(!rendering_client)
+		return list() // Everything's broken somehow, giving up.
+
+	var/dirs_list = list()
+	dirs_list |= dirs
+
+	var/list/ret = list()
+
+	var/obj/dummy = new
+	dummy.icon = icon
+	dummy.icon_state = icon_state
+	dummy.alpha = alpha
+	dummy.color = color
+	dummy.transform = transform
+
+	for(var/current_dir in dirs_list)
+		dummy.underlays.Cut()
+		dummy.overlays.Cut()
+		dummy.set_dir(current_dir)
+
+		for(var/I in underlays)
+			var/image/image = image(I)
+			if(image.plane == EMISSIVE_PLANE)
+				continue
+			image.dir = current_dir
+			dummy.underlays += image
+
+		for(var/I in overlays)
+			var/image/image = image(I)
+			if(image.plane == EMISSIVE_PLANE)
+				continue
+			image.dir = current_dir
+			dummy.overlays += image
+
+		ret += icon(rendering_client.RenderIcon(dummy))
+
+	qdel(dummy)
+	return ret

--- a/code/game/objects/items/weapons/cards_ids.dm
+++ b/code/game/objects/items/weapons/cards_ids.dm
@@ -172,12 +172,9 @@ var/const/NO_EMAG_ACT = -50
 	SetName(final_name)
 
 /obj/item/card/id/proc/set_id_photo(mob/M)
-	front = icon('icons/top_secret.dmi')
-	side = icon('icons/top_secret.dmi')
-//	 !!! REMOVED TILL WE MOVE TO 515 !!!
-//	M.ImmediateOverlayUpdate()
-//	front = getFlatIcon(M, SOUTH, always_use_defdir = TRUE)
-//	side = getFlatIcon(M, WEST, always_use_defdir = TRUE)
+	M.ImmediateOverlayUpdate()
+	front = M.get_flat_icon(M, SOUTH)
+	side = M.get_flat_icon(M, WEST)
 
 /mob/proc/set_id_info(obj/item/card/id/id_card)
 	id_card.age = 0

--- a/code/modules/modular_computers/file_system/crew_record.dm
+++ b/code/modules/modular_computers/file_system/crew_record.dm
@@ -124,16 +124,13 @@ GLOBAL_LIST_INIT(department_flags_to_text, list(
 	set_antagRecord((H && H.exploit_record && !jobban_isbanned(H, "Records") ? H.exploit_record : ""))
 
 /datum/computer_file/crew_record/proc/take_mob_photo(mob/living/carbon/human/H)
-	photo_front = icon('icons/top_secret.dmi')
-	photo_side = icon('icons/top_secret.dmi')
-//	 !!! REMOVED TILL WE MOVE TO 515 !!!
-//	if(istype(H))
-//		H.ImmediateOverlayUpdate()
-//		photo_front = getFlatIcon(H, SOUTH, always_use_defdir = TRUE)
-//		photo_side = getFlatIcon(H, WEST, always_use_defdir = TRUE)
-//	else
-//		photo_front = icon('icons/mob/human_races/r_human.dmi', "preview_m", SOUTH)
-//		photo_side = icon('icons/mob/human_races/r_human.dmi', "preview_m", WEST)
+	if(istype(H))
+		H.ImmediateOverlayUpdate()
+		photo_front = H.get_flat_icon(H, SOUTH)
+		photo_side = H.get_flat_icon(H, WEST)
+	else
+		photo_front = icon('icons/mob/human_races/r_human.dmi', "preview_m", SOUTH)
+		photo_side = icon('icons/mob/human_races/r_human.dmi', "preview_m", WEST)
 
 // Returns independent copy of this file.
 /datum/computer_file/crew_record/clone(rename = 0)


### PR DESCRIPTION
```yml
🆑
experiment: Фотографии космонавтов вернулись на ID-карточки и в Crew Records благодаря 515-магии. На этот раз, в теории, без расшатывания сервера.
/🆑
```

---
рост (поддерживается)
![image](https://github.com/ChaoticOnyx/OnyxBay/assets/45202681/420cf9f4-d3ee-433b-949d-890a1a884819)![image](https://github.com/ChaoticOnyx/OnyxBay/assets/45202681/7ff08934-86b7-4d24-9bc9-dffabccb7aa7)
![image](https://github.com/ChaoticOnyx/OnyxBay/assets/45202681/e415c455-c3e6-4b16-b37a-d69dd5e71bab)

---

- [x] Pull Request полностью завершен, мне не нужна помощь чтобы его закончить.
- [x] Я внимательно прочитал все свои изменения и багов в них не нашел.
- [x] Я запускал сервер со своими изменениями локально и все протестировал.
- [x] Я ознакомился c [Guide to Contribute](https://github.com/ChaoticOnyx/OnyxBay/blob/dev/docs/contributing.md).
