### PR TITLE
fix(vending): GC will no longer consume cartridges

### DIFF
--- a/code/game/machinery/vending/_vending.dm
+++ b/code/game/machinery/vending/_vending.dm
@@ -250,9 +250,10 @@
 	V.set_dir(dir)
 	V.state = 3
 	for(var/obj/I in component_parts)
+		component_parts -= I
 		I.forceMove(V)
-	cartridge = null
 	V.refresh_cartridge()
+	cartridge = null
 	V.update_icon()
 	V.update_desc()
 	qdel(src)


### PR DESCRIPTION
Fixes #11304

<details>
<summary>Чейнджлог</summary>

```yml
🆑
bugfix: При разборке вендоматов больше не пропадают картриджи.
/🆑
```

</details>

- [x] Pull Request полностью завершен, мне не нужна помощь чтобы его закончить.
- [x] Я внимательно прочитал все свои изменения и багов в них не нашел.
- [x] Я запускал сервер со своими изменениями локально и все протестировал.
- [x] Я ознакомился c [Guide to Contribute](https://github.com/ChaoticOnyx/OnyxBay/blob/dev/docs/contributing.md).
