### PR TITLE
fix(portal): portals no longer cause recursion

### DIFF
--- a/code/game/machinery/teleporter.dm
+++ b/code/game/machinery/teleporter.dm
@@ -6,7 +6,7 @@
 	desc = "It's the hub of a teleporting machine."
 	icon_state = "tele_gate_off"
 	icon = 'icons/obj/machines/teleporter.dmi'
-	density = FALSE
+	density = TRUE
 	anchored = TRUE
 	idle_power_usage = 10 WATTS
 	active_power_usage = 2 KILO WATTS
@@ -109,9 +109,11 @@
 		do_teleport(A, target)
 	return
 
-/obj/machinery/teleporter_gate/Crossed(A)
+/obj/machinery/teleporter_gate/Bumped(AM)
+	. = ..()
+
 	if(is_ready())
-		teleport(A)
+		teleport(AM)
 
 /obj/machinery/teleporter_gate/power_change()
 	. = ..()

--- a/code/game/objects/effects/portals.dm
+++ b/code/game/objects/effects/portals.dm
@@ -3,7 +3,7 @@
 	desc = "Looks unstable. Best to test it with the clown."
 	icon = 'icons/obj/portals.dmi'
 	icon_state = "portal"
-	density = FALSE
+	density = TRUE
 	unacidable = TRUE // Can't destroy energy portals.
 	var/atom/target = null
 	var/creator = null
@@ -12,7 +12,8 @@
 	var/failchance = 0
 	var/teleport_type = /decl/teleport/sparks
 
-/obj/effect/portal/Crossed(AM)
+/obj/effect/portal/Bumped(AM)
+	. = ..()
 	teleport(AM)
 
 /obj/effect/portal/attack_hand(mob/user)


### PR DESCRIPTION
Заменил `Crossed`, который вызывается при наложении атомов друг на друга, на `Bumped`, вызываемый лишь при соприкосновении.

<details>
<summary>Чейнджлог</summary>

```yml
🆑
bugfix: Порталы больше не убивают сервер рекурсией.
/🆑
```

</details>

close #11947

- [x] Pull Request полностью завершен, мне не нужна помощь чтобы его закончить.
- [x] Я внимательно прочитал все свои изменения и багов в них не нашел.
- [x] Я запускал сервер со своими изменениями локально и все протестировал.
- [x] Я ознакомился c [Guide to Contribute](https://github.com/ChaoticOnyx/OnyxBay/blob/dev/docs/contributing.md).
