### PR TITLE
bugfix(sounds): ugly drop sounds are no longer played on rejuv/gib

### DIFF
--- a/code/modules/mob/organs/organ.dm
+++ b/code/modules/mob/organs/organ.dm
@@ -52,6 +52,11 @@ var/list/organ_cache = list()
 		owner = null
 	dna = null
 	QDEL_NULL(food_organ)
+
+	if(ismob(loc))
+		var/mob/M = loc
+		M.drop(src, force = TRUE, changing_slots = TRUE) // Changing_slots prevents drop_sound from playing
+
 	return ..()
 
 /obj/item/organ/proc/update_health()


### PR DESCRIPTION
<details>
<summary>Чейнджлог</summary>

```yml
🆑
bugfix: Исправлено недоразумение в результате которого проигрывался убогий звук при реджуве/гибе.
/🆑
```

</details>

- [x] Pull Request полностью завершен, мне не нужна помощь чтобы его закончить.
- [x] Я внимательно прочитал все свои изменения и багов в них не нашел.
- [x] Я запускал сервер со своими изменениями локально и все протестировал.
- [x] Я ознакомился c [Guide to Contribute](https://github.com/ChaoticOnyx/OnyxBay/blob/dev/docs/contributing.md).
