### PR TITLE
fix(openspace): carpets now don't see on z-levels

### DIFF
--- a/code/game/turfs/simulated/floor_icon.dm
+++ b/code/game/turfs/simulated/floor_icon.dm
@@ -64,7 +64,7 @@ var/list/flooring_cache = list()
 /turf/simulated/floor/proc/get_flooring_overlay(cache_key, icon_base, icon_dir = 0)
 	if(!flooring_cache[cache_key])
 		var/image/I = image(icon = flooring.icon, icon_state = icon_base, dir = icon_dir)
-		I.plane = plane
+//		I.plane = plane
 		I.layer = DECAL_LAYER
 		flooring_cache[cache_key] = I
 	return flooring_cache[cache_key]

--- a/code/game/turfs/simulated/floor_icon.dm
+++ b/code/game/turfs/simulated/floor_icon.dm
@@ -64,7 +64,6 @@ var/list/flooring_cache = list()
 /turf/simulated/floor/proc/get_flooring_overlay(cache_key, icon_base, icon_dir = 0)
 	if(!flooring_cache[cache_key])
 		var/image/I = image(icon = flooring.icon, icon_state = icon_base, dir = icon_dir)
-//		I.plane = plane
 		I.layer = DECAL_LAYER
 		flooring_cache[cache_key] = I
 	return flooring_cache[cache_key]


### PR DESCRIPTION
Ковры теперь (и прочие возможные вещи) не будут просвечивать с нижнего этажа.

- [x] Pull Request полностью завершен, мне не нужна помощь чтобы его закончить.
- [x] Я внимательно прочитал все свои изменения и багов в них не нашел.
- [x] Я запускал сервер со своими изменениями локально и все протестировал.
- [x] Я ознакомился c [Guide to Contribute](https://github.com/ChaoticOnyx/OnyxBay/blob/dev/docs/contributing.md).
