### PR TITLE
fix(pump): fix pump hotkeys for borgs

### DIFF
--- a/code/_onclick/cyborg.dm
+++ b/code/_onclick/cyborg.dm
@@ -144,9 +144,6 @@
 /obj/machinery/turretid/BorgAltClick() //turret lethal on/off. Forwards to AI code.
 	AIAltClick()
 
-/obj/machinery/atmospherics/binary/pump/BorgAltClick()
-	return AltClick()
-
 /*
 	As with AI, these are not used in click code,
 	because the code for robots is specific, not generic.

--- a/code/modules/atmospherics/components/binary_devices/pump.dm
+++ b/code/modules/atmospherics/components/binary_devices/pump.dm
@@ -45,22 +45,29 @@ Thus, the two variables affect pump operation are set in New():
 	return ..()
 
 /obj/machinery/atmospherics/binary/pump/AltClick(mob/user)
-	if(user.stat || user.restrained())
+	if(user.is_ic_dead() || user.restrained())
 		return
+
 	if(!Adjacent(user, src) && !issilicon(user))
 		return
+
 	if(!allowed(user))
 		return
+
+	show_splash_text(user, "toggled [use_power ? "off" : "on"]")
 	update_use_power(!use_power)
 	update_icon()
 
 /obj/machinery/atmospherics/binary/pump/AltRightClick(mob/user)
-	if(user.stat || user.restrained())
+	if(user.is_ic_dead() || user.restrained())
 		return
+
 	if(!Adjacent(user, src) && !issilicon(user))
 		return
+
 	if(!allowed(user))
 		return
+
 	target_pressure = max_pressure_setting
 	show_splash_text(user, "target pressure set to [target_pressure] kPa")
 


### PR DESCRIPTION
Борги снова могут использовать хоткеи для переключения состояния помпы. При включении помпы выводится сообщение, чего реально не хватало и его отсутствие выглядит как баг.

close #10282

<details>
<summary>Чейнджлог</summary>

```yml
🆑
bugfix: Борги снова могут взаимодействовать с помпой через хоткеи.
tweak: При включении помпы через хоткей выводится сообщение.
/🆑
```

</details>

- [x] Pull Request полностью завершен, мне не нужна помощь чтобы его закончить.
- [x] Я внимательно прочитал все свои изменения и багов в них не нашел.
- [x] Я запускал сервер со своими изменениями локально и все протестировал.
- [x] Я ознакомился c [Guide to Contribute](https://github.com/ChaoticOnyx/OnyxBay/blob/dev/docs/contributing.md).
