### PR TITLE
fix(mecha): goliath hide overlay and generators fixes

### DIFF
--- a/code/game/mecha/mecha.dm
+++ b/code/game/mecha/mecha.dm
@@ -1129,7 +1129,7 @@
 	forceMove(src.loc)
 	log_append_to_last("[H] moved in as pilot.")
 	icon_state = src.reset_icon()
-	on_update_icon()
+	update_icon()
 	set_dir(dir_in)
 	playsound(src, 'sound/machines/windowdoor.ogg', 50, 1)
 	if(!hasInternalDamage())

--- a/code/game/mecha/mecha.dm
+++ b/code/game/mecha/mecha.dm
@@ -1129,6 +1129,7 @@
 	forceMove(src.loc)
 	log_append_to_last("[H] moved in as pilot.")
 	icon_state = src.reset_icon()
+	on_update_icon()
 	set_dir(dir_in)
 	playsound(src, 'sound/machines/windowdoor.ogg', 50, 1)
 	if(!hasInternalDamage())
@@ -1309,6 +1310,7 @@
 		occupant = null
 		icon_state = reset_icon()+"-open"
 		set_dir(dir_in)
+		on_update_icon()
 	return
 
 /////////////////////////

--- a/code/game/mecha/mecha.dm
+++ b/code/game/mecha/mecha.dm
@@ -1310,7 +1310,7 @@
 		occupant = null
 		icon_state = reset_icon()+"-open"
 		set_dir(dir_in)
-		on_update_icon()
+		update_icon()
 	return
 
 /////////////////////////

--- a/code/game/mecha/working/ripley.dm
+++ b/code/game/mecha/working/ripley.dm
@@ -27,9 +27,9 @@
 	if(hides)
 		ClearOverlays()
 		if(hides < 3)
-			AddOverlays(OVERLAY("mecha.dmi", occupant ? "ripley-g" : "ripley-g-open"))
+			AddOverlays(image("mecha.dmi", src, occupant ? "ripley-g" : "ripley-g-open"))
 		else
-			AddOverlays(OVERLAY("mecha.dmi", occupant ? "ripley-g-full" : "ripley-g-full-open"))
+			AddOverlays(image("mecha.dmi", src, occupant ? "ripley-g-full" : "ripley-g-full-open"))
 
 /obj/mecha/working/ripley/firefighter
 	desc = "Standart APLU chassis was refitted with additional thermal protection and cistern."


### PR DESCRIPTION
Поправил проверки в генераторах мехов и, НАДЕЮСЬ, правильно починил оверлей брони из кожи голиафа на рипли

<details>
<summary>Чейнджлог</summary>

```yml
🆑BaraBara
bugfix: Броня из голиафа теперь корректно отображается на рипли
bugfix: Генераторы мехов теперь принимают в себя ресурсы и вырабатывают энергию
/🆑
```

</details>

- [x] Pull Request полностью завершен, мне не нужна помощь чтобы его закончить.
- [ ] Я внимательно прочитал все свои изменения и багов в них не нашел.
- [x] Я запускал сервер со своими изменениями локально и все протестировал.
- [x] Я ознакомился c [Guide to Contribute](https://github.com/ChaoticOnyx/OnyxBay/blob/dev/docs/contributing.md).
