### PR TITLE
tweak(admin): adds a second line of defense in restart proc

### DIFF
--- a/code/modules/admin/admin.dm
+++ b/code/modules/admin/admin.dm
@@ -672,24 +672,30 @@ var/global/floorIsLava = 0
 
 	var/list/options = list("Regular Restart", "Hard Restart (Skip MC Shutdown)", "Hardest Restart (Direct world.Reboot) \[Dangerous\]")
 
-	var/result = input(usr, "Select reboot method", "World Reboot", options[1]) as null|anything in options
-	if(result)
-		feedback_set_details("end_error","admin reboot - by [key_name(usr)]")
-		feedback_add_details("admin_verb","R") //If you are copy-pasting this, ensure the 2nd parameter is unique to the new proc!
-		var/init_by = "<span class='notice'>Initiated by [key_name(usr)].</span>"
-		switch(result)
-			if("Regular Restart")
-				to_world("<span class='danger'>Restarting world!</span> [init_by]")
-				log_admin("[key_name(usr)] initiated a reboot.")
-				world.Reboot()
-			if("Hard Restart (Skip MC Shutdown)")
-				to_world("<span class='boldannounce'>Hard world restart.</span> [init_by]")
-				log_admin("[key_name(usr)] initiated a hard reboot.")
-				world.Reboot(reboot_hardness = REBOOT_HARD)
-			if("Hardest Restart (Direct world.Reboot) \[Dangerous\]")
-				to_world("<span class='boldannounce'>Hardest world restart.</span> [init_by]")
-				log_admin("[key_name(usr)] initiated a hardest reboot.")
-				world.Reboot(reboot_hardness = REBOOT_REALLY_HARD)
+	var/result = tgui_input_list(usr, "Select reboot method", "World Reboot", options)
+	if(!result)
+		return
+
+	var/failsafe = tgui_alert(usr, "Are you absolutely sure you want to reboot with the following method: [result]?", "WORLD REBOOT. THINK TWICE!!!", list("Yes", "No"), autofocus = FALSE)
+	if(failsafe != "Yes")
+		return
+
+	feedback_set_details("end_error","admin reboot - by [key_name(usr)]")
+	feedback_add_details("admin_verb","R") //If you are copy-pasting this, ensure the 2nd parameter is unique to the new proc!
+	var/init_by = "<span class='notice'>Initiated by [key_name(usr)].</span>"
+	switch(result)
+		if("Regular Restart")
+			to_world("<span class='danger'>Restarting world!</span> [init_by]")
+			log_admin("[key_name(usr)] initiated a reboot.")
+			world.Reboot()
+		if("Hard Restart (Skip MC Shutdown)")
+			to_world("<span class='boldannounce'>Hard world restart.</span> [init_by]")
+			log_admin("[key_name(usr)] initiated a hard reboot.")
+			world.Reboot(reboot_hardness = REBOOT_HARD)
+		if("Hardest Restart (Direct world.Reboot) \[Dangerous\]")
+			to_world("<span class='boldannounce'>Hardest world restart.</span> [init_by]")
+			log_admin("[key_name(usr)] initiated a hardest reboot.")
+			world.Reboot(reboot_hardness = REBOOT_REALLY_HARD)
 
 /datum/admins/proc/end_round()
 	set category = "Server"

--- a/code/modules/admin/admin.dm
+++ b/code/modules/admin/admin.dm
@@ -676,8 +676,8 @@ var/global/floorIsLava = 0
 	if(!result)
 		return
 
-	var/failsafe = tgui_alert(usr, "Are you absolutely sure you want to reboot with the following method: [result]?", "WORLD REBOOT. THINK TWICE!!!", list("Yes", "No"), autofocus = FALSE)
-	if(failsafe != "Yes")
+	var/failsafe = tgui_input_text(usr, "To confirm, type ["Server Restart"] in the box below", "WORLD REBOOT. THINK TWICE!!!")
+	if(failsafe != "Server Restart")
 		return
 
 	feedback_set_details("end_error","admin reboot - by [key_name(usr)]")

--- a/code/modules/admin/admin.dm
+++ b/code/modules/admin/admin.dm
@@ -676,7 +676,7 @@ var/global/floorIsLava = 0
 	if(!result)
 		return
 
-	var/failsafe = tgui_input_text(usr, "To confirm, type ["Server Restart"] in the box below", "WORLD REBOOT. THINK TWICE!!!")
+	var/failsafe = tgui_input_text(usr, "To confirm, type \"Server Restart\" in the box below", "WORLD REBOOT. THINK TWICE!!!")
 	if(failsafe != "Server Restart")
 		return
 


### PR DESCRIPTION
<details>
<summary>Чейнджлог</summary>

```yml
🆑
admin: Теперь педалям придется дважды подтверждать свое намерение перезагрузить сервер. 
/🆑
```

</details>

- [x] Pull Request полностью завершен, мне не нужна помощь чтобы его закончить.
- [x] Я внимательно прочитал(-а) все свои изменения и багов в них не нашёл(-ла).
- [ ] Я запускал(-а) сервер со своими изменениями локально и все протестировал(-а).
- [x] Я ознакомился(-ась) c [Guide to Contribute](https://github.com/ChaoticOnyx/OnyxBay/blob/dev/docs/contributing.md).
