### PR TITLE
fix(secdoor_assembly): anchoring fix

### DIFF
--- a/code/game/objects/structures/secure_door_assembly.dm
+++ b/code/game/objects/structures/secure_door_assembly.dm
@@ -80,6 +80,9 @@
 	qdel(src)
 
 /obj/structure/secure_door_assembly/wrench_floor_bolts(mob/user, delay = 40)
+	if(!(state == STATE_EMPTY || state == STATE_UNANCHORED))
+		return
+
 	. = ..()
 
 	if(anchored)

--- a/code/game/objects/structures/secure_door_assembly.dm
+++ b/code/game/objects/structures/secure_door_assembly.dm
@@ -80,7 +80,7 @@
 	qdel(src)
 
 /obj/structure/secure_door_assembly/wrench_floor_bolts(mob/user, delay = 40)
-	if(!(state == STATE_EMPTY || state == STATE_UNANCHORED))
+	if(state > STATE_UNANCHORED)
 		return
 
 	. = ..()


### PR DESCRIPTION
close #12234

<details>
<summary>Чейнджлог</summary>

```yml
🆑BaraBara
bugfix: Теперь створки нельзя открутить на неверном этапе сборки
/🆑
```

</details>

- [x] Pull Request полностью завершен, мне не нужна помощь чтобы его закончить.
- [x] Я внимательно прочитал(-а) все свои изменения и багов в них не нашёл(-ла).
- [ ] Я запускал(-а) сервер со своими изменениями локально и все протестировал(-а).
- [x] Я ознакомился(-ась) c [Guide to Contribute](https://github.com/ChaoticOnyx/OnyxBay/blob/dev/docs/contributing.md).
