### PR TITLE
tweak(guns): toggle safety verb is now config-aware

### DIFF
--- a/code/modules/projectiles/gun.dm
+++ b/code/modules/projectiles/gun.dm
@@ -104,6 +104,9 @@
 	if(isnull(scoped_accuracy))
 		scoped_accuracy = accuracy
 
+	if(config.misc.toogle_gun_safety)
+		verbs |= /obj/item/gun/proc/toggle_safety_verb
+
 /obj/item/gun/Destroy()
 	// autofire timer is automatically cleaned up
 	autofiring_at = null
@@ -674,7 +677,7 @@
 	if(safety_icon)
 		AddOverlays((image(icon,"[safety_icon][safety()]")))
 
-/obj/item/gun/verb/toggle_safety_verb()
+/obj/item/gun/proc/toggle_safety_verb()
 	set src in usr
 	set category = "Object"
 	set name = "Toggle Gun Safety"


### PR DESCRIPTION
Я окончательно искорежился от этого верба в контекстном меню. Теперь его нет, но он есть. Парадокс шредингера. 

Да, наверное время инита вырастет - с другой стороны лучше так. 

<details>
<summary>Чейнджлог</summary>

```yml
🆑
tweak: Прок toggle gun safety больше не будет показываться при выключенном предохранителе в конфиге.
/🆑
```

</details>

- [x] Pull Request полностью завершен, мне не нужна помощь чтобы его закончить.
- [x] Я внимательно прочитал все свои изменения и багов в них не нашел.
- [x] Я запускал сервер со своими изменениями локально и все протестировал.
- [x] Я ознакомился c [Guide to Contribute](https://github.com/ChaoticOnyx/OnyxBay/blob/dev/docs/contributing.md).
