### PR TITLE
tweak(shuttle): adds dynamic light to shuttles

### DIFF
--- a/code/game/turfs/flooring/flooring_shuttle.dm
+++ b/code/game/turfs/flooring/flooring_shuttle.dm
@@ -1,6 +1,7 @@
 /turf/simulated/floor/shuttle
 	name = "floor"
 	icon = 'icons/turf/shuttle.dmi'
+	dynamic_lighting = TRUE
 
 /turf/simulated/floor/shuttle/blue
 	icon_state = "floor"

--- a/code/game/turfs/simulated/wall_shuttle.dm
+++ b/code/game/turfs/simulated/wall_shuttle.dm
@@ -3,6 +3,7 @@
 	icon = 'icons/turf/shuttle.dmi'
 	thermal_conductivity = 0.05
 	heat_capacity = 0
+	dynamic_lighting = TRUE
 
 /turf/simulated/shuttle/wall
 	name = "wall"

--- a/code/game/turfs/unsimulated/floor.dm
+++ b/code/game/turfs/unsimulated/floor.dm
@@ -28,3 +28,4 @@
 
 /turf/unsimulated/floor/shuttle_ceiling
 	icon_state = "reinforced"
+	dynamic_lighting = TRUE

--- a/code/game/turfs/unsimulated/walls.dm
+++ b/code/game/turfs/unsimulated/walls.dm
@@ -14,8 +14,10 @@
 
 /turf/unsimulated/wall/fakeglass
 	name = "window"
+	icon = 'icons/turf/walls.dmi'
 	icon_state = "fakewindows"
 	opacity = 0
 
 /turf/unsimulated/wall/other
-	icon_state = "r_wall"
+	icon = 'icons/turf/wall_masks.dmi'
+	icon_state = "rgeneric"


### PR DESCRIPTION
Шаттлы теперь тоже страдают от темноты.
Заодно пофиксил пропавшие иконочки у несимулируемых окон и стен (Их не юзают).

<details>
<summary>Чейнджлог</summary>

```yml
🆑KreeperHLC
tweak: Шаттлы теперь тоже страдают от темноты.
/🆑
```

</details>

- [x] Pull Request полностью завершен, мне не нужна помощь чтобы его закончить.
- [x] Я внимательно прочитал все свои изменения и багов в них не нашел.
- [x] Я запускал сервер со своими изменениями локально и все протестировал.
- [x] Я ознакомился c [Guide to Contribute](https://github.com/ChaoticOnyx/OnyxBay/blob/dev/docs/contributing.md).
