### PR TITLE
fix(rubber_pig): rubber pigs can now be removed from inventory

### DIFF
--- a/code/game/objects/items/toys.dm
+++ b/code/game/objects/items/toys.dm
@@ -1024,6 +1024,7 @@
 	oink(user, "squeezes")
 
 /obj/item/toy/pig/attack_hand(mob/user)
+	..()
 	oink(user, pick("presses", "squeezes", "squashes", "champs", "pinches"))
 
 /obj/item/toy/pig/MouseDrop(mob/user)


### PR DESCRIPTION
Свинопасы в ахуе. Плебеи трепещат в ужасе. Демагоги ушли в запой. А все почему? Да потому что свиньи сломаны!

Теперь свинью можно достать из рюкзака. 
Из минусов - нельзя хрюкать свиньей в рюкзаке не доставая ее. 


<details>
<summary>Чейнджлог</summary>

```yml
🆑
bugfix: Резиновую свинью теперь можно достать из рюкзака.
/🆑
```

</details>

- [x] Pull Request полностью завершен, мне не нужна помощь чтобы его закончить.
- [x] Я внимательно прочитал все свои изменения и багов в них не нашел.
- [x] Я запускал сервер со своими изменениями локально и все протестировал.
- [x] Я ознакомился c [Guide to Contribute](https://github.com/ChaoticOnyx/OnyxBay/blob/dev/docs/contributing.md).
