### PR TITLE
feat(storage): adds ability to click on border overlays in storage

### DIFF
--- a/code/_onclick/hud/screen_objects.dm
+++ b/code/_onclick/hud/screen_objects.dm
@@ -67,18 +67,37 @@
 /atom/movable/screen/storage
 	name = "storage"
 
-/atom/movable/screen/storage/Click()
+/atom/movable/screen/storage/Click(location, control, params)
 	if(!usr.canClick())
-		return 1
+		return TRUE
+
 	if(usr.stat || usr.paralysis || usr.stunned || usr.weakened)
-		return 1
+		return TRUE
+
 	if (istype(usr.loc,/obj/mecha)) // stops inventory actions in a mech
-		return 1
+		return TRUE
 	if(master)
 		var/obj/item/I = usr.get_active_hand()
 		if(I)
 			usr.ClickOn(master)
-	return 1
+
+		var/obj/item/storage/S = master
+		if(!S?.storage_ui)
+			return
+
+		// Tries to find items by their border overlay.
+		var/list/PM = params2list(params)
+		var/list/screen_loc_params = splittext(PM["screen-loc"], ",")
+		var/list/screen_loc_X = splittext(screen_loc_params[1], ":")
+		var/click_x = text2num(screen_loc_X[1]) * WORLD_ICON_SIZE + text2num(screen_loc_X[2]) - 144
+
+		for(var/i = 1, i <= S.storage_ui.click_border_start.len, i++)
+			if(S.storage_ui.click_border_start[i] <= click_x && click_x <= S.storage_ui.click_border_end[i] && i <= S.contents.len)
+				I = S.contents[i]
+				I?.Click(location, control, params)
+				return
+
+	return TRUE
 
 /atom/movable/screen/stored
 	name = "stored"

--- a/code/game/objects/items/storage/storage_ui/default.dm
+++ b/code/game/objects/items/storage/storage_ui/default.dm
@@ -212,17 +212,13 @@
 		O.screen_loc = "[cx]:16,[cy]:16"
 		O.maptext = ""
 		O.hud_layerise()
+		click_border_start += (cx - 4) * 32
+		click_border_end += (cx - 4) * 32 + 32
+
 		cx++
 		if (cx > (4+cols))
 			cx = 4
 			cy--
-
-	click_border_start += (cx - 4) * 32
-	click_border_end += (cx - 4) * 32 + 32
-	cx++
-	if(cx > (4 + cols))
-		cx = 4
-		cy--
 
 	closer.screen_loc = "[4 + cols + 1]:16,2:16"
 

--- a/code/game/objects/items/storage/storage_ui/default.dm
+++ b/code/game/objects/items/storage/storage_ui/default.dm
@@ -192,9 +192,12 @@
 
 //This proc determins the size of the inventory to be displayed. Please touch it only if you know what you're doing.
 /datum/storage_ui/default/proc/slot_orient_objs()
+	click_border_start.Cut()
+	click_border_end.Cut()
+
 	var/adjusted_contents = storage.contents.len
 	var/row_num = 0
-	var/col_count = min(7,storage.storage_slots) -1
+	var/col_count = min(7, storage.storage_slots) - 1
 	if (adjusted_contents > 7)
 		row_num = round((adjusted_contents-1) / 7) // 7 is the maximum allowed width.
 	arrange_item_slots(row_num, col_count)
@@ -214,7 +217,14 @@
 			cx = 4
 			cy--
 
-	closer.screen_loc = "[4+cols+1]:16,2:16"
+	click_border_start += (cx - 4) * 32
+	click_border_end += (cx - 4) * 32 + 32
+	cx++
+	if(cx > (4 + cols))
+		cx = 4
+		cy--
+
+	closer.screen_loc = "[4 + cols + 1]:16,2:16"
 
 /datum/storage_ui/default/proc/space_orient_objs()
 
@@ -223,6 +233,8 @@
 	var/stored_cap_width = 4 //length of sprite for start and end of the box representing the stored item
 	var/storage_width = min( round( 224 * storage.max_storage_space/baseline_max_storage_space ,1) ,284) //length of sprite for the box representing total storage space
 
+	click_border_start.Cut()
+	click_border_end.Cut()
 	storage_start.ClearOverlays()
 
 	storage_continue.SetTransform(scale_x = (storage_width - storage_cap_width * 2 + 3) / 32)
@@ -237,6 +249,9 @@
 	for(var/obj/item/O in storage.contents)
 		startpoint = endpoint + 1
 		endpoint += storage_width * O.get_storage_cost()/storage.max_storage_space
+
+		click_border_start.Add(startpoint)
+		click_border_end.Add(endpoint)
 
 		stored_start.SetTransform(offset_x = startpoint)
 		stored_end.SetTransform(offset_x = endpoint - stored_cap_width)

--- a/code/game/objects/items/storage/storage_ui/storage_ui.dm
+++ b/code/game/objects/items/storage/storage_ui/storage_ui.dm
@@ -1,5 +1,8 @@
 /datum/storage_ui
 	var/obj/item/storage/storage
+	var/list/click_border_start = list()
+	var/list/click_border_end = list()
+
 
 /datum/storage_ui/New(storage)
 	src.storage = storage


### PR DESCRIPTION
<details>
<summary>Видео</summary>

https://github.com/ChaoticOnyx/OnyxBay/assets/23741266/d405957b-dd13-42e7-b9ad-37065a3ba1ce


</details>

<details>
<summary>Чейнджлог</summary>

```yml
🆑
tweak: Пиксельхантинг отменяется. Теперь можно доставать предметы из инвентаря просто кликая по их оверлею, а не только по самим предметам. 
/🆑
```

</details>


- [x] Pull Request полностью завершен, мне не нужна помощь чтобы его закончить.
- [x] Я внимательно прочитал все свои изменения и багов в них не нашел.
- [x] Я запускал сервер со своими изменениями локально и все протестировал.
- [x] Я ознакомился c [Guide to Contribute](https://github.com/ChaoticOnyx/OnyxBay/blob/dev/docs/contributing.md).
