### PR TITLE
Fixing dat movespeed

### DIFF
--- a/code/game/dna/dna2_helpers.dm
+++ b/code/game/dna/dna2_helpers.dm
@@ -173,7 +173,7 @@
 			else
 				H.gender = MALE
 
-		H.body_build = H.species.get_body_build(H.gender, dna.body_build)
+		H.change_body_build(H.species.get_body_build(H.gender, dna.body_build))
 		H.fix_body_build()
 		H.body_height = dna.body_height
 

--- a/code/game/objects/items/crayons.dm
+++ b/code/game/objects/items/crayons.dm
@@ -172,7 +172,7 @@
 			to_chat(user, SPAN_WARNING("\The [blocked] is in the way!"))
 			return 1
 		to_chat(M, "You take a bite of the [src.name] and swallow it.")
-		M.nutrition += 1
+		M.add_nutrition(1)
 		M.reagents.add_reagent(/datum/reagent/crayon_dust,min(5,uses)/3)
 		reduce_uses(5, "ate")
 	else if(istype(M,/mob/living/carbon/human) && M.lying)

--- a/code/modules/client/preferences.dm
+++ b/code/modules/client/preferences.dm
@@ -441,7 +441,7 @@ datum/preferences/proc/clear_character_previews()
 	character.religion = religion
 
 	if(!character.isSynthetic())
-		character.nutrition = rand(140, 360) * character.body_build.stomach_capacity
+		character.set_nutrition(rand(140, 360) * character.body_build.stomach_capacity)
 
 	return
 

--- a/code/modules/client/preferences.dm
+++ b/code/modules/client/preferences.dm
@@ -301,7 +301,7 @@ datum/preferences/proc/clear_character_previews()
 	var/datum/species/S = all_species[species]
 
 	character.gender = gender
-	character.body_build = S.get_body_build(gender, body)
+	character.change_body_build(S.get_body_build(gender, body))
 	character.fix_body_build()
 	character.age = age
 	character.b_type = b_type

--- a/code/modules/mob/living/carbon/alien/diona/life.dm
+++ b/code/modules/mob/living/carbon/alien/diona/life.dm
@@ -8,7 +8,7 @@
 		var/turf/T = loc
 		light_amount = T.get_lumcount() * 5
 
-	nutrition += light_amount
+	add_nutrition(light_amount)
 
 	if(nutrition > 450)
 		nutrition = 450

--- a/code/modules/mob/living/carbon/alien/life.dm
+++ b/code/modules/mob/living/carbon/alien/life.dm
@@ -43,7 +43,7 @@
 		return
 	var/rads = radiation / (0.05 SIEVERT)
 	radiation = max(SPACE_RADIATION, radiation - rads)
-	nutrition += rads
+	add_nutrition(rads)
 	heal_overall_damage(rads, rads)
 	adjustOxyLoss(-rads)
 	adjustToxLoss(-rads)

--- a/code/modules/mob/living/carbon/carbon_defines.dm
+++ b/code/modules/mob/living/carbon/carbon_defines.dm
@@ -24,6 +24,7 @@
 	var/cpr_time = 1.0
 	var/lastpuke = 0
 	var/nutrition = 400
+	var/last_nutrition_speed_update
 
 	var/obj/item/tank/internal = null//Human/Monkey
 

--- a/code/modules/mob/living/carbon/carbon_nutrition.dm
+++ b/code/modules/mob/living/carbon/carbon_nutrition.dm
@@ -1,13 +1,15 @@
+#define UPDATE_DELAY 1 MINUTE
+
 /// Helper for adding nutrition. Automatically updates movespeed. Use this instead of adding nutrition manually.
 /mob/living/carbon/proc/add_nutrition(amount)
 	nutrition = max(0, nutrition += amount)
-	if(amount >= 1) // This proc is often called with extremely small amounts
+	if(amount >= 1 || world.time >= last_nutrition_speed_update + UPDATE_DELAY) // This proc is often called with extremely small amounts
 		update_nutrition_movespeed_if_necessary()
 
 /// Helper for subtracting nutrition. Automatically updates movespeed. Use this instead of subtracting nutrition manually.
 /mob/living/carbon/proc/remove_nutrition(amount)
 	nutrition = max(0, nutrition -= amount)
-	if(amount >= 1) // This proc is often called with extremely small amounts
+	if(amount >= 1  || world.time >= last_nutrition_speed_update + UPDATE_DELAY) // This proc is often called with extremely small amounts
 		update_nutrition_movespeed_if_necessary()
 
 /// Helper for setting nutrition. Automatically updates movespeed. Use this instead of subtracting nutrition manually.
@@ -22,6 +24,7 @@
 	return
 
 /mob/living/carbon/human/update_nutrition_movespeed_if_necessary()
+	last_nutrition_speed_update = world.time
 	if(full_prosthetic)
 		return
 
@@ -33,3 +36,5 @@
 			add_or_update_variable_movespeed_modifier(/datum/movespeed_modifier/nutrition_slowdown, slowdown = ((normalized_nutrition / 100) - 4.25))
 		else if(has_movespeed_modifier(/datum/movespeed_modifier/nutrition_slowdown))
 			remove_movespeed_modifier(/datum/movespeed_modifier/nutrition_slowdown)
+
+#undef UPDATE_DELAY

--- a/code/modules/mob/living/carbon/carbon_nutrition.dm
+++ b/code/modules/mob/living/carbon/carbon_nutrition.dm
@@ -2,25 +2,26 @@
 /mob/living/carbon/proc/add_nutrition(amount)
 	nutrition = max(0, nutrition += amount)
 	if(amount >= 1) // This proc is often called with extremely small amounts
-		update_movespeed_if_necessary()
+		update_nutrition_movespeed_if_necessary()
 
 /// Helper for subtracting nutrition. Automatically updates movespeed. Use this instead of subtracting nutrition manually.
 /mob/living/carbon/proc/remove_nutrition(amount)
 	nutrition = max(0, nutrition -= amount)
 	if(amount >= 1) // This proc is often called with extremely small amounts
-		update_movespeed_if_necessary()
+		update_nutrition_movespeed_if_necessary()
 
 /// Helper for setting nutrition. Automatically updates movespeed. Use this instead of subtracting nutrition manually.
 /mob/living/carbon/proc/set_nutrition(amount)
-	if(nutrition != amount)
-		update_movespeed_if_necessary()
-
+	var/nut_old = nutrition
 	nutrition = max(0, amount)
 
-/mob/living/carbon/proc/update_movespeed_if_necessary()
+	if(nut_old != nutrition)
+		update_nutrition_movespeed_if_necessary()
+
+/mob/living/carbon/proc/update_nutrition_movespeed_if_necessary()
 	return
 
-/mob/living/carbon/human/update_movespeed_if_necessary()
+/mob/living/carbon/human/update_nutrition_movespeed_if_necessary()
 	if(full_prosthetic)
 		return
 

--- a/code/modules/mob/living/carbon/human/appearance.dm
+++ b/code/modules/mob/living/carbon/human/appearance.dm
@@ -33,14 +33,17 @@
 /mob/living/carbon/human/proc/sanitize_body()
 	var/list/body_builds = src.species.get_body_build_datum_list(src.gender)
 	if(!(body_build in body_builds))
-		body_build = body_builds[1]
+		change_body_build(body_builds[1])
 		regenerate_icons()
 
+/// Use this proc to set body build or I will eat your liver
 /mob/living/carbon/human/proc/change_body_build(body_build)
 	if(src.body_build == body_build)
 		return
 
-	remove_movespeed_modifier(src.body_build.movespeed_modifier)
+	if(src.body_build?.movespeed_modifier)
+		remove_movespeed_modifier(src.body_build.movespeed_modifier)
+
 	src.body_build = body_build
 	add_movespeed_modifier(src.body_build.movespeed_modifier)
 	regenerate_icons()

--- a/code/modules/mob/living/carbon/human/human.dm
+++ b/code/modules/mob/living/carbon/human/human.dm
@@ -1232,7 +1232,7 @@
 		return 1
 	for(var/datum/body_build/BB in species.body_builds)
 		if(gender in BB.genders)
-			body_build = BB
+			change_body_build(BB)
 			return 1
 	to_world_log("Can't find possible body_build. Gender = [gender], Species = [species]")
 	return 0

--- a/code/modules/mob/living/carbon/human/human_powers.dm
+++ b/code/modules/mob/living/carbon/human/human_powers.dm
@@ -416,4 +416,4 @@
 		if(target.getBruteLoss() > target.maxHealth)
 			target.gib()
 		adjustBruteLoss(-25)
-		nutrition += 20
+		add_nutrition(20)

--- a/code/modules/mob/living/carbon/human/life.dm
+++ b/code/modules/mob/living/carbon/human/life.dm
@@ -969,7 +969,7 @@
 				if(life_tick % 3 == 1)
 					if(!(M.status_flags & GODMODE))
 						M.adjustBruteLoss(5)
-					nutrition += 10
+					add_nutrition(10)
 
 /mob/living/carbon/human/proc/handle_shock()
 	if(!can_feel_pain())

--- a/code/modules/mob/living/carbon/human/species/species_shapeshift.dm
+++ b/code/modules/mob/living/carbon/human/species/species_shapeshift.dm
@@ -211,5 +211,5 @@ var/list/wrapped_species_by_ref = list()
 	var/datum/species/S = all_species[wrapped_species_by_ref["\ref[src]"]]
 	var/list/body_builds = S.get_body_build_datum_list(src.gender)
 	if(!(body_build in body_builds))
-		body_build = body_builds[1]
+		change_body_build(body_builds[1])
 		regenerate_icons()

--- a/code/modules/mob/living/carbon/human/species/station/golems.dm
+++ b/code/modules/mob/living/carbon/human/species/station/golems.dm
@@ -306,7 +306,7 @@
 	if(isturf(H.loc)) //else, there's considered to be no light
 		var/turf/T = H.loc
 		light_amount = min(1, T.get_lumcount()) - 0.5
-		H.nutrition += 5 * light_amount
+		H.add_nutrition(5 * light_amount)
 		if(H.nutrition > STOMACH_FULLNESS_HIGH)
 			H.nutrition = STOMACH_FULLNESS_HIGH
 		if(light_amount > 0.2) //if there's enough light, heal

--- a/code/modules/mob/living/carbon/human/species/station/prometheans/prometheans.dm
+++ b/code/modules/mob/living/carbon/human/species/station/prometheans/prometheans.dm
@@ -130,7 +130,7 @@
 		if(H.nutrition >= STOMACH_FULLNESS_LOW)
 			jelly_vessel.add_jelly(PROMETHEAN_REGEN_RATE * 0.1)
 			if(jelly_volume <= BLOOD_VOLUME_LOSE_NUTRITION) // don't lose nutrition if we are above a certain threshold, otherwise metroids on IV drips will still lose nutrition
-				H.nutrition += -1.25 * 0.1
+				H.add_nutrition(-1.25 * 0.1)
 
 	// we call lose_blood() here rather than quirk/process() to make sure that the blood loss happens in sync with life()
 	if(HAS_TRAIT(H, TRAIT_BLOOD_DEFICIENCY))

--- a/code/modules/mob/living/carbon/human/species/station/prometheans/slime.dm
+++ b/code/modules/mob/living/carbon/human/species/station/prometheans/slime.dm
@@ -62,7 +62,7 @@
 	else if(H.nutrition >= STOMACH_FULLNESS_HIGH)
 		jelly_vessel.add_jelly(0.15)
 		if(jelly_volume <= BLOOD_VOLUME_LOSE_NUTRITION)
-			H.nutrition += -0.125
+			H.remove_nutrition(0.125)
 
 	..()
 

--- a/code/modules/mob/living/carbon/xenobiological/crossbreeding/_status_effects.dm
+++ b/code/modules/mob/living/carbon/xenobiological/crossbreeding/_status_effects.dm
@@ -953,7 +953,7 @@
 		drained.adjustCloneLoss(heal_amount * DRAIN_DAMAGE_MULTIPLIER)
 		C.adjustCloneLoss(-heal_amount)
 
-	C.nutrition += 3
+	C.add_nutrition(3)
 
 #undef DRAIN_DAMAGE_MULTIPLIER
 

--- a/code/modules/mob/living/carbon/xenobiological/xenobiological.dm
+++ b/code/modules/mob/living/carbon/xenobiological/xenobiological.dm
@@ -342,7 +342,7 @@
 	return 0
 
 /mob/living/carbon/metroid/proc/gain_nutrition(amount)
-	nutrition += amount
+	add_nutrition(amount)
 	if(prob(amount * 2)) // Gain around one level per 50 nutrition
 		powerlevel++
 		if(powerlevel > 10)

--- a/code/modules/mob/living/silicon/robot/robot_upgrades.dm
+++ b/code/modules/mob/living/silicon/robot/robot_upgrades.dm
@@ -209,15 +209,14 @@
 	require_module = 1
 
 /obj/item/borg/upgrade/vtec/action(mob/living/silicon/robot/R)
-	if(..()) return 0
+	if(..()) return FALSE
 
-	if(R.speed == -1)
-		return 0
+	if(R.has_movespeed_modifier(/datum/movespeed_modifier/vtec_speedup))
+		return FALSE
 
-	R.speed--
-	installed = 1
-	return 1
-
+	R.add_movespeed_modifier(/datum/movespeed_modifier/vtec_speedup)
+	installed = TRUE
+	return TRUE
 
 /obj/item/borg/upgrade/tasercooler
 	name = "robotic Rapid Taser Cooling Module"

--- a/code/modules/mob/movement/modifiers/mobs.dm
+++ b/code/modules/mob/movement/modifiers/mobs.dm
@@ -66,3 +66,7 @@
 /datum/movespeed_modifier/robot_movement/New()
 	. = ..()
 	slowdown = config.movement.robot_delay
+
+/datum/movespeed_modifier/vtec_speedup
+	flags = MOVESPEED_FLAG_SPACEMOVEMENT
+	slowdown = -1

--- a/code/modules/mob/movement/modifiers/variable_slowdowns.dm
+++ b/code/modules/mob/movement/modifiers/variable_slowdowns.dm
@@ -27,7 +27,7 @@
 		if(equipment_slowdown + 1 > body_build.equipment_modifier)  // Lowering equipment cooldown if it's higher
 			equipment_slowdown += equipment_slowdown - body_build.equipment_modifier // than equipment_modifier, ignoring it otherwise
 		else
-			equipment_slowdown -= 1 // Since default equipment_slowdown is -1 for some reason
+			equipment_slowdown = -1 // Since default equipment_slowdown is -1 for some reason
 	else if(equipment_slowdown > -1)
 		equipment_slowdown += equipment_slowdown - body_build.equipment_modifier
 

--- a/code/modules/mob/movement/movespeed_modifier.dm
+++ b/code/modules/mob/movement/movespeed_modifier.dm
@@ -140,8 +140,10 @@ GLOBAL_LIST_EMPTY(movespeed_modification_cache)
 		var/datum/movespeed_modifier/M = movespeed_modification[key]
 		var/amt = M.slowdown
 		calculated_slowdown += amt
+
 		if(M.flags & MOVESPEED_FLAG_SPACEMOVEMENT)
 			calculated_slowdown_space += amt
+
 		if(M.flags & MOVESPEED_FLAG_OVERRIDING_SPEED)
 			cached_slowdown = M.slowdown
 			return

--- a/code/modules/projectiles/projectile/special.dm
+++ b/code/modules/projectiles/projectile/special.dm
@@ -159,7 +159,7 @@
 	if(ishuman(target)) //These rays make plantmen fat.
 		var/mob/living/carbon/human/H = M
 		if((H.species.species_flags & SPECIES_FLAG_IS_PLANT) && (H.nutrition < 500))
-			H.nutrition += 30
+			H.add_nutrition(30)
 	else if (istype(target, /mob/living/carbon))
 		M.show_message(SPAN_NOTICE("The radiation beam dissipates harmlessly through your body."))
 	else

--- a/code/modules/reagents/Chemistry-Reagents/basic.dm
+++ b/code/modules/reagents/Chemistry-Reagents/basic.dm
@@ -433,7 +433,7 @@
 	glass_icon = DRINK_ICON_NOISY
 
 /datum/reagent/sugar/affect_blood(mob/living/carbon/M, alien, removed)
-	M.nutrition += removed * 3
+	M.add_nutrition(removed * 3)
 
 	if(alien == IS_UNATHI)
 		if(M.chem_doses[type] < 2)

--- a/code/modules/reagents/Chemistry-Reagents/ethanol.dm
+++ b/code/modules/reagents/Chemistry-Reagents/ethanol.dm
@@ -29,7 +29,7 @@
 	return
 
 /datum/reagent/ethanol/affect_ingest(mob/living/carbon/M, alien, removed)
-	M.nutrition += nutriment_factor * removed
+	M.add_nutrition(nutriment_factor * removed)
 	var/strength_mod = 1
 	if(alien == IS_SKRELL)
 		strength_mod *= 5

--- a/code/modules/reagents/Chemistry-Reagents/food_drinks.dm
+++ b/code/modules/reagents/Chemistry-Reagents/food_drinks.dm
@@ -47,7 +47,7 @@
 /datum/reagent/nutriment/proc/adjust_nutrition(mob/living/carbon/M, alien, removed)
 	switch(alien)
 		if(IS_UNATHI) removed *= 0.1 // Unathi get most of their nutrition from meat.
-	M.nutrition += nutriment_factor * removed // For hunger and fatness
+	M.add_nutrition(nutriment_factor * removed) // For hunger and fatness
 
 /datum/reagent/nutriment/glucose
 	name = "Glucose"
@@ -70,7 +70,7 @@
 /datum/reagent/nutriment/protein/adjust_nutrition(mob/living/carbon/M, alien, removed)
 	switch(alien)
 		if(IS_UNATHI) removed *= 2.25
-	M.nutrition += nutriment_factor * removed // For hunger and fatness
+	M.add_nutrition(nutriment_factor * removed) // For hunger and fatness
 
 /datum/reagent/nutriment/protein/affect_blood(mob/living/carbon/M, alien, removed)
 	if(alien && alien == IS_SKRELL)
@@ -422,7 +422,7 @@
 	return
 
 /datum/reagent/drink/affect_ingest(mob/living/carbon/M, alien, removed)
-	M.nutrition += nutrition * removed
+	M.add_nutrition(nutrition * removed)
 	M.dizziness = max(0, M.dizziness + adj_dizzy)
 	M.drowsyness = max(0, M.drowsyness + adj_drowsy)
 	M.sleeping = max(0, M.sleeping + adj_sleepy)

--- a/code/modules/xenoarcheaology/effects/heal.dm
+++ b/code/modules/xenoarcheaology/effects/heal.dm
@@ -17,7 +17,7 @@
 						affecting.heal_damage(25 * weakness, 25 * weakness)
 				//H:heal_organ_damage(25, 25)
 				H.vessel.add_reagent(/datum/reagent/blood,5)
-				H.nutrition += 50 * weakness
+				H.add_nutrition(50 * weakness)
 				H.adjustBrainLoss(-25 * weakness)
 				H.radiation -= min(H.radiation, 25 * weakness)
 				H.bodytemperature = initial(H.bodytemperature)


### PR DESCRIPTION
Нерф свиней и толстых, теперь они не бегают как обычные хуманы.

```yml
🆑
bugfix: толстый бодибилд снова дает слоудаун.
bugfix: VTEC модуль боргов снова корректно уменьшает замедление
/🆑
```

- [x] Pull Request полностью завершен, мне не нужна помощь чтобы его закончить.
- [x] Я внимательно прочитал все свои изменения и багов в них не нашел.
- [x] Я запускал сервер со своими изменениями локально и все протестировал.
- [x] Я ознакомился c [Guide to Contribute](https://github.com/ChaoticOnyx/OnyxBay/blob/dev/docs/contributing.md).
