### PR TITLE
Фикс просветов. 

### DIFF
--- a/code/__defines/__renderer.dm
+++ b/code/__defines/__renderer.dm
@@ -26,7 +26,7 @@
 
 #define WARP_EFFECT_PLANE -6
 
-#define BLACKNESS_PLANE                 -5 //Blackness plane as per DM documentation.
+#define BLACKNESS_PLANE                 0 //Blackness plane as per DM documentation.
 
 #define SPACE_PLANE               -4
 	#define SPACE_LAYER                  1
@@ -36,9 +36,7 @@
 	#define DEBRIS_LAYER                 1
 	#define DUST_LAYER                   2
 
-#define TURF_PLANE -1
-
-#define DEFAULT_PLANE                   1
+#define DEFAULT_PLANE                   -1
 	#define PLATING_LAYER               1
 	//ABOVE PLATING
 	#define HOLOMAP_LAYER               1.01

--- a/code/__defines/_render.dm
+++ b/code/__defines/_render.dm
@@ -121,9 +121,8 @@ INITIALIZE_IMMEDIATE(/atom/movable/renderer)
 	name  = LETTERBOX_RENDERER
 	group = RENDER_GROUP_SCENE
 	plane = BLACKNESS_PLANE
-	appearance_flags = PLANE_MASTER | NO_CLIENT_COLOR
+	appearance_flags = PLANE_MASTER | NO_CLIENT_COLOR | PIXEL_SCALE
 	blend_mode = BLEND_MULTIPLY
-	color = list(null, null, null, "#0000", "#000f")
 	mouse_opacity = MOUSE_OPACITY_UNCLICKABLE
 
 
@@ -143,7 +142,7 @@ INITIALIZE_IMMEDIATE(/atom/movable/renderer)
 /atom/movable/renderer/turf
 	name  = TURF_RENDERER
 	group = RENDER_GROUP_SCENE
-	plane = TURF_PLANE
+	plane = DEFAULT_PLANE
 
 // Draws the game world; live mobs, items, turfs, etc.
 /atom/movable/renderer/game

--- a/code/_onclick/click.dm
+++ b/code/_onclick/click.dm
@@ -482,6 +482,7 @@
 
 /mob
 	var/datum/stack/click_handlers
+	sight = SEE_BLACKNESS
 
 var/const/CLICK_HANDLER_NONE                 = 0
 var/const/CLICK_HANDLER_REMOVE_ON_MOB_LOGOUT = 1

--- a/code/datums/chatmessage.dm
+++ b/code/datums/chatmessage.dm
@@ -157,7 +157,7 @@
 			if(QDELETED(m))
 				continue
 
-			animate(m.message, pixel_y = m.message.pixel_y + mheight, time = CHAT_MESSAGE_SPAWN_TIME)
+			animate(m.message, pixel_z = m.message.pixel_z + mheight, time = CHAT_MESSAGE_SPAWN_TIME)
 			combined_height += m.approx_lines
 			var/sched_remaining = m.scheduled_destruction - world.time
 			if (!m.eol_complete)
@@ -170,10 +170,10 @@
 
 	// Build message image
 	message = image(loc = message_loc, layer = CHAT_LAYER + CHAT_LAYER_Z_STEP * current_z_idx++)
-	message.plane = FLOAT_PLANE
-	message.appearance_flags = APPEARANCE_UI_IGNORE_ALPHA | KEEP_APART | TILE_BOUND
+	message.plane = DEFAULT_PLANE
+	message.appearance_flags = APPEARANCE_UI_IGNORE_ALPHA | KEEP_APART | TILE_BOUND | RESET_TRANSFORM | RESET_COLOR | RESET_ALPHA
 	message.alpha = 0
-	message.pixel_y = owner.bound_height * 0.95
+	message.pixel_z = owner.bound_height * 0.95
 	message.maptext_width = CHAT_MESSAGE_WIDTH
 	message.maptext_height = mheight
 	message.maptext_x = (CHAT_MESSAGE_WIDTH - owner.bound_width) * -0.5

--- a/code/game/machinery/hologram.dm
+++ b/code/game/machinery/hologram.dm
@@ -38,7 +38,7 @@ var/const/HOLOPAD_MODE = RANGE_BASED
 
 
 	layer = ABOVE_TILE_LAYER
-	plane = TURF_PLANE
+	plane = DEFAULT_PLANE
 
 	var/power_per_hologram = 500 //per usage per hologram
 	idle_power_usage = 5 WATTS

--- a/code/game/turfs/simulated/walls.dm
+++ b/code/game/turfs/simulated/walls.dm
@@ -6,7 +6,7 @@
 	opacity = 1
 	density = 1
 	blocks_air = 1
-	plane = TURF_PLANE
+	plane = DEFAULT_PLANE
 	thermal_conductivity = WALL_HEAT_TRANSFER_COEFFICIENT
 	heat_capacity = 312500 //a little over 5 cm thick , 312500 for 1 m by 2.5 m by 0.25 m plasteel wall
 	hitby_sound = 'sound/effects/metalhit2.ogg'

--- a/code/game/turfs/turf.dm
+++ b/code/game/turfs/turf.dm
@@ -3,7 +3,7 @@
 	level = 1
 
 	layer = TURF_LAYER
-	plane = TURF_PLANE
+	plane = DEFAULT_PLANE
 	vis_flags = VIS_INHERIT_PLANE|VIS_INHERIT_ID
 
 	var/turf_flags

--- a/code/modules/atmospherics/atmospherics.dm
+++ b/code/modules/atmospherics/atmospherics.dm
@@ -17,7 +17,7 @@ Pipelines + Other Objects -> Pipe network
 	var/nodealert = 0
 	var/power_rating //the maximum amount of power the machine can use to do work, affects how powerful the machine is, in Watts
 
-	plane = TURF_PLANE
+	plane = DEFAULT_PLANE
 	layer = EXPOSED_PIPE_LAYER
 
 	var/connect_types = CONNECT_TYPE_REGULAR

--- a/code/modules/atmospherics/components/unary/vent_pump.dm
+++ b/code/modules/atmospherics/components/unary/vent_pump.dm
@@ -10,7 +10,7 @@
 /obj/machinery/atmospherics/unary/vent_pump
 	icon = 'icons/atmos/vent_pump.dmi'
 	icon_state = "map_vent"
-	plane = TURF_PLANE
+	plane = DEFAULT_PLANE
 
 	name = "Air Vent"
 	desc = "Has a valve and pump attached to it."

--- a/code/modules/atmospherics/components/unary/vent_scrubber.dm
+++ b/code/modules/atmospherics/components/unary/vent_scrubber.dm
@@ -1,7 +1,7 @@
 /obj/machinery/atmospherics/unary/vent_scrubber
 	icon = 'icons/atmos/vent_scrubber.dmi'
 	icon_state = "map_scrubber_off"
-	plane = TURF_PLANE
+	plane = DEFAULT_PLANE
 
 	name = "Air Scrubber"
 	desc = "Has a valve and pump attached to it."

--- a/code/modules/mob/grab/grab_datum.dm
+++ b/code/modules/mob/grab/grab_datum.dm
@@ -105,7 +105,7 @@
 	var/mob/living/carbon/human/affecting = G.affecting
 
 	if(can_throw)
-		animate(affecting, pixel_x = 0, pixel_y = 0, 4, 1)
+		animate(affecting, pixel_w = 0, pixel_z = 0, 4, 1)
 		qdel(G)
 		return affecting
 	return null
@@ -164,16 +164,16 @@
 
 	switch(adir)
 		if(NORTH)
-			animate(affecting, pixel_x = 0, pixel_y =-shift, 5, 1, LINEAR_EASING)
+			animate(affecting, pixel_w = 0, pixel_z =-shift, 5, 1, LINEAR_EASING)
 			G.draw_affecting_under()
 		if(SOUTH)
-			animate(affecting, pixel_x = 0, pixel_y = shift, 5, 1, LINEAR_EASING)
+			animate(affecting, pixel_w = 0, pixel_z = shift, 5, 1, LINEAR_EASING)
 			G.draw_affecting_over()
 		if(WEST)
-			animate(affecting, pixel_x = shift, pixel_y = 0, 5, 1, LINEAR_EASING)
+			animate(affecting, pixel_w = shift, pixel_z = 0, 5, 1, LINEAR_EASING)
 			G.draw_affecting_under()
 		if(EAST)
-			animate(affecting, pixel_x =-shift, pixel_y = 0, 5, 1, LINEAR_EASING)
+			animate(affecting, pixel_w =-shift, pixel_z = 0, 5, 1, LINEAR_EASING)
 			G.draw_affecting_under()
 
 	affecting.reset_plane_and_layer()
@@ -184,7 +184,7 @@
 	var/mob/living/carbon/human/affecting = G.affecting
 
 	if(!affecting.buckled)
-		animate(affecting, pixel_x = 0, pixel_y = 0, 4, 1, LINEAR_EASING)
+		animate(affecting, pixel_w = 0, pixel_z = 0, 4, 1, LINEAR_EASING)
 	affecting.reset_plane_and_layer()
 
 /*

--- a/code/modules/modifier/helpers.dm
+++ b/code/modules/modifier/helpers.dm
@@ -52,7 +52,8 @@
 		rotate_deg += 180
 		translate_y = -16 * ((tf_scale_y || 1) * body_height - 1)
 
-	reset_layer()
+	pixel_w = translate_x
+	pixel_z = translate_y
 
 	animate(
 		src,
@@ -60,12 +61,11 @@
 			scale_x = (tf_scale_x || 1),
 			scale_y = (tf_scale_y || 1) * body_height,
 			rotation = (tf_rotation || 0) + rotate_deg,
-			offset_x = (tf_offset_x || 0) + translate_x,
-			offset_y = (tf_offset_y || 0) + translate_y
 		),
 		time = anim_time
 	)
 
+	reset_layer()
 
 /mob/living/proc/update_modifier_visuals()
 	return

--- a/code/modules/power/cable.dm
+++ b/code/modules/power/cable.dm
@@ -36,7 +36,7 @@ var/list/possible_cable_coil_colours
 	var/d2 = 1
 
 	layer = TURF_DETAIL_LAYER
-	plane = TURF_PLANE
+	plane = DEFAULT_PLANE
 
 	color = COLOR_RED
 	var/obj/machinery/power/breakerbox/breaker_box

--- a/code/modules/power/terminal.dm
+++ b/code/modules/power/terminal.dm
@@ -7,7 +7,7 @@
 	icon_state = "term"
 	desc = "It's an underfloor wiring terminal for power equipment."
 	level = 1
-	plane = TURF_PLANE
+	plane = DEFAULT_PLANE
 	layer = EXPOSED_WIRE_TERMINAL_LAYER
 	var/obj/machinery/power/master = null
 	anchored = 1

--- a/code/modules/random_map/automata/diona.dm
+++ b/code/modules/random_map/automata/diona.dm
@@ -18,7 +18,7 @@
 	anchored = 1
 	density = 1
 	opacity = 0
-	plane = ABOVE_TURF_PLANE
+	plane = ABOVE_DEFAULT_PLANE
 	layer = PLANT_LAYER
 
 /obj/structure/diona/vines

--- a/code/modules/recycling/disposal.dm
+++ b/code/modules/recycling/disposal.dm
@@ -639,7 +639,7 @@
 	icon = 'icons/obj/pipes/disposal.dmi'
 	name = "disposal pipe"
 	desc = "An underfloor disposal pipe."
-	plane = TURF_PLANE
+	plane = DEFAULT_PLANE
 	layer = TURF_DETAIL_LAYER
 	anchored = 1
 	density = 0


### PR DESCRIPTION
BLACKNESS_PLANE должен быть выше, чем игровые плейны (турфы мобы и.т.д.). Иначе - брух. 
От смещения слоев умерли эмиссивы и AO, перед мержем надо понять почему и починить.

<details>
  <summary>Blackness plane now correctly masks atoms</summary>

Вот тут например. Сейчас на проде мы бы видели docking hatch controller поверх черного квадрата. 

https://github.com/ChaoticOnyx/OnyxBay/assets/23741266/476ae12a-85ad-43ed-9d75-a02ed488b484

</details>

Убиты просветы. Полностью. pixel_w/pixel_z вместо pixel_x/pixel_y, кажется, чинят проблему. Спасибо документации ТГ.

`There are two "types" of each direction offset. There's the "real" offset (x/y) and the "fake" offset (w,z).
Real offsets will change both the visual position (IE: where it renders) and also the positional position (IE: where the renderer thinks they are).
Fake offsets only effect visual position.`