### PR TITLE
spellcheck(announces): typo fix

### DIFF
--- a/code/__defines/announce.dm
+++ b/code/__defines/announce.dm
@@ -23,7 +23,7 @@ GLOBAL_VAR_CONST(PREF_ANNOUNCER_TGSTATION, "\[Cargo\] /TG/station (Legacy)")
 	title = "Gravity Failure"
 
 /datum/announce/solar_storm_approach
-	text = "A solar storm has been detected approaching the %STATION_NAME%. Please halt all EVA activites immediately and return inside."
+	text = "A solar storm has been detected approaching the %STATION_NAME%. Please halt all EVA activities immediately and return inside."
 	title = "%STATION_NAME% Sensor Array"
 
 /datum/announce/solar_storm_start


### PR DESCRIPTION
Исправил очепяточку в анонсе. Жду награду за баг уровня "нереально"
Обосрался в названии коммита, кста. Да и похуй

`close #11281`


<details>
<summary>Чейнджлог</summary>

```yml
🆑 IngeS
spellcheck: Исправлена опечатка в аннонсе о солнечном шторме.
/🆑
```


- [x] Pull Request полностью завершен, мне не нужна помощь чтобы его закончить.
- [x] Я внимательно прочитал все свои изменения и багов в них не нашел.
- [x] Я запускал сервер со своими изменениями локально и все протестировал.
- [x] Я ознакомился c [Guide to Contribute](https://github.com/ChaoticOnyx/OnyxBay/blob/dev/docs/contributing.md).
