### PR TITLE
Removes <i>s from emotes

### DIFF
--- a/code/modules/emotes/emote.dm
+++ b/code/modules/emotes/emote.dm
@@ -146,14 +146,14 @@ GLOBAL_LIST_INIT(all_emotes, list(); for(var/emotepath in subtypesof(/datum/emot
 
 	var/msg_1p = get_emote_message_1p(user, target, additional_params)
 	var/text_3p = get_emote_message_3p(user, target, additional_params)
-	var/msg_3p = text_3p ? "<b>[user]</b> <i>[text_3p]</i>" : null
+	var/msg_3p = text_3p ? "<b>[user]</b> [text_3p]" : null
 	var/range = !isnull(emote_range) ? emote_range : world.view
 	var/impaired_msg = get_impaired_msg(user)
 	if(impaired_msg)
 		if(message_type & VISIBLE_MESSAGE)
 			impaired_msg = "<i>[impaired_msg]</i>"
 		else if(message_type & AUDIBLE_MESSAGE)
-			impaired_msg = "<b>[user]</b> <i>[impaired_msg]</i>"
+			impaired_msg = "<b>[user]</b> [impaired_msg]"
 
 	if(!msg_1p)
 		msg_1p = msg_3p

--- a/code/modules/emotes/emote_mob.dm
+++ b/code/modules/emotes/emote_mob.dm
@@ -79,9 +79,9 @@
 		message += "."
 
 	if(findtext(message, "^"))
-		message = "<i>[capitalize(replacetext(message, regex(@"\^+", "g"), user_name))]</i>"
+		message = "[capitalize(replacetext(message, regex(@"\^+", "g"), user_name))]"
 	else
-		message = "[user_name] <i>[message]</i>"
+		message = "[user_name] [message]"
 
 	if(message_type & VISIBLE_MESSAGE)
 		visible_message(message, checkghosts = /datum/client_preference/ghost_sight)


### PR DESCRIPTION
1. глаза текут
2. ебаный курсив ломает и иммерсив и стилистику, проводя чёткую линию между "геймплейными" сообщениями и эмоутами

эмоуты от первого лица (типа "_You cough._") всё ещё курсивятся чтоб подчеркнуть их кринжовость

```yml
🆑
bugfix: Исправлена ошибка, из-за которой эмоуты выделялись курсивом.
/🆑
```

- [x] Pull Request полностью завершен, мне не нужна помощь чтобы его закончить.
- [x] Я внимательно прочитал все свои изменения и багов в них не нашел.
- [x] Я запускал сервер со своими изменениями локально и все протестировал.
- [x] Я ознакомился c [Guide to Contribute](https://github.com/ChaoticOnyx/OnyxBay/blob/dev/docs/contributing.md).
