### PR TITLE
Ограничение количества дереликтов + их ротация

### DIFF
--- a/code/__defines/mapping.dm
+++ b/code/__defines/mapping.dm
@@ -45,3 +45,6 @@
 #define MAP_BAR_CLASSIC "classic"
 #define MAP_BAR_MODERN  "modern"
 #define MAP_BAR_SALOON  "saloon"
+
+// Derelicts amount
+#define MAP_DERELICTS_AMOUNT  2

--- a/code/datums/configuration/mapping_section.dm
+++ b/code/datums/configuration/mapping_section.dm
@@ -4,12 +4,15 @@
 	var/preferable_engine = MAP_ENG_SINGULARITY
 	var/preferable_biodome = MAP_BIO_FOREST
 	var/preferable_bar = MAP_BAR_CLASSIC
+	var/derelicts_amount = MAP_DERELICTS_AMOUNT
 	var/list/allowed_maps = list()
 
 /datum/configuration_section/mapping/load_data(list/data)
+
 	CONFIG_LOAD_STR(preferable_engine,  data["preferable_engine"])
 	CONFIG_LOAD_STR(preferable_biodome, data["preferable_biodome"])
 	CONFIG_LOAD_STR(preferable_bar, 	data["preferable_bar"])
+	CONFIG_LOAD_NUM(derelicts_amount,	data["derelicts_amount"])
 	CONFIG_LOAD_LIST(allowed_maps, data["allowed_maps"])
 
 	if(!(preferable_engine in list(MAP_ENG_RANDOM, MAP_ENG_SINGULARITY, MAP_ENG_MATTER)))

--- a/config/example/config.toml
+++ b/config/example/config.toml
@@ -541,6 +541,9 @@ forbid_singulo_following = true
 toggle_gun_safety = false
 
 [mapping]
+## How many derelicts are going to show up
+derelicts_amount = 2
+
 ## Which engine should be on map (not all the maps support this).
 ## Pick one from: "random", "singularity", "supermatter"
 preferable_engine = "singularity"

--- a/maps/exodus/exodus_define.dm
+++ b/maps/exodus/exodus_define.dm
@@ -35,17 +35,24 @@
 		new /datum/space_level/exodus_3,
 		new /datum/space_level/exodus_4,
 		new /datum/space_level/null_space,
-		new /datum/space_level/telecomms,
+		new /datum/space_level/telecomms
+	)
+
+	derelict_levels = list(
 		new /datum/space_level/construction_site,
 		new /datum/space_level/snow_asteroid,
 		new /datum/space_level/derelict,
-		new /datum/space_level/bearcat_1,
-		new /datum/space_level/bearcat_2,
 		new /datum/space_level/jungle_level,
 		new /datum/space_level/old_restaurant,
 		new /datum/space_level/sensor_array,
+		list(
+		new /datum/space_level/bearcat_1,
+		new /datum/space_level/bearcat_2
+		),
+		list(
 		new /datum/space_level/science_ship_1,
 		new /datum/space_level/science_ship_2
+		)
 	)
 
 	station_name  = "NSS Exodus"

--- a/maps/~mapsystem/maps.dm
+++ b/maps/~mapsystem/maps.dm
@@ -30,6 +30,8 @@ var/const/MAP_HAS_RANK = 2		//Rank system, also togglable
 	var/shuttle_types = null         // Only the specified shuttles will be initialized.
 	var/list/map_levels
 
+	var/list/derelict_levels		// List for random derelicts
+
 	var/list/usable_email_tlds = list("freemail.nt")
 	var/base_floor_type = /turf/simulated/floor/plating/airless // The turf type used when generating floors between Z-levels at startup.
 	var/base_floor_area                                 // Replacement area, if a base_floor_type is generated. Leave blank to skip.
@@ -142,6 +144,14 @@ var/const/MAP_HAS_RANK = 2		//Rank system, also togglable
 
 /datum/map/proc/setup_map()
 	ASSERT(length(map_levels))
+
+	var/derelicts_index = config.mapping.derelicts_amount
+	while(length(derelict_levels) && derelicts_index)
+		var/list/rand_derelict = pick(derelict_levels)
+		derelict_levels.Remove(rand_derelict)
+		map_levels.Add(rand_derelict)
+		derelicts_index--
+
 	for(var/level = 1; level <= length(map_levels); level++)
 		var/datum/space_level/L = map_levels[level]
 


### PR DESCRIPTION
ПР добавляет ротацию дереликтам.

**Как их включить?**
_Добавить в дефайн карты дефайн нужных дереликтов. Многоуровневые идут листом. Пример есть в дефайне Исхода._

**Почему именно через дефайн карты?**
_Потому что на Экзампле Дереликты не нужны, так что для какой-то карты некоторые тоже могут не подходить._

Также в конфиг добавлена переменна, указывающая количество возможных дереликтов на спавн.

<details>
<summary>Чейнджлог</summary>

```yml
🆑KreeperHLC
admin: Теперь педали могут выбрать сколько будет спавниться дереликтов через конфиг.
balance: Добавлена рандомизация дереликтов и уменьшено их количество до двух (Педали могут это изменить).
/🆑
```

</details>

- [x] Pull Request полностью завершен, мне не нужна помощь чтобы его закончить.
- [x] Я внимательно прочитал все свои изменения и багов в них не нашел.
- [x] Я запускал сервер со своими изменениями локально и все протестировал.
- [x] Я ознакомился c [Guide to Contribute](https://github.com/ChaoticOnyx/OnyxBay/blob/dev/docs/contributing.md).
