### PR TITLE
Обработка сообщений эмоутов

### DIFF
--- a/code/modules/emotes/emote_mob.dm
+++ b/code/modules/emotes/emote_mob.dm
@@ -53,26 +53,22 @@
 
 	emote.do_emote(src, act, intentional, target)
 
-/mob/proc/make_emote_message(mob/user, message)
-	var/user_name = "<b>[user]</b>"
+/// A simple emote - just the message, and it's type. For anything more complex use datumized emotes.
+/mob/proc/custom_emote(message_type = VISIBLE_MESSAGE, message, intentional = FALSE)
+	log_emote("[key_name(src)] : [message]")
 
-	message = replacetext(message, regex(@"\^+", "g"), user_name)
+	var/user_name = "<b>[src]</b>"
 
 	var/end_char = message[length(message)]
 	if(end_char != "." && end_char != "?" && end_char != "!" && end_char != "\"")
 		message += "."
 
-	if(findtext(message, user_name))
-		return capitalize("<i>[message]</i>")
-
-	return "[user_name] <i>[message]</i>"
-
-/// A simple emote - just the message, and it's type. For anything more complex use datumized emotes.
-/mob/proc/custom_emote(message_type = VISIBLE_MESSAGE, message, intentional = FALSE)
-	log_emote("[key_name(src)] : [message]")
-
-	var/msg = make_emote_message(src, message)
-	if(message_type & VISIBLE_MESSAGE)
-		visible_message(msg)
+	if(findtext(message, "^"))
+		message = "<i>[capitalize(replacetext(message, regex(@"\^+", "g"), user_name))]</i>"
 	else
-		audible_message(msg)
+		message = "[user_name] <i>[message]</i>"
+
+	if(message_type & VISIBLE_MESSAGE)
+		visible_message(message)
+	else
+		audible_message(message)

--- a/code/modules/emotes/emote_mob.dm
+++ b/code/modules/emotes/emote_mob.dm
@@ -53,11 +53,25 @@
 
 	emote.do_emote(src, act, intentional, target)
 
+/mob/proc/make_emote_message(mob/user, message)
+	var/user_name = "<b>[user]</b>"
+
+	message = replacetext(message, regex(@"\^+", "g"), user_name)
+
+	var/end_char = message[length(message)]
+	if(end_char != "." && end_char != "?" && end_char != "!" && end_char != "\"")
+		message += "."
+
+	if(findtext(message, user_name))
+		return capitalize("<i>[message]</i>")
+
+	return "[user_name] <i>[message]</i>"
+
 /// A simple emote - just the message, and it's type. For anything more complex use datumized emotes.
 /mob/proc/custom_emote(message_type = VISIBLE_MESSAGE, message, intentional = FALSE)
 	log_emote("[key_name(src)] : [message]")
 
-	var/msg = "<b>[src]</b> <i>[message]</i>"
+	var/msg = make_emote_message(src, message)
 	if(message_type & VISIBLE_MESSAGE)
 		visible_message(msg)
 	else


### PR DESCRIPTION
- В эмоутах снова можно ставить карет, который заменится на имя персонажа (из начала эмоута оно, соответственно, уберётся, а текст всегда будет с заглавной буквы).
- - Можно ставить сколько угодно каретов, но цепочки из них, не разделённых другими символами, будут расцениваться как один (так, "^" эквивалентно "^^" эквивалентно "^^^^^" и так далее). Как говорится, не срать.

<details>
<summary>Чейнджлог</summary>

```yml
🆑TheUnknownOne
rscadd: В эмоутах вновь можно пользоваться каретом (^) для подставки имени персонажа в любое место в тексте эмоута, в том числе несколько раз.
/🆑
```

</details>

- [x] Pull Request полностью завершен, мне не нужна помощь чтобы его закончить.
- [x] Я внимательно прочитал все свои изменения и багов в них не нашел.
- [x] Я запускал сервер со своими изменениями локально и все протестировал.
- [x] Я ознакомился c [Guide to Contribute](https://github.com/ChaoticOnyx/OnyxBay/blob/dev/docs/contributing.md).
