### PR TITLE
Machinery re fuc ktor

### DIFF
--- a/code/game/antagonist/outsider/abductor/equipment/abductors_gear.dm
+++ b/code/game/antagonist/outsider/abductor/equipment/abductors_gear.dm
@@ -715,10 +715,10 @@ Congratulations! You are now trained for invasive xenobiology research!"}
 		STOP_PROCESSING(SSmachines, src)
 		return
 
-	M.adjustBrainLoss(-25)
+	H.adjustBrainLoss(-25)
 	for(var/chemical in injected_reagents)
-		if(M.reagents.get_reagent_amount(chemical) < inject_am )
-			M.reagents.add_reagent(chemical, inject_am )
+		if(H.reagents.get_reagent_amount(chemical) < inject_am )
+			H.reagents.add_reagent(chemical, inject_am )
 
 /obj/structure/closet/abductor
 	name = "alien locker"

--- a/code/game/antagonist/outsider/abductor/equipment/abductors_gear.dm
+++ b/code/game/antagonist/outsider/abductor/equipment/abductors_gear.dm
@@ -709,50 +709,16 @@ Congratulations! You are now trained for invasive xenobiology research!"}
 
 	var/static/list/injected_reagents = list(/datum/reagent/inaprovaline, /datum/reagent/dexalinp, /datum/reagent/painkiller/tramadol)
 
-/obj/machinery/optable/abductor/take_victim(mob/living/carbon/C, mob/living/carbon/user)
-	if (C == user)
-		user.visible_message("[user] climbs on \the [src].","You climb on \the [src].")
-	else
-		visible_message("<span class='notice'>\The [C] has been laid on \the [src] by [user].</span>")
-	if (C.client)
-		C.client.perspective = EYE_PERSPECTIVE
-		C.client.eye = src
-	C.resting = 1
-	C.dropInto(loc)
-	for(var/obj/O in src)
-		if(O in component_parts)
-			continue
-		O.dropInto(loc)
-	src.add_fingerprint(user)
-	if(ishuman(C))
-		set_next_think(world.time + 1 SECOND)
-		var/mob/living/carbon/human/H = C
-		src.victim = H
-		to_chat(C, SPAN_DANGER("You feel a series of tiny pricks!"))
+/obj/machinery/optable/abductor/Process()
+	var/mob/living/carbon/human/H = victim?.resolve()
+	if(!istype(H) || H.loc != loc)
+		STOP_PROCESSING(SSmachines, src)
+		return
 
-/obj/machinery/optable/abductor/check_victim()
-	if(locate(/mob/living/carbon/human, src.loc))
-		play_beep()
-		var/mob/living/carbon/human/M = locate(/mob/living/carbon/human, src.loc)
-		if(M.lying)
-			src.victim = M
-			return 1
-	src.victim = null
-	return 0
-
-/obj/machinery/optable/abductor/think()
-	if(locate(/mob/living/carbon/human, src.loc))
-		var/mob/living/carbon/human/M = locate(/mob/living/carbon/human, src.loc)
-		if(M.lying)
-			src.victim = M
-			M.adjustBrainLoss(-25)
-			for(var/chemical in injected_reagents)
-				if(M.reagents.get_reagent_amount(chemical) < inject_am )
-					M.reagents.add_reagent(chemical, inject_am )
-
-			set_next_think(world.time + 1 SECOND)
-
-	src.victim = null
+	M.adjustBrainLoss(-25)
+	for(var/chemical in injected_reagents)
+		if(M.reagents.get_reagent_amount(chemical) < inject_am )
+			M.reagents.add_reagent(chemical, inject_am )
 
 /obj/structure/closet/abductor
 	name = "alien locker"

--- a/code/game/machinery/OpTable.dm
+++ b/code/game/machinery/OpTable.dm
@@ -7,12 +7,13 @@
 	anchored = 1.0
 	idle_power_usage = 1 WATTS
 	active_power_usage = 5 WATTS
-	var/mob/living/carbon/human/victim = null
 	var/strapped = 0.0
 	var/busy = FALSE
 	var/time_to_strip = 5 SECONDS
-
-	var/obj/machinery/computer/operating/computer = null
+	/// Weakref to an operating computer
+	var/weakref/opcomp
+	/// Weakref to a patient on this table
+	var/weakref/victim
 
 	component_types = list(
 		/obj/item/circuitboard/optable,
@@ -20,6 +21,41 @@
 	)
 
 	beepsounds = SFX_BEEP_MEDICAL
+
+/obj/machinery/optable/Initialize()
+	. = ..()
+	var/obj/machinery/computer/operating/comp = locate(/obj/machinery/computer/operating) in orange(2, src)
+	if(istype(comp) && !comp.optable)
+		comp.optable = weakref(src)
+		opcomp = weakref(comp)
+
+	register_signal(src, SIGNAL_MOVED, nameof(.proc/on_moved))
+	var/turf/turf_to_listen = get_turf(src)
+	if(istype(turf_to_listen))
+		register_signal(turf_to_listen, SIGNAL_EXITED, nameof(.proc/atom_exited))
+
+	RefreshParts()
+	update_icon()
+
+/obj/machinery/optable/proc/on_moved()
+	var/turf/turf_to_listen = get_turf(src)
+	if(istype(turf_to_listen))
+		register_signal(turf_to_listen, SIGNAL_EXITED, nameof(.proc/atom_exited))
+
+/obj/machinery/optable/proc/atom_exited(atom, atom/movable/exitee)
+	if(ishuman(exitee) && exitee == victim?.resolve())
+		victim = null
+		icon_state = "table2-idle"
+		STOP_PROCESSING(SSmachines, src)
+
+/obj/machinery/optable/Process()
+	var/mob/living/carbon/human/H = victim?.resolve()
+	if(!istype(H) || H.loc != loc)
+		STOP_PROCESSING(SSmachines, src)
+		return
+
+	play_beep()
+	icon_state = H.pulse() ? "table2-active" : "table2-idle"
 
 /obj/machinery/optable/RefreshParts()
     var/default_strip = 6 SECONDS
@@ -29,171 +65,147 @@
             efficiency += 0.25 * P.rating
     time_to_strip = clamp(default_strip - efficiency, 1 SECONDS, 5 SECONDS)
 
-/obj/machinery/optable/Initialize()
-	. = ..()
-	for(dir in list(NORTH,EAST,SOUTH,WEST))
-		computer = locate(/obj/machinery/computer/operating, get_step(src, dir))
-		if(!computer || computer?.table)
-			continue
-		computer.table = src
-		break
-	RefreshParts()
-	update_icon()
-
 /obj/machinery/optable/ex_act(severity)
-
 	switch(severity)
-		if(1.0)
-			//SN src = null
-			qdel(src)
-			return
-		if(2.0)
-			if (prob(50))
-				//SN src = null
-				qdel(src)
-				return
-		if(3.0)
-			if (prob(25))
-				src.set_density(0)
-	return
+		if(EXPLODE_DEVASTATE)
+			qdel_self()
+		if(EXPLODE_HEAVY)
+			if(prob(50))
+				qdel_self()
+		if(EXPLODE_LIGHT)
+			if(prob(25))
+				src.set_density(FALSE)
 
 /obj/machinery/optable/attack_hand(mob/user as mob)
-	if (MUTATION_HULK in usr.mutations)
-		visible_message("<span class='danger'>\The [usr] destroys \the [src]!</span>")
-		src.set_density(0)
-		qdel(src)
-	return
+	if(MUTATION_HULK in usr.mutations)
+		visible_message(SPAN_DANGER("\The [usr] destroys \the [src]!"))
+		qdel_self()
 
 /obj/machinery/optable/CanPass(atom/movable/mover, turf/target)
 	if(istype(mover) && mover.pass_flags & PASS_FLAG_TABLE)
 		return TRUE
-	return FALSE
 
+	return FALSE
 
 /obj/machinery/optable/MouseDrop_T(obj/O, mob/user)
 	if((!istype(O, /obj/item) || user.get_active_hand() != O) || !user.drop(O))
 		return
+
 	if(O.loc != loc)
 		step(O, get_dir(O, src))
-	return
 
 /obj/machinery/optable/verb/remove_clothes()
 	set name = "Remove Clothes"
 	set category = "Object"
 	set src in oview(1)
 
-	if(!ishuman(usr) && !issilicon(usr))
-		return
 	if(usr.incapacitated())
 		return
-	if(!victim)
-		to_chat(usr, SPAN_DANGER("There is no patient on the table."))
+
+	if(inoperable(MAINT))
+		show_splash_text(usr, "No power!")
 		return
-	if(!ishuman(victim))
-		to_chat(usr, SPAN_DANGER("[victim] can't be undressed for some biological reasons."))
+
+	var/mob/living/carbon/human/patient = victim?.resolve()
+	if(!istype(patient))
+		show_splash_text(usr, "No patient detected!")
 		return
-	if(istype(victim.back, /obj/item/rig) && !victim.back.can_be_unequipped_by(victim, slot_back, TRUE))
-		to_chat(usr, SPAN_DANGER("\The [victim.back] must be removed."))
+
+	if(istype(patient?.back, /obj/item/rig) && !patient?.back.can_be_unequipped_by(patient, slot_back, TRUE))
+		show_splash_text(usr, "Manual undressing required!")
 		return
-	if(!locate(/obj/item/clothing) in victim.contents)
-		to_chat(usr, SPAN_DANGER("[victim] has no clothes to remove."))
+
+	if(!locate(/obj/item/clothing) in patient?.contents)
+		show_splash_text(usr, "No clothes found!")
 		return
-	if(stat & (BROKEN|NOPOWER))
-		to_chat(usr, SPAN_DANGER("\The [src] is unpowered."))
-		return
+
 	if(busy)
-		to_chat(usr, SPAN_DANGER("[victim] is already undressing."))
+		show_splash_text(usr, "Action already in progress!")
 		return
 
 	busy = TRUE
-	usr.visible_message(SPAN_DANGER("[usr] begins to undress [victim] on the table with the built-in tool."),
-						SPAN_NOTICE("You begin to undress [victim] on the table with the built-in tool."))
-	if(do_after(usr, time_to_strip, victim))
-		if(!victim)
+	usr.visible_message(SPAN_DANGER("[usr] begins to undress [patient] on the table with the built-in tool."),
+						SPAN_NOTICE("You begin to undress [patient] on the table with the built-in tool."))
+	if(do_after(usr, time_to_strip, patient))
+		if(!patient)
 			busy = FALSE
 			return
-		for(var/obj/item/clothing/C in victim.contents)
+
+		for(var/obj/item/clothing/C in patient?.contents)
 			if(istype(C, /obj/item/clothing/mask/breath/anesthetic))
 				continue
-			victim.drop(C)
+
+			patient?.drop(C)
 			use_power_oneoff(100)
 		usr.visible_message(SPAN_DANGER("[usr] successfully removes all clothing from [victim]."),
 							SPAN_NOTICE("You successfully remove all clothing from [victim]."))
+
 	busy = FALSE
 
-/obj/machinery/optable/proc/check_victim()
-	if(locate(/mob/living/carbon/human, src.loc))
-		play_beep()
-		var/mob/living/carbon/human/M = locate(/mob/living/carbon/human, src.loc)
-		if(M.lying)
-			src.victim = M
-			icon_state = M.pulse() ? "table2-active" : "table2-idle"
-			return 1
-	src.victim = null
-	icon_state = "table2-idle"
-	return 0
-
-/obj/machinery/optable/Process()
-	check_victim()
-
 /obj/machinery/optable/proc/take_victim(mob/living/carbon/C, mob/living/carbon/user as mob)
-	if (C == user)
+	if(C == user)
 		user.visible_message("[user] climbs on \the [src].","You climb on \the [src].")
 	else
 		visible_message("<span class='notice'>\The [C] has been laid on \the [src] by [user].</span>")
-	if (C.client)
+
+	if(C.client)
 		C.client.perspective = EYE_PERSPECTIVE
 		C.client.eye = src
-	C.resting = 1
+
+	C.resting = TRUE
 	C.dropInto(loc)
-	for(var/obj/O in src)
-		if(O in component_parts)
-			continue
-		O.dropInto(loc)
-	src.add_fingerprint(user)
+	add_fingerprint(user)
+
 	if(ishuman(C))
-		var/mob/living/carbon/human/H = C
-		src.victim = H
-		icon_state = H.pulse() ? "table2-active" : "table2-idle"
-	else
-		icon_state = "table2-idle"
+		victim = weakref(C)
+		START_PROCESSING(SSmachines, src)
+		update_icon()
 
 /obj/machinery/optable/MouseDrop_T(mob/target, mob/user)
-
 	var/mob/living/M = user
-	if(user.stat || user.restrained() || user.incapacitated(INCAPACITATION_ALL) || !check_table(user) || !iscarbon(target))
+	if(user.is_ic_dead() || user.incapacitated(INCAPACITATION_ALL) || !check_table(user) || !iscarbon(target))
 		return
+
 	if(istype(M))
 		take_victim(target,user)
 	else
 		return ..()
 
 /obj/machinery/optable/climb_on()
-	if(usr.stat || !ishuman(usr) || usr.restrained() || !check_table(usr))
+	if(usr.is_ic_dead() || !ishuman(usr) || usr.incapacitated() || !check_table(usr))
 		return
 
-	take_victim(usr,usr)
+	take_victim(usr, usr)
 
-/obj/machinery/optable/attackby(obj/item/W as obj, mob/living/carbon/user as mob)
+/obj/machinery/optable/attackby(obj/item/W, mob/living/carbon/user)
 	if(default_deconstruction_screwdriver(user, W))
 		return
+
 	if(default_deconstruction_crowbar(user, W))
 		return
+
 	if(default_part_replacement(user, W))
 		return
+
 	if(istype(W, /obj/item/grab))
 		var/obj/item/grab/G = W
 		if(iscarbon(G.affecting) && check_table(G.affecting))
-			take_victim(G.affecting,usr)
+			take_victim(G.affecting, usr)
 			qdel(W)
-			return
 
-/obj/machinery/optable/proc/check_table(mob/living/carbon/patient as mob)
-	check_victim()
-	if(src.victim && get_turf(victim) == get_turf(src) && victim.lying)
-		to_chat(usr, "<span class='warning'>\The [src] is already occupied!</span>")
-		return 0
+/obj/machinery/optable/proc/check_table(mob/living/carbon/patient)
+	var/mob/living/carbon/human/occupant = victim?.resolve()
+	if(istype(occupant) && get_turf(occupant) == get_turf(src) && occupant.lying)
+		show_splash_text(usr, "Already occupied!")
+		return FALSE
+
 	if(patient.buckled)
-		to_chat(usr, "<span class='notice'>Unbuckle \the [patient] first!</span>")
-		return 0
-	return 1
+		show_splash_text(usr, "Unbuckle the patient first!")
+		return FALSE
+
+	return TRUE
+
+/obj/machinery/optable/Destroy()
+	opcomp = null
+	victim = null
+	return ..()

--- a/code/game/machinery/computer/Operating.dm
+++ b/code/game/machinery/computer/Operating.dm
@@ -8,17 +8,8 @@
 	icon_screen = "crew"
 	light_color = "#5284E7"
 	circuit = /obj/item/circuitboard/operating
-	var/mob/living/carbon/human/victim = null
-	var/obj/machinery/optable/table = null
-
-/obj/machinery/computer/operating/New()
-	..()
-	for(dir in list(NORTH,EAST,SOUTH,WEST))
-		table = locate(/obj/machinery/optable, get_step(src, dir))
-		if(!table || table?.computer)
-			continue
-		table.computer = src
-		break
+	/// Weakref to a connected operating table
+	var/weakref/optable
 
 /obj/machinery/computer/operating/attack_hand(mob/user)
 	. = ..()
@@ -42,12 +33,20 @@
 
 	switch(action)
 		if("remove_clothes")
+			var/obj/machinery/optable/table = optable?.resolve()
 			table?.remove_clothes()
 			return TRUE
 
 /obj/machinery/computer/operating/tgui_data(mob/user)
-	var/list/data = list(
-		"medical_data" = table.victim?.get_medical_data_ui()
-	)
+	var/list/data = list()
+
+	var/obj/machinery/optable/table = optable?.resolve()
+	var/mob/living/carbon/human/H = table?.victim?.resolve()
+
+	data["medical_data"] = H?.get_medical_data_ui()
 
 	return data
+
+/obj/machinery/computer/operating/Destroy()
+	optable = null
+	return ..()

--- a/code/game/machinery/computer/computer.dm
+++ b/code/game/machinery/computer/computer.dm
@@ -130,4 +130,4 @@
 	attack_hand(ghost)
 
 /obj/machinery/computer/proc/locate_unit(unit_type)
-	return locate(unit_type) in oview(2, src)
+	return locate(unit_type) in orange(2, src)

--- a/code/game/objects/structures/watercloset.dm
+++ b/code/game/objects/structures/watercloset.dm
@@ -1,4 +1,6 @@
-//todo: toothbrushes, and some sort of "toilet-filthinator" for the hos
+#define SHOWER_MAX_WORKING_TIME 30 SECONDS
+#define MIST_SPAWN_DELAY 10 SECONDS
+#define SHOWER_WASH_FLOOR_INTERVAL 10 SECONDS
 
 /obj/structure/toilet
 	name = "toilet"
@@ -88,33 +90,32 @@
 	anchored = TRUE
 	use_power = 0
 	layer = ABOVE_WINDOW_LAYER
-	var/on = 0
-	var/obj/effect/mist/mymist = null
-	var/ismist = 0				//needs a var so we can make it linger~
 	var/watertemp = "normal"	//freezing, normal, or boiling
 	var/is_washing = 0
+	/// Used to track when it should stop processing automatically.
+	var/time_enabled
+	/// Tracks interval at which it should wash the floor
+	var/next_wash_time
 	var/list/temperature_settings = list("normal" = 310, "boiling" = 100 CELSIUS, "freezing" = 0 CELSIUS)
+	/// Mist effect will be spawned only once per activation.
+	var/hasmist = FALSE
 
 /obj/machinery/shower/ex_act(severity)
 	switch(severity)
 		if(EXPLODE_DEVASTATE)
-			qdel(src)
-			return
+			qdel_self()
 		if(EXPLODE_HEAVY)
 			if(prob(50))
 				if(prob(50))
 					new /obj/item/shower_parts(get_turf(src))
-				qdel(src)
-				return
+				qdel_self()
 		if(EXPLODE_LIGHT)
 			if(prob(25))
 				new /obj/item/shower_parts(get_turf(src))
-				qdel(src)
-				return
-	return
+				qdel_self()
 
-/obj/machinery/shower/New()
-	..()
+/obj/machinery/shower/Initialize(mapload, ...)
+	. = ..()
 	create_reagents(50)
 
 //add heat controls? when emagged, you can freeze to death in it?
@@ -147,36 +148,28 @@
 		qdel_self()
 	return
 
-/obj/effect/mist
-	name = "mist"
-	icon = 'icons/obj/watercloset.dmi'
-	icon_state = "mist"
-
-	layer = ABOVE_HUMAN_LAYER
-	anchored = 1
-	mouse_opacity = 0
-
 /obj/machinery/shower/attack_hand(mob/M as mob)
-	on = !on
+	if(is_processing)
+		STOP_PROCESSING(SSmachines, src)
+	else
+		time_enabled = world.time
+		hasmist = FALSE
+		START_PROCESSING(SSmachines, src)
+
 	update_icon()
-	if(on)
-		if (M.loc == loc)
-			wash(M)
-			process_heat(M)
-		for (var/atom/movable/G in src.loc)
-			G.clean_blood()
 
 /obj/machinery/shower/attackby(obj/item/I as obj, mob/user as mob)
 	if(isScrewdriver(I))
-		if(on)
+		if(is_processing)
 			to_chat(user, SPAN("warning", "The first thing to do is to turn off the water."))
 			return
+
 		playsound(loc, 'sound/items/Screwdriver.ogg', 100, 1)
 		new /obj/item/shower_parts(get_turf(src))
-		qdel(src)
+		qdel_self()
 
 	if(I.type == /obj/item/device/analyzer)
-		to_chat(user, "<span class='notice'>The water temperature seems to be [watertemp].</span>")
+		to_chat(user, SPAN_NOTICE("The water temperature seems to be [watertemp]."))
 		return
 
 	if(isWrench(I))
@@ -184,11 +177,11 @@
 		if(!Adjacent(user))
 			return
 
-		to_chat(user, "<span class='notice'>You begin to adjust the temperature valve with \the [I].</span>")
+		to_chat(user, SPAN_NOTICE("You begin to adjust the temperature valve with \the [I]."))
 		playsound(src.loc, 'sound/items/Ratchet.ogg', 50, 1)
 		if(do_after(user, 50, src))
 			watertemp = newtemp
-			user.visible_message("<span class='notice'>\The [user] adjusts \the [src] with \the [I].</span>", "<span class='notice'>You adjust the shower with \the [I].</span>")
+			user.visible_message(SPAN_NOTICE("\The [user] adjusts \the [src] with \the [I]."), SPAN_NOTICE("You adjust the shower with \the [I]."))
 			add_fingerprint(user)
 		return
 
@@ -196,34 +189,14 @@
 
 /obj/machinery/shower/on_update_icon()	//this is terribly unreadable, but basically it makes the shower mist up
 	ClearOverlays()					//once it's been on for a while, in addition to handling the water overlay.
-	if(mymist)
-		qdel(mymist)
-		mymist = null
 
-	if(on)
+	if(is_processing)
 		AddOverlays(image('icons/obj/watercloset.dmi', src, "water", MOB_LAYER + 1, dir))
-		if(temperature_settings[watertemp] < (20 CELSIUS))
-			return //no mist for cold water
-		if(!ismist)
-			spawn(50)
-				if(src && on)
-					ismist = 1
-					mymist = new /obj/effect/mist(loc)
-		else
-			ismist = 1
-			mymist = new /obj/effect/mist(loc)
-	else if(ismist)
-		ismist = 1
-		mymist = new /obj/effect/mist(loc)
-		spawn(250)
-			if(src && !on)
-				qdel(mymist)
-				mymist = null
-				ismist = 0
 
 //Yes, showers are super powerful as far as washing goes.
-/obj/machinery/shower/proc/wash(atom/movable/O as obj|mob)
-	if(!on) return
+/obj/machinery/shower/proc/wash(atom/movable/O)
+	if(!is_processing)
+		return
 
 	if(isliving(O))
 		var/mob/living/L = O
@@ -321,7 +294,14 @@
 	reagents.splash(O, 10)
 
 /obj/machinery/shower/Process()
-	if(!on) return
+	if(world.time >= time_enabled + SHOWER_MAX_WORKING_TIME)
+		STOP_PROCESSING(SSmachines, src)
+		update_icon()
+		return
+
+	if(!hasmist && world.time >= time_enabled + MIST_SPAWN_DELAY && temperature_settings[watertemp] > (20 CELSIUS))
+		new /obj/effect/mist/showermist(get_turf(src))
+		hasmist = TRUE
 
 	for(var/thing in loc)
 		var/atom/movable/AM = thing
@@ -330,21 +310,21 @@
 			wash(AM)
 			if(istype(L))
 				process_heat(L)
-	wash_floor()
+
+	if(world.time >= next_wash_time)
+		next_wash_time = world.time + SHOWER_WASH_FLOOR_INTERVAL
+		wash_floor()
+
 	reagents.add_reagent(/datum/reagent/water, reagents.get_free_space())
 
 /obj/machinery/shower/proc/wash_floor()
-	if(!ismist && is_washing)
-		return
-	is_washing = 1
 	var/turf/T = get_turf(src)
 	reagents.splash(T, reagents.total_volume)
 	T.clean(src)
-	spawn(100)
-		is_washing = 0
 
 /obj/machinery/shower/proc/process_heat(mob/living/M)
-	if(!on || !istype(M)) return
+	if(!is_processing || !istype(M))
+		return
 
 	var/temperature = temperature_settings[watertemp]
 	var/temp_adj = between(BODYTEMP_COOLING_MAX, temperature - M.bodytemperature, BODYTEMP_HEATING_MAX)
@@ -353,9 +333,22 @@
 	if(ishuman(M))
 		var/mob/living/carbon/human/H = M
 		if(temperature >= H.species.heat_level_1)
-			to_chat(H, "<span class='danger'>The water is searing hot!</span>")
+			to_chat(H, SPAN_DANGER("The water is searing hot!"))
 		else if(temperature <= H.species.cold_level_1)
-			to_chat(H, "<span class='warning'>The water is freezing cold!</span>")
+			to_chat(H, SPAN_WARNING("The water is freezing cold!"))
+
+/obj/effect/mist
+	name = "mist"
+	icon = 'icons/obj/watercloset.dmi'
+	icon_state = "mist"
+
+	layer = ABOVE_HUMAN_LAYER
+	anchored = TRUE
+	mouse_opacity = 0
+
+/obj/effect/mist/showermist/Initialize(mapload, ...) // This mist self-deletes after some time, ridding us of tracking mist in shower's Process()
+	. = ..()
+	QDEL_IN(src, SHOWER_MAX_WORKING_TIME)
 
 /obj/item/bikehorn/rubberducky
 	name = "rubber ducky"
@@ -515,3 +508,7 @@
 	icon_state = "puddle-splash"
 	..()
 	icon_state = "puddle"
+
+#undef SHOWER_MAX_WORKING_TIME
+#undef MIST_SPAWN_DELAY
+#undef SHOWER_WASH_FLOOR_INTERVAL

--- a/code/modules/power/breaker_box.dm
+++ b/code/modules/power/breaker_box.dm
@@ -133,6 +133,3 @@
 		update_locked = 1
 		spawn(600)
 			update_locked = 0
-
-/obj/machinery/power/breakerbox/Process()
-	return 1


### PR DESCRIPTION
- Optable:
    - Меньше холостого процессинга (процессимся только если на столе есть хуман)
    - Больше викрефов (Викреф на самого хумана на столе и на консоль)
    - Больше сплешей, меньше засирания чата
    - Оптейбл и его консоль не ищут друг друга по всей карте (Локейт в orange(2), потанцевально локейт по списку турфов от RANGE_TURFS() будет быстрее но это надо замерять

- Shower:
    - Меньше процессинга
    - Душ автоматически выключается через 30 секунд после включения
    - Убрал sleep() из душа. 
    - Код стал чуть-чуть адекватнее.
  


<details>
<summary>Чейнджлог</summary>

```yml
🆑
tweak: Небольшой рефактор машинерии (операционный стол и душ). Кроме того, что душ теперь автоматически выключается через 30 секунд после включения особых изменений в игре нет. 
/🆑
```

</details>

- [x] Pull Request полностью завершен, мне не нужна помощь чтобы его закончить.
- [x] Я внимательно прочитал все свои изменения и багов в них не нашел.
- [x] Я запускал сервер со своими изменениями локально и все протестировал.
- [x] Я ознакомился c [Guide to Contribute](https://github.com/ChaoticOnyx/OnyxBay/blob/dev/docs/contributing.md).
