### PR TITLE
Fix da fukken rcd

### DIFF
--- a/code/game/turfs/simulated/floor_acts.dm
+++ b/code/game/turfs/simulated/floor_acts.dm
@@ -179,7 +179,7 @@
 				if(istype(door, /obj/machinery/door/firedoor))
 					continue
 
-				show_splash_text(user, "there's already a door!", "\icon[src] There's already a door!")
+				show_splash_text(user, "there's already a door!", "There's already a door!")
 				return FALSE
 
 			//create the assembly and let it finish itself

--- a/code/game/turfs/simulated/floor_acts.dm
+++ b/code/game/turfs/simulated/floor_acts.dm
@@ -180,7 +180,9 @@
 				return FALSE
 
 			//create the assembly and let it finish itself
-			var/obj/structure/door_assembly/assembly = new (src)
+			var/obj/machinery/door/airlock/airlock = airlock_type
+			var/assembly_path = airlock::assembly_type
+			var/obj/structure/door_assembly/assembly = new assembly_path(src)
 			if(initial(airlock_type.glass))
 				assembly.glass = TRUE
 				assembly.glass_type = airlock_type

--- a/code/game/turfs/simulated/floor_acts.dm
+++ b/code/game/turfs/simulated/floor_acts.dm
@@ -176,6 +176,9 @@
 				return TRUE
 
 			for(var/obj/machinery/door/door in src)
+				if(istype(door, /obj/machinery/door/firedoor))
+					continue
+
 				show_splash_text(user, "there's already a door!", "\icon[src] There's already a door!")
 				return FALSE
 

--- a/code/modules/rcd/_rcd.dm
+++ b/code/modules/rcd/_rcd.dm
@@ -42,7 +42,7 @@
 	spark_system.attach(src)
 
 ///returns local local_matter units available. overriden by rcd borg to return power units available
-/obj/item/construction/proc/get_matter()
+/obj/item/construction/proc/get_matter(mob/user)
 	return local_matter
 
 /obj/item/construction/examine(mob/user, infix)

--- a/code/modules/rcd/_rcd.dm
+++ b/code/modules/rcd/_rcd.dm
@@ -83,7 +83,6 @@
 	if(istype(item, /obj/item/rcd_ammo))
 		var/obj/item/rcd_ammo/ammo = item
 		var/load = min(ammo.ammoamt, max_matter - local_matter)
-		load = round(load / MATTER_REDUCTION_COEFFICIENT)
 		if(load <= 0)
 			show_splash_text(user, "storage full!", SPAN("warning", "\The [src] is full!"))
 			return FALSE

--- a/code/modules/rcd/_rcd.dm
+++ b/code/modules/rcd/_rcd.dm
@@ -42,12 +42,12 @@
 	spark_system.attach(src)
 
 ///returns local local_matter units available. overriden by rcd borg to return power units available
-/obj/item/construction/proc/get_matter(mob/user)
+/obj/item/construction/proc/get_matter()
 	return local_matter
 
 /obj/item/construction/examine(mob/user, infix)
 	. = ..()
-	. += "It currently holds [get_matter(user)]/[max_matter] local_matter-units."
+	. += "It currently holds [get_matter()]/[max_matter] matter-units."
 
 /obj/item/construction/Destroy()
 	QDEL_NULL(spark_system)

--- a/code/modules/rcd/_rcd.dm
+++ b/code/modules/rcd/_rcd.dm
@@ -47,7 +47,7 @@
 
 /obj/item/construction/examine(mob/user, infix)
 	. = ..()
-	. += "It currently holds [get_matter()]/[max_matter] matter-units."
+	. += "It currently holds [get_matter(user)]/[max_matter] matter-units."
 
 /obj/item/construction/Destroy()
 	QDEL_NULL(spark_system)

--- a/code/modules/rcd/rcd.dm
+++ b/code/modules/rcd/rcd.dm
@@ -45,6 +45,8 @@
 
 	var/static/list/designs_icons = list()
 
+	matter = list(MATERIAL_STEEL = 20000, MATERIAL_GLASS = 10000)
+
 /obj/effect/rcd_hologram
 	name = "hologram"
 	mouse_opacity = MOUSE_OPACITY_TRANSPARENT


### PR DESCRIPTION
Resolves #12280 
Resolves #12275
Resolves #12274

<details>
<summary>Чейнджлог</summary>

```yml
🆑
bugfix: РЦД вернулся во взломанный протолат.
bugfix: РЦД снова дает строить шлюзы поверх аварийных створок.
bugfix: Шлюзы, построенные РЦД, больше не сбрасываются до стандартных после разборки.
/🆑
```

</details>

- [x] Pull Request полностью завершен, мне не нужна помощь чтобы его закончить.
- [x] Я внимательно прочитал(-а) все свои изменения и багов в них не нашёл(-ла).
- [ ] Я запускал(-а) сервер со своими изменениями локально и все протестировал(-а).
- [x] Я ознакомился(-ась) c [Guide to Contribute](https://github.com/ChaoticOnyx/OnyxBay/blob/dev/docs/contributing.md).
