### PR TITLE
fix(view): fixes assorted view-related runtimes

### DIFF
--- a/code/_helpers/view.dm
+++ b/code/_helpers/view.dm
@@ -11,5 +11,5 @@
 		var/totalviewrange = 1 + 2 * view
 		return list(totalviewrange, totalviewrange)
 
-	var/list/viewrangelist = splittext(view,"x")
+	var/list/viewrangelist = splittext(view, "x")
 	return list(text2num(viewrangelist[1]), text2num(viewrangelist[2]))

--- a/code/_onclick/click.dm
+++ b/code/_onclick/click.dm
@@ -314,7 +314,9 @@
 /mob/observer/ghost/TurfAdjacent(turf/T)
 	if(!isturf(loc) || !client)
 		return FALSE
-	return z == T.z && (get_dist(loc, T) <= client.view)
+
+	var/list/view_sizes = get_view_size(client.view)
+	return z == T.z && (get_dist(loc, T) <= max(view_sizes[1], view_sizes[2]))
 
 /*
 	Control+Shift click

--- a/code/_onclick/hud/movable_screen_objects.dm
+++ b/code/_onclick/hud/movable_screen_objects.dm
@@ -64,7 +64,7 @@
 		var/num = text2num(copytext(X,6)) //Trim EAST-
 		if(!num)
 			num = 0
-		. = view_width*2 + 1 - num
+		. = view_width * 2 + 1 - num
 	else if(findtext(X,"WEST+"))
 		var/num = text2num(copytext(X,6)) //Trim WEST+
 		if(!num)
@@ -78,8 +78,8 @@
 	var/view_height = floor(view_sizes[2] / 2)
 
 	if(Y > view_height+1)
-		. = "NORTH-[view_height*2 + 1-Y]"
-	else if(Y < view_height+1)
+		. = "NORTH-[view_height * 2 + 1-Y]"
+	else if(Y < view_height + 1)
 		. = "SOUTH+[Y-1]"
 	else
 		. = "CENTER"
@@ -92,14 +92,14 @@
 		var/num = text2num(copytext(Y,7)) //Trim NORTH-
 		if(!num)
 			num = 0
-		. = view_height*2 + 1 - num
+		. = view_height * 2 + 1 - num
 	else if(findtext(Y,"SOUTH+"))
 		var/num = text2num(copytext(Y,7)) //Time SOUTH+
 		if(!num)
 			num = 0
 		. = num+1
 	else if(findtext(Y,"CENTER"))
-		. = view_height+1
+		. = view_height + 1
 
 //Debug procs
 /client/proc/test_movable_UI()

--- a/code/_onclick/hud/movable_screen_objects.dm
+++ b/code/_onclick/hud/movable_screen_objects.dm
@@ -45,53 +45,61 @@
 		screen_loc = "[screen_loc_X[1]]:[pix_X],[screen_loc_Y[1]]:[pix_Y]"
 
 /atom/movable/screen/movable/proc/encode_screen_X(X, mob/viewer)
-	var/view = viewer.client ? viewer.client.view : world.view
-	if(X > view+1)
-		. = "EAST-[view*2 + 1-X]"
-	else if(X < view+1)
+	var/list/view_sizes = get_view_size(isnull(viewer.client) ? world.view : viewer.client.view)
+	var/view_width = floor(view_sizes[1] / 2)
+
+	if(X > view_width+1)
+		. = "EAST-[view_width*2 + 1-X]"
+	else if(X < view_width+1)
 		. = "WEST+[X-1]"
 	else
 		. = "CENTER"
 
 /atom/movable/screen/movable/proc/decode_screen_X(X, mob/viewer)
-	var/view = viewer.client ? viewer.client.view : world.view
+	var/list/view_sizes = get_view_size(isnull(viewer.client) ? world.view : viewer.client.view)
+	var/view_width = floor(view_sizes[1] / 2)
+
 	//Find EAST/WEST implementations
 	if(findtext(X,"EAST-"))
 		var/num = text2num(copytext(X,6)) //Trim EAST-
 		if(!num)
 			num = 0
-		. = view*2 + 1 - num
+		. = view_width*2 + 1 - num
 	else if(findtext(X,"WEST+"))
 		var/num = text2num(copytext(X,6)) //Trim WEST+
 		if(!num)
 			num = 0
 		. = num+1
 	else if(findtext(X,"CENTER"))
-		. = view+1
+		. = view_width+1
 
 /atom/movable/screen/movable/proc/encode_screen_Y(Y, mob/viewer)
-	var/view = viewer.client ? viewer.client.view : world.view
-	if(Y > view+1)
-		. = "NORTH-[view*2 + 1-Y]"
-	else if(Y < view+1)
+	var/list/view_sizes = get_view_size(isnull(viewer.client) ? world.view : viewer.client.view)
+	var/view_height = floor(view_sizes[2] / 2)
+
+	if(Y > view_height+1)
+		. = "NORTH-[view_height*2 + 1-Y]"
+	else if(Y < view_height+1)
 		. = "SOUTH+[Y-1]"
 	else
 		. = "CENTER"
 
 /atom/movable/screen/movable/proc/decode_screen_Y(Y, mob/viewer)
-	var/view = viewer.client ? viewer.client.view : world.view
+	var/list/view_sizes = get_view_size(isnull(viewer.client) ? world.view : viewer.client.view)
+	var/view_height = floor(view_sizes[2] / 2)
+
 	if(findtext(Y,"NORTH-"))
 		var/num = text2num(copytext(Y,7)) //Trim NORTH-
 		if(!num)
 			num = 0
-		. = view*2 + 1 - num
+		. = view_height*2 + 1 - num
 	else if(findtext(Y,"SOUTH+"))
 		var/num = text2num(copytext(Y,7)) //Time SOUTH+
 		if(!num)
 			num = 0
 		. = num+1
 	else if(findtext(Y,"CENTER"))
-		. = view+1
+		. = view_height+1
 
 //Debug procs
 /client/proc/test_movable_UI()

--- a/code/modules/admin/verbs/randomverbs.dm
+++ b/code/modules/admin/verbs/randomverbs.dm
@@ -736,7 +736,7 @@ Ccomp's first proc.
 	set name = "Change View Range"
 
 	if(view_size.is_zooming())
-		view_size.reset_to_default()
+		view_size.set_default(get_screen_size(get_preference_value("WIDESCREEN") == GLOB.PREF_YES))
 	else
 		var/choice = tgui_input_list(src, "Select view range.", "FUCK YE", list(1,2,3,4,5,6,7,8,9,10,11,12,13,14,128))
 		if(isnull(choice))

--- a/code/modules/mob/living/carbon/human/human_helpers.dm
+++ b/code/modules/mob/living/carbon/human/human_helpers.dm
@@ -205,7 +205,8 @@
 	next_sonar_ping += 10 SECONDS
 	var/heard_something = FALSE
 	to_chat(src, "<span class='notice'>You take a moment to listen in to your environment...</span>")
-	for(var/mob/living/L in range(client.view, src))
+	var/list/view_sizes = get_view_size(client.view)
+	for(var/mob/living/L in range(max(view_sizes[1], view_sizes[2]), src))
 		var/turf/T = get_turf(L)
 		if(!T || L == src || L.is_ic_dead() || is_below_sound_pressure(T))
 			continue

--- a/code/modules/nano/interaction/default.dm
+++ b/code/modules/nano/interaction/default.dm
@@ -12,8 +12,14 @@ GLOBAL_DATUM_INIT(default_state, /datum/topic_state/default, new)
 /mob/observer/ghost/default_can_use_topic(src_object)
 	if(can_admin_interact())
 		return STATUS_INTERACTIVE							// Admins are more equal
-	if(!client || get_dist(src_object, src)	> client.view)	// Preventing ghosts from having a million windows open by limiting to objects in range
+
+	if(isnull(client))
 		return STATUS_CLOSE
+
+	var/list/view_sizes = get_view_size(client.view)
+	if(get_dist(src_object, src) >= max(view_sizes[1], view_sizes[2]))	// Preventing ghosts from having a million windows open by limiting to objects in range
+		return STATUS_CLOSE
+
 	return STATUS_UPDATE									// Ghosts can view updates
 
 /mob/living/silicon/pai/default_can_use_topic(src_object)
@@ -28,7 +34,8 @@ GLOBAL_DATUM_INIT(default_state, /datum/topic_state/default, new)
 		return
 
 	// robots can interact with things they can see within their view range
-	if((src_object in view(src)) && get_dist(src_object, src) <= src.client.view)
+	var/list/view_sizes = get_view_size(client.view)
+	if((src_object in view(src)) && get_dist(src_object, src) <= max(view_sizes[1], view_sizes[2]))
 		return STATUS_INTERACTIVE	// interactive (green visibility)
 	return STATUS_DISABLED			// no updates, completely disabled (red visibility)
 
@@ -53,8 +60,10 @@ GLOBAL_DATUM_INIT(default_state, /datum/topic_state/default, new)
 		if(cameranet && !cameranet.is_turf_visible(get_turf(src_object)))
 			return STATUS_CLOSE
 		return STATUS_INTERACTIVE
-	else if(get_dist(src_object, src) <= client.view)	// View does not return what one would expect while installed in an inteliCard
-		return STATUS_INTERACTIVE
+	else
+		var/list/view_sizes = get_view_size(client.view)
+		if(get_dist(src_object, src) <= max(view_sizes[1], view_sizes[2]))	// View does not return what one would expect while installed in an inteliCard
+			return STATUS_INTERACTIVE
 
 	return STATUS_CLOSE
 


### PR DESCRIPTION
Забавно, что Бйонд изначально поддерживал текстовый `view`, но наши предшественники писали код так, как будто движок кушал только числа во `view`.

- [x] Pull Request полностью завершен, мне не нужна помощь чтобы его закончить.
- [x] Я внимательно прочитал(-а) все свои изменения и багов в них не нашёл(-ла).
- [x] Я запускал(-а) сервер со своими изменениями локально и все протестировал(-а).
- [x] Я ознакомился(-ась) c [Guide to Contribute](https://github.com/ChaoticOnyx/OnyxBay/blob/dev/docs/contributing.md).
