### PR TITLE
Removes lack of chat flooding

### DIFF
--- a/code/datums/surgery/steps/generic.dm
+++ b/code/datums/surgery/steps/generic.dm
@@ -51,7 +51,7 @@
 		return .
 
 	if(!parent_organ.get_incision(TRUE))
-		target.show_splash_text(user, "no incisions that can be closed cleanly!")
+		target.show_splash_text(user, "no incisions that can be closed cleanly!", "There are no incisions that can be closed cleanly!")
 		return SURGERY_FAILURE
 
 	if(parent_organ.is_stump())

--- a/code/datums/surgery/steps/implant.dm
+++ b/code/datums/surgery/steps/implant.dm
@@ -136,7 +136,7 @@
 		max_volume -= O.get_storage_cost()
 
 	if(tool.get_storage_cost() > max_volume || parent_organ.cavity_max_w_class < tool.w_class)
-		target.show_splash_text(user, "tool is too big!")
+		target.show_splash_text(user, "tool is too big!", "\The [tool] is too big to fit inside!")
 		return SURGERY_FAILURE
 
 	var/total_volume = tool.get_storage_cost()
@@ -147,7 +147,7 @@
 		total_volume += I.get_storage_cost()
 
 	if(total_volume > max_volume)
-		target.show_splash_text(user, "not enough space!")
+		target.show_splash_text(user, "not enough space!", "There's not enough space!")
 		return FALSE
 
 	return TRUE

--- a/code/datums/surgery/steps/internal.dm
+++ b/code/datums/surgery/steps/internal.dm
@@ -239,27 +239,27 @@
 		return FALSE
 
 	if(BP_IS_ROBOTIC(parent_organ) && !BP_IS_ROBOTIC(target_organ))
-		target.show_splash_text(user, "organic organ can't be connected to a robotic body!")
+		target.show_splash_text(user, "organic organ can't be connected to a robotic body!", "An organic organ can't be connected to a robotic body!")
 		return SURGERY_FAILURE
 
 	if(!target.species)
 		CRASH("Target ([target]) of surgery [type] has no species!")
 
 	if(target_organ.organ_tag == BP_POSIBRAIN && !target.species.has_organ[BP_POSIBRAIN])
-		target.show_splash_text(user, "this type of body isn't supported!")
+		target.show_splash_text(user, "this type of body isn't supported!", "This type of body isn't supported!")
 		return SURGERY_FAILURE
 
 	if(target_organ.damage > (target_organ.max_damage * 0.75))
-		target.show_splash_text(user, "organ is too damaged!")
+		target.show_splash_text(user, "organ is too damaged!", "The organ is too damaged!")
 		return SURGERY_FAILURE
 
 	if(target_organ.w_class > parent_organ.cavity_max_w_class)
-		target.show_splash_text(user, "organ won't fit inside!")
+		target.show_splash_text(user, "organ won't fit inside!", "The organ won't fit inside!")
 		return SURGERY_FAILURE
 
 	var/obj/item/organ/internal/O = target.internal_organs_by_name[target_organ.organ_tag]
 	if(O && (O.parent_organ == parent_organ.organ_tag || istype(target_organ, /obj/item/organ/internal/stack)))
-		target.show_splash_text(user, "stack is already present!")
+		target.show_splash_text(user, "stack is already present!", "There's already a stack present!")
 		return SURGERY_FAILURE
 
 	var/used_volume = 0
@@ -271,7 +271,7 @@
 	for(var/obj/item/I in parent_organ.internal_organs)
 		used_volume += I.get_storage_cost()
 	if((base_storage_capacity(parent_organ.cavity_max_w_class) + parent_organ.internal_organs_size) < used_volume + target_organ.get_storage_cost())
-		target.show_splash_text(user, "not enough space!")
+		target.show_splash_text(user, "not enough space!", "There's not enough space!")
 		return SURGERY_FAILURE
 
 	return TRUE
@@ -369,7 +369,7 @@
 		return FALSE
 
 	if(!target_organ.can_recover())
-		target.show_splash_text(user, "organ is damaged beyond recover!")
+		target.show_splash_text(user, "organ is damaged beyond recover!", "The organ is damaged beyond recover!")
 		return SURGERY_FAILURE
 
 	return !!target_organ.damage
@@ -394,11 +394,11 @@
 		return FALSE
 
 	if(!. && !organ_fixer.emagged)
-		target.show_splash_text(user, "organ doesn't require any healing!")
+		target.show_splash_text(user, "organ doesn't require any healing!", "The organ doesn't require any healing!!")
 		return SURGERY_FAILURE
 
 	if(organ_fixer.gel_amt == 0)
-		target.show_splash_text(user, "not enough gel!")
+		target.show_splash_text(user, "not enough gel!", "There's not enough somatic gel!")
 		return SURGERY_FAILURE
 
 	return TRUE
@@ -491,7 +491,7 @@
 
 	var/obj/item/stack/medical/M = tool
 	if(M.amount < 1)
-		target.show_splash_text(user, "not enough medicine to complete this step!")
+		target.show_splash_text(user, "not enough medicine to complete this step!", "There's not enough medicine to complete this step!")
 		return SURGERY_FAILURE
 
 	return TRUE
@@ -574,7 +574,7 @@
 		return FALSE
 
 	if(organ_fixer.gel_amt == 0)
-		target.show_splash_text(user, "not enough gel!")
+		target.show_splash_text(user, "not enough gel!", "There's not enough somatic gel!")
 		return SURGERY_FAILURE
 
 	for(var/obj/item/organ/internal/I in parent_organ.internal_organs)
@@ -720,7 +720,7 @@
 		return FALSE
 
 	if(!target_organ.can_recover() && istype(target_organ, /obj/item/organ/internal/cerebrum/brain))
-		target.show_splash_text(user, "organ is damaged beyond recover!")
+		target.show_splash_text(user, "organ is damaged beyond recover!", "The organ is damaged beyond recover!")
 		return SURGERY_FAILURE
 
 	return TRUE

--- a/code/datums/surgery/steps/limb.dm
+++ b/code/datums/surgery/steps/limb.dm
@@ -35,11 +35,11 @@
 
 	var/obj/item/organ/external/P = target.get_organ(E.parent_organ)
 	if(isnull(P) || P.is_stump())
-		target.show_splash_text(user, "limb is already present!")
+		target.show_splash_text(user, "limb is already present!", "There's already a limb present!")
 		return SURGERY_FAILURE
 
 	if(BP_IS_ROBOTIC(P) && !BP_IS_ROBOTIC(E))
-		target.show_splash_text(user, "organic limb can't be connected to a robotic body!")
+		target.show_splash_text(user, "organic limb can't be connected to a robotic body!", "An organic limb can't be connected to a robotic body!")
 		return SURGERY_FAILURE
 
 	return !isnull(target.species.has_limbs["[E.organ_tag]"])
@@ -216,7 +216,7 @@
 		return
 
 	if(parent_organ.open())
-		target.show_splash_text(user, "can't get a clean cut due to present incisions!")
+		target.show_splash_text(user, "can't get a clean cut due to present incisions!", "You can't get a clean cut due to present incisions!")
 		return SURGERY_FAILURE
 
 	return parent_organ.limb_flags & ORGAN_FLAG_CAN_AMPUTATE

--- a/code/datums/surgery/steps/robotic.dm
+++ b/code/datums/surgery/steps/robotic.dm
@@ -229,7 +229,7 @@
 		return FALSE
 
 	if(!C.use(3))
-		target.show_splash_text(user, "not enough coil length!")
+		target.show_splash_text(user, "not enough coil length!", "Not enought coil length to repair!")
 		return SURGERY_FAILURE
 
 	return TRUE

--- a/code/game/machinery/OpTable.dm
+++ b/code/game/machinery/OpTable.dm
@@ -118,7 +118,7 @@
 		return
 
 	if(inoperable(MAINT))
-		show_splash_text(usr, "no power!")
+		show_splash_text(usr, "no power!", "\The [src] is unpowered!")
 		return
 
 	var/mob/living/carbon/human/patient = victim_ref?.resolve()
@@ -210,11 +210,11 @@
 /obj/machinery/optable/proc/check_table(mob/living/carbon/patient)
 	var/mob/living/carbon/human/occupant = victim_ref?.resolve()
 	if(istype(occupant) && get_turf(occupant) == get_turf(src) && occupant.lying)
-		show_splash_text(usr, "already occupied!")
+		show_splash_text(usr, "already occupied!", "\The [src] is already occupied!")
 		return FALSE
 
 	if(patient.buckled)
-		show_splash_text(usr, "unbuckle the patient first!")
+		show_splash_text(usr, "unbuckle the patient first!", "You must unbuckle [patient] first!")
 		return FALSE
 
 	return TRUE

--- a/code/game/machinery/doors/firedoor_assembly.dm
+++ b/code/game/machinery/doors/firedoor_assembly.dm
@@ -81,7 +81,7 @@
 /obj/structure/firelock_frame/rcd_act(mob/user, obj/item/construction/rcd/the_rcd, list/rcd_data)
 	switch(rcd_data["[RCD_DESIGN_MODE]"])
 		if(RCD_UPGRADE_SIMPLE_CIRCUITS)
-			show_splash_text(user, "circuit installed")
+			show_splash_text(user, "circuit installed", SPAN("notice", "You install the circuit into \the [src]!"))
 			new /obj/machinery/door/firedoor(get_turf(src))
 			qdel_self()
 			return TRUE

--- a/code/game/machinery/fire_alarm.dm
+++ b/code/game/machinery/fire_alarm.dm
@@ -325,7 +325,7 @@ Just a object used in constructing fire alarms
 /obj/machinery/firealarm/rcd_act(mob/user, obj/item/construction/rcd/the_rcd, list/rcd_data)
 	switch(rcd_data["[RCD_DESIGN_MODE]"])
 		if(RCD_WALLFRAME)
-			show_splash_text(user, "circuit installed")
+			show_splash_text(user, "circuit installed", SPAN("notice", "You install the circuit into \the [src]!"))
 			buildstage = FIREALARM_NOWIRES
 			update_icon()
 			return TRUE

--- a/code/game/machinery/floor_light.dm
+++ b/code/game/machinery/floor_light.dm
@@ -108,7 +108,7 @@
 			var/new_color = show_radial_menu(user, src, colors, require_near = TRUE)
 			if(new_color)
 				colour = new_color
-				show_splash_text_to_viewers("color changed")
+				show_splash_text_to_viewers("color changed", force_skip_chat = TRUE)
 				update_icon()
 		if("paste")
 			var/obj/item/I = user.get_active_item()
@@ -121,7 +121,7 @@
 				show_splash_text(user, "settings copied")
 		if("invert")
 			inverted = !inverted
-			show_splash_text_to_viewers("lights inverted")
+			show_splash_text_to_viewers("lights inverted", force_skip_chat = TRUE)
 			update_icon()
 		if("slow")
 			glow_mode = GLOW_SLOW
@@ -157,7 +157,7 @@
 	colour = FL.colour
 	inverted = FL.inverted
 	glow_mode = FL.glow_mode
-	show_splash_text_to_viewers("new settings applied.")
+	show_splash_text_to_viewers("new settings applied", force_skip_chat = TRUE)
 
 
 /obj/machinery/floor_light/attack_hand(mob/user)
@@ -171,17 +171,16 @@
 
 /obj/machinery/floor_light/proc/toggle(mob/user)
 	if(!anchored)
-		show_splash_text(user, "must be screwed down first!")
+		show_splash_text(user, "must be screwed down first!", "\The [src] must be screwed down first!")
 		return
 
 	if(stat & BROKEN)
-		show_splash_text(user, "too damaged to be used!")
+		show_splash_text(user, "too damaged to be used!", "\The [src] is too damaged to be used!")
 		return
 
 	on = !on
 	update_icon()
 	update_use_power(on ? POWER_USE_ACTIVE : POWER_USE_OFF)
-	show_splash_text_to_viewers("turned [on ? "on" : "off"]")
 
 
 /obj/machinery/floor_light/ex_act(severity)

--- a/code/game/machinery/secsmith.dm
+++ b/code/game/machinery/secsmith.dm
@@ -28,24 +28,24 @@
 /obj/machinery/secsmith/attackby(obj/item/I, mob/user)
 	if(istype(I, /obj/item/gun/energy/security))
 		if(taser)
-			show_splash_text(user, "already contains a taser!")
+			show_splash_text(user, "already contains a taser!", "[src] already contains a taser!")
 			return
 
 		if(!user.drop(I, src))
 			return
 
-		show_splash_text(user, "taser inserted!")
+		show_splash_text(user, "taser inserted!", "You insert \the [I] into [src].")
 		taser = I
 		update_icon()
 		tgui_update()
 		return
 
 	else if(istype(I, /obj/item/gun/energy/classictaser))
-		show_splash_text(user, "taser not supported!")
+		show_splash_text(user, "taser not supported!", "\The [I]'s model is outdated, and not supported by [src].")
 		return
 
 	else if(istype(I, /obj/item/gun))
-		show_splash_text(user, "gun not supported!")
+		show_splash_text(user, "gun not supported!", "[src] is not suited for this type of weapon.")
 		return
 
 	..()

--- a/code/game/objects/items/devices/megaphone.dm
+++ b/code/game/objects/items/devices/megaphone.dm
@@ -34,7 +34,7 @@ GLOBAL_LIST_INIT(megaphone_insults, world.file2list("config/translation/megaphon
 
 
 /obj/item/device/megaphone/attack_self(mob/living/user)
-	show_splash_text(user, "toggled [active ? "off" : "on"]")
+	show_splash_text(user, "toggled [active ? "off" : "on"]", "You toggle \the [src] [active ? "off" : "on"].")
 	active = !active
 	update_icon()
 
@@ -47,7 +47,7 @@ GLOBAL_LIST_INIT(megaphone_insults, world.file2list("config/translation/megaphon
 		return
 
 	if(world.time <= last_use + MEGAPHONE_COOLDOWN)
-		show_splash_text(loc, "needs to recharge!")
+		show_splash_text(loc, "needs to recharge!", "\The [src] needs to recharge!")
 		return
 
 	_speak(M, capitalize(text), speaking)
@@ -73,7 +73,7 @@ GLOBAL_LIST_INIT(megaphone_insults, world.file2list("config/translation/megaphon
 	if(emagged)
 		return FALSE
 
-	show_splash_text(user, "overload voice synthesizer!")
+	show_splash_text(user, "overload voice synthesizer!", "You overload the voice synthesizer, setting the loudness setting way above the safe levels.")
 	emagged = TRUE
 	return TRUE
 

--- a/code/game/objects/items/devices/radio/intercom.dm
+++ b/code/game/objects/items/devices/radio/intercom.dm
@@ -177,10 +177,10 @@
 
 /obj/item/device/radio/intercom/proc/unscrew_frame(mob/user)
 	playsound(loc, 'sound/items/Screwdriver.ogg', 100, 1)
-	show_splash_text(user, "unscrewing...")
+	show_splash_text(user, "unscrewing...", "Now unscrewing \the [src]...")
 
 	if(do_after(user, 40, src))
-		show_splash_text(user, "unscrewed!")
+		show_splash_text(user, "unscrewed!", SPAN("notice", "You have unscrewed \the [src]!"))
 		new /obj/item/intercom_assembly(loc, dir, src)
 		qdel(src)
 

--- a/code/game/objects/items/devices/radio/intercom_frame.dm
+++ b/code/game/objects/items/devices/radio/intercom_frame.dm
@@ -90,28 +90,28 @@
 
 /obj/item/intercom_assembly/proc/add_cable(obj/item/stack/cable_coil/C, mob/user)
 	if(C.get_amount() < 1)
-		show_splash_text(user, "need more coil!")
+		show_splash_text(user, "need more coil!", SPAN("warning", "You need more cable to wire \the [src]!"))
 		return
 
-	show_splash_text(user, "wiring...")
+	show_splash_text(user, "wiring...", "Now wiring \the [src]...")
 	if(do_after(user, 40, src))
 		if(C.use(1))
-			show_splash_text(user, "wired!")
+			show_splash_text(user, "wired!", SPAN("notice", "You have wired \the [src]!"))
 			buildstage = INTERCOM_WIRED
 			update_icon()
 
 /obj/item/intercom_assembly/proc/remove_cable(mob/user)
 	playsound(loc, 'sound/items/Wirecutter.ogg', 100, 1)
-	show_splash_text(user, "cutting cable...")
+	show_splash_text(user, "cutting cable...", "Now cutting cable out of \the [src]...")
 
 	if(do_after(user, 40, src))
-		show_splash_text(user, "cut out!")
+		show_splash_text(user, "cut out!", SPAN("notice", "You have cut the cable out of \the [src]!"))
 		new /obj/item/stack/cable_coil(loc, 1)
 		buildstage = INTERCOM_EMPTY
 		update_icon()
 
 /obj/item/intercom_assembly/proc/deconstruct_frame(obj/item/weldingtool/WT, mob/user)
-	show_splash_text(user, "dissasembling...")
+	show_splash_text(user, "dissasembling...", "Now dissasembling \the [src]...")
 	if(!WT.use_tool(src, user, delay = 4 SECONDS, amount = 5))
 		return
 
@@ -123,33 +123,33 @@
 
 /obj/item/intercom_assembly/proc/add_radio(obj/item/device/radio/R, mob/user)
 	playsound(loc, 'sound/items/Screwdriver.ogg', 100, 1)
-	show_splash_text(user, "installing radio...")
+	show_splash_text(user, "installing radio...", "Now installing the radio into \the [src]...")
 
 	if(do_after(user, 40, src))
 		if(!user.drop(R, src))
 			return
 
-		show_splash_text(user, "installed!")
+		show_splash_text(user, "installed!", SPAN("notice", "You have installed the radio into \the [src]!"))
 		qdel(R)
 		buildstage = INTERCOM_RADIO
 		update_icon()
 
 /obj/item/intercom_assembly/proc/eject_radio(mob/user)
 	playsound(loc, 'sound/items/Crowbar.ogg', 50, 1)
-	show_splash_text(user, "removing radio...")
+	show_splash_text(user, "removing radio...", "Now removing the radio from \the [src]...")
 
 	if(do_after(user, 40, src))
-		show_splash_text(user, "removed radio!")
+		show_splash_text(user, "removed radio!", SPAN("notice", "You have removed the radio from \the [src]!"))
 		new /obj/item/device/radio(user.loc, 1)
 		buildstage = INTERCOM_WIRED
 		update_icon()
 
 /obj/item/intercom_assembly/proc/finish_frame(mob/user)
 	playsound(loc, 'sound/items/Screwdriver.ogg', 100, 1)
-	show_splash_text(user, "finishing \the [src]...")
+	show_splash_text(user, "finishing \the [src]...", "Now finishing \the [src]...")
 
 	if(do_after(user, 40, src))
-		show_splash_text(user, "finished \the [src]!")
+		show_splash_text(user, "finished \the [src]!", SPAN("notice", "You have finished assembing \the [src]!"))
 		new /obj/item/device/radio/intercom(loc, dir)
 		qdel(src)
 

--- a/code/game/objects/items/storage/secure/_secure.dm
+++ b/code/game/objects/items/storage/secure/_secure.dm
@@ -66,11 +66,11 @@
 				return
 
 			open = !open
-			show_splash_text(user, "service panel [open ? "opened" : "closed"]")
+			show_splash_text(user, "service panel [open ? "opened" : "closed"]", "You [open ? "open" : "close"] \the [src] service panel.")
 			return
 
 		if(isMultitool(W) && open && !hacking)
-			show_splash_text(user, "resetting internal memory...")
+			show_splash_text(user, "resetting internal memory...", "You begin resetting \the [src] internal memory...")
 			hacking = TRUE
 			if(!do_after(usr, 100, src))
 				return
@@ -80,13 +80,13 @@
 
 			if(prob(40))
 				lock_setshort = TRUE
-				show_splash_text(user, "internal memory reset!")
+				show_splash_text(user, "internal memory reset!", SPAN("notice", "You reset \the [src] internal memory!"))
 				sleep(80)
 				lock_setshort = FALSE
 				hacking = FALSE
 				lock_code = null
 			else
-				show_splash_text(user, "unable to reset internal memory!")
+				show_splash_text(user, "unable to reset internal memory!", SPAN("warning", "You have failed to reset \the [src] internal memory!"))
 				hacking = FALSE
 				hacking = FALSE
 

--- a/code/game/objects/items/storage/secure/briefcase.dm
+++ b/code/game/objects/items/storage/secure/briefcase.dm
@@ -15,7 +15,7 @@
 
 /obj/item/storage/secure/briefcase/attack_hand(mob/user)
 	if(loc == user && locked)
-		show_splash_text(user, "locked!")
+		show_splash_text(user, "locked!", SPAN("warning", "\The [src] is locked!"))
 
 	else if(loc == user && !locked)
 		open(user)

--- a/code/game/objects/items/storage/secure/guncases.dm
+++ b/code/game/objects/items/storage/secure/guncases.dm
@@ -25,7 +25,7 @@
 
 /obj/item/storage/secure/guncase/attack_hand(mob/user)
 	if(loc == user && locked == 1)
-		show_splash_text(user, "locked!")
+		show_splash_text(user, "locked!", SPAN("warning", "\The [src] is locked!"))
 
 	else if(loc == user && !locked)
 		open(usr)
@@ -162,7 +162,7 @@
 
 /obj/item/storage/secure/guncase/detective/open(mob/user)
 	if(!guntype)
-		show_splash_text(user, "no gun selected!")
+		show_splash_text(user, "no gun selected!", SPAN("warning", "You must select a gun first!"))
 		return
 
 	if(!gunspawned)
@@ -211,11 +211,11 @@
 	var/obj/item/card/id/I = W.get_id_card()
 	if(istype(I))
 		if(!allowed(user))
-			show_splash_text(user, "access denied!")
+			show_splash_text(user, "access denied!", SPAN("warning", "\icon[src] Access Denied!"))
 			return
 
 		if(!guntype)
-			show_splash_text(user, "no gun selected!")
+			show_splash_text(user, "no gun selected!", SPAN("warning", "You must select a gun first!"))
 			return
 
 		if(!gunspawned)
@@ -224,7 +224,7 @@
 			for(var/obj/item/gun/energy/security/gun in contents)
 				gun.owner = I.registered_name
 
-		show_splash_text(user, "[locked ? "un" : ""]locked")
+		show_splash_text(user, "[locked ? "un" : ""]locked", SPAN("notice", "You [locked ? "un" : ""]lock \the [src]."))
 		locked = !locked
 		update_icon()
 		return

--- a/code/game/objects/items/tools/welding.dm
+++ b/code/game/objects/items/tools/welding.dm
@@ -347,11 +347,11 @@
 
 /obj/item/weldingtool/use_tool(atom/target, mob/living/user, delay = 0, amount = 0, volume = 0, can_move = FALSE, datum/callback/extra_checks)
 	if(!is_tool_on())
-		show_splash_text(user, "Welder must be turned on!")
+		show_splash_text(user, "Welder must be turned on!", "\The [src] must be turned on!")
 		return
 
 	if(amount > get_fuel())
-		show_splash_text(user, "Not enough fuel!")
+		show_splash_text(user, "Not enough fuel!", "\icon[src] Not enough fuel!")
 		return
 
 	playsound(loc, 'sound/items/Welder.ogg', 100, 1)
@@ -365,7 +365,7 @@
 /obj/item/weldingtool/use_tool_resources(amount, mob)
 	. = remove_fuel(amount, mob)
 	if(!.)
-		show_splash_text(mob, "Not enough fuel!")
+		show_splash_text(mob, "Not enough fuel!", "\icon[src] Not enough fuel!")
 
 /obj/item/weldingtool/proc/start_welding(atom/target) // Process of welding something
 	var/datum/effect/effect/system/spark_spread/spark = new /datum/effect/effect/system/spark_spread(volume = 10)

--- a/code/game/objects/structures/barricade/material.dm
+++ b/code/game/objects/structures/barricade/material.dm
@@ -57,15 +57,15 @@
 
 
 /obj/structure/barricade/material/proc/_deconstruct(mob/user)
-	show_splash_text(user, "starting deconstruction.")
+	show_splash_text(user, "starting deconstruction.", "You begin deconstructing <b>\the [src]</b>!")
 	if(do_after(user, 20, src))
-		show_splash_text(user, "barricade deconstucted.")
+		show_splash_text(user, "barricade deconstucted.", "You deconstruct <b>\the [src]</b>!")
 		playsound(loc, 'sound/items/Deconstruct.ogg', 50, 1)
 
 		_dismantle()
 		return
 
-	show_splash_text(user, "action interrupted!")
+	show_splash_text(user, "action interrupted!", "You must remain still while deconstructing!")
 
 
 /obj/structure/barricade/material/proc/_repair_damage(obj/item/stack/S, mob/user)
@@ -73,18 +73,18 @@
 		return
 
 	if(S.get_amount() < 1)
-		show_splash_text(user, "not enough material!")
+		show_splash_text(user, "not enough material!", "There's not enough [S] to repair <b>\the [src]</b>!")
 		return
 
-	show_splash_text(user, "starting repair.")
+	show_splash_text(user, "starting repair.", "You begin to repair <b>\the [src]</b>.")
 	if(do_after(user, 20, src) && damage != 0)
 		if(S.use(1))
 			damage = 0
 
-			show_splash_text(user, "repair finished.")
+			show_splash_text(user, "repair finished.", "You have repaired <b>\the [src]!</b>")
 			return
 
-	show_splash_text(user, "action interrupted!")
+	show_splash_text(user, "action interrupted!", "You must remain still while repairing!")
 
 
 /obj/structure/barricade/material/Break()

--- a/code/game/objects/structures/barricade/security.dm
+++ b/code/game/objects/structures/barricade/security.dm
@@ -71,7 +71,7 @@
 	anchored = locked
 
 	update_icon()
-	show_splash_text(user, "bolts [locked ? "dropped" : "lifted"].")
+	show_splash_text(user, "bolts [locked ? "dropped" : "lifted"].", "You [locked ? "drop" : "lift"] \the [src] bolts.")
 
 
 /obj/structure/barricade/security/proc/_repair_damage(mob/user, obj/item/weldingtool/WT)
@@ -88,7 +88,7 @@
 
 /obj/structure/barricade/security/wrench_floor_bolts(mob/user, delay)
 	if(locked)
-		show_splash_text(user, "bolts prevent wrenching!")
+		show_splash_text(user, "bolts prevent wrenching!", "\The [src] bolts prevent wrenching!")
 		return
 
 	return ..()
@@ -116,7 +116,7 @@
 	s.start()
 
 	playsound(src.loc, 'sound/effects/computer_emag.ogg', 25)
-	show_splash_text(user, "bolt locks broken!")
+	show_splash_text(user, "bolt locks broken!", "You burn out \the [src] bolt locks!")
 
 	return TRUE
 

--- a/code/game/objects/structures/door_assembly.dm
+++ b/code/game/objects/structures/door_assembly.dm
@@ -293,7 +293,7 @@
 	update_state()
 
 /obj/structure/door_assembly/proc/finish_door(user)
-	show_splash_text(user, "Door finished!")
+	show_splash_text(user, "Door finished!", SPAN("notice", "You have finished assembling the door!"))
 	var/path = get_finished_type()
 
 	if(!isnull(path))

--- a/code/game/objects/structures/extinguisher.dm
+++ b/code/game/objects/structures/extinguisher.dm
@@ -114,7 +114,7 @@
 	if(emagged)
 		return NO_EMAG_ACT
 
-	show_splash_text(user, "cabinet emagged!")
+	show_splash_text(user, "cabinet emagged!", "You hack \the [src] reagent fabricator!")
 	emagged = TRUE
 	return TRUE
 

--- a/code/game/objects/structures/mop_bucket.dm
+++ b/code/game/objects/structures/mop_bucket.dm
@@ -26,12 +26,12 @@
 /obj/structure/mopbucket/attackby(obj/item/I, mob/user)
 	if(istype(I, /obj/item/mop))
 		if(reagents.total_volume < 1)
-			show_splash_text(user, "no water!")
+			show_splash_text(user, "no water!", SPAN("warning", "\The [src] is empty!"))
 			return
 
 		else
 			reagents.trans_to_obj(I, 5)
-			show_splash_text(user, "you wet the mop!")
+			show_splash_text(user, "you wet the mop!", SPAN("notice", "You wet \the [I] in \the [src]."))
 			playsound(loc, 'sound/effects/slosh.ogg', 25, 1)
 			return
 
@@ -46,7 +46,7 @@
 			return
 
 		if(reagents.total_volume < 1)
-			show_splash_text(user, "no water!")
+			show_splash_text(user, "no water!", SPAN("warning", "\The [src] is empty!"))
 			return
 
 		user.visible_message(SPAN_DANGER("[user] starts to put [G.affecting.name]'s head into \the [src]!"), \
@@ -60,7 +60,7 @@
 		if(QDELETED(src) || !G?.affecting)
 			return
 
-		
+
 		user.visible_message(SPAN_DANGER("[user] finally raises [G.affecting.name]'s head out of \the [src]!"), \
 								SPAN_DANGER("You raise [G.affecting.name]'s head out of \the [src]!"))
 		reagents.trans_to(G.affecting, min(reagents.total_volume, 5))

--- a/code/game/objects/structures/plasticflaps.dm
+++ b/code/game/objects/structures/plasticflaps.dm
@@ -51,7 +51,7 @@
 /obj/structure/plasticflaps/attackby(obj/item/O, mob/user)
 	if(isWrench(O))
 		playsound(loc, 'sound/items/Ratchet.ogg', 100, 1)
-		show_splash_text(user, "deconstructing...")
+		show_splash_text(user, "deconstructing...", "You begin deconstructing <b>\the [src]</b>.")
 		if(do_after(user, 30, src))
 			new /obj/item/stack/material/plastic(loc, 5)
 			qdel(src)

--- a/code/game/objects/structures/roulette.dm
+++ b/code/game/objects/structures/roulette.dm
@@ -20,7 +20,7 @@
 
 /obj/structure/casino/roulette/attack_hand(mob/user)
 	if(spinning)
-		show_splash_text(user, "already spinning!")
+		show_splash_text(user, "already spinning!", "The roulette is already spinning!")
 		return
 
 	visible_message(SPAN("notice", "[user] spins \the [src] and throws a little ball inside!"))

--- a/code/game/objects/structures/watercloset.dm
+++ b/code/game/objects/structures/watercloset.dm
@@ -35,7 +35,7 @@
 
 	if(cistern && !lid_open)
 		if(!contents.len)
-			show_splash_text(user, "the cistern is empty!")
+			show_splash_text(user, "the cistern is empty!", SPAN("notice", "The cistern is empty."))
 			return
 		else
 			var/obj/item/I = pick(contents)
@@ -55,7 +55,7 @@
 
 /obj/structure/toilet/attackby(obj/item/I, mob/living/user)
 	if(isCrowbar(I))
-		show_splash_text(user, "[cistern? "replacing the lid" : "lifting the lid"]")
+		show_splash_text(user, "[cistern? "replacing the lid" : "lifting the lid"]", SPAN("notice", "You start to [cistern ? "replace the lid on the cistern" : "lift the lid off the cistern"]."))
 		playsound(loc, 'sound/effects/stonedoor_openclose.ogg', 50, 1)
 		if(!do_after(user, 3 SECONDS, src))
 			return
@@ -76,11 +76,11 @@
 			return
 
 		if(G.current_grab.state_name == NORM_PASSIVE)
-			show_splash_text(user, "tighter grip is needed!")
+			show_splash_text(user, "tighter grip is needed!", SPAN("warning", "You need a tigher grip!"))
 			return
 
 		if(get_turf(G.affecting) != get_turf(src))
-			show_splash_text(user, "victim needs to be on the toilet!")
+			show_splash_text(user, "victim needs to be on the toilet!", SPAN("warning", "The vicim must be held right above the toilet!"))
 
 		if(lid_open && !swirlie)
 			user.visible_message(SPAN_DANGER("[user] starts to give [G.affecting.name] a swirlie!"), \
@@ -110,17 +110,17 @@
 
 	if(cistern && !istype(user, /mob/living/silicon/robot)) //STOP PUTTING YOUR MODULES IN THE TOILET.
 		if(I.w_class > ITEM_SIZE_NORMAL)
-			show_splash_text(user, "won't fit!")
+			show_splash_text(user, "won't fit!", SPAN("notice", "\The [I] does not fit."))
 			return
 
 		if(w_items + I.w_class > 5)
-			show_splash_text(user, "cistern is full!")
+			show_splash_text(user, "cistern is full!", SPAN("notice", "The cistern is full."))
 			return
 
 		if(!user.drop(I, src))
 			return
 		w_items += I.w_class
-		show_splash_text(user, "item placed into the cistern")
+		show_splash_text(user, "item placed into the cistern", "You carefully place \the [I] into the cistern.")
 		return
 
 	return ..()

--- a/code/game/objects/structures/windoor_assembly.dm
+++ b/code/game/objects/structures/windoor_assembly.dm
@@ -222,7 +222,7 @@
 
 /obj/structure/windoor_assembly/proc/finish_door(mob/user)
 	set_density(TRUE)
-	show_splash_text(user, "Door finished!")
+	show_splash_text(user, "Door finished!", SPAN("notice", "You have finished assembling the door!"))
 
 	if(secure)
 		var/obj/machinery/door/window/brigdoor/windoor = new created_windoor_secure(get_turf(loc))

--- a/code/game/turfs/simulated/floor_acts.dm
+++ b/code/game/turfs/simulated/floor_acts.dm
@@ -166,7 +166,7 @@
 				for(var/obj/machinery/door/door in src)
 					if(istype(door, /obj/machinery/door/window))
 						continue
-					show_splash_text(user, "there's already a door!")
+					show_splash_text(user, "there's already a door!", "\icon[src] There's already a door!")
 					return FALSE
 
 				var/obj/structure/windoor_assembly/assembly = new (src, user.dir)
@@ -176,7 +176,7 @@
 				return TRUE
 
 			for(var/obj/machinery/door/door in src)
-				show_splash_text(user, "there's already a door!")
+				show_splash_text(user, "there's already a door!", "\icon[src] There's already a door!")
 				return FALSE
 
 			//create the assembly and let it finish itself
@@ -205,7 +205,7 @@
 
 		if(RCD_DECONSTRUCT)
 			if(rcd_proof)
-				show_splash_text(user, "it's too thick!")
+				show_splash_text(user, "it's too thick!", "\icon[src] It's too thick!")
 				return FALSE
 
 			dismantle_floor()

--- a/code/modules/atmospherics/components/binary_devices/pump.dm
+++ b/code/modules/atmospherics/components/binary_devices/pump.dm
@@ -54,7 +54,7 @@ Thus, the two variables affect pump operation are set in New():
 	if(!allowed(user))
 		return
 
-	show_splash_text(user, "toggled [use_power ? "off" : "on"]")
+	show_splash_text(user, "toggled [use_power ? "off" : "on"]", "You toggle \the [src] [use_power ? "off" : "on"].")
 	update_use_power(!use_power)
 	update_icon()
 
@@ -69,7 +69,7 @@ Thus, the two variables affect pump operation are set in New():
 		return
 
 	target_pressure = max_pressure_setting
-	show_splash_text(user, "target pressure set to [target_pressure] kPa")
+	show_splash_text(user, "target pressure set to [target_pressure] kPa", "You set the target pressure to <b>[target_pressure] kPa</b>.")
 
 /obj/machinery/atmospherics/binary/pump/on
 	icon_state = "map_on"

--- a/code/modules/client/preference_setup/global/preferences.dm
+++ b/code/modules/client/preference_setup/global/preferences.dm
@@ -43,6 +43,9 @@ GLOBAL_VAR_CONST(PREF_DARKNESS_VISIBLE, "Fully visible")
 GLOBAL_VAR_CONST(PREF_DARKNESS_MOSTLY_VISIBLE, "Mostly visible")
 GLOBAL_VAR_CONST(PREF_DARKNESS_BARELY_VISIBLE, "Barely visible")
 GLOBAL_VAR_CONST(PREF_DARKNESS_INVISIBLE, "Invisible")
+GLOBAL_VAR_CONST(PREF_SPLASH_MAPTEXT, "Maptext only")
+GLOBAL_VAR_CONST(PREF_SPLASH_CHAT, "Chat only")
+GLOBAL_VAR_CONST(PREF_SPLASH_BOTH, "Maptext and chat")
 
 var/global/list/_client_preferences
 var/global/list/_client_preferences_by_key
@@ -124,8 +127,8 @@ var/global/list/_client_preferences_by_type
 /datum/client_preference/splashes
 	description = "Show Splashes (Runechat-Like-Popups)"
 	key = "CHAT_SPLASHES"
-	default_value = GLOB.PREF_YES
-	options = list(GLOB.PREF_YES, GLOB.PREF_NO)
+	default_value = GLOB.PREF_SPLASH_BOTH
+	options = list(GLOB.PREF_SPLASH_BOTH, GLOB.PREF_SPLASH_MAPTEXT, GLOB.PREF_SPLASH_CHAT)
 
 /datum/client_preference/play_admin_midis
 	description ="Play admin midis"

--- a/code/modules/mining/machines/mineral.dm
+++ b/code/modules/mining/machines/mineral.dm
@@ -30,7 +30,7 @@
 
 /obj/machinery/mineral/attackby(obj/item/W, mob/user)
 	if(!(stat & POWEROFF))
-		show_splash_text(user, "turn off first!")
+		show_splash_text(user, "turn off first!", "You have to turn \the [src] off first!")
 		return
 
 	if(default_deconstruction_screwdriver(user, W))
@@ -104,7 +104,7 @@
 	if(istype(hhelper))
 		qdel(hhelper)
 
-	show_splash_text(usr, "holo-projector enabled.")
+	show_splash_text(usr, "holo-projector enabled.", "You toggle the holo-projector!")
 	holohelper = weakref(new holodir_helper_path(loc, src))
 
 /obj/machinery/mineral/power_change()

--- a/code/modules/mining/machines/processing.dm
+++ b/code/modules/mining/machines/processing.dm
@@ -39,7 +39,7 @@
 	if(response  == "Yes" && Adjacent(user))
 		var/obj/machinery/mineral/processing_unit/p_unit = locate_unit(/obj/machinery/mineral/processing_unit)
 		if(!p_unit)
-			show_splash_text(user, "no ore processing unit found!")
+			show_splash_text(user, "no ore processing unit found!", SPAN("warning", "\The [src] has failed to detect any ore stacking units!"))
 			return
 
 		p_unit.console_ref = weakref(src)

--- a/code/modules/mining/machines/stacking.dm
+++ b/code/modules/mining/machines/stacking.dm
@@ -32,7 +32,7 @@
 	if(response  == "Yes" && Adjacent(user))
 		var/obj/machinery/mineral/stacking_machine/s_machine = locate_unit(/obj/machinery/mineral/stacking_machine)
 		if(!s_machine)
-			show_splash_text(user, "no ore stacking units found!")
+			show_splash_text(user, "no ore stacking units found!", SPAN("warning", "\The [src] has failed to detect any ore stacking units!")
 			return
 
 		machine_ref = weakref(s_machine)

--- a/code/modules/mining/machines/stacking.dm
+++ b/code/modules/mining/machines/stacking.dm
@@ -32,7 +32,7 @@
 	if(response  == "Yes" && Adjacent(user))
 		var/obj/machinery/mineral/stacking_machine/s_machine = locate_unit(/obj/machinery/mineral/stacking_machine)
 		if(!s_machine)
-			show_splash_text(user, "no ore stacking units found!", SPAN("warning", "\The [src] has failed to detect any ore stacking units!")
+			show_splash_text(user, "no ore stacking units found!", SPAN("warning", "\The [src] has failed to detect any ore stacking units!"))
 			return
 
 		machine_ref = weakref(s_machine)

--- a/code/modules/mining/machines/unloading.dm
+++ b/code/modules/mining/machines/unloading.dm
@@ -38,7 +38,7 @@
 		return
 
 	toggle()
-	show_splash_text(user, "you toggle \the [src] [!(stat & POWEROFF) ? "on" : "off"].")
+	show_splash_text(user, "you toggle \the [src] [!(stat & POWEROFF) ? "on" : "off"].", "You toggle <b>\the [src]</b> [!(stat & POWEROFF) ? "on" : "off"].")
 
 /obj/machinery/mineral/unloading_machine/attackby(obj/item/W, mob/user)
 	..()

--- a/code/modules/mob/living/carbon/xenobiological/crossbreeding/reproductive.dm
+++ b/code/modules/mob/living/carbon/xenobiological/crossbreeding/reproductive.dm
@@ -20,18 +20,18 @@
 
 /obj/item/metroidcross/reproductive/attackby(obj/item/O, mob/user)
 	if((last_meal + DIGESTION_COOLDOWN) > world.time)
-		show_splash_text(user, "still digesting!")
+		show_splash_text(user, "still digesting!", "\The [src] is still digesting!")
 		return
 
 	if(istype(O, /obj/item/reagent_containers/food/monkeycube))
 		if(!_feed_extract(O))
 			return
-		show_splash_text(user, "cube was successfuly fed.")
+		show_splash_text(user, "cube was successfuly fed.", "You feed \the [src] with \the [O].")
 
 	if(istype(O, /obj/item/storage/xenobag))
 		if(!_feed_extracts_from_bag(O, user))
 			return
-		show_splash_text(user, "extract was successfuly fed from bag.")
+		show_splash_text(user, "extract was successfuly fed from bag.", "You feed \the [src] from \the [O].")
 
 	_reproduce()
 
@@ -72,7 +72,7 @@
 	if(meals_left > 0)
 		return
 
-	show_splash_text_to_viewers("starts to swell!")
+	show_splash_text_to_viewers("starts to swell!", "\The [src] starts to swell!")
 	meals_left = REPRODUCTIVE_EXTRACT_VOLUME
 	last_meal = world.time
 

--- a/code/modules/mob/organs/internal/man_machine_interface.dm
+++ b/code/modules/mob/organs/internal/man_machine_interface.dm
@@ -63,19 +63,19 @@ GLOBAL_LIST_INIT(whitelisted_mmi_species, list(
 		return
 
 	if(brainobj || brainmob?.key)
-		show_splash_text(user, "already has a brain inside!")
+		show_splash_text(user, "already has a brain inside!", "\The [src] already has a brain inside!")
 		return
 
 	if(new_brain.damage >= new_brain.max_damage)
-		show_splash_text(user, "brain is truly dead!")
+		show_splash_text(user, "brain is truly dead!", "The brain is truly dead!")
 		return
 
 	if(!new_brain.brainmob || !(new_brain.species?.name in GLOB.whitelisted_mmi_species))
-		show_splash_text(user, "won't fit into device!")
+		show_splash_text(user, "won't fit into device!", "The brain won't fit into \the [src]!")
 		return
 
 	_add_brain(new_brain, user)
-	show_splash_text(user, "brain inserted into device.")
+	show_splash_text(user, "brain inserted into device.", "You have inserted a brain into \the [src]!")
 	feedback_inc("cyborg_mmis_filled", 1)
 
 /obj/item/organ/internal/cerebrum/mmi/proc/try_access(mob/user)
@@ -83,11 +83,11 @@ GLOBAL_LIST_INIT(whitelisted_mmi_species, list(
 		return
 
 	if(!allowed(user))
-		show_splash_text(user, "access denied!")
+		show_splash_text(user, "access denied!", "\icon[src] Access Denied!")
 		return
 
 	if(isnull(brainobj))
-		show_splash_text(user, "no suitable brain to lock!")
+		show_splash_text(user, "no suitable brain to lock!", "There's no suitable brain to lock in \the [src]!")
 		return
 
 	locked = !locked
@@ -96,11 +96,11 @@ GLOBAL_LIST_INIT(whitelisted_mmi_species, list(
 
 /obj/item/organ/internal/cerebrum/mmi/attack_self(mob/user)
 	if(isnull(brainobj))
-		show_splash_text(user, "no brain detected!")
+		show_splash_text(user, "no brain detected!", "No brain detected in \the [src]!")
 		return
 
 	if(locked)
-		show_splash_text(user, "brain is clamped into place!")
+		show_splash_text(user, "brain is clamped into place!", "The brain is clamped into place!")
 		return
 
 	_remove_brain()

--- a/code/modules/mob/organs/internal/posibrain.dm
+++ b/code/modules/mob/organs/internal/posibrain.dm
@@ -47,7 +47,7 @@
 /obj/item/organ/internal/cerebrum/posibrain/proc/reset_search()
 	if(!searching || brainmob?.key)
 		return
-	else show_splash_text_to_viewers("no suitable intelligence found!")
+	else show_splash_text_to_viewers("no suitable intelligence found!", "<b>\The [src]</b> couldn't find a suitable intelligence.")
 
 	searching = FALSE
 	brainmob.controllable = TRUE
@@ -69,7 +69,7 @@
 	brainmob.controllable = TRUE
 	GLOB.available_mobs_for_possess["\ref[brainmob]"] |= brainmob
 
-	show_splash_text(user, "started search of suitable intelligence.")
+	show_splash_text(user, "started search of suitable intelligence.", "<b>\The [src]</b> has started searching for a suitable intelligence.")
 	update_icon()
 
 /obj/item/organ/internal/cerebrum/posibrain/attack_ghost(mob/observer/ghost/user)

--- a/code/modules/multiz/structures.dm
+++ b/code/modules/multiz/structures.dm
@@ -196,7 +196,7 @@
 		var/turf/target = get_turf(below)
 		var/turf/source = get_turf(A)
 		if(!(locate(/obj/structure/stairs) in below))
-			show_splash_text(A, "the stairs cut off")
+			show_splash_text(A, "the stairs cut off", "There stairs appear to be cut off!")
 			return
 
 		A.forceMove(target)
@@ -208,7 +208,7 @@
 			playsound(source, SFX_FOOTSTEP_STAIRS, 50)
 			playsound(target, SFX_FOOTSTEP_STAIRS, 50)
 	else
-		show_splash_text(A, "nothing of interest in this direction")
+		show_splash_text(A, "nothing of interest in this direction", "There's nothing of interest in this direction.")
 
 /obj/structure/up/CheckExit(atom/movable/mover as mob|obj, turf/target as turf)
 	if(get_dir(loc, target) == turn(dir, 180) && (get_turf(mover) == loc))
@@ -245,7 +245,7 @@
 		var/turf/target = get_turf(above)
 		var/turf/source = get_turf(A)
 		if(!(locate(/obj/structure/up) in above))
-			show_splash_text(A, "the stairs cut off")
+			show_splash_text(A, "the stairs cut off", "There stairs appear to be cut off!")
 		if(above.CanZPass(source, UP) && target.Enter(A, src))
 			A.forceMove(target)
 			if(isliving(A))
@@ -256,9 +256,9 @@
 				playsound(source, SFX_FOOTSTEP_STAIRS, 50)
 				playsound(target, SFX_FOOTSTEP_STAIRS, 50)
 		else
-			show_splash_text(A, "something blocks the path")
+			show_splash_text(A, "something blocks the path", "There's something blocking the path.")
 	else
-		show_splash_text(A, "nothing of interest in this direction")
+		show_splash_text(A, "nothing of interest in this direction", "There's nothing of interest in this direction.")
 
 // type paths to make mapping easier.
 /obj/structure/stairs/north

--- a/code/modules/paperwork/faxmachine.dm
+++ b/code/modules/paperwork/faxmachine.dm
@@ -151,9 +151,9 @@ GLOBAL_LIST_EMPTY(adminfaxes)	//cache for faxes that have been sent to admins
 			continue
 
 		if(F.recievefax(copyitem))
-			show_splash_text(usr, "nessage transmitted successfully")
+			show_splash_text(usr, "message transmitted successfully", SPAN("notice", "\The [src] has transmitted the message successfully."))
 
-	show_splash_text(usr, "error transmitting message")
+	show_splash_text(usr, "error transmitting message", SPAN("warning", "\The [src] cannot transmit the message!"))
 
 /obj/machinery/photocopier/faxmachine/proc/recievefax(obj/item/incoming)
 	if(stat & (BROKEN|NOPOWER))
@@ -200,11 +200,11 @@ GLOBAL_LIST_EMPTY(adminfaxes)	//cache for faxes that have been sent to admins
 		var/obj/item/complaint_folder/CF = copyitem
 		var/fail_reason = CF.prevalidate()
 		if (fail_reason)
-			show_splash_text(usr, "error transmitting message")
+			show_splash_text(usr, "error transmitting message", SPAN("warning", "\The [src] cannot transmit the message!"))
 			return
 		rcvdcopy = complaintcopy(copyitem, 0)
 	else
-		show_splash_text(usr, "error transmitting message")
+		show_splash_text(usr, "error transmitting message", SPAN("warning", "\The [src] cannot transmit the message!"))
 		return
 
 	rcvdcopy.forceMove(null) //hopefully this shouldn't cause trouble
@@ -238,7 +238,7 @@ GLOBAL_LIST_EMPTY(adminfaxes)	//cache for faxes that have been sent to admins
 				message_admins("Complaint postvalidation failed: [fail_reason]. Check received fax to manually correct it.")
 
 	sleep(50)
-	show_splash_text(usr, "message transmitted successfully")
+	show_splash_text(usr, "message transmitted successfully", SPAN("notice", "\The [src] has transmitted the message successfully."))
 
 /obj/machinery/photocopier/faxmachine/proc/fax_message_admins(mob/sender, faxname, obj/item/sent, reply_type, font_colour="#006100")
 	var/msg = "<span class='notice'><b><font color='[font_colour]'>[faxname]: </font>[get_options_bar(sender, 2,1,1)]"

--- a/code/modules/rcd/_rcd.dm
+++ b/code/modules/rcd/_rcd.dm
@@ -64,10 +64,10 @@
 /// Installs an upgrade into the RCD checking if it is already installed, or if it is a banned upgrade
 /obj/item/construction/proc/install_upgrade(obj/item/rcd_upgrade/design_disk, mob/user)
 	if(design_disk.upgrade & upgrade)
-		show_splash_text(user, "already installed!")
+		show_splash_text(user, "already installed!", SPAN("warning", "\The [src] already has this upgrade!"))
 		return FALSE
 	if(design_disk.upgrade & banned_upgrades)
-		show_splash_text(user, "cannot install upgrade!")
+		show_splash_text(user, "cannot install upgrade!", SPAN("warning", "\The [src] cannot have this upgrade!"))
 		return FALSE
 	upgrade |= design_disk.upgrade
 	playsound(loc, 'sound/machines/click.ogg', 50, TRUE)
@@ -85,7 +85,7 @@
 		var/load = min(ammo.ammoamt, max_matter - local_matter)
 		load = round(load / MATTER_REDUCTION_COEFFICIENT)
 		if(load <= 0)
-			show_splash_text(user, "storage full!")
+			show_splash_text(user, "storage full!", SPAN("warning", "\The [src] is full!"))
 			return FALSE
 		ammo.ammoamt -= load
 		if(ammo.ammoamt <= 0)
@@ -101,7 +101,7 @@
 
 /obj/item/construction/proc/loadwithsheets(obj/item/stack/the_stack, mob/user)
 	if(the_stack.amount <= 0)
-		show_splash_text(user, "invalid sheets!")
+		show_splash_text(user, "invalid sheets!", SPAN("warning", "\The [src] refuses to accept this."))
 		return FALSE
 
 	var/sheet_amt_to_matter = round(the_stack.amount / MATTER_REDUCTION_COEFFICIENT)
@@ -113,7 +113,7 @@
 		playsound(loc, 'sound/machines/click.ogg', 50, TRUE)
 		return TRUE
 
-	show_splash_text(user, "storage full!")
+	show_splash_text(user, "storage full!", SPAN("warning", "\The [src] is full!"))
 	return FALSE
 
 /obj/item/construction/proc/activate()
@@ -134,7 +134,7 @@
 /obj/item/construction/proc/useResource(amount, mob/user)
 	if(local_matter < amount)
 		if(user)
-			show_splash_text(user, "not enough local_matter!")
+			show_splash_text(user, "not enough local_matter!", SPAN("warning", "Not enough local_matter!"))
 		return FALSE
 
 	local_matter -= amount
@@ -172,7 +172,7 @@
 	. = local_matter >= amount
 
 	if(!. && user)
-		show_splash_text(user, "low ammo!")
+		show_splash_text(user, "low ammo!", SPAN("warning", "Not enough matter!"))
 		if(has_ammobar)
 			flick("[icon_state]_empty", src) //somewhat hacky thing to make RCDs with ammo counters actually have a blinking yellow light
 
@@ -182,7 +182,7 @@
 	if(target.z != user.z)
 		return
 	if(!(target in dview(7, get_turf(user))))
-		show_splash_text(user, "out of range!")
+		show_splash_text(user, "out of range!", SPAN("warning", "Out of range!"))
 		flick("[icon_state]_empty", src)
 		return FALSE
 	else

--- a/code/modules/rcd/rcd.dm
+++ b/code/modules/rcd/rcd.dm
@@ -106,7 +106,7 @@
 			//check if we can build our window on the grill
 			if(is_blocked_turf(target_turf, caller = null, exclude_mobs = FALSE, ignore_atoms = structures_to_ignore))
 				playsound(loc, 'sound/machines/click.ogg', 50, TRUE)
-				show_splash_text(user, "something is blocking the turf")
+				show_splash_text(user, "something is blocking the turf", SPAN("warning", "There's something blocking the turf!"))
 				return FALSE
 
 		/**
@@ -117,7 +117,7 @@
 			//if a player builds a wallgirder on top of himself manually with iron sheets he can't finish the wall if he is still on the girder. Exclude the girder itself when checking for other dense objects on the turf
 			if(istype(target, /obj/structure/girder) && is_blocked_turf(target_turf))
 				playsound(loc, 'sound/machines/click.ogg', 50, TRUE)
-				show_splash_text(user, "something is on the girder!")
+				show_splash_text(user, "something is on the girder!", SPAN("warning", "There's something blocking the girder!"))
 				return FALSE
 
 		//check if turf is blocked in for dense structures
@@ -146,7 +146,7 @@
 			//check if the structure can fit on this turf
 			if(is_blocked_turf(target_turf))
 				playsound(loc, 'sound/machines/click.ogg', 50, TRUE)
-				show_splash_text(user, "something is on the tile!")
+				show_splash_text(user, "something is on the tile!", SPAN("warning", "There's something blocking the tile!"))
 				return FALSE
 
 	return TRUE

--- a/code/modules/rcd/rcd_borg.dm
+++ b/code/modules/rcd/rcd_borg.dm
@@ -23,7 +23,7 @@
 
 	. = borgy.cell.use(amount * energyfactor) //borgs get 1.3x the use of their RCDs
 	if(!. && user)
-		show_splash_text(user, "insufficient charge!")
+		show_splash_text(user, "insufficient charge!", SPAN("warning", "\The [src] is out of charge!"))
 	return .
 
 /obj/item/construction/rcd/borg/checkResource(amount, mob/user)
@@ -36,5 +36,5 @@
 
 	. = borgy.cell.charge >= (amount * energyfactor)
 	if(!. && user)
-		show_splash_text(user, "insufficient charge!")
+		show_splash_text(user, "insufficient charge!", SPAN("warning", "\The [src] is out of charge!"))
 	return .

--- a/code/modules/rcd/rcd_mounted.dm
+++ b/code/modules/rcd/rcd_mounted.dm
@@ -18,7 +18,7 @@
 				. = module.holder.cell.use(amount)
 
 	if(!. && user)
-		show_splash_text(user, "insufficient charge!")
+		show_splash_text(user, "insufficient charge!", SPAN("warning", "\The [src] is out of charge!"))
 	return .
 
 /obj/item/construction/rcd/mounted/checkResource(amount, mob/user)
@@ -31,7 +31,7 @@
 				. = module.holder.cell.charge >= amount
 
 	if(!. && user)
-		show_splash_text(user, "insufficient charge!")
+		show_splash_text(user, "insufficient charge!", SPAN("warning", "\The [src] is out of charge!"))
 	return .
 
 /obj/item/construction/rcd/mounted/tgui_state(mob/user)

--- a/code/modules/reagents/Chemistry-Machinery.dm
+++ b/code/modules/reagents/Chemistry-Machinery.dm
@@ -517,11 +517,14 @@
 		if("grind")
 			grind()
 		if("dump")
-			show_splash_text(user, "contents dumped.")
+			show_splash_text(user, "contents dumped", SPAN("notice", "You dump the contents of \the [src]."))
 			eject()
 		if("detach")
-			show_splash_text(user, beaker ? "beaker detached." : "no beaker present!")
-			detach()
+			if(beaker)
+				show_splash_text(user, "beaker detached", SPAN("notice", "You detach \the [beaker] from \the [src]."))
+				detach()
+			else
+				show_splash_text(user, "no beaker present!", SPAN("notice", "There's no beaker in \the [src]."))
 
 /obj/machinery/reagentgrinder/proc/_generate_buttons()
 	LAZYINITLIST(choices)

--- a/code/modules/reagents/reagent_containers/vessel/unsorted.dm
+++ b/code/modules/reagents/reagent_containers/vessel/unsorted.dm
@@ -59,10 +59,10 @@
 
 	else if(istype(D, /obj/item/mop) || (atom_flags & ATOM_FLAG_OPEN_CONTAINER))
 		if(reagents.total_volume < 1)
-			show_splash_text(user, "no water!")
+			show_splash_text(user, "no water!", SPAN("warning", "\The [src] is empty!"))
 		else
 			reagents.trans_to_obj(D, 5)
-			show_splash_text(user, "you wet the mop!")
+			show_splash_text(user, "you wet the mop!", SPAN("notice", "You wet \the [D] in \the [src]."))
 			playsound(loc, 'sound/effects/slosh.ogg', 25, 1)
 		return
 
@@ -77,7 +77,7 @@
 			return
 
 		if(reagents.total_volume < 1)
-			show_splash_text(user, "no water!")
+			show_splash_text(user, "no water!", SPAN("warning", "\The [src] is empty!"))
 			return
 
 		user.visible_message(SPAN_DANGER("[user] starts to put [G.affecting.name]'s head into \the [src]!"), \
@@ -91,7 +91,7 @@
 		if(QDELETED(src) || !G?.affecting)
 			return
 
-		
+
 		user.visible_message(SPAN_DANGER("[user] finally raises [G.affecting.name]'s head out of \the [src]!"), \
 								SPAN_DANGER("You raise [G.affecting.name]'s head out of \the [src]!"))
 		reagents.trans_to(G.affecting, min(reagents.total_volume, 5))


### PR DESCRIPTION
```yml
🆑
rscadd: Изменена логика работы префа "Show Splashes (Runechat-Like-Popups)", поскольку многие сообщения переделываются в сплеши, которые не на каждом экране можно разглядеть. Теперь имеются три опции - выводить сплеш только на экране, выводить его только в чате, либо выводить и туда, и сюда. Настоятельно рекомендуется обновить преф вручную, ибо он мог сбиться.
/🆑
```

- [x] Pull Request полностью завершен, мне не нужна помощь чтобы его закончить.
- [x] Я внимательно прочитал все свои изменения и багов в них не нашел.
- [x] Я запускал сервер со своими изменениями локально и все протестировал.
- [x] Я ознакомился c [Guide to Contribute](https://github.com/ChaoticOnyx/OnyxBay/blob/dev/docs/contributing.md).
