### PR TITLE
fix(ckey linkage): probably fixed ckey to discord linkage

### DIFF
--- a/code/modules/donations/donations.dm
+++ b/code/modules/donations/donations.dm
@@ -50,13 +50,13 @@ SUBSYSTEM_DEF(donations)
 	var/was_donator = player.donator_info.donator
 
 	var/DBQuery/query = sql_query({"
-		SELECT 
+		SELECT
 			patron_types.type
-		FROM 
+		FROM
 			players
-		JOIN 
+		JOIN
 			patron_types ON players.patron_type = patron_types.id
-		WHERE 
+		WHERE
 			ckey = $ckey
 		LIMIT 0,1
 	"}, dbcon_don, list(ckey = player.ckey))
@@ -65,13 +65,13 @@ SUBSYSTEM_DEF(donations)
 		player.donator_info.patron_type = query.item[1]
 
 	query = sql_query({"
-		SELECT 
+		SELECT
 			`change`
-		FROM 
+		FROM
 			points_transactions
-		JOIN 
+		JOIN
 			players ON players.id = points_transactions.player
-		WHERE 
+		WHERE
 			ckey = $ckey
 	"}, dbcon_don, list(ckey = player.ckey))
 
@@ -94,11 +94,11 @@ SUBSYSTEM_DEF(donations)
 		return FALSE
 
 	var/DBQuery/query = sql_query({"
-		SELECT 
+		SELECT
 			item_path
-		FROM 
+		FROM
 			store_players_items
-		WHERE 
+		WHERE
 			player = (SELECT id FROM players WHERE ckey = $ckey)
 	"}, dbcon_don, list(ckey = player.ckey))
 
@@ -134,16 +134,16 @@ SUBSYSTEM_DEF(donations)
 
 	var/transaction_id
 	var/DBQuery/query = sql_query({"
-		SELECT 
+		SELECT
 			id
-		FROM 
+		FROM
 			points_transactions
 		WHERE
-			player = (SELECT id FROM players WHERE ckey = $ckey) 
+			player = (SELECT id FROM players WHERE ckey = $ckey)
 			AND
 			comment = $comment
-		ORDER BY 
-			id 
+		ORDER BY
+			id
 			DESC
 	"}, dbcon_don, list(ckey = player.ckey, comment = comment))
 
@@ -207,7 +207,13 @@ SUBSYSTEM_DEF(donations)
 
 	var/discord_id = query.item[2]
 
-	sql_query("UPDATE players SET discord = $discord_id WHERE ckey = $ckey", dbcon_don, list(discord_id = discord_id, ckey = player.ckey))
+	query = sql_query("SELECT ckey FROM players WHERE discord = $discord_id  LIMIT 0,1", dbcon_don, list(discord_id = discord_id))
+
+	if(query.NextRow())
+		sql_query("UPDATE players SET ckey = $ckey WHERE discord = $discord_id", dbcon_don, list(discord_id = discord_id, ckey = player.ckey))
+	else
+		sql_query("UPDATE players SET discord = $discord_id WHERE ckey = $ckey", dbcon_don, list(discord_id = discord_id, ckey = player.ckey))
+
 
 	sql_query("DELETE FROM tokens WHERE token = $token", dbcon_don, list(token = token))
 


### PR DESCRIPTION
В теории должно пофиксить проблему привязки сикея к дискорду через хаб.
Ибо хаб создаёт запись плеера с пустым сикеем.
А текущий код ищет запись по сикею.

Теперь он будет проверять нет ли записи по дискорду, если есть то обновлять её.
Если нет то по старинке.

- [x] Pull Request полностью завершен, мне не нужна помощь чтобы его закончить.
- [x] Я внимательно прочитал все свои изменения и багов в них не нашел.
- [ ] Я запускал сервер со своими изменениями локально и все протестировал.
- [x] Я ознакомился c [Guide to Contribute](https://github.com/ChaoticOnyx/OnyxBay/blob/dev/docs/contributing.md).
