### PR TITLE
tweak(who): makes watchlisted griefers more noticeable in who

### DIFF
--- a/code/game/verbs/who.dm
+++ b/code/game/verbs/who.dm
@@ -78,6 +78,9 @@
 
 			entry += " (<A HREF='?_src_=holder;adminmoreinfo=\ref[C.mob]'>?</A>)"
 
+			if(config.external.sql_enabled && watchlist.Check(C.ckey))
+				lines += "(<A HREF='?_src_=holder;adminmoreinfo=\ref[C.mob]'>IN WATCHLIST!</A>)"
+
 			lines += entry
 	else if(rights)
 		for(var/client/C in GLOB.clients)


### PR DESCRIPTION
Resolves #2293

<details>
<summary>Чейнджлог</summary>

```yml
🆑
admin: Улучшение видимости людей в вотчлисте - теперь они отдельно помечаются в педальном who.
/🆑
```

</details>

- [x] Pull Request полностью завершен, мне не нужна помощь чтобы его закончить.
- [x] Я внимательно прочитал все свои изменения и багов в них не нашел.
- [x] Я запускал сервер со своими изменениями локально и все протестировал.
- [x] Я ознакомился c [Guide to Contribute](https://github.com/ChaoticOnyx/OnyxBay/blob/dev/docs/contributing.md).
