### PR TITLE
feat(input): add alternative input position

### DIFF
--- a/code/game/verbs/ooc.dm
+++ b/code/game/verbs/ooc.dm
@@ -40,6 +40,7 @@
 
 	if(alert(usr, "Are you sure? You have to switch to the English keyboard layout first.\nWarning: This will close all open windows.", "Fix hotkeys", "Yes", "No") == "Yes")
 		winset(src, null, "reset=true")
+		update_chat_position()
 		nuke_chat()
 
 /client/verb/info_storyteller()

--- a/code/modules/client/client_procs.dm
+++ b/code/modules/client/client_procs.dm
@@ -468,6 +468,63 @@
 	if(world.byond_version >= 511 && byond_version >= 511 && client_fps >= CLIENT_MIN_FPS && client_fps <= CLIENT_MAX_FPS)
 		fps = client_fps
 
+#define VERTICAL_INPUT_MARGIN 9
+
+/**
+ * Manages `input` and `input_alt` visibility, due to skin limitations this proc is extreely
+ * snowflake, thus be sure to change `VERTICAL_INPUT_MARGIN` when moving it's elements
+ * inside `skin.dmf`.
+ *
+ * Known bugs:
+ * - Doesn't mount instantly due to user prefs loading.
+ * - Doesn't display typing indicator 'cause code copypasta is bad.
+ */
+/client/proc/update_chat_position(new_position)
+	var/alternate = winget(src, "input", "is-default") == "false"
+
+	if(!alternate && new_position == GLOB.PREF_LEGACY)
+		var/list/game_size = splittext(winget(src, "mainvsplit", "size"), "x")
+		var/list/input_size = splittext(winget(src, "input_alt", "size"), "x")
+
+		winset(src, "mainvsplit", "size=[game_size[1]]x[text2num(game_size[2]) - text2num(input_size[2]) - VERTICAL_INPUT_MARGIN]")
+
+		var/list/chat_size = splittext(winget(src, "outputwindow", "size"), "x")
+
+		winset(src, "browseroutput", "size=[chat_size[1]]x[chat_size[2]]")
+		winset(src, "output", "size=[chat_size[1]]x[chat_size[2]]")
+
+		winset(src, "input_alt", "is-visible=true;is-disabled=false;is-default=true")
+		winset(src, "saybutton_alt", "is-visible=true;is-disabled=false;is-default=true")
+		winset(src, "hotkey_toggle_alt", "is-visible=true;is-disabled=false;is-default=true")
+
+		winset(src, "input", "is-visible=false;is-disabled=true;is-default=false")
+		winset(src, "saybutton", "is-visible=false;is-disabled=true;is-default=false")
+		winset(src, "hotkey_toggle", "is-visible=false;is-disabled=true;is-default=false")
+
+	else if(alternate && new_position == GLOB.PREF_MODERN)
+		var/list/game_size = splittext(winget(src, "mainvsplit", "size"), "x")
+		var/list/alt_input_size = splittext(winget(src, "input_alt", "size"), "x")
+
+		winset(src, "mainvsplit", "size=[game_size[1]]x[text2num(game_size[2]) + text2num(alt_input_size[2]) + 9]")
+
+		var/list/chat_size = splittext(winget(src, "outputwindow", "size"), "x")
+		var/list/input_size = splittext(winget(src, "input", "size"), "x")
+
+		var/output_height = text2num(chat_size[2]) - text2num(input_size[2]) - VERTICAL_INPUT_MARGIN
+
+		winset(src, "browseroutput", "size=[chat_size[1]]x[output_height]")
+		winset(src, "output", "size=[chat_size[1]]x[output_height]")
+
+		winset(src, "input_alt", "is-visible=false;is-disabled=true;is-default=false")
+		winset(src, "saybutton_alt", "is-visible=false;is-disabled=true;is-default=false")
+		winset(src, "hotkey_toggle_alt", "is-visible=false;is-disabled=true;is-default=false")
+
+		winset(src, "input", "is-visible=true;is-disabled=false;is-default=true")
+		winset(src, "saybutton", "is-visible=true;is-disabled=false;is-default=true")
+		winset(src, "hotkey_toggle", "is-visible=true;is-disabled=false;is-default=true")
+
+#undef VERTICAL_INPUT_MARGIN
+
 /client/proc/toggle_fullscreen(new_value)
 	if((new_value == GLOB.PREF_BASIC) || (new_value == GLOB.PREF_FULL))
 		winset(src, "mainwindow", "is-maximized=false;can-resize=false;titlebar=false")

--- a/code/modules/client/preference_setup/global/preferences.dm
+++ b/code/modules/client/preference_setup/global/preferences.dm
@@ -19,6 +19,8 @@ GLOBAL_VAR_CONST(PREF_X3, "x3")
 GLOBAL_VAR_CONST(PREF_NORMAL, "Normal")
 GLOBAL_VAR_CONST(PREF_DISTORT, "Distort")
 GLOBAL_VAR_CONST(PREF_BLUR, "Blur")
+GLOBAL_VAR_CONST(PREF_MODERN, "Modern")
+GLOBAL_VAR_CONST(PREF_LEGACY, "Legacy")
 GLOBAL_VAR_CONST(PREF_PRIMARY, "Primary")
 GLOBAL_VAR_CONST(PREF_ALL, "All")
 GLOBAL_VAR_CONST(PREF_OFF, "Off")
@@ -356,6 +358,16 @@ var/global/list/_client_preferences_by_type
 
 /datum/client_preference/statusbar/changed(mob/preference_mob, new_value)
 	winset(preference_mob, "statusbar", "is-visible=[new_value == GLOB.PREF_YES]")
+
+/datum/client_preference/legacy_input
+	description = "Oldschool™ Input Position"
+	key = "INPUT_POSITION"
+	category = PREF_CATEGORY_UI
+	options = list(GLOB.PREF_MODERN, GLOB.PREF_LEGACY)
+	default_value = GLOB.PREF_MODERN
+
+/datum/client_preference/legacy_input/changed(mob/preference_mob, new_value)
+	preference_mob?.client?.update_chat_position(new_value)
 
 /datum/client_preference/cinema_credits
 	description = "Show Cinema-like Credits At Round-end"

--- a/code/modules/client/preferences.dm
+++ b/code/modules/client/preferences.dm
@@ -475,6 +475,8 @@ datum/preferences/proc/clear_character_previews()
 
 	client.apply_fps(clientfps)
 
+	client.update_chat_position(client.get_preference_value("INPUT_POSITION"))
+
 	var/zoom = client.get_preference_value("PIXEL_SIZE")
 	winset(client, "mapwindow.map", "zoom=[zoom_pref2value(zoom)]")
 

--- a/interface/skin.dmf
+++ b/interface/skin.dmf
@@ -961,6 +961,44 @@ window "mainwindow"
 		saved-params = "splitter"
 		right = "infowindow"
 		is-vert = true
+	elem "input_alt"
+		type = INPUT
+		pos = 2,396
+		size = 514x20
+		anchor1 = 0,100
+		anchor2 = 100,100
+		background-color = #d3b5b5
+		is-visible = false
+		border = line
+		saved-params = "command"
+	elem "saybutton_alt"
+		type = BUTTON
+		pos = 518,396
+		size = 40x20
+		anchor1 = 100,100
+		anchor2 = -1,-1
+		background-color = none
+		is-visible = false
+		border = line
+		saved-params = "is-checked"
+		text = "Chat"
+		command = ".winset \"saybutton_alt.is-checked=true?input_alt.command=\"!Say \\\"\" macrobutton.is-checked=false:input_alt.command=\""
+		is-flat = true
+		button-type = pushbox
+	elem "hotkey_toggle_alt"
+		type = BUTTON
+		pos = 560,396
+		size = 78x20
+		anchor1 = 100,100
+		anchor2 = -1,-1
+		background-color = none
+		is-visible = false
+		border = line
+		saved-params = ""
+		text = "Hotkey Toggle"
+		command = ".winset \"mainwindow.macro!=macro ? mainwindow.macro=macro hotkey_toggle_alt.is-checked=false input_alt.focus=true : mainwindow.macro=hotkeymode hotkey_toggle_alt.is-checked=true mapwindow.map.focus=true\""
+		is-flat = true
+		button-type = pushbox
 
 window "mapwindow"
 	elem "mapwindow"
@@ -994,11 +1032,11 @@ window "mapwindow"
 		pos = 0,464
 		size = 280x16
 		anchor1 = 0,100
-		is-visible = true
+		anchor2 = -1,-1
+		border = line
+		saved-params = ""
 		text = ""
 		align = left
-		border = line
-
 
 window "outputwindow"
 	elem "outputwindow"
@@ -1040,7 +1078,7 @@ window "outputwindow"
 		anchor2 = 100,100
 		background-color = #d3b5b5
 		is-default = true
-		border = sunken
+		border = line
 		saved-params = "command"
 		on-focus = ".add_speech_bubble"
 		on-blur = ".remove_speech_bubble"
@@ -1050,10 +1088,11 @@ window "outputwindow"
 		size = 40x20
 		anchor1 = 100,100
 		anchor2 = -1,-1
-		background-color = none
+		border = line
 		saved-params = "is-checked"
 		text = "Chat"
 		command = ".winset \"saybutton.is-checked=true?input.command=\"!say \\\"\" macrobutton.is-checked=false:input.command=\""
+		is-flat = true
 		button-type = pushbox
 	elem "hotkey_toggle"
 		type = BUTTON
@@ -1061,10 +1100,11 @@ window "outputwindow"
 		size = 78x20
 		anchor1 = 100,100
 		anchor2 = -1,-1
-		background-color = none
+		border = line
 		saved-params = ""
 		text = "Hotkey Toggle"
 		command = ".winset \"mainwindow.macro!=macro ? mainwindow.macro=macro hotkey_toggle.is-checked=false input.focus=true : mainwindow.macro=hotkeymode hotkey_toggle.is-checked=true mapwindow.map.focus=true\""
+		is-flat = true
 		button-type = pushbox
 
 


### PR DESCRIPTION
- Добавлена возможность ~~есть говно~~  играть со старой позицией чата. По стандарту всем игрокам будет выставлена современная позиция, но игроки могут поставить старую через настройки.
- Кнопки и инпутбокс теперь плоские, глаза больше не вытекают при их виде.

<details>
<summary>Скриншоты</summary>

![dreamseeker_7nlNlHtVTD](https://github.com/ChaoticOnyx/OnyxBay/assets/137328283/89c1b493-5c27-4e2b-b391-5e762942b23e)
![dreamseeker_zz5U4ek820](https://github.com/ChaoticOnyx/OnyxBay/assets/137328283/8990ea3d-0dea-48c8-b2d7-4c7c57014092)


</details>

<details>
<summary>Чейнджлог</summary>

```yml
🆑
rscadd: Добавлена возможность играть со старой позицией чата. По стандарту у всех игроков стоит "совремнная" версия.
tweak: Кнопки и инпутбокс теперь плоские, глаза больше не вытекают при их виде.
/🆑
```

</details>

- [x] Pull Request полностью завершен, мне не нужна помощь чтобы его закончить.
- [x] Я внимательно прочитал все свои изменения и багов в них не нашел.
- [ ] Я запускал сервер со своими изменениями локально и все протестировал.
- [x] Я ознакомился c [Guide to Contribute](https://github.com/ChaoticOnyx/OnyxBay/blob/dev/docs/contributing.md).
