### PR TITLE
Вендоматы ускоряются

### DIFF
--- a/code/game/machinery/vending/_vending.dm
+++ b/code/game/machinery/vending/_vending.dm
@@ -61,9 +61,11 @@
 	var/scan_id = 1
 	var/obj/item/material/coin/coin
 	var/datum/wires/vending/wires = null
-	var/stuck_chance = 1
-	var/is_stuck = FALSE // If true - `currently_vending` is the thing stuck in the vending.
-	var/knocks // However many more times you need to knock it to get it to unstuck.
+
+	/// If true - `currently_vending` is the thing stuck in the vending.
+	var/is_stuck = FALSE
+	/// However many more times you need to knock it to get it to unstuck.
+	var/knocks
 
 	// Content-related stuff
 	var/list/products = list() // In case we want to add something extra to our vending machine
@@ -422,11 +424,7 @@
 			SPAN("danger", "You knock \the [src]!"),
 			SPAN("danger", "You hear a knock sound."))
 
-		if(!is_stuck)
-			return
-
-		knocks--
-		if(knocks <= 0)
+		if(is_stuck && prob(50))
 			unstuck()
 
 		return
@@ -595,7 +593,7 @@
 
 	spawn(vend_delay) //Time to vend
 		// A chance to stuck in.
-		if(prob(stuck_chance))
+		if(prob(1))
 			stuck()
 			return
 

--- a/code/game/machinery/vending/_vending.dm
+++ b/code/game/machinery/vending/_vending.dm
@@ -64,8 +64,6 @@
 
 	/// If true - `currently_vending` is the thing stuck in the vending.
 	var/is_stuck = FALSE
-	/// However many more times you need to knock it to get it to unstuck.
-	var/knocks
 
 	// Content-related stuff
 	var/list/products = list() // In case we want to add something extra to our vending machine
@@ -624,14 +622,12 @@
 	status_message = "Unexpected error occurred. Please contact technical support."
 	speak(status_message)
 	status_error = TRUE
-	knocks = rand(1, 5)
 	is_stuck = TRUE
 
 /obj/machinery/vending/proc/unstuck()
 	ASSERT(is_stuck)
 
 	playsound(src, 'sound/signals/error25.ogg', 40, FALSE)
-	knocks = null
 	is_stuck = FALSE
 
 	spawn(1 SECOND)


### PR DESCRIPTION
- Вендоматы в целом быстрее выдают предметы (4-8 секунд задержки -> 2-4 секунд);
- Вендоматы реже заклинивают (шанс 5% -> 1%) и быстрее отклинивают (шанс 20% при каждом пинке -> 50% -- как правило, требуется 1-2 пинка с редкими исключениями).

closes #7945 (не написано, насколько именно снизить, но ПР подходит)

<details>
<summary>Чейнджлог</summary>

```yml
🆑TheUnknownOne
tweak: Вендоматы теперь реже заклинивают, быстрее отклинивают и быстрее выдают предметы.
/🆑
```

</details>

- [x] Pull Request полностью завершен, мне не нужна помощь чтобы его закончить.
- [x] Я внимательно прочитал все свои изменения и багов в них не нашел.
- [x] Я запускал сервер со своими изменениями локально и все протестировал.
- [x] Я ознакомился c [Guide to Contribute](https://github.com/ChaoticOnyx/OnyxBay/blob/dev/docs/contributing.md).
