### PR TITLE
Fix dat fukken inventory

### DIFF
--- a/code/modules/mob/holder.dm
+++ b/code/modules/mob/holder.dm
@@ -72,7 +72,9 @@ var/list/holder_mob_icon_cache = list()
 	return I ? I.GetAccess() : ..()
 
 /obj/item/holder/attack_self()
-	held_mob.show_inv(usr)
+	if(!held_mob.show_inv(usr))
+		return
+
 	usr.show_inventory?.open()
 
 /obj/item/holder/attack(mob/target, mob/user)

--- a/code/modules/mob/living/carbon/alien/alien.dm
+++ b/code/modules/mob/living/carbon/alien/alien.dm
@@ -49,4 +49,4 @@
 	return 0
 
 /mob/living/carbon/alien/show_inv(mob/user)
-	return //Consider adding cuffs and hats to this, for the sake of fun.
+	return FALSE//Consider adding cuffs and hats to this, for the sake of fun.

--- a/code/modules/mob/living/carbon/carbon.dm
+++ b/code/modules/mob/living/carbon/carbon.dm
@@ -479,7 +479,7 @@
 	<BR>"}
 	show_browser(user, dat, text("window=mob[];size=325x500", name))
 	onclose(user, "mob[name]")
-	return
+	return TRUE
 
 /**
  *  Return FALSE if victim can't be devoured, DEVOUR_FAST if they can be devoured quickly, DEVOUR_SLOW for slow devour

--- a/code/modules/mob/living/carbon/human/human.dm
+++ b/code/modules/mob/living/carbon/human/human.dm
@@ -243,59 +243,22 @@
 /mob/living/carbon/human/var/co2overloadtime = null
 /mob/living/carbon/human/var/temperature_resistance = 75 CELSIUS
 
-/mob/living/carbon/human/show_inv(mob/user)
+/mob/living/carbon/human/show_inv(mob/user, underwear_only = FALSE)
 	if(user.incapacitated())
-		return
+		return FALSE
+
 	if(!(user.Adjacent(src) || (istype(loc, /obj/item/holder) && loc.loc == user)))
-		return
-	if(!user.IsAdvancedToolUser(TRUE))
-		show_inv_reduced(user)
-		return
+		return FALSE
+
 	var/dat = "<B><HR><FONT size=3>[name]</FONT></B><BR><HR>"
-	var/firstline = TRUE
-	for(var/entry in species.hud.gear)
-		var/list/slot_ref = species.hud.gear[entry]
-		if((slot_ref["slot"] in list(slot_l_store, slot_r_store)))
-			continue
-		var/obj/item/thing_in_slot = get_equipped_item(slot_ref["slot"])
-		if(firstline)
-			firstline = FALSE
-		else
-			dat += "<BR>"
-		dat += "<B>[slot_ref["name"]]:</b> <a href='?src=\ref[src];item=[slot_ref["slot"]]'>[istype(thing_in_slot) ? thing_in_slot : "nothing"]</a>"
-		if(istype(thing_in_slot, /obj/item/clothing))
-			var/obj/item/clothing/C = thing_in_slot
-			if(LAZYLEN(C.accessories))
-				dat += "<BR><A href='?src=\ref[src];item=tie;holder=\ref[C]'>Remove accessory</A>"
-	dat += "<HR>"
+	if(!user.IsAdvancedToolUser(TRUE))
+		dat += underwear_only ? "" : show_inv_get_slots_reduced()
+		dat += underwear_only ? "" : show_inv_get_ending()
+	else
+		dat += underwear_only ? "" : show_inv_get_slots()
+		dat += show_inv_get_underwear()
 
-	if(species.hud.has_hands)
-		dat += "<b>Left hand:</b> <A href='?src=\ref[src];item=[slot_l_hand]'>[istype(l_hand) ? l_hand : "nothing"]</A>"
-		dat += "<BR><b>Right hand:</b> <A href='?src=\ref[src];item=[slot_r_hand]'>[istype(r_hand) ? r_hand : "nothing"]</A>"
-
-	// Do they get an option to set internals?
-	if(istype(wear_mask, /obj/item/clothing/mask) || istype(head, /obj/item/clothing/head/helmet/space))
-		if(istype(back, /obj/item/tank) || istype(belt, /obj/item/tank) || istype(s_store, /obj/item/tank))
-			dat += "<BR><A href='?src=\ref[src];item=internals'>Toggle internals.</A>"
-
-	var/obj/item/clothing/under/suit = w_uniform
-	// Other incidentals.
-	if(istype(suit))
-		dat += "<BR><b>Pockets:</b> <A href='?src=\ref[src];item=pockets'>Empty or Place Item</A>"
-		if(suit.rolled_down != -1)
-			dat += "<BR><A href='?src=\ref[src];item=rolldown'>Roll Down Jumpsuit</A>"
-		if(suit.has_sensor == 1)
-			dat += "<BR><A href='?src=\ref[src];item=sensors'>Set sensors</A>"
-	if(handcuffed)
-		dat += "<BR><A href='?src=\ref[src];item=[slot_handcuffed]'>Handcuffed</A>"
-
-	for(var/entry in worn_underwear)
-		var/obj/item/underwear/UW = entry
-		dat += "<BR><a href='?src=\ref[src];item=\ref[UW]'>Remove \the [UW]</a>"
-
-	dat += "<BR><A href='?src=\ref[src];item=splints'>Remove splints</A>"
-	dat += "<HR><A href='?src=\ref[src];refresh=1'>Refresh</A>"
-	dat += "<BR><A href='?src=\ref[user];inv_close=1'>Close</A>"
+	dat += show_inv_get_ending(user, underwear_only)
 
 	if(!user.show_inventory || user.show_inventory.user != user)
 		user.show_inventory = new /datum/browser(user, "mob[name]", "Inventory", 340, 560)
@@ -303,15 +266,12 @@
 	else
 		user.show_inventory.set_content(dat)
 		user.show_inventory.update()
-	return
 
-// Used when the user is not an advanced tool user (i.e. xenomorph)
-/mob/living/carbon/human/proc/show_inv_reduced(mob/user) // aka show_inv_to_a_moron
-	if(user.incapacitated())
-		return
-	if(!(user.Adjacent(src) || (istype(loc, /obj/item/holder) && loc.loc == user)))
-		return
-	var/dat = "<B><HR><FONT size=3>[name]</FONT></B><BR><HR>"
+	return TRUE
+
+/mob/living/carbon/human/proc/show_inv_get_slots_reduced()
+	var/data
+
 	var/firstline = TRUE
 	for(var/entry in species.hud.gear)
 		var/list/slot_ref = species.hud.gear[entry]
@@ -321,24 +281,76 @@
 		if(firstline)
 			firstline = FALSE
 		else
-			dat += "<BR>"
-		dat += "<B>[slot_ref["name"]]:</b> <a href='?src=\ref[src];item=[slot_ref["slot"]]'>[istype(thing_in_slot) ? thing_in_slot : "nothing"]</a>"
-	dat += "<HR>"
+			data += "<BR>"
+		data += "<B>[slot_ref["name"]]:</b> <a href='?src=\ref[src];item=[slot_ref["slot"]]'>[istype(thing_in_slot) ? thing_in_slot : "nothing"]</a>"
+	data += "<HR>"
 
 	if(species.hud.has_hands)
-		dat += "<b>Left hand:</b> <A href='?src=\ref[src];item=[slot_l_hand]'>[istype(l_hand) ? l_hand : "nothing"]</A>"
-		dat += "<BR><b>Right hand:</b> <A href='?src=\ref[src];item=[slot_r_hand]'>[istype(r_hand) ? r_hand : "nothing"]</A>"
+		data += "<b>Left hand:</b> <A href='?src=\ref[src];item=[slot_l_hand]'>[istype(l_hand) ? l_hand : "nothing"]</A>"
+		data += "<BR><b>Right hand:</b> <A href='?src=\ref[src];item=[slot_r_hand]'>[istype(r_hand) ? r_hand : "nothing"]</A>"
 
-	dat += "<HR><A href='?src=\ref[src];refresh=1'>Refresh</A>"
-	dat += "<BR><A href='?src=\ref[user];inv_close=1'>Close</A>"
+	return data
 
-	if(!user.show_inventory || user.show_inventory.user != user)
-		user.show_inventory = new /datum/browser(user, "mob[name]", "Inventory", 340, 560)
-		user.show_inventory.set_content(dat)
-	else
-		user.show_inventory.set_content(dat)
-		user.show_inventory.update()
-	return
+/mob/living/carbon/human/proc/show_inv_get_slots()
+	var/data
+
+	var/firstline = TRUE
+	for(var/entry in species.hud.gear)
+		var/list/slot_ref = species.hud.gear[entry]
+		if((slot_ref["slot"] in list(slot_l_store, slot_r_store)))
+			continue
+		var/obj/item/thing_in_slot = get_equipped_item(slot_ref["slot"])
+		if(firstline)
+			firstline = FALSE
+		else
+			data += "<BR>"
+		data += "<B>[slot_ref["name"]]:</b> <a href='?src=\ref[src];item=[slot_ref["slot"]]'>[istype(thing_in_slot) ? thing_in_slot : "nothing"]</a>"
+		if(istype(thing_in_slot, /obj/item/clothing))
+			var/obj/item/clothing/C = thing_in_slot
+			if(LAZYLEN(C.accessories))
+				data += "<BR><A href='?src=\ref[src];item=tie;holder=\ref[C]'>Remove accessory</A>"
+	data += "<HR>"
+
+	if(species.hud.has_hands)
+		data += "<b>Left hand:</b> <A href='?src=\ref[src];item=[slot_l_hand]'>[istype(l_hand) ? l_hand : "nothing"]</A>"
+		data += "<BR><b>Right hand:</b> <A href='?src=\ref[src];item=[slot_r_hand]'>[istype(r_hand) ? r_hand : "nothing"]</A>"
+
+	// Do they get an option to set internals?
+	if(istype(wear_mask, /obj/item/clothing/mask) || istype(head, /obj/item/clothing/head/helmet/space))
+		if(istype(back, /obj/item/tank) || istype(belt, /obj/item/tank) || istype(s_store, /obj/item/tank))
+			data += "<BR><A href='?src=\ref[src];item=internals'>Toggle internals.</A>"
+
+	var/obj/item/clothing/under/suit = w_uniform
+	// Other incidentals.
+	if(istype(suit))
+		data += "<BR><b>Pockets:</b> <A href='?src=\ref[src];item=pockets'>Empty or Place Item</A>"
+		if(suit.rolled_down != -1)
+			data += "<BR><A href='?src=\ref[src];item=rolldown'>Roll Down Jumpsuit</A>"
+		if(suit.has_sensor == 1)
+			data += "<BR><A href='?src=\ref[src];item=sensors'>Set sensors</A>"
+	if(handcuffed)
+		data += "<BR><A href='?src=\ref[src];item=[slot_handcuffed]'>Handcuffed</A>"
+
+	return data
+
+/mob/living/carbon/human/proc/show_inv_get_underwear()
+	var/data
+
+	for(var/entry in worn_underwear)
+		var/obj/item/underwear/UW = entry
+		data += "<BR><a href='?src=\ref[src];item=\ref[UW]'>Remove \the [UW]</a>"
+
+	return data
+
+/mob/living/carbon/human/proc/show_inv_get_ending(mob/user, underwear_only = FALSE)
+	var/data
+
+	if(!underwear_only && user.IsAdvancedToolUser(TRUE))
+		data += "<BR><A href='?src=\ref[src];item=splints'>Remove splints</A>"
+	data += "<HR><A href='?src=\ref[src];refresh=1;underwear_only=[underwear_only]'>Refresh</A>"
+	data += "<BR><A href='?src=\ref[user];inv_close=1'>Close</A>"
+
+	return data
 
 // called when something steps onto a human
 // this handles mulebots and vehicles
@@ -487,7 +499,7 @@
 
 	if(href_list["refresh"])
 		if(Adjacent(src, usr))
-			show_inv(usr)
+			show_inv(usr, href_list["underwear_only"])
 
 	if(href_list["inv_close"])
 		if(usr.show_inventory)
@@ -1668,6 +1680,15 @@
 		log_and_message_admins("has succumbed")
 		adjustBrainLoss(brain.max_damage)
 		updatehealth()
+
+/mob/living/carbon/human/verb/remove_underwear()
+	set name = "Remove Underwear"
+	set category = "IC"
+
+	if(!show_inv(src, TRUE))
+		return
+
+	usr.show_inventory?.open()
 
 /mob/living/carbon/human/get_runechat_color()
 	return species.get_species_runechat_color(src)

--- a/code/modules/mob/living/carbon/human/human.dm
+++ b/code/modules/mob/living/carbon/human/human.dm
@@ -498,7 +498,7 @@
 
 	if(href_list["refresh"])
 		if(Adjacent(src, usr))
-			show_inv(usr, href_list["underwear_only"])
+			show_inv(usr, text2num(href_list["underwear_only"]))
 
 	if(href_list["inv_close"])
 		if(usr.show_inventory)

--- a/code/modules/mob/living/carbon/human/human.dm
+++ b/code/modules/mob/living/carbon/human/human.dm
@@ -253,7 +253,6 @@
 	var/dat = "<B><HR><FONT size=3>[name]</FONT></B><BR><HR>"
 	if(!user.IsAdvancedToolUser(TRUE))
 		dat += underwear_only ? "" : show_inv_get_slots_reduced()
-		dat += underwear_only ? "" : show_inv_get_ending()
 	else
 		dat += underwear_only ? "" : show_inv_get_slots()
 		dat += show_inv_get_underwear()

--- a/code/modules/mob/living/simple_animal/friendly/corgi.dm
+++ b/code/modules/mob/living/simple_animal/friendly/corgi.dm
@@ -134,7 +134,8 @@
 
 /mob/living/simple_animal/corgi/show_inv(mob/user)
 	user.set_machine(src)
-	if(user.stat) return
+	if(user.stat)
+		return FALSE
 
 	var/dat = 	"<meta charset=\"utf-8\"><div align='center'><b>Inventory of [name]</b></div><p>"
 	if(hat)
@@ -143,7 +144,7 @@
 		dat +=	"<br><b>Head:</b> <a href='?src=\ref[src];add_inv=hat'>Nothing</a>"
 	show_browser(user, dat, text("window=mob[];size=325x325", name))
 	onclose(user, "mob[real_name]")
-	return
+	return TRUE
 
 /mob/living/simple_animal/corgi/Topic(href, href_list)
 	//Can the usr physically do this?

--- a/code/modules/mob/living/simple_animal/friendly/parrot.dm
+++ b/code/modules/mob/living/simple_animal/friendly/parrot.dm
@@ -158,7 +158,8 @@
  */
 /mob/living/simple_animal/parrot/show_inv(mob/user as mob)
 	user.set_machine(src)
-	if(user.stat) return
+	if(user.stat)
+		return FALSE
 
 	var/dat = 	"<meta charset=\"utf-8\"><div align='center'><b>Inventory of [name]</b></div><p>"
 	if(ears)
@@ -173,7 +174,7 @@
 
 	show_browser(user, dat, text("window=mob[];size=325x500", name))
 	onclose(user, "mob[real_name]")
-	return
+	return TRUE
 
 /mob/living/simple_animal/parrot/Topic(href, href_list)
 

--- a/code/modules/mob/mob.dm
+++ b/code/modules/mob/mob.dm
@@ -294,6 +294,13 @@
 				client.eye = loc
 	return
 
+/**
+ * This proc creates content for nano inventory.
+ * Returns TRUE if there is content to show.
+ * In case there's nothing to show - returns FALSE.
+ * This is done to prevent UI from showing last opened inventory.
+ * Do not forget to check what this proc has returned before actually opening UI!
+ */
 /mob/proc/show_inv(mob/user)
 	return FALSE
 

--- a/code/modules/mob/mob.dm
+++ b/code/modules/mob/mob.dm
@@ -295,7 +295,7 @@
 	return
 
 /mob/proc/show_inv(mob/user)
-	return
+	return FALSE
 
 // Mob verbs are faster than object verbs. See http://www.byond.com/forum/?post=1326139&page=2#comment8198716 for why this isn't atom/verb/examine()
 /mob/verb/examinate(atom/to_axamine as mob|obj|turf in view(client.eye))
@@ -610,7 +610,10 @@
 		return
 	if(istype(M,/mob/living/silicon/ai))
 		return
-	show_inv(usr)
+
+	if(!show_inv(usr))
+		return
+
 	usr.show_inventory?.open()
 
 /mob/verb/stop_pulling_verb()


### PR DESCRIPTION
Атомизация для гоев.

Resolves #7815
Решается просто - прок show_inv() возвращает не нулл а TRUE/FALSE в зависимости от наличия контента. Если показывать нехер - то возвращается FALSE и браузер не показывается. 

Плюс добавил нормальную кнопку Remove Underwear в категорию IC, она показывает наноуи с нижним бельем. Пока Remove Underwear из Object убирать не буду, народ искорежится от потери привычной кнопки. 

<details>
<summary>Чейнджлог</summary>

```yml
🆑
bugfix: Исправлен баг в результате которого при открытии инвентаря симплмоба открывался последний открытый инвентарь.
tweak: Добавлена более удобная кнопка Remove Underwear в категорию IC. Она показывает человеческий инвентарь с нижним бельем, а не список на белом фоне. 
/🆑
```

</details>

- [x] Pull Request полностью завершен, мне не нужна помощь чтобы его закончить.
- [x] Я внимательно прочитал(-а) все свои изменения и багов в них не нашёл(-ла).
- [x] Я запускал(-а) сервер со своими изменениями локально и все протестировал(-а).
- [x] Я ознакомился(-ась) c [Guide to Contribute](https://github.com/ChaoticOnyx/OnyxBay/blob/dev/docs/contributing.md).
