### PR TITLE
Necrotweaks and necrofixes

### DIFF
--- a/code/game/gamemodes/wizard/wizard_heals.dm
+++ b/code/game/gamemodes/wizard/wizard_heals.dm
@@ -21,7 +21,7 @@
 			E.mend_fracture()
 			E.stage = 0
 
-		if(heal.removes_shrapnel)
+		if(heal.removes_embeded)
 			for(var/obj/implanted_object in E.implants)
 				implanted_object.dropInto(get_turf(loc))
 				E.implants -= implanted_object

--- a/code/game/gamemodes/wizard/wizard_heals.dm
+++ b/code/game/gamemodes/wizard/wizard_heals.dm
@@ -25,6 +25,9 @@
 			for(var/obj/implanted_object in E.implants)
 				implanted_object.dropInto(get_turf(loc))
 				E.implants -= implanted_object
+				if(istype(implanted_object, /obj/item/implant))
+					var/obj/item/implant/removed_implant = implanted_object
+					removed_implant.removed()
 				for(var/datum/wound/wound in E.wounds)
 					if(implanted_object in wound.embedded_objects)
 						wound.embedded_objects -= implanted_object

--- a/code/game/gamemodes/wizard/wizard_heals.dm
+++ b/code/game/gamemodes/wizard/wizard_heals.dm
@@ -20,6 +20,16 @@
 		if(E.status & ORGAN_BROKEN && heal.heal_bones) // some calcium
 			E.mend_fracture()
 			E.stage = 0
+
+		if(heal.removes_shrapnel)
+			for(var/obj/implanted_object in E.implants)
+				implanted_object.dropInto(get_turf(loc))
+				E.implants -= implanted_object
+				for(var/datum/wound/wound in E.wounds)
+					if(implanted_object in wound.embedded_objects)
+						wound.embedded_objects -= implanted_object
+						break
+
 	for(var/A in internal_organs)
 		var/obj/item/organ/internal/E = A
 		if(BP_IS_ROBOTIC(E))

--- a/code/modules/mob/observer/ghost/say.dm
+++ b/code/modules/mob/observer/ghost/say.dm
@@ -20,6 +20,6 @@
 			var/mob/M = m
 			M.show_message(SPAN_DEADSAY("<B>[gg]</B>: [message_to_send]"), AUDIBLE_MESSAGE)
 			if(M.get_preference_value("CHAT_RUNECHAT") == GLOB.PREF_YES)
-				M.create_chat_message(src, message_to_send)
+				M.create_chat_message(gg, message_to_send)
 
 	sanitize_and_communicate(/decl/communication_channel/dsay, client, message)

--- a/code/modules/mob/observer/ghost/say.dm
+++ b/code/modules/mob/observer/ghost/say.dm
@@ -7,6 +7,19 @@
 			continue
 
 		var/message_to_send = stars(message, 85)
-		gg.audible_message(SPAN_DEADSAY(message_to_send))
+
+		var/list/hearing_mobs = list()
+		var/list/hearing_objs = list()
+		get_mobs_and_objs_in_view_fast(get_turf(gg), world.view, hearing_mobs, hearing_objs, checkghosts = null)
+
+		for(var/o in hearing_objs)
+			var/obj/O = o
+			O.show_message(SPAN_DEADSAY("<B>[gg]</B>: [message_to_send]"), AUDIBLE_MESSAGE)
+
+		for(var/m in hearing_mobs)
+			var/mob/M = m
+			M.show_message(SPAN_DEADSAY("<B>[gg]</B>: [message_to_send]"), AUDIBLE_MESSAGE)
+			if(M.get_preference_value("CHAT_RUNECHAT") == GLOB.PREF_YES)
+				M.create_chat_message(src, message_to_send)
 
 	sanitize_and_communicate(/decl/communication_channel/dsay, client, message)

--- a/code/modules/mob/observer/ghost/say.dm
+++ b/code/modules/mob/observer/ghost/say.dm
@@ -7,6 +7,6 @@
 			continue
 
 		var/message_to_send = stars(message, 85)
-		gg.audible_message(SPAN_DEADSAY("<B>[gg]</B>: [message_to_send]"))
+		gg.audible_message(SPAN_DEADSAY(message_to_send))
 
 	sanitize_and_communicate(/decl/communication_channel/dsay, client, message)

--- a/code/modules/spells/artifacts/ghost_gramophone.dm
+++ b/code/modules/spells/artifacts/ghost_gramophone.dm
@@ -6,7 +6,7 @@ GLOBAL_LIST_EMPTY(ghost_gramophones)
 	name = "Strange gramophone"
 	desc = "Artifact that allows you to temporarily hear spirits from a parallel dimension."
 	var/active = FALSE
-	var/last_activated = 0
+	var/last_activated = - 3 MINUTES
 	icon_state = "ghostgramophone0"
 
 /obj/item/device/ghost_gramophone/Initialize()

--- a/code/modules/spells/artifacts/plague_bell.dm
+++ b/code/modules/spells/artifacts/plague_bell.dm
@@ -166,6 +166,7 @@
 	heals_external_bleeding = TRUE
 	heal_bones = TRUE
 	amt_organ = 20
+	removes_shrapnel = TRUE
 
 #undef VALUE_REDUCTION
 #undef HEALING_THRESHOLD_MINOR

--- a/code/modules/spells/artifacts/plague_bell.dm
+++ b/code/modules/spells/artifacts/plague_bell.dm
@@ -166,7 +166,7 @@
 	heals_external_bleeding = TRUE
 	heal_bones = TRUE
 	amt_organ = 20
-	removes_shrapnel = TRUE
+	removes_embeded = TRUE
 
 #undef VALUE_REDUCTION
 #undef HEALING_THRESHOLD_MINOR

--- a/code/modules/spells/hand/marsh_of_the_dead.dm
+++ b/code/modules/spells/hand/marsh_of_the_dead.dm
@@ -19,7 +19,7 @@
 	override_base = "const"
 	charge_max = 600
 	cooldown_min = 300
-	max_casts = 3
+	max_casts = 1
 
 /datum/spell/hand/charges/marsh_of_the_dead/cast_hand(atom/a, mob/user)
 	for(var/turf/simulated/T in view(1,a))

--- a/code/modules/spells/targeted/targeted.dm
+++ b/code/modules/spells/targeted/targeted.dm
@@ -31,6 +31,8 @@ Targeted spells have two useful flags: INCLUDEUSER and SELECTABLE. These are exp
 	var/heal_bones = 0
 	var/amt_eye_blind = 0
 	var/amt_eye_blurry = 0
+	/// Determines whether healing will remove embeded objects
+	var/removes_shrapnel = FALSE
 	var/list/compatible_mobs = list()
 
 

--- a/code/modules/spells/targeted/targeted.dm
+++ b/code/modules/spells/targeted/targeted.dm
@@ -32,7 +32,7 @@ Targeted spells have two useful flags: INCLUDEUSER and SELECTABLE. These are exp
 	var/amt_eye_blind = 0
 	var/amt_eye_blurry = 0
 	/// Determines whether healing will remove embeded objects
-	var/removes_shrapnel = FALSE
+	var/removes_embeded = FALSE
 	var/list/compatible_mobs = list()
 
 


### PR DESCRIPTION
Снизил заряды у топи мертвых. Три - слишком сильно. 

Посох некроманта теперь убирает шрапнель при мажорном хиле, как и задумано.

Грамофон нельзя было включить пока world.time не будет больше трех минут, небольшой баг, впрочем это игроки вряд-ли заметили.

<details>
<summary>Чейнджлог</summary>

```yml
🆑
bugfix: Посох некроманта теперь убирает шрапнель при лечении.
tweak: Уменьшено максимальное количество зарядов у заклинания marsh of the dead c трех до одного.
/🆑
```

</details>

- [x] Pull Request полностью завершен, мне не нужна помощь чтобы его закончить.
- [x] Я внимательно прочитал все свои изменения и багов в них не нашел.
- [x] Я запускал сервер со своими изменениями локально и все протестировал.
- [x] Я ознакомился c [Guide to Contribute](https://github.com/ChaoticOnyx/OnyxBay/blob/dev/docs/contributing.md).
