### PR TITLE
feat(skin): remove alternate input, add settings & character setup shortcuts, move scaling preferences to settings

### DIFF
--- a/code/game/verbs/ooc.dm
+++ b/code/game/verbs/ooc.dm
@@ -40,7 +40,6 @@
 
 	if(alert(usr, "Are you sure? You have to switch to the English keyboard layout first.\nWarning: This will close all open windows.", "Fix hotkeys", "Yes", "No") == "Yes")
 		winset(src, null, "reset=true")
-		update_chat_position()
 		nuke_chat()
 
 /client/verb/info_storyteller()
@@ -51,4 +50,3 @@
 		to_chat(src, "<b>Current Storyteller:</b> N/A")
 	else
 		to_chat(src, "<b>Current Storyteller:</b> [SSstoryteller.character.name] - [SSstoryteller.character.desc]")
-

--- a/code/modules/client/client_procs.dm
+++ b/code/modules/client/client_procs.dm
@@ -468,53 +468,6 @@
 	if(world.byond_version >= 511 && byond_version >= 511 && client_fps >= CLIENT_MIN_FPS && client_fps <= CLIENT_MAX_FPS)
 		fps = client_fps
 
-/client/proc/update_chat_position(use_alternative)
-	var/input_height = 0
-	var/mode = get_preference_value(/datum/client_preference/chat_position)
-	var/currently_alternative = (winget(src, "input", "is-default") == "false") ? TRUE : FALSE
-
-	// Hell
-	if(mode == GLOB.PREF_YES && !currently_alternative)
-		input_height = winget(src, "input", "size")
-		input_height = text2num(splittext(input_height, "x")[2])
-
-		winset(src, "input_alt", "is-visible=true;is-disabled=false;is-default=true")
-		winset(src, "hotkey_toggle_alt", "is-visible=true;is-disabled=false;is-default=true")
-		winset(src, "saybutton_alt", "is-visible=true;is-disabled=false;is-default=true")
-
-		winset(src, "input", "is-visible=false;is-disabled=true;is-default=false")
-		winset(src, "hotkey_toggle", "is-visible=false;is-disabled=true;is-default=false")
-		winset(src, "saybutton", "is-visible=false;is-disabled=true;is-default=false")
-
-		var/current_size = splittext(winget(src, "outputwindow.output", "size"), "x")
-		var/new_size = "[current_size[1]]x[text2num(current_size[2]) - input_height]"
-		winset(src, "outputwindow.output", "size=[new_size]")
-		winset(src, "outputwindow.browseroutput", "size=[new_size]")
-
-		current_size = splittext(winget(src, "mainwindow.mainvsplit", "size"), "x")
-		new_size = "[current_size[1]]x[text2num(current_size[2]) + input_height]"
-		winset(src, "mainwindow.mainvsplit", "size=[new_size]")
-	else if(mode == GLOB.PREF_NO && currently_alternative)
-		input_height = winget(src, "input_alt", "size")
-		input_height = text2num(splittext(input_height, "x")[2])
-
-		winset(src, "input_alt", "is-visible=false;is-disabled=true;is-default=false")
-		winset(src, "hotkey_toggle_alt", "is-visible=false;is-disabled=true;is-default=false")
-		winset(src, "saybutton_alt", "is-visible=false;is-disabled=true;is-default=false")
-
-		winset(src, "input", "is-visible=true;is-disabled=false;is-default=true")
-		winset(src, "hotkey_toggle", "is-visible=true;is-disabled=false;is-default=true")
-		winset(src, "saybutton", "is-visible=true;is-disabled=false;is-default=true")
-
-		var/current_size = splittext(winget(src, "outputwindow.output", "size"), "x")
-		var/new_size = "[current_size[1]]x[text2num(current_size[2]) + input_height]"
-		winset(src, "outputwindow.output", "size=[new_size]")
-		winset(src, "outputwindow.browseroutput", "size=[new_size]")
-
-		current_size = splittext(winget(src, "mainwindow.mainvsplit", "size"), "x")
-		new_size = "[current_size[1]]x[text2num(current_size[2]) - input_height]"
-		winset(src, "mainwindow.mainvsplit", "size=[new_size]")
-
 /client/proc/toggle_fullscreen(new_value)
 	if((new_value == GLOB.PREF_BASIC) || (new_value == GLOB.PREF_FULL))
 		winset(src, "mainwindow", "is-maximized=false;can-resize=false;titlebar=false")

--- a/code/modules/client/preference_setup/global/preferences.dm
+++ b/code/modules/client/preference_setup/global/preferences.dm
@@ -10,6 +10,15 @@ GLOBAL_VAR_CONST(PREF_SHOW, "Show")
 GLOBAL_VAR_CONST(PREF_HIDE, "Hide")
 GLOBAL_VAR_CONST(PREF_FANCY, "Fancy")
 GLOBAL_VAR_CONST(PREF_PLAIN, "Plain")
+GLOBAL_VAR_CONST(PREF_STRETCH, "Stretch to Fit")
+GLOBAL_VAR_CONST(PREF_X1, "x1")
+GLOBAL_VAR_CONST(PREF_X15, "x1.5")
+GLOBAL_VAR_CONST(PREF_X2, "x2")
+GLOBAL_VAR_CONST(PREF_X25, "x2.5")
+GLOBAL_VAR_CONST(PREF_X3, "x3")
+GLOBAL_VAR_CONST(PREF_NORMAL, "normal")
+GLOBAL_VAR_CONST(PREF_DISTORT, "distort")
+GLOBAL_VAR_CONST(PREF_BLUR, "blur")
 GLOBAL_VAR_CONST(PREF_PRIMARY, "Primary")
 GLOBAL_VAR_CONST(PREF_ALL, "All")
 GLOBAL_VAR_CONST(PREF_OFF, "Off")
@@ -304,6 +313,25 @@ var/global/list/_client_preferences_by_type
 	if(preference_mob?.client)
 		var/atom/movable/renderer/R = preference_mob.renderers[GAME_RENDERER]
 		R.GraphicsUpdate()
+
+/datum/client_preference/pixel_size
+	description = "Pixel Size"
+	key = "PIXEL_SIZE"
+	category = PREF_CATEGORY_GRAPHICS
+	options = list(GLOB.PREF_STRETCH, GLOB.PREF_X1, GLOB.PREF_X15, GLOB.PREF_X2, GLOB.PREF_X25, GLOB.PREF_X3)
+
+/datum/client_preference/pixel_size/changed(mob/preference_mob, new_value)
+	winset(preference_mob, "mapwindow.map", "zoom=[max(0, options.Find(new_value) - 1)]")
+
+/datum/client_preference/scaling_method
+	description = "Scaling Method"
+	key = "SCALING_METHOD"
+	category = PREF_CATEGORY_GRAPHICS
+	options = list(GLOB.PREF_NORMAL, GLOB.PREF_DISTORT, GLOB.PREF_BLUR)
+	default_value = GLOB.PREF_NORMAL
+
+/datum/client_preference/scaling_method/changed(mob/preference_mob, new_value)
+	winset(preference_mob, "mapwindow.map", "zoom-mode=[lowertext(new_value)]")
 
 /datum/client_preference/fullscreen_mode
 	description = "Fullscreen Mode"

--- a/code/modules/client/preference_setup/global/preferences.dm
+++ b/code/modules/client/preference_setup/global/preferences.dm
@@ -16,9 +16,9 @@ GLOBAL_VAR_CONST(PREF_X15, "x1.5")
 GLOBAL_VAR_CONST(PREF_X2, "x2")
 GLOBAL_VAR_CONST(PREF_X25, "x2.5")
 GLOBAL_VAR_CONST(PREF_X3, "x3")
-GLOBAL_VAR_CONST(PREF_NORMAL, "normal")
-GLOBAL_VAR_CONST(PREF_DISTORT, "distort")
-GLOBAL_VAR_CONST(PREF_BLUR, "blur")
+GLOBAL_VAR_CONST(PREF_NORMAL, "Normal")
+GLOBAL_VAR_CONST(PREF_DISTORT, "Distort")
+GLOBAL_VAR_CONST(PREF_BLUR, "Blur")
 GLOBAL_VAR_CONST(PREF_PRIMARY, "Primary")
 GLOBAL_VAR_CONST(PREF_ALL, "All")
 GLOBAL_VAR_CONST(PREF_OFF, "Off")
@@ -319,6 +319,7 @@ var/global/list/_client_preferences_by_type
 	key = "PIXEL_SIZE"
 	category = PREF_CATEGORY_GRAPHICS
 	options = list(GLOB.PREF_STRETCH, GLOB.PREF_X1, GLOB.PREF_X15, GLOB.PREF_X2, GLOB.PREF_X25, GLOB.PREF_X3)
+	default_value = GLOB.PREF_STRETCH
 
 /datum/client_preference/pixel_size/changed(mob/preference_mob, new_value)
 	winset(preference_mob, "mapwindow.map", "zoom=[max(0, options.Find(new_value) - 1)]")

--- a/code/modules/client/preference_setup/global/preferences.dm
+++ b/code/modules/client/preference_setup/global/preferences.dm
@@ -316,16 +316,6 @@ var/global/list/_client_preferences_by_type
 	if(preference_mob.client)
 		preference_mob.client.toggle_fullscreen(new_value)
 
-/datum/client_preference/chat_position
-	description = "Use Alternative Chat Position"
-	key = "CHAT_ALT"
-	category = PREF_CATEGORY_UI
-	options = list(GLOB.PREF_NO, GLOB.PREF_YES)
-
-/datum/client_preference/chat_position/changed(mob/preference_mob, new_value)
-	if(preference_mob.client)
-		preference_mob.client.update_chat_position()
-
 /datum/client_preference/cinema_credits
 	description = "Show Cinema-like Credits At Round-end"
 	key = "SHOW_CREDITS"

--- a/code/modules/client/preferences.dm
+++ b/code/modules/client/preferences.dm
@@ -475,6 +475,13 @@ datum/preferences/proc/clear_character_previews()
 
 	client.apply_fps(clientfps)
 
+	var/datum/client_preference/zoom_pref = get_client_preference_by_key("PIXEL_SIZE")
+	var/zoom = client.get_preference_value("PIXEL_SIZE")
+	winset(client, "mapwindow.map", "zoom=[max(0, zoom_pref.options.Find(zoom) - 1)]")
+
+	var/zoom_mode = client.get_preference_value("SCALING_METHOD")
+	winset(client, "mapwindow.map", "zoom-mode=[lowertext(zoom_mode)]")
+
 	if(client.get_preference_value(/datum/client_preference/fullscreen_mode) != GLOB.PREF_NO)
 		client.toggle_fullscreen(client.get_preference_value(/datum/client_preference/fullscreen_mode))
 

--- a/code/modules/client/preferences.dm
+++ b/code/modules/client/preferences.dm
@@ -474,7 +474,6 @@ datum/preferences/proc/clear_character_previews()
 	ASSERT(client)
 
 	client.apply_fps(clientfps)
-	client.update_chat_position(client.get_preference_value(/datum/client_preference/chat_position))
 
 	if(client.get_preference_value(/datum/client_preference/fullscreen_mode) != GLOB.PREF_NO)
 		client.toggle_fullscreen(client.get_preference_value(/datum/client_preference/fullscreen_mode))

--- a/interface/interface.dm
+++ b/interface/interface.dm
@@ -50,7 +50,7 @@
 	return
 
 /client/verb/bugreport()
-	set name = "In-game Bug Report"
+	set name = "Report Bug"
 	set desc = "Create bug report to developers."
 	set hidden = 1
 

--- a/interface/skin.dmf
+++ b/interface/skin.dmf
@@ -975,7 +975,7 @@ window "mainwindow"
 	elem "mainwindow"
 		type = MAIN
 		pos = 281,0
-		size = 640x440
+		size = 640x420
 		anchor1 = -1,-1
 		anchor2 = -1,-1
 		is-default = true
@@ -1001,39 +1001,6 @@ window "mainwindow"
 		saved-params = "splitter"
 		right = "infowindow"
 		is-vert = true
-	elem "input"
-		type = INPUT
-		pos = 3,420
-		size = 517x20
-		anchor1 = 0,100
-		anchor2 = 100,100
-		background-color = #d3b5b5
-		is-default = true
-		border = sunken
-		saved-params = "command"
-		on-focus = ".add_speech_bubble"
-		on-blur = ".remove_speech_bubble"
-	elem "saybutton"
-		type = BUTTON
-		pos = 520,420
-		size = 40x20
-		anchor1 = 100,100
-		anchor2 = -1,-1
-		saved-params = "is-checked"
-		text = "Chat"
-		command = ".winset \"saybutton.is-checked=true?input.command=\"!Say \\\"\" macrobutton.is-checked=false:input.command=\""
-		button-type = pushbox
-	elem "hotkey_toggle"
-		type = BUTTON
-		pos = 560,420
-		size = 80x20
-		anchor1 = 100,100
-		anchor2 = -1,-1
-		saved-params = ""
-		text = "Hotkey Toggle"
-		command = ".winset \"mainwindow.macro!=macro ? mainwindow.macro=macro hotkey_toggle.is-checked=false input.focus=true : mainwindow.macro=hotkeymode hotkey_toggle.is-checked=true mapwindow.map.focus=true\""
-		button-type = pushbox
-
 
 window "mapwindow"
 	elem "mapwindow"
@@ -1076,10 +1043,11 @@ window "mapwindow"
 window "outputwindow"
 	elem "outputwindow"
 		type = MAIN
-		pos = 281,0
+		pos = 291,13
 		size = 640x480
-		anchor1 = none
-		anchor2 = none
+		anchor1 = -1,-1
+		anchor2 = -1,-1
+		background-color = none
 		saved-params = "pos;size;is-minimized;is-maximized"
 		titlebar = false
 		statusbar = false
@@ -1090,7 +1058,7 @@ window "outputwindow"
 	elem "browseroutput"
 		type = BROWSER
 		pos = 0,0
-		size = 640x480
+		size = 640x451
 		anchor1 = 0,0
 		anchor2 = 100,100
 		background-color = #ffffff
@@ -1099,47 +1067,44 @@ window "outputwindow"
 	elem "output"
 		type = OUTPUT
 		pos = 0,0
-		size = 640x480
+		size = 640x451
 		anchor1 = 0,0
 		anchor2 = 100,100
 		is-default = true
 		saved-params = ""
-	elem "saybutton_alt"
-		type = BUTTON
-		pos = 519,460
-		size = 40x20
-		anchor1 = 100,100
-		anchor2 = -1,-1
-		is-visible = false
-		is-disabled = true
-		saved-params = "is-checked"
-		text = "Chat"
-		command = ".winset \"saybutton_alt.is-checked=true?input_alt.command=\"!say \\\"\" macrobutton.is-checked=false:input_alt.command=\""
-		button-type = pushbox
-	elem "input_alt"
+	elem "input"
 		type = INPUT
-		pos = 1,460
-		size = 517x20
+		pos = 2,455
+		size = 514x20
 		anchor1 = 0,100
 		anchor2 = 100,100
 		background-color = #d3b5b5
-		is-visible = false
-		is-disabled = true
+		is-default = true
 		border = sunken
 		saved-params = "command"
 		on-focus = ".add_speech_bubble"
 		on-blur = ".remove_speech_bubble"
-	elem "hotkey_toggle_alt"
+	elem "saybutton"
 		type = BUTTON
-		pos = 560,460
-		size = 80x20
+		pos = 518,455
+		size = 40x20
 		anchor1 = 100,100
 		anchor2 = -1,-1
-		is-visible = false
-		is-disabled = true
+		background-color = none
+		saved-params = "is-checked"
+		text = "Chat"
+		command = ".winset \"saybutton.is-checked=true?input.command=\"!say \\\"\" macrobutton.is-checked=false:input.command=\""
+		button-type = pushbox
+	elem "hotkey_toggle"
+		type = BUTTON
+		pos = 560,455
+		size = 78x20
+		anchor1 = 100,100
+		anchor2 = -1,-1
+		background-color = none
 		saved-params = ""
 		text = "Hotkey Toggle"
-		command = ".winset \"mainwindow.macro!=macro ? mainwindow.macro=macro hotkey_toggle_alt.is-checked=false input_alt.focus=true : mainwindow.macro=hotkeymode hotkey_toggle_alt.is-checked=true mapwindow.map.focus=true\""
+		command = ".winset \"mainwindow.macro!=macro ? mainwindow.macro=macro hotkey_toggle.is-checked=false input.focus=true : mainwindow.macro=hotkeymode hotkey_toggle.is-checked=true mapwindow.map.focus=true\""
 		button-type = pushbox
 
 

--- a/interface/skin.dmf
+++ b/interface/skin.dmf
@@ -902,58 +902,18 @@ menu "menu"
 		category = "&File"
 		saved-params = "is-checked"
 	elem
-		name = "&Icons"
+		name = "&Preferences"
 		command = ""
 		saved-params = "is-checked"
-	elem "stretch"
-		name = "&Stretch to fit"
-		command = ".winset \"mapwindow.map.icon-size=0\""
-		category = "&Icons"
-		is-checked = true
-		can-check = true
-		group = "size"
+	elem
+		name = "&Game Settings"
+		command = "settings"
+		category = "&Preferences"
 		saved-params = "is-checked"
-	elem "icon128"
-		name = "&128x128"
-		command = ".winset \"mapwindow.map.icon-size=128\""
-		category = "&Icons"
-		can-check = true
-		group = "size"
-		saved-params = "is-checked"
-	elem "icon96"
-		name = "&96x96"
-		command = ".winset \"mapwindow.map.icon-size=96\""
-		category = "&Icons"
-		can-check = true
-		group = "size"
-		saved-params = "is-checked"
-	elem "icon64"
-		name = "&64x64"
-		command = ".winset \"mapwindow.map.icon-size=64\""
-		category = "&Icons"
-		can-check = true
-		group = "size"
-		saved-params = "is-checked"
-	elem "icon48"
-		name = "&48x48"
-		command = ".winset \"mapwindow.map.icon-size=48\""
-		category = "&Icons"
-		can-check = true
-		group = "size"
-		saved-params = "is-checked"
-	elem "icon32"
-		name = "&32x32"
-		command = ".winset \"mapwindow.map.icon-size=32\""
-		category = "&Icons"
-		can-check = true
-		group = "size"
-		saved-params = "is-checked"
-	elem "zoommode"
-		name = "&Smooth scaling"
-		command = ".winset \"zoommode.is-checked=true?map.zoom-mode=normal:map.zoom-mode=distort\""
-		category = "&Icons"
-		is-checked = true
-		can-check = true
+	elem
+		name = "&Character Setup"
+		command = "character-setup"
+		category = "&Preferences"
 		saved-params = "is-checked"
 	elem
 		name = "&Help"

--- a/interface/skin.dmf
+++ b/interface/skin.dmf
@@ -1211,8 +1211,8 @@ window "infowindow"
 		anchor1 = 56,0
 		anchor2 = 67,0
 		saved-params = "is-checked"
-		text = "In-Game Bug Report"
-		command = "bug-report"
+		text = "Report Bug"
+		command = "report-bug"
 		group = "rpanemode"
 	elem "changelog"
 		type = BUTTON


### PR DESCRIPTION
- На дворе шел двадцать четвертый год, а поля для ввода текста все еще занимали больше пятидесяти процентов игрового окна. Поле ввода перенесено под чат, добавлены отступы(!!!), альтернативная позиция победила и убила свою соперницу.
- В скин добавлены шорткаты для открытия **НОВОГО** меню настроек и редактора персонажа, больше никакого поиска нужной опции во вкладке "OOC".
- Настройки апскейлинга и приближения переехали в нормальные настройки.

![Пикча](https://github.com/ChaoticOnyx/OnyxBay/assets/137328283/1cd6a853-a6c9-4ba8-bc85-f4bf54b3b089)


<details>
<summary>Чейнджлог</summary>

```yml
🆑
tweak: Настройки зума и апскейлинга перенесены из верхнего меню в меню настроек.
rscdel: Окно игры стало еще больше: удалена нижняя позиция чата.
rscadd: Ввод перенесен под чат, добавлены эстетичные отступы от краев и между элементами.
rscadd: Добавлено больше опций в настройку апскейлинга, на выбор предлагаются следующие варианты: нормальный, ближайший сосед, размытие.
/🆑
```

</details>

- [x] Pull Request полностью завершен, мне не нужна помощь чтобы его закончить.
- [x] Я внимательно прочитал все свои изменения и багов в них не нашел.
- [x] Я запускал сервер со своими изменениями локально и все протестировал.
- [x] Я ознакомился c [Guide to Contribute](https://github.com/ChaoticOnyx/OnyxBay/blob/dev/docs/contributing.md).
