### PR TITLE
fix(vending): fixes vendomat not playing cool animation due to its UI state

### DIFF
--- a/baystation12.dme
+++ b/baystation12.dme
@@ -2902,6 +2902,7 @@
 #include "code\modules\tgui\states\human_adjacent.dm"
 #include "code\modules\tgui\states\inventory.dm"
 #include "code\modules\tgui\states\machinery.dm"
+#include "code\modules\tgui\states\machinery_noacess.dm"
 #include "code\modules\tgui\states\never.dm"
 #include "code\modules\tgui\states\new_player.dm"
 #include "code\modules\tgui\states\not_incapacitated.dm"

--- a/code/game/machinery/vending/_vending.dm
+++ b/code/game/machinery/vending/_vending.dm
@@ -429,6 +429,9 @@
 
 	tgui_interact(user)
 
+/obj/machinery/vending/tgui_state(mob/user)
+	return GLOB.tgui_machinery_noaccess_state
+
 /obj/machinery/vending/tgui_interact(mob/user, datum/tgui/ui)
 	ui = SStgui.try_update_ui(user, src, ui)
 

--- a/code/modules/paperwork/faxmachine.dm
+++ b/code/modules/paperwork/faxmachine.dm
@@ -52,7 +52,7 @@ GLOBAL_LIST_EMPTY(adminfaxes)	//cache for faxes that have been sent to admins
 	tgui_interact(user)
 
 /obj/machinery/photocopier/faxmachine/tgui_state(mob/user)
-	return GLOB.tgui_machinery_no_access_check_state
+	return GLOB.tgui_machinery_noaccess_state
 
 /obj/machinery/photocopier/faxmachine/tgui_interact(mob/user, datum/tgui/ui)
 	ui = SStgui.try_update_ui(user, src, ui)

--- a/code/modules/tgui/states/machinery.dm
+++ b/code/modules/tgui/states/machinery.dm
@@ -10,13 +10,3 @@ GLOBAL_DATUM_INIT(tgui_machinery_state, /datum/ui_state/machinery, new)
 		return UI_UPDATE
 
 	return user.tgui_default_can_use_topic(src_object)
-
-GLOBAL_DATUM_INIT(tgui_machinery_no_access_check_state, /datum/ui_state/machinery_noaccesscheck, new)
-
-/datum/ui_state/machinery_noaccesscheck/can_use_topic(obj/machinery/src_object, mob/user)
-	ASSERT(istype(src_object))
-
-	if(src_object.stat & (BROKEN | NOPOWER))
-		return UI_CLOSE
-
-	return user.tgui_default_can_use_topic(src_object)

--- a/code/modules/tgui/states/machinery_noacess.dm
+++ b/code/modules/tgui/states/machinery_noacess.dm
@@ -1,0 +1,9 @@
+GLOBAL_DATUM_INIT(tgui_machinery_noaccess_state, /datum/ui_state/machinery_noaccess, new)
+
+/datum/ui_state/machinery_noaccess/can_use_topic(obj/machinery/src_object, mob/user)
+	ASSERT(istype(src_object))
+
+	if(src_object.stat & (BROKEN | NOPOWER))
+		return UI_CLOSE
+
+	return user.tgui_default_can_use_topic(src_object)


### PR DESCRIPTION
Вендинговые машинки снова могут быть использованы без доступа и даже проигрывают анимацию отказа. Теперь заживем.

<details>
<summary>Чейнджлог</summary>

```yml
🆑
bugfix: С вендоматами вновь можно взаимодействовать без карточки, что позволит насладиться прекрасными анимациями отказа.
/🆑
```

</details>

- [x] Pull Request полностью завершен, мне не нужна помощь чтобы его закончить.
- [x] Я внимательно прочитал все свои изменения и багов в них не нашел.
- [ ] Я запускал сервер со своими изменениями локально и все протестировал.
- [x] Я ознакомился c [Guide to Contribute](https://github.com/ChaoticOnyx/OnyxBay/blob/dev/docs/contributing.md).
