### PR TITLE
Necromancer: day one patch

### DIFF
--- a/code/__defines/mobs.dm
+++ b/code/__defines/mobs.dm
@@ -414,7 +414,7 @@
 									/datum/reagent/mindbreaker,\
 									/datum/reagent/psilocybin)
 
-#define SPELL_NOREMORSE_GHOST_DAMAGE 2 ///How much damage the ghosts do when attacking mobs during no remorse spell
+#define SPELL_NOREMORSE_GHOST_DAMAGE 1 ///How much damage the ghosts do when attacking mobs during no remorse spell
 
 /proc/human_height_text(x)
 	switch(x)

--- a/code/game/gamemodes/wizard/undead/undead_datum.dm
+++ b/code/game/gamemodes/wizard/undead/undead_datum.dm
@@ -33,7 +33,7 @@
 	my_mob.add_spell(new /datum/spell/toggled/lich_form)
 	my_mob.add_spell(new /datum/spell/aoe_turf/knock)
 	my_mob.add_spell(new /datum/spell/targeted/projectile/magic_missile)
-	my_mob.add_spell(new /datum/spell/hand/marsh_of_the_dead)
+	my_mob.add_spell(new /datum/spell/hand/charges/marsh_of_the_dead)
 	my_mob.add_spell(new /datum/spell/toggled/immaterial_form)
 
 /datum/wizard/undead/Destroy()

--- a/code/modules/ghosttrap/trap.dm
+++ b/code/modules/ghosttrap/trap.dm
@@ -226,10 +226,16 @@ var/list/ghost_traps
 		if(pref_check && !O.client.wishes_to_be_role(pref_check))
 			continue
 
-		spawn(0)
-			var/player_choice = tgui_alert(O, "A necromancer is requesting a soul to animate an undead body.", "Would you like to become undead?", list("Yes", "No"), request_timeout)
-			if(player_choice == "Yes" && !target.key)
-				transfer_personality(O, target)
+		INVOKE_ASYNC(src, nameof(.proc/send_request), target, O, request_timeout)
+
+/datum/ghosttrap/undead/proc/send_request(mob/target, mob/observer/ghost, request_timeout)
+	var/player_choice = tgui_alert(ghost, "A necromancer is requesting a soul to animate an undead body.", "Would you like to become undead?", list("Yes", "No"), request_timeout)
+	if(player_choice == "Yes")
+		if(target.key)
+			to_chat(ghost, SPAN_WARNING("Target is already occupied!"))
+			return
+
+		transfer_personality(ghost, target)
 
 /datum/ghosttrap/undead/transfer_personality(mob/candidate, mob/target)
 	target.ckey = candidate.ckey

--- a/code/modules/spells/artifacts/ghost_gramophone.dm
+++ b/code/modules/spells/artifacts/ghost_gramophone.dm
@@ -23,6 +23,7 @@ GLOBAL_LIST_EMPTY(ghost_gramophones)
 		active = TRUE
 		last_activated = world.time
 		visible_message(SPAN_NOTICE("The gramophone starts spinning its record with a squeak."))
+		notify_ghosts("A ghost gramophone is channeling words said nearby it!", null, src, action = NOTIFY_JUMP, posses_mob = FALSE)
 		set_next_think(world.time + GRAMOPHONE_ACTIVE_TIME)
 	else
 		to_chat(user, SPAN_NOTICE("You try to turn on the [src], but to no avail! Maybe you should try again later?"))

--- a/code/modules/spells/artifacts/plague_bell.dm
+++ b/code/modules/spells/artifacts/plague_bell.dm
@@ -79,7 +79,7 @@
 		if(M == master)
 			continue
 
-		if(M.is_ic_dead() || M.isSynthetic() || isundead(M))
+		if(M.isSynthetic() || isundead(M))
 			continue
 
 		M.adjustBruteLoss(DAMAGE_PER_TICK)

--- a/code/modules/spells/artifacts/plague_bell.dm
+++ b/code/modules/spells/artifacts/plague_bell.dm
@@ -72,21 +72,11 @@
 
 	var/damage_delivered = 0 //The necromancer will be healed by a percentage of the total damage delivered this tick.
 
-	for(var/atom/A in hearers(6, get_turf(loc))) // Here we will actually damage mobs in range
-		if(A == master)
+	for(var/mob/living/M in GLOB.living_mob_list_) // Here we will actually damage mobs in range
+		if(get_dist(master, M) > world.view)
 			continue
 
-		var/mob/living/M = null
-
-		if(isliving(A))
-			M = A
-		else if(istype(A,/obj/mecha))
-			var/obj/mecha/mecha = A
-			if(!mecha.occupant)
-				continue
-
-			M = mecha.occupant
-		else
+		if(M == master)
 			continue
 
 		if(M.is_ic_dead() || M.isSynthetic() || isundead(M))

--- a/code/modules/spells/artifacts/plague_bell.dm
+++ b/code/modules/spells/artifacts/plague_bell.dm
@@ -75,10 +75,11 @@
 	for(var/atom/A in hearers(6, get_turf(loc))) // Here we will actually damage mobs in range
 		if(A == master)
 			continue
-		
-		var/mob/living/M = A
-		if(!istype(M))
-			continue
+
+		var/mob/living/M = null
+
+		if(isliving(A))
+			M = A
 		else if(istype(A,/obj/mecha))
 			var/obj/mecha/mecha = A
 			if(!mecha.occupant)

--- a/code/modules/spells/artifacts/plague_bell.dm
+++ b/code/modules/spells/artifacts/plague_bell.dm
@@ -73,7 +73,7 @@
 	var/damage_delivered = 0 //The necromancer will be healed by a percentage of the total damage delivered this tick.
 
 	for(var/mob/living/M in GLOB.living_mob_list_) // Here we will actually damage mobs in range
-		if(get_dist(master, M) > world.view)
+		if(get_dist(master, get_turf(M)) > world.view)
 			continue
 
 		if(M == master)

--- a/code/modules/spells/classes/necromancer.dm
+++ b/code/modules/spells/classes/necromancer.dm
@@ -8,7 +8,7 @@
 	spells = list(
 		SPELL_DATA(/datum/spell/targeted/raiseundead,                 1),
 		SPELL_DATA(/datum/spell/targeted/raiseundead/lichify,         3),
-		SPELL_DATA(/datum/spell/hand/marsh_of_the_dead,               1),
+		SPELL_DATA(/datum/spell/hand/charges/marsh_of_the_dead,       1),
 		SPELL_DATA(/datum/spell/toggled/immaterial_form,              1),
 		SPELL_DATA(/datum/spell/targeted/noremorse,                   1),
 		SPELL_DATA(/datum/spell/aoe_turf/conjure/tombstone,           1),

--- a/code/modules/spells/hand/marsh_of_the_dead.dm
+++ b/code/modules/spells/hand/marsh_of_the_dead.dm
@@ -3,7 +3,7 @@
 #define MARSH_MAX_UNBUCKLE_TIME 40 SECONDS
 #define MARSH_DAMAGE_PER_UPGRADE 10
 
-/datum/spell/hand/marsh_of_the_dead
+/datum/spell/hand/charges/marsh_of_the_dead
 	name = "Marsh of the dead"
 	desc = "This spell creates a puddle of vile pus, staggering any mortal."
 	school = "necromancy"
@@ -12,20 +12,21 @@
 	spell_flags = 0
 	invocation_type = SPI_NONE
 	show_message = "snaps their fingers."
-	spell_delay = 50
+	spell_delay = 2 SECONDS
 	icon_state = "wiz_marsh"
 	level_max = list(SP_TOTAL = 3, SP_SPEED = 1, SP_POWER = 2)
 	var/damage = 0
 	override_base = "const"
 	charge_max = 600
 	cooldown_min = 300
+	max_casts = 3
 
-/datum/spell/hand/marsh_of_the_dead/cast_hand(atom/a, mob/user)
+/datum/spell/hand/charges/marsh_of_the_dead/cast_hand(atom/a, mob/user)
 	for(var/turf/simulated/T in view(1,a))
 		new /obj/effect/deadhands(T, damage)
 	return ..()
 
-/datum/spell/hand/marsh_of_the_dead/empower_spell()
+/datum/spell/hand/charges/marsh_of_the_dead/empower_spell()
 	. = ..()
 	if(!.)
 		return FALSE
@@ -80,7 +81,7 @@
 		if(H.species.species_flags & SPECIES_FLAG_NO_TANGLE)
 			return
 
-	victim.visible_message(SPAN_DANGER("You're stuck in \the [src]!"))
+	to_chat(victim, SPAN_DANGER("You're stuck in \the [src]!"))
 
 	victim.forceMove(loc)
 

--- a/code/modules/spells/targeted/no_remorse.dm
+++ b/code/modules/spells/targeted/no_remorse.dm
@@ -28,7 +28,7 @@
 
 	ADD_TRAIT(victim, TRAIT_GHOSTATTACKABLE)
 
-	notify_ghosts("A powerful necromancer has allowed you to exact revenge on [victim]! Click on him to unleash your fury!", null, victim, action = NOTIFY_JUMP, posses_mob = FALSE)
+	notify_ghosts("A powerful necromancer has allowed you to exact revenge on [victim]! Click on him to unleash your fury!", null, victim, action = NOTIFY_ATTACK, posses_mob = FALSE)
 
 /datum/modifier/status_effect/ghostattackable
-	duration = 15 SECONDS
+	duration = 10 SECONDS

--- a/code/modules/spells/targeted/no_remorse.dm
+++ b/code/modules/spells/targeted/no_remorse.dm
@@ -1,7 +1,7 @@
 /datum/spell/targeted/noremorse
 	name = "No remorse"
-	desc = ""
-	feedback = ""
+	desc = "Designate a mortal who will be attacked by beings from the Realm Of The Dead. Those beings however may choose not to obey your will."
+	feedback = "NR"
 	school = "necromancy"
 
 	invocation = "Facite vindictam!"

--- a/code/modules/spells/targeted/raiseundead.dm
+++ b/code/modules/spells/targeted/raiseundead.dm
@@ -42,9 +42,9 @@
 	if(should_lichify && (target.mind?.wizard in user.mind.wizard.thralls)) // Lichifying him without further ado
 		target.make_undead(user, should_lichify)
 
-	if(!target.client || target.mind)
+	if(!target.client && target.mind)
 		for(var/mob/observer/ghost/ghost in GLOB.ghost_mob_list)
-			if(ghost.mind?.key != target.mind.key)
+			if(ghost.mind?.key != target.mind?.key)
 				continue
 
 			ghost.can_reenter_corpse = TRUE
@@ -103,7 +103,7 @@
 	if(!mind)
 		return
 
-	if(mind.wizard && !istype(mind.wizard, /datum/wizard/undead))
+	if(!istype(mind.wizard, /datum/wizard/undead))
 		GLOB.wizards.add_antagonist_mind(mind, TRUE, "undead", "<b>You are undead! Your job is to serve your master!</b>")
 		mind.wizard = new /datum/wizard/undead(src, necromancer)
 
@@ -132,7 +132,6 @@
 		to_chat(src, SPAN_DANGER("<font size=6>You are now a lich serving as an apprentice to your master, \the [necromancer].</font>"))
 	else
 		to_chat(necromancer, SPAN_DANGER("You feel a soul answering your call. You now have a new thrall."))
-		to_chat(src, SPAN_DANGER("<font size=6>Your consciousness awakens in a cold body. You are alive, but at what cost?</font>"))
 		to_chat(src, SPAN_DANGER("<font size=6>Raised as undead, stripped of free will you now have one task - obey your master, \the [necromancer].</font>"))
 
 #undef RAISE_UNDEAD_TIMEOUT

--- a/code/modules/spells/targeted/raiseundead.dm
+++ b/code/modules/spells/targeted/raiseundead.dm
@@ -10,9 +10,9 @@
 	invocation = "De sepulchro suscitate et servite mihi!"
 	invocation_type = SPI_SHOUT
 	max_targets = 1
-	charge_max = 6000
-	cooldown_min = 3000
-	cooldown_reduc = 1000
+	charge_max = 3600
+	cooldown_min = 1800
+	cooldown_reduc = 600
 	level_max = list(SP_TOTAL = 3, SP_SPEED = 3, SP_POWER = 0)
 	compatible_mobs = list(/mob/living/carbon/human)
 	icon_state = "wiz_raiseundead"


### PR DESCRIPTION
- Closes #11209
Перевел умение на hand/charges, теперь у жижи три заряда. Как и должно быть.

- Closes #11208

- No remorse теперь работает через экшн баттон в правом верхнем углу экрана. Просто кликайте по кнопке и наслаждайтесь горением моба.
При этом пришлось снизить длительность заклинания до 10 секунд, а урон - обратно на единицу. Иначе очень жирно. 


- Raise the Dead теперь выводит гостам tgui_alert с предложением занять тело. 
Сообщение в чатике с кнопкой "Occupy" теряется мгновенно. Так должно быть лучше, по идее ничего не сломалось.

- Снизил КД на raise the dead: с десяти минут до 6. Минимальное КД - 3 минуты. 
Посмотрим что выйдет, может потом опять подниму.





<details>
<summary>Чейнджлог</summary>

```yml
🆑
tweak: При включении граммофона теперь приходит уведомлялка гостам.
tweak: Raise the Dead теперь выводит гостам тгуи алерт с предложением занять тело. Больше никто не потеряет сообщение в чате.
tweak: Снизил кулдаун у заклинания Raise The Dead до 6 минут. 
tweak: No remorse теперь работает через экшн баттон в правом верхнем углу экрана. Просто кликайте по кнопке и наносите урон цели. 
bugfix: Исправлена ошибка в результате которой некромант мог бесконечно кидать лужи с жижей через Marsh of The Dead.
bugfix: Исправлено неверное сообщение в чат при застревании игрока в жиже некроманта.
bugfix: Добавлено утерянное описание No Remorse
bugfix: Посох-колокол теперь работает корректно и высасывает жизнь.
/🆑
```

</details>




Далее честно заполняем галочки. Чем больше галочек, тем быстрее проверять Pull Request, соответственно он быстрее будет принят. Чтобы отметить - ставим x внутри квадратных скобочек вот так: `- [x] ...`. Галочки можно доставлять позже по мере окончания работы над ПРом. ЭТУ СТРОЧКУ НУЖНО УДАЛИТЬ.

- [x] Pull Request полностью завершен, мне не нужна помощь чтобы его закончить.
- [x] Я внимательно прочитал все свои изменения и багов в них не нашел.
- [x] Я запускал сервер со своими изменениями локально и все протестировал.
- [x] Я ознакомился c [Guide to Contribute](https://github.com/ChaoticOnyx/OnyxBay/blob/dev/docs/contributing.md).
