### PR TITLE
tweak(stairs): stairs won't grief players anymore

### DIFF
--- a/code/modules/multiz/movement.dm
+++ b/code/modules/multiz/movement.dm
@@ -171,6 +171,10 @@
 
 /atom/movable/proc/handle_fall(turf/landing)
 	forceMove(landing)
+
+	if(locate(/obj/structure/stairs) in landing)
+		return
+
 	handle_fall_effect(landing)
 
 /atom/movable/proc/handle_fall_effect(turf/landing)


### PR DESCRIPTION
<details>
<summary>Чейнджлог</summary>

```yml
🆑
bugfix: Лестницы устроили массовый гриф. Им был выписан бан. Больше такое не повторится.
/🆑
```

</details>

- [x] Pull Request полностью завершен, мне не нужна помощь чтобы его закончить.
- [x] Я внимательно прочитал все свои изменения и багов в них не нашел.
- [x] Я запускал сервер со своими изменениями локально и все протестировал.
- [x] Я ознакомился c [Guide to Contribute](https://github.com/ChaoticOnyx/OnyxBay/blob/dev/docs/contributing.md).
