### PR TITLE
Меньше денег на счета персонажей

### DIFF
--- a/code/game/jobs/job/job.dm
+++ b/code/game/jobs/job/job.dm
@@ -86,7 +86,7 @@
 
 	var/species_modifier = economic_species_modifier[H.species.type]
 
-	var/money_amount = (rand(5,50) + rand(5, 50)) * loyalty * economic_modifier * species_modifier * GLOB.using_map.salary_modifier
+	var/money_amount = (rand(4,20) + rand(4, 20)) * loyalty * economic_modifier * species_modifier * GLOB.using_map.salary_modifier
 	var/datum/money_account/M = create_account(H.real_name, money_amount, null, off_station)
 	if(H.client)
 		M.security_level = H.client.prefs.bank_security

--- a/code/game/jobs/job/job.dm
+++ b/code/game/jobs/job/job.dm
@@ -86,7 +86,7 @@
 
 	var/species_modifier = economic_species_modifier[H.species.type]
 
-	var/money_amount = (rand(4,20) + rand(4, 20)) * loyalty * economic_modifier * species_modifier * GLOB.using_map.salary_modifier
+	var/money_amount = (rand(2,13) + rand(2, 13)) * loyalty * economic_modifier * species_modifier * GLOB.using_map.salary_modifier
 	var/datum/money_account/M = create_account(H.real_name, money_amount, null, off_station)
 	if(H.client)
 		M.security_level = H.client.prefs.bank_security


### PR DESCRIPTION
Теперь у всех профессий стало меньше денег на личных счетах.

До PR'а: ассистент с opposed отношением к НТ может получить 378 кредитов в каком-то из случаев.
После PR'a: ассистент с opposed отношением к НТ может получить от примерно 80 до максимум 200 кредитов. 
 

<details>
<summary>Чейнджлог</summary>

```yml
🆑
balance: Теперь у всех профессий стало меньше денег на личных счетах.
/🆑
```

</details>

- [x] Pull Request полностью завершен, мне не нужна помощь чтобы его закончить.
- [x] Я внимательно прочитал все свои изменения и багов в них не нашел.
- [x] Я запускал сервер со своими изменениями локально и все протестировал.
- [x] Я ознакомился c [Guide to Contribute](https://github.com/ChaoticOnyx/OnyxBay/blob/dev/docs/contributing.md).
