### PR TITLE
Добавление маптекста

### DIFF
--- a/baystation12.dme
+++ b/baystation12.dme
@@ -199,6 +199,7 @@
 #include "code\_onclick\hud\gun_mode.dm"
 #include "code\_onclick\hud\hud.dm"
 #include "code\_onclick\hud\human.dm"
+#include "code\_onclick\hud\maptext.dm"
 #include "code\_onclick\hud\metroid.dm"
 #include "code\_onclick\hud\movable_screen_objects.dm"
 #include "code\_onclick\hud\radial.dm"

--- a/code/_onclick/hud/hud.dm
+++ b/code/_onclick/hud/hud.dm
@@ -45,6 +45,8 @@
 	/// List of all buttons that never exit the view
 	var/list/obj/screen/always_visible_inventory
 
+	var/obj/screen/maptext/maptext
+
 /datum/hud/New(mob/owner)
 	mymob = owner
 	instantiate()
@@ -62,6 +64,10 @@
 	toggleable_inventory = null
 	always_visible_inventory = null
 	mymob = null
+
+	if(maptext)
+		qdel(maptext)
+	maptext = null
 
 /datum/hud/proc/hidden_inventory_update()
 	if(!mymob) return
@@ -189,6 +195,9 @@
 	hud_version = hud_style > 0 ? hud_style : hud_version + 1
 	if(hud_version > HUD_STYLE_TOTAL)
 		hud_version = HUD_STYLE_STANDART
+
+	maptext = new(src)
+	mymob.client.screen += maptext
 
 	switch(hud_version)
 		if(HUD_STYLE_STANDART)

--- a/code/_onclick/hud/human.dm
+++ b/code/_onclick/hud/human.dm
@@ -107,7 +107,7 @@
 		static_inventory += using
 
 		inv_box = new /obj/screen/inventory()
-		inv_box.SetName("right hand")
+		inv_box.SetName("r_hand")
 		inv_box.icon = ui_style
 		inv_box.icon_state = "r_hand_inactive"
 		if(mymob && !mymob.hand)	//This being 0 or null means the right hand is in use
@@ -121,7 +121,7 @@
 		static_inventory += inv_box
 
 		inv_box = new /obj/screen/inventory()
-		inv_box.SetName("left hand")
+		inv_box.SetName("l_hand")
 		inv_box.icon = ui_style
 		inv_box.icon_state = "l_hand_inactive"
 		if(mymob && mymob.hand)	//This being 1 means the left hand is in use

--- a/code/_onclick/hud/human.dm
+++ b/code/_onclick/hud/human.dm
@@ -107,7 +107,7 @@
 		static_inventory += using
 
 		inv_box = new /obj/screen/inventory()
-		inv_box.SetName("r_hand")
+		inv_box.SetName("right hand")
 		inv_box.icon = ui_style
 		inv_box.icon_state = "r_hand_inactive"
 		if(mymob && !mymob.hand)	//This being 0 or null means the right hand is in use
@@ -121,7 +121,7 @@
 		static_inventory += inv_box
 
 		inv_box = new /obj/screen/inventory()
-		inv_box.SetName("l_hand")
+		inv_box.SetName("left hand")
 		inv_box.icon = ui_style
 		inv_box.icon_state = "l_hand_inactive"
 		if(mymob && mymob.hand)	//This being 1 means the left hand is in use

--- a/code/_onclick/hud/maptext.dm
+++ b/code/_onclick/hud/maptext.dm
@@ -17,8 +17,10 @@
 			if(mob.hud_used.maptext.last_word == obj_name)
 				return
 			obj_name = uppertext(obj_name)
-			if(mob.mind.assigned_role == "Clown")
+			if(mob.mind.special_role == "Changeling")
 				mob.hud_used.maptext.maptext = "<font size=4 style=\"font: 'Comic Sans MS'; text-align: center; text-shadow: 1px 1px 2px black;\">[obj_name]</font>"
+			else if(mob.mind.assigned_role == "Clown")
+				mob.hud_used.maptext.maptext = "<font size=4 style=\"font: 'Exocet'; text-align: center; text-shadow: 1px 1px 2px black;\">[obj_name]</font>"
 			else
 				mob.hud_used.maptext.maptext = "<font size=4 style=\"font: 'Small Fonts'; text-align: center; text-shadow: 1px 1px 2px black;\">[obj_name]</font>"
 			mob.hud_used.maptext.last_word = obj_name

--- a/code/_onclick/hud/maptext.dm
+++ b/code/_onclick/hud/maptext.dm
@@ -1,0 +1,27 @@
+/obj/screen/maptext
+	screen_loc = "NORTH:14,WEST"
+	plane = HUD_PLANE
+	layer = HUD_BASE_LAYER
+	maptext_height = 32
+	maptext_width = 480
+	var/last_word = null
+
+/client/MouseEntered(object, location)
+	..()
+	if(!maptext_toggle)
+		return
+	if(istype(object, /atom) && !istype(object, /obj/screen/splash))
+		var/atom/A = object
+		if(mob.hud_used)
+			var/obj_name = A.name
+			if(mob.hud_used.maptext.last_word == obj_name)
+				return
+			obj_name = uppertext(obj_name)
+			if(mob.mind.assigned_role == "Clown")
+				mob.hud_used.maptext.maptext = "<font size=4 style=\"font: 'Comic Sans MS'; text-align: center; text-shadow: 1px 1px 2px black;\">[obj_name]</font>"
+			else
+				mob.hud_used.maptext.maptext = "<font size=4 style=\"font: 'Small Fonts'; text-align: center; text-shadow: 1px 1px 2px black;\">[obj_name]</font>"
+			mob.hud_used.maptext.last_word = obj_name
+
+/client
+	var/maptext_toggle = TRUE

--- a/code/_onclick/hud/maptext.dm
+++ b/code/_onclick/hud/maptext.dm
@@ -8,7 +8,7 @@
 
 /client/MouseEntered(object, location)
 	..()
-	if(!maptext_toggle)
+	if(get_preference_value(/datum/client_preference/maptext) == GLOB.PREF_NO)
 		return
 	if(istype(object, /atom) && !istype(object, /obj/screen/splash))
 		var/atom/A = object
@@ -24,6 +24,3 @@
 			else
 				mob.hud_used.maptext.maptext = "<font size=4 style=\"font: 'Small Fonts'; text-align: center; text-shadow: 1px 1px 2px black;\">[obj_name]</font>"
 			mob.hud_used.maptext.last_word = obj_name
-
-/client
-	var/maptext_toggle = TRUE

--- a/code/modules/client/preference_setup/global/preferences.dm
+++ b/code/modules/client/preference_setup/global/preferences.dm
@@ -102,6 +102,12 @@ var/global/list/_client_preferences_by_type
 	options = list(GLOB.PREF_YES, GLOB.PREF_NO, GLOB.PREF_AS_GHOST, GLOB.PREF_AS_LIVING)
 	default_value = GLOB.PREF_YES
 
+/datum/client_preference/maptext
+	description = "Show Maptext"
+	key = "SHOW_TMAPTEXT"
+	options = list(GLOB.PREF_YES, GLOB.PREF_NO)
+	default_value = GLOB.PREF_NO
+
 /datum/client_preference/runechat
 	description = "Show Runechat (Above-Head-Speech)"
 	key = "CHAT_RUNECHAT"


### PR DESCRIPTION
Лучшая фича пришла и на Опух.
Вместо той строчки внизу слева теперь буковки по центру.
Пока что у Клоуна и Генок уникальные шрифты, последний - обычного человека.
А, ну и ещё слоты рук переименовал. Надеюсь не выстрелит в колено.
![image](https://github.com/ChaoticOnyx/OnyxBay/assets/14943437/a1ebfc5e-6dc0-4296-bb3e-0e6b4c62d044)
![image](https://github.com/ChaoticOnyx/OnyxBay/assets/14943437/9597c27d-cbd8-44fb-b1aa-8f5745b21979)
![image](https://github.com/ChaoticOnyx/OnyxBay/assets/14943437/76360ba7-f97e-4a1b-8c97-834125dcbec8)

<details>
<summary>Чейнджлог</summary>

```yml
🆑kreeperHLC
rscadd: Добавлен маптекст. Также добавлены уникальные маптексты Клоуну и Генкам.
/🆑
```

</details>

- [x] Pull Request полностью завершен, мне не нужна помощь чтобы его закончить.
- [x] Я внимательно прочитал все свои изменения и багов в них не нашел.
- [x] Я запускал сервер со своими изменениями локально и все протестировал.
- [x] Я ознакомился c [Guide to Contribute](https://github.com/ChaoticOnyx/OnyxBay/blob/dev/docs/contributing.md).
