### PR TITLE
fix(light): fix light's update_icon causing negative power consumption

### DIFF
--- a/code/modules/power/lighting.dm
+++ b/code/modules/power/lighting.dm
@@ -609,7 +609,7 @@
 		if(lightbulb && !(lightbulb.status == LIGHT_BROKEN))
 			playsound(src.loc, GET_SFX(SFX_GLASS_HIT), 75, 1)
 
-		if(has_power())
+		if(powered())
 			s.set_up(3, 1, src)
 			s.start()
 
@@ -623,6 +623,7 @@
 
 	lightbulb.status = LIGHT_OK
 
+	on = has_power()
 	update(FALSE)
 
 // explosion effect

--- a/code/modules/power/lighting.dm
+++ b/code/modules/power/lighting.dm
@@ -144,7 +144,9 @@
 	active_power_usage = 20 WATTS
 	power_channel = STATIC_LIGHT //Lights are calc'd via area so they dont need to be in the machine list
 
+	/// Whether light is currently turned on.
 	var/on = TRUE
+	/// Whether bulb is currently asynchronously flickering.
 	var/flickering = FALSE
 	var/light_type = /obj/item/light/tube		// the type of light item
 	var/construct_type = /obj/machinery/light_construct
@@ -245,7 +247,7 @@
 	. = ..()
 
 /obj/machinery/light/proc/update_glow()
-	if(!on || isnull(lightbulb) || (stat & (BROKEN | NOPOWER)))
+	if(!on)
 		set_light(0)
 		return FALSE
 
@@ -472,10 +474,12 @@
 	update(TRUE)
 
 /**
- * Updates lighting, icon and optionally calls `switch_on` on the inserted lightbulb.
+ * Updates lighting, icon and optionally calls `switch_on` on the inserted lightbulb. This
+ * method is prefered over `update_icon` due to multiple edge-case handlers.
  *
  * Vars:
  * * trigger - If set to `TRUE` calls `switch_on` on a lightbulb.
+ *
  */
 /obj/machinery/light/proc/update(trigger = FALSE)
 	switch(get_status())


### PR DESCRIPTION
Как выяснилось если помещать в `update_icon` логику напрямую с ней не связанную, то выйдет шляпа. В нашем случае лампочки уводили потребление электроэнергии у зоны в минус, отказывались проигрывать смешные звуки при включении и ломаться. Да-да, это тоже вызывалось в `update_icon`.

Я полностью переписал логику обновления иконок так как старая была отвратительна. Теперь для обновления состояния лампы мы должны использовать `update` так как в нем идет обработка некоторых особенностей и крайних случаев. Переписал прок `flicker` с использованием более современных фишек бйонда, от спавна избавиться не вышло, к сожалению.

<details>
<summary>Чейнджлог</summary>

```yml
🆑
bugfix: Лампочки снова научились взрываться, проигрывать звуки и с небольшим шаенсом ломаться при включении.
bugfix: Исправлено отрицательное потребление электроэнергии в сауне Исхода.
/🆑
```

</details>

- [x] Pull Request полностью завершен, мне не нужна помощь чтобы его закончить.
- [x] Я внимательно прочитал все свои изменения и багов в них не нашел.
- [x] Я запускал сервер со своими изменениями локально и все протестировал.
- [x] Я ознакомился c [Guide to Contribute](https://github.com/ChaoticOnyx/OnyxBay/blob/dev/docs/contributing.md).
