### PR TITLE
fix(sound_player): fixes null.loc runtime

### DIFF
--- a/code/datums/sound_player.dm
+++ b/code/datums/sound_player.dm
@@ -221,6 +221,9 @@ GLOBAL_DATUM_INIT(sound_player, /decl/sound_player, new)
 	var/turf/source_turf = get_turf(source)
 	var/turf/listener_turf = get_turf(listener)
 
+	if(!source_turf || !listener_turf)
+		return
+
 	var/distance = get_dist(source_turf, listener_turf)
 	if(!listener_turf || (distance > range) || !(listener_turf in can_be_heard_from))
 		if(prefer_mute)

--- a/code/datums/sound_player.dm
+++ b/code/datums/sound_player.dm
@@ -221,8 +221,7 @@ GLOBAL_DATUM_INIT(sound_player, /decl/sound_player, new)
 	var/turf/source_turf = get_turf(source)
 	var/turf/listener_turf = get_turf(listener)
 
-	if(!source_turf || !listener_turf)
-		return
+	ASSERT(istype(source_turf) && istype(listener_turf))
 
 	var/distance = get_dist(source_turf, listener_turf)
 	if(!listener_turf || (distance > range) || !(listener_turf in can_be_heard_from))


### PR DESCRIPTION
Прода постоянно рантаймит на null.loc, периодически при удалении sound_token проебываются listener's и получаем тонну рантаймов. Это не фиксит обнуление слушателей, а только маскирует ошибку. Впрочем, у меня нет сил переводить плеер на викрефы сейчас. 

CL не нужен потому что юзеры с этим никак не взаимодействуют. 

- [x] Pull Request полностью завершен, мне не нужна помощь чтобы его закончить.
- [x] Я внимательно прочитал все свои изменения и багов в них не нашел.
- [ ] Я запускал сервер со своими изменениями локально и все протестировал.
- [x] Я ознакомился c [Guide to Contribute](https://github.com/ChaoticOnyx/OnyxBay/blob/dev/docs/contributing.md).
