### PR TITLE
fix(barricade): adds anchoring logic to a card interaction with barrier

### DIFF
--- a/code/game/objects/structures/barricade/security.dm
+++ b/code/game/objects/structures/barricade/security.dm
@@ -68,7 +68,7 @@
 		return
 
 	locked = !locked
-	anchored = !locked
+	anchored = locked
 
 	update_icon()
 	show_splash_text(user, "bolts [locked ? "dropped" : "lifted"].")

--- a/code/game/objects/structures/barricade/security.dm
+++ b/code/game/objects/structures/barricade/security.dm
@@ -68,6 +68,7 @@
 		return
 
 	locked = !locked
+	anchored = !locked
 
 	update_icon()
 	show_splash_text(user, "bolts [locked ? "dropped" : "lifted"].")


### PR DESCRIPTION
При рефакторе упустил строчку, которая ставила состояние прикрученности при интеракции карточкой - возвращаю.

<details>
<summary>Чейнджлог</summary>

```yml
🆑
bugfix: Блокировка и разблокировка барьера вновь влияет на состояние болтов.
/🆑
```

</details>

- [x] Pull Request полностью завершен, мне не нужна помощь чтобы его закончить.
- [x] Я внимательно прочитал все свои изменения и багов в них не нашел.
- [ ] Я запускал сервер со своими изменениями локально и все протестировал.
- [x] Я ознакомился c [Guide to Contribute](https://github.com/ChaoticOnyx/OnyxBay/blob/dev/docs/contributing.md).
