### PR TITLE
fix(lamp): light bulb deletion no longer causes light runtime

### DIFF
--- a/code/modules/power/lighting.dm
+++ b/code/modules/power/lighting.dm
@@ -517,7 +517,7 @@
 		update(FALSE)
 		sleep(rand(5, 15))
 
-	on = get_status() == LIGHT_OK
+	on = has_power()
 	update(FALSE)
 
 	flickering = FALSE
@@ -584,7 +584,6 @@
 
 	// create a light tube/bulb item and put it in the user's hand
 	user.put_in_active_hand(remove_bulb())	//puts it in our active hand
-
 
 /obj/machinery/light/attack_tk(mob/user)
 	if(!lightbulb)
@@ -829,7 +828,7 @@
 		L.lightbulb = null
 		L.current_mode = null
 		if(!QDELETED(L))
-			L.update_icon()
+			update(FALSE)
 	return ..()
 
 /obj/item/light/_examine_text(mob/user)

--- a/code/modules/power/lighting.dm
+++ b/code/modules/power/lighting.dm
@@ -828,7 +828,7 @@
 		L.lightbulb = null
 		L.current_mode = null
 		if(!QDELETED(L))
-			update(FALSE)
+			L.update(FALSE)
 	return ..()
 
 /obj/item/light/_examine_text(mob/user)


### PR DESCRIPTION
Произошло то, о чем я писал в комменте над проком `update`.

<details>
<summary>Чейнджлог</summary>

```yml
🆑
bugfix: Лампа после взрыва больше не оставляет фантомный свет.
/🆑
```

</details>

close #11690

- [x] Pull Request полностью завершен, мне не нужна помощь чтобы его закончить.
- [x] Я внимательно прочитал все свои изменения и багов в них не нашел.
- [ ] Я запускал сервер со своими изменениями локально и все протестировал.
- [x] Я ознакомился c [Guide to Contribute](https://github.com/ChaoticOnyx/OnyxBay/blob/dev/docs/contributing.md).
