### PR TITLE
fix(uplink): fixes inability to buy rig modules

### DIFF
--- a/code/datums/components/uplink.dm
+++ b/code/datums/components/uplink.dm
@@ -208,7 +208,7 @@
 	if(!user || user.incapacitated())
 		return
 
-	if(telecrystals < U.item_cost)
+	if(telecrystals < U.cost(telecrystals, src))
 		return
 
 	U.buy(src, user)

--- a/code/datums/uplink/categories/badassery.dm
+++ b/code/datums/uplink/categories/badassery.dm
@@ -87,7 +87,7 @@
 * Surplus Crate *
 ****************/
 /datum/uplink_item/item/badassery/surplus
-	name = "\improper Surplus Crate"
+	name = "Surplus Crate"
 	item_cost = DEFAULT_TELECRYSTAL_AMOUNT * 2
 	var/item_worth = DEFAULT_TELECRYSTAL_AMOUNT * 3
 	var/icon

--- a/code/datums/uplink/categories/powersuit_modules.dm
+++ b/code/datums/uplink/categories/powersuit_modules.dm
@@ -5,36 +5,36 @@
 	category = /datum/uplink_category/powersuit_modules
 
 /datum/uplink_item/item/powersuit_modules/thermal
-	name = "\improper Thermal Scanner"
+	name = "Thermal Scanner"
 	item_cost = 4
 	path = /obj/item/rig_module/vision/thermal
 
 /datum/uplink_item/item/powersuit_modules/energy_net
-	name = "\improper Net Projector"
+	name = "Net Projector"
 	item_cost = 6
 	path = /obj/item/rig_module/fabricator/energy_net
 
 /datum/uplink_item/item/powersuit_modules/ewar_voice
-	name = "\improper Electrowarfare Suite and Voice Synthesiser"
+	name = "Electrowarfare Suite and Voice Synthesiser"
 	item_cost = 3
 	path = /obj/item/storage/backpack/satchel/syndie_kit/ewar_voice
 
 /datum/uplink_item/item/powersuit_modules/maneuvering_jets
-	name = "\improper Maneuvering Jets"
+	name = "Maneuvering Jets"
 	item_cost = 2
 	path = /obj/item/rig_module/maneuvering_jets
 
 /datum/uplink_item/item/powersuit_modules/egun
-	name = "\improper Mounted Energy Gun"
+	name = "Mounted Energy Gun"
 	item_cost = 5
 	path = /obj/item/rig_module/mounted/egun
 
 /datum/uplink_item/item/powersuit_modules/power_sink
-	name = "\improper Power Sink"
+	name = "Power Sink"
 	item_cost = 6
 	path = /obj/item/rig_module/power_sink
 
 /datum/uplink_item/item/powersuit_modules/laser_canon
-	name = "\improper Mounted Laser Cannon"
+	name = "Mounted Laser Cannon"
 	item_cost = 11 // This thing mounted on a RIG turns you into a walking siege machine
 	path = /obj/item/rig_module/mounted


### PR DESCRIPTION
Resolves #12355
Resolves #12361

<details>
<summary>Чейнджлог</summary>

```yml
🆑
bugfix: Исправлено недоразумение в результате которого нельзя было купить модули для рига в аплинке.
bugfix: Исправлена невозможность купить бесплатную вещь в аплинке. 
/🆑
```

</details>

- [x] Pull Request полностью завершен, мне не нужна помощь чтобы его закончить.
- [x] Я внимательно прочитал(-а) все свои изменения и багов в них не нашёл(-ла).
- [x] Я запускал(-а) сервер со своими изменениями локально и все протестировал(-а).
- [x] Я ознакомился(-ась) c [Guide to Contribute](https://github.com/ChaoticOnyx/OnyxBay/blob/dev/docs/contributing.md).
