### PR TITLE
fix(ckey linkage): probably fixed ckey to discord linkage

### DIFF
--- a/code/modules/donations/donations.dm
+++ b/code/modules/donations/donations.dm
@@ -50,13 +50,13 @@ SUBSYSTEM_DEF(donations)
 	var/was_donator = player.donator_info.donator
 
 	var/DBQuery/query = sql_query({"
-		SELECT 
+		SELECT
 			patron_types.type
-		FROM 
+		FROM
 			players
-		JOIN 
+		JOIN
 			patron_types ON players.patron_type = patron_types.id
-		WHERE 
+		WHERE
 			ckey = $ckey
 		LIMIT 0,1
 	"}, dbcon_don, list(ckey = player.ckey))
@@ -65,13 +65,13 @@ SUBSYSTEM_DEF(donations)
 		player.donator_info.patron_type = query.item[1]
 
 	query = sql_query({"
-		SELECT 
+		SELECT
 			`change`
-		FROM 
+		FROM
 			points_transactions
-		JOIN 
+		JOIN
 			players ON players.id = points_transactions.player
-		WHERE 
+		WHERE
 			ckey = $ckey
 	"}, dbcon_don, list(ckey = player.ckey))
 
@@ -94,11 +94,11 @@ SUBSYSTEM_DEF(donations)
 		return FALSE
 
 	var/DBQuery/query = sql_query({"
-		SELECT 
+		SELECT
 			item_path
-		FROM 
+		FROM
 			store_players_items
-		WHERE 
+		WHERE
 			player = (SELECT id FROM players WHERE ckey = $ckey)
 	"}, dbcon_don, list(ckey = player.ckey))
 
@@ -134,16 +134,16 @@ SUBSYSTEM_DEF(donations)
 
 	var/transaction_id
 	var/DBQuery/query = sql_query({"
-		SELECT 
+		SELECT
 			id
-		FROM 
+		FROM
 			points_transactions
 		WHERE
-			player = (SELECT id FROM players WHERE ckey = $ckey) 
+			player = (SELECT id FROM players WHERE ckey = $ckey)
 			AND
 			comment = $comment
-		ORDER BY 
-			id 
+		ORDER BY
+			id
 			DESC
 	"}, dbcon_don, list(ckey = player.ckey, comment = comment))
 
@@ -218,7 +218,7 @@ SUBSYSTEM_DEF(donations)
 		var/old_record_player_id = query.item[1]
 
 		//Update donations to old format record
-		query = sql_query("SELECT id FROM points_transactions WHERE player=$player_id", dbcon_don, list(player_id = old_record_player_id))
+		query = sql_query("SELECT id FROM points_transactions WHERE player=$old_record_player_id", dbcon_don, list(old_record_player_id = old_record_player_id))
 		if(query.NextRow())
 			sql_query("UPDATE points_transactions SET player=$new_record_player_id WHERE player=$old_record_player_id", dbcon_don, list(new_record_player_id = new_record_player_id, old_record_player_id = old_record_player_id))
 

--- a/code/modules/donations/donations.dm
+++ b/code/modules/donations/donations.dm
@@ -209,16 +209,21 @@ SUBSYSTEM_DEF(donations)
 
 	// Check if we have two distinct records for user's discord and ckey in the players table
 	// If that's true, then we have to merge them
-	query = sql_query("SELECT id FROM players WHERE discord=$discord_id AND ckey IS NULL", dbcon_don, list(discord_id = discord_id))
+	query = sql_query("SELECT id FROM players WHERE discord = $discord_id AND ckey IS NULL", dbcon_don, list(discord_id = discord_id))
 	if(!query.NextRow()) //We don't have that, use an old method
 		sql_query("UPDATE players SET discord = $discord_id WHERE ckey = $ckey", dbcon_don, list(discord_id = discord_id, ckey = player.ckey))
 	else
 		var/discord_player_id = query.item[1]
-		query = sql_query("SELECT id FROM players WHERE ckey=$ckey", dbcon_don, list(ckey = player.ckey))
+		query = sql_query("SELECT id FROM players WHERE ckey = $ckey", dbcon_don, list(ckey = player.ckey))
+
+		if(!query.NextRow())
+			return FALSE
+
 		var/ckey_player_id = query.item[1]
 
 		//Update donations to old record
-		sql_query("UPDATE points_transactions SET player=$discord_player_id WHERE player=$ckey_player_id", dbcon_don, list(discord_player_id = discord_player_id, ckey_player_id = ckey_player_id))
+		sql_query("UPDATE points_transactions SET player = $discord_player_id WHERE player = $ckey_player_id", dbcon_don, list(discord_player_id = discord_player_id, ckey_player_id = ckey_player_id))
+		sql_query("UPDATE money_transactions SET player = $discord_player_id WHERE player = $ckey_player_id", dbcon_don, list(discord_player_id = discord_player_id, ckey_player_id = ckey_player_id))
 
 		sql_query("DELETE FROM players WHERE id = $ckey_player_id", dbcon_don, list(ckey_player_id = ckey_player_id))
 		sql_query("UPDATE players SET ckey = $ckey WHERE discord = $discord_id", dbcon_don, list(ckey = player.ckey, discord_id = discord_id))

--- a/code/modules/donations/donations.dm
+++ b/code/modules/donations/donations.dm
@@ -207,22 +207,20 @@ SUBSYSTEM_DEF(donations)
 
 	var/discord_id = query.item[2]
 
-	//Checking if we have new donation format record
+	// Check if we have two distinct records for user's discord and ckey in the players table
+	// If that's true, then we have to merge them
 	query = sql_query("SELECT id FROM players WHERE discord=$discord_id AND ckey IS NULL", dbcon_don, list(discord_id = discord_id))
 	if(!query.NextRow()) //We don't have that, use an old method
 		sql_query("UPDATE players SET discord = $discord_id WHERE ckey = $ckey", dbcon_don, list(discord_id = discord_id, ckey = player.ckey))
 	else
-
-		var/new_record_player_id = query.item[1]
+		var/discord_player_id = query.item[1]
 		query = sql_query("SELECT id FROM players WHERE ckey=$ckey", dbcon_don, list(ckey = player.ckey))
-		var/old_record_player_id = query.item[1]
+		var/ckey_player_id = query.item[1]
 
-		//Update donations to old format record
-		query = sql_query("SELECT id FROM points_transactions WHERE player=$old_record_player_id", dbcon_don, list(old_record_player_id = old_record_player_id))
-		if(query.NextRow())
-			sql_query("UPDATE points_transactions SET player=$new_record_player_id WHERE player=$old_record_player_id", dbcon_don, list(new_record_player_id = new_record_player_id, old_record_player_id = old_record_player_id))
+		//Update donations to old record
+		sql_query("UPDATE points_transactions SET player=$discord_player_id WHERE player=$ckey_player_id", dbcon_don, list(discord_player_id = discord_player_id, ckey_player_id = ckey_player_id))
 
-		sql_query("DELETE FROM players WHERE id = $old_record_player_id", dbcon_don, list(old_record_player_id = old_record_player_id))
+		sql_query("DELETE FROM players WHERE id = $ckey_player_id", dbcon_don, list(ckey_player_id = ckey_player_id))
 		sql_query("UPDATE players SET ckey = $ckey WHERE discord = $discord_id", dbcon_don, list(ckey = player.ckey, discord_id = discord_id))
 
 	sql_query("DELETE FROM tokens WHERE token = $token", dbcon_don, list(token = token))

--- a/code/modules/donations/donations.dm
+++ b/code/modules/donations/donations.dm
@@ -215,17 +215,15 @@ SUBSYSTEM_DEF(donations)
 	else
 		var/discord_player_id = query.item[1]
 		query = sql_query("SELECT id FROM players WHERE ckey = $ckey", dbcon_don, list(ckey = player.ckey))
+		if(query.NextRow())
+			var/ckey_player_id = query.item[1]
 
-		if(!query.NextRow())
-			return FALSE
+			//Update donations to old record
+			sql_query("UPDATE points_transactions SET player = $discord_player_id WHERE player = $ckey_player_id", dbcon_don, list(discord_player_id = discord_player_id, ckey_player_id = ckey_player_id))
+			sql_query("UPDATE money_transactions SET player = $discord_player_id WHERE player = $ckey_player_id", dbcon_don, list(discord_player_id = discord_player_id, ckey_player_id = ckey_player_id))
 
-		var/ckey_player_id = query.item[1]
+			sql_query("DELETE FROM players WHERE id = $ckey_player_id", dbcon_don, list(ckey_player_id = ckey_player_id))
 
-		//Update donations to old record
-		sql_query("UPDATE points_transactions SET player = $discord_player_id WHERE player = $ckey_player_id", dbcon_don, list(discord_player_id = discord_player_id, ckey_player_id = ckey_player_id))
-		sql_query("UPDATE money_transactions SET player = $discord_player_id WHERE player = $ckey_player_id", dbcon_don, list(discord_player_id = discord_player_id, ckey_player_id = ckey_player_id))
-
-		sql_query("DELETE FROM players WHERE id = $ckey_player_id", dbcon_don, list(ckey_player_id = ckey_player_id))
 		sql_query("UPDATE players SET ckey = $ckey WHERE discord = $discord_id", dbcon_don, list(ckey = player.ckey, discord_id = discord_id))
 
 	sql_query("DELETE FROM tokens WHERE token = $token", dbcon_don, list(token = token))

--- a/code/modules/donations/donations.dm
+++ b/code/modules/donations/donations.dm
@@ -214,7 +214,7 @@ SUBSYSTEM_DEF(donations)
 	else
 
 		var/new_record_player_id = query.item[1]
-		query = sql_query("SELECT id FROM players WHERE ckey=$discord_id AND discord IS NULL", dbcon_don, list(ckey = player.ckey))
+		query = sql_query("SELECT id FROM players WHERE ckey=$ckey", dbcon_don, list(ckey = player.ckey))
 		var/old_record_player_id = query.item[1]
 
 		//Update donations to old format record


### PR DESCRIPTION
В теории должно пофиксить проблему привязки сикея к дискорду через хаб.
Ибо хаб создаёт запись плеера с пустым сикеем.
А текущий код ищет запись по сикею.

Теперь он будет проверять нет ли записи по дискорду, если есть то обновлять донаты к старой записи и удалять старую.

Если нет то по старинке.

- [x] Pull Request полностью завершен, мне не нужна помощь чтобы его закончить.
- [x] Я внимательно прочитал все свои изменения и багов в них не нашел.
- [x] Я запускал сервер со своими изменениями локально и все протестировал.
- [x] Я ознакомился c [Guide to Contribute](https://github.com/ChaoticOnyx/OnyxBay/blob/dev/docs/contributing.md).
