### PR TITLE
fix(fitness): weightlifting no longer consumse synth's nutriments

### DIFF
--- a/code/game/objects/structures/fitness.dm
+++ b/code/game/objects/structures/fitness.dm
@@ -57,7 +57,8 @@
 		flick("[icon_state]_[weight]", src)
 		if(do_after(user, 20 + (weight * 10)))
 			playsound(src.loc, 'sound/effects/weightdrop.ogg', 25, 1)
-			user.remove_nutrition(weight * 10)
+			if(!user.isSynthetic())
+				user.remove_nutrition(weight * 10)
 			to_chat(user, "<span class='notice'>You lift the weights [qualifiers[weight]].</span>")
 			being_used = 0
 		else


### PR DESCRIPTION
Closes #11645

<details>
<summary>Чейнджлог</summary>

```yml
🆑
bugfix: Синты снова могут качаться и не терять нутриенты.
/🆑
```

</details>

- [x] Pull Request полностью завершен, мне не нужна помощь чтобы его закончить.
- [x] Я внимательно прочитал все свои изменения и багов в них не нашел.
- [ ] Я запускал сервер со своими изменениями локально и все протестировал.
- [x] Я ознакомился c [Guide to Contribute](https://github.com/ChaoticOnyx/OnyxBay/blob/dev/docs/contributing.md).
