### PR TITLE
fix(stat panel): fixes rig crashing entire panel

### DIFF
--- a/code/controllers/subsystems/statpanels.dm
+++ b/code/controllers/subsystems/statpanels.dm
@@ -76,7 +76,10 @@ SUBSYSTEM_DEF(statpanels)
 			if(target.stat_tab in target.spell_tabs)
 				update_actions = TRUE
 
-			if(!length(target.spell_tabs) && (length(target_mob?.ability_master?.ability_objects) || istype(target_mob?.back, /obj/item/rig)))
+			if(istype(target_mob?.back, /obj/item/rig))
+				update_actions = TRUE
+
+			if(!length(target.spell_tabs) && length(target_mob?.ability_master?.ability_objects))
 				update_actions = TRUE
 
 			if(update_actions && num_fires % default_wait == 0)
@@ -224,7 +227,10 @@ SUBSYSTEM_DEF(statpanels)
 	if(target.stat_tab in target.spell_tabs)
 		update_actions = TRUE
 
-	if(!length(target.spell_tabs) && (length(target_mob?.ability_master?.ability_objects) || istype(target_mob?.back, /obj/item/rig)))
+	if(istype(target_mob?.back, /obj/item/rig))
+		update_actions = TRUE
+
+	if(!length(target.spell_tabs) && length(target_mob?.ability_master?.ability_objects))
 		update_actions = TRUE
 
 	if(update_actions)

--- a/code/game/atoms.dm
+++ b/code/game/atoms.dm
@@ -846,6 +846,9 @@ its easier to just keep the beam vertical.
 
 /// Advanced-use proc only! Handles verb addition to target's stat panel without tempering with source's verbs.
 /atom/proc/_add_verb_to_stat(mob/target, verb_or_list_to_add)
+	if(isnull(verb_or_list_to_add))
+		return
+
 	if(!islist(verb_or_list_to_add))
 		verb_or_list_to_add = list(verb_or_list_to_add)
 
@@ -865,7 +868,7 @@ its easier to just keep the beam vertical.
 		var/procpath/verb_to_add = thing
 		output_list[++output_list.len] = list(verb_to_add.category, verb_to_add.name)
 
-	if(!LAZYLEN(output_list))
+	if(!length(output_list))
 		return
 
 	target.client?.stat_panel.send_message("add_verb_list", output_list)
@@ -886,6 +889,9 @@ its easier to just keep the beam vertical.
 
 /// Advanced-use proc only! Handles verb removal from target's stat panel without tempering with source's verbs.
 /atom/proc/_remove_verb_from_stat(mob/target, verb_or_list_to_remove)
+	if(isnull(verb_or_list_to_remove))
+		return
+
 	if(!islist(verb_or_list_to_remove))
 		verb_or_list_to_remove = list(verb_or_list_to_remove)
 
@@ -905,7 +911,7 @@ its easier to just keep the beam vertical.
 		var/procpath/verb_to_remove = thing
 		output_list[++output_list.len] = list(verb_to_remove.category, verb_to_remove.name)
 
-	if(!LAZYLEN(output_list))
+	if(!length(output_list))
 		return
 
 	target.client?.stat_panel.send_message("remove_verb_list", output_list)

--- a/html/statbrowser/statbrowser.js
+++ b/html/statbrowser/statbrowser.js
@@ -140,7 +140,11 @@ function remove_verb(v) {
 
 function check_verbs() {
   for (var v = verb_tabs.length - 1; v >= 0; v--) {
-    verbs_cat_check(verb_tabs[v]);
+    var cat = verb_tabs[v];
+
+    if (cat == null) continue;
+
+    verbs_cat_check(cat);
   }
 }
 


### PR DESCRIPTION
Тайпсейфти придумали слабаки, которые не любят дебажить по брейкпоинтам через уродскую программу от майкрософт.

<details>
<summary>Чейнджлог</summary>

```yml
🆑
bugfix: Исправлен вылет статус панели при использовании ригов.
/🆑
```

</details>

- [x] Pull Request полностью завершен, мне не нужна помощь чтобы его закончить.
- [x] Я внимательно прочитал(-а) все свои изменения и багов в них не нашёл(-ла).
- [x] Я запускал(-а) сервер со своими изменениями локально и все протестировал(-а).
- [x] Я ознакомился(-ась) c [Guide to Contribute](https://github.com/ChaoticOnyx/OnyxBay/blob/dev/docs/contributing.md).
