### PR TITLE
fix(grab): qdeled tables will no longer send mobs to nullspace

### DIFF
--- a/code/modules/tables/interactions.dm
+++ b/code/modules/tables/interactions.dm
@@ -126,9 +126,14 @@
 				G.assailant.next_move = world.time + 13 //also should prevent user from triggering this repeatedly
 				visible_message("<span class='warning'>[G.assailant] starts putting [G.affecting] on \the [src].</span>")
 				if(!do_after(G.assailant, 13))
-					return 0
+					return FALSE
+
 				if(!G) //check that we still have a grab
-					return 0
+					return FALSE
+
+				if(QDELETED(src) || QDESTROYING(src))
+					return FALSE
+
 				G.affecting.forceMove(src.loc)
 				G.affecting.Weaken(rand(1,4))
 				G.affecting.Stun(1)

--- a/code/modules/tables/interactions.dm
+++ b/code/modules/tables/interactions.dm
@@ -131,7 +131,7 @@
 				if(!G) //check that we still have a grab
 					return FALSE
 
-				if(QDELETED(src) || QDESTROYING(src))
+				if(QDELETED(src))
 					return FALSE
 
 				G.affecting.forceMove(src.loc)


### PR DESCRIPTION
<details>
<summary>Чейнджлог</summary>

```yml
🆑
bugfix: Удаленные столы должны перестать отправлять космонавтиков в бэкрумс.
/🆑
```

</details>

- [x] Pull Request полностью завершен, мне не нужна помощь чтобы его закончить.
- [x] Я внимательно прочитал все свои изменения и багов в них не нашел.
- [x] Я запускал сервер со своими изменениями локально и все протестировал.
- [x] Я ознакомился c [Guide to Contribute](https://github.com/ChaoticOnyx/OnyxBay/blob/dev/docs/contributing.md).
