### PR TITLE
tweak(contraband): -hair comb +3 random items

### DIFF
--- a/code/game/objects/random/random.dm
+++ b/code/game/objects/random/random.dm
@@ -198,8 +198,7 @@
 	spawn_nothing_percentage = 66
 
 /obj/random/contraband/spawn_choices()
-	return list(/obj/item/haircomb = 4,
-				/obj/item/storage/pill_bottle/tramadol = 3,
+	return list(/obj/item/storage/pill_bottle/tramadol = 3,
 				/obj/item/storage/pill_bottle/happy = 2,
 				/obj/item/storage/pill_bottle/zoom = 2,
 				/obj/item/reagent_containers/vessel/beaker/vial/random/toxin = 1,
@@ -219,7 +218,10 @@
 				/obj/item/clothing/under/syndicate = 2,
 				/obj/item/reagent_containers/syringe = 3,
 				/obj/item/reagent_containers/syringe/steroid/packaged = 2,
-				/obj/item/reagent_containers/syringe/drugs = 1)
+				/obj/item/reagent_containers/syringe/drugs = 1,
+				/obj/item/melee/baton/cattleprod = 2,
+				/obj/item/gun/projectile/pistol/holdout = 1,
+				/obj/item/material/brass_knuckle = 3)
 
 /obj/random/drinkbottle
 	name = "random drink"


### PR DESCRIPTION
Добавил в рандомный спавнер контрабанды действительно контрабандные вещи. Кастет, самодельную дубинку и 9мм пистолет. Но удалил расчёску (зачем она там?). Если что, у этого спавнера шанс НИЧЕГО не наспавнить 66%. И сам этот спавнер практически нигде не представлен, на Исходе я нашёл один такой на складе карго.

<details>
<summary>Чейнджлог</summary>

```yml
🆑
tweak: Кастет, самодельная дубинка и пистолет могут быть найдены на месте спавна контрабанды.
/🆑
```

</details>

- [x] Pull Request полностью завершен, мне не нужна помощь чтобы его закончить.
- [x] Я внимательно прочитал все свои изменения и багов в них не нашел.
- [x] Я запускал сервер со своими изменениями локально и все протестировал.
- [x] Я ознакомился c [Guide to Contribute](https://github.com/ChaoticOnyx/OnyxBay/blob/dev/docs/contributing.md).
