### PR TITLE
Removes inability to shoot regular .38s from M2019

### DIFF
--- a/code/modules/projectiles/guns/projectile/revolver.dm
+++ b/code/modules/projectiles/guns/projectile/revolver.dm
@@ -240,14 +240,20 @@
 		return ..()
 	insert_cell(C, user)
 	return 1
+
 /obj/item/gun/projectile/revolver/m2019/detective/proc/usecharge(UC)
-	if(bcell && chambered?.expend())
-		if(bcell.checked_use(UC))
-			return 1
-		else
-			update_icon()
-			return 0
-	return null
+	if(!bcell)
+		return
+
+	if(!chambered)
+		return
+
+	if(!chambered.projectile_type || chambered.is_spent)
+		return
+
+	if(bcell.checked_use(UC))
+		update_icon()
+		return TRUE
 
 /obj/item/gun/projectile/revolver/m2019/detective/proc/insert_cell(obj/item/cell/B, mob/user)
 	if(bcell)


### PR DESCRIPTION
```yml
🆑
bugfix: M2019 снова научился стрелять обычными патронами своего калибра.
/🆑
```

- [x] Pull Request полностью завершен, мне не нужна помощь чтобы его закончить.
- [x] Я внимательно прочитал все свои изменения и багов в них не нашел.
- [ ] Я запускал сервер со своими изменениями локально и все протестировал.
- [x] Я ознакомился c [Guide to Contribute](https://github.com/ChaoticOnyx/OnyxBay/blob/dev/docs/contributing.md).
