### PR TITLE
fix(runechat): messages are now correctly displayed

### DIFF
--- a/code/datums/chatmessage.dm
+++ b/code/datums/chatmessage.dm
@@ -147,7 +147,7 @@
 	approx_lines = max(1, mheight / CHAT_MESSAGE_APPROX_LHEIGHT)
 
 	// Translate any existing messages upwards, apply exponential decay factors to timers
-	message_loc = target
+	message_loc = isturf(target) ? target : get_atom_on_turf(target)
 	if (owned_by.seen_messages)
 		var/idx = 1
 		var/combined_height = approx_lines

--- a/code/game/atoms.dm
+++ b/code/game/atoms.dm
@@ -526,7 +526,8 @@ its easier to just keep the beam vertical.
 	for(var/m in hearing_mobs)
 		var/mob/M = m
 		M.show_message(message, AUDIBLE_MESSAGE, deaf_message, VISIBLE_MESSAGE)
-		show_splash_text(M, message)
+		if(M.get_preference_value("CHAT_RUNECHAT") == GLOB.PREF_YES)
+			M.create_chat_message(src, message)
 
 /atom/movable/proc/dropInto(atom/destination)
 	while(istype(destination))


### PR DESCRIPTION
Исправил какое-то недоразумение. 

А еще поменял сплэш на рунчат в лавгивере. Потому что рунчат - круто, а с моим фиксом оно еще и работает теперь.

<details>
<summary>Чейнджлог</summary>

```yml
🆑
bugfix: Сообщения рунчата теперь будут выводиться корректно даже если моб в мехе/ящике/контентсах объекта.
/🆑
```

</details>

- [x] Pull Request полностью завершен, мне не нужна помощь чтобы его закончить.
- [x] Я внимательно прочитал все свои изменения и багов в них не нашел.
- [x] Я запускал сервер со своими изменениями локально и все протестировал.
- [x] Я ознакомился c [Guide to Contribute](https://github.com/ChaoticOnyx/OnyxBay/blob/dev/docs/contributing.md).
