### PR TITLE
fix(emotes): bugfixes and lost emotes

### DIFF
--- a/code/modules/emotes/emote_mob_defines.dm
+++ b/code/modules/emotes/emote_mob_defines.dm
@@ -77,7 +77,16 @@
 		/datum/emote/handshake,
 		/datum/emote/dance,
 		/datum/emote/vomit,
-		/datum/emote/giggle
+		/datum/emote/giggle,
+		/datum/emote/whistle,
+		/datum/emote/signal,
+		/datum/emote/synth/beep,
+		/datum/emote/synth/ping,
+		/datum/emote/synth/buzz,
+		/datum/emote/synth/deny,
+		/datum/emote/synth/confirm,
+		/datum/emote/synth/law,
+		/datum/emote/synth/halt
 	)
 
 /mob/living/carbon/metroid/load_default_emotes()

--- a/code/modules/emotes/generic/audible.dm
+++ b/code/modules/emotes/generic/audible.dm
@@ -649,3 +649,22 @@
 	set name = "Chirp"
 	set category = "Emotes"
 	emote("chirp")
+
+/datum/emote/whistle
+	key = "whistle"
+
+	message_1p = "You whistle."
+	message_3p = "whistles!"
+
+	message_type = AUDIBLE_MESSAGE
+
+	sound = SFX_WHISTLE
+
+	state_checks = EMOTE_CHECK_CONSCIOUS
+
+	statpanel_proc = /mob/proc/whistle_emote
+
+/mob/proc/whistle_emote()
+	set name = "Whistle"
+	set category = "Emotes"
+	emote("whistle")

--- a/code/modules/emotes/generic/visual.dm
+++ b/code/modules/emotes/generic/visual.dm
@@ -635,3 +635,20 @@
 	set name = "Vomit"
 	set category = "Emotes"
 	emote("vomit", intentional = TRUE)
+
+/datum/emote/signal
+	key = "signal"
+
+	message_1p = "You signal."
+	message_3p = "signals."
+
+	message_type = VISIBLE_MESSAGE
+
+	state_checks = EMOTE_CHECK_CONSCIOUS
+
+	statpanel_proc = /mob/proc/signal_emote
+
+/mob/proc/signal_emote()
+	set name = "Signal"
+	set category = "Emotes"
+	emote("signal", intentional = TRUE)

--- a/code/modules/mob/mob.dm
+++ b/code/modules/mob/mob.dm
@@ -88,6 +88,9 @@
 /mob/proc/show_message(msg, type, alt, alt_type)//Message, type of message (1 or 2), alternative message, alt message type (1 or 2)
 	if(!client)	return
 
+	if(is_blind() && is_deaf())
+		return // We're both blind & deaf, nothing to do here
+
 	//spaghetti code
 	if(type)
 		if((type & VISIBLE_MESSAGE) && is_blind())//Vision related


### PR DESCRIPTION
Resolves #11434, #11436, #11435

<details>
<summary>Чейнджлог</summary>

```yml
🆑
bugfix: Эмоуты боргов снова доступны синтам.
bugfix: Вернул потерянные эмоуты (Whistle & signal).
bugfix: Космонавты больше не будут видеть эмоуты через сон.
/🆑
```

</details>

- [x] Pull Request полностью завершен, мне не нужна помощь чтобы его закончить.
- [x] Я внимательно прочитал все свои изменения и багов в них не нашел.
- [x] Я запускал сервер со своими изменениями локально и все протестировал.
- [x] Я ознакомился c [Guide to Contribute](https://github.com/ChaoticOnyx/OnyxBay/blob/dev/docs/contributing.md).
