### PR TITLE
tweak(orbit): adds captain's spare to POI

### DIFF
--- a/code/game/objects/items/weapons/cards_ids.dm
+++ b/code/game/objects/items/weapons/cards_ids.dm
@@ -281,6 +281,7 @@ var/const/NO_EMAG_ACT = -50
 	item_state = "gold_id"
 	registered_name = "Captain"
 	assignment = "Captain"
+	is_poi = TRUE
 
 /obj/item/card/id/captains_spare/New()
 	access = get_all_station_access()


### PR DESCRIPTION
<details>
<summary>Чейнджлог</summary>

```yml
🆑
tweak: Запасная карта капитана отображается в панели орбита.
/🆑
```

</details>

- [x] Pull Request полностью завершен, мне не нужна помощь чтобы его закончить.
- [x] Я внимательно прочитал(-а) все свои изменения и багов в них не нашёл(-ла).
- [x] Я запускал(-а) сервер со своими изменениями локально и все протестировал(-а).
- [x] Я ознакомился(-ась) c [Guide to Contribute](https://github.com/ChaoticOnyx/OnyxBay/blob/dev/docs/contributing.md).
