### PR TITLE
fix(announcer): death alarm should hijack announces no more

### DIFF
--- a/code/controllers/subsystems/announce.dm
+++ b/code/controllers/subsystems/announce.dm
@@ -128,7 +128,7 @@ SUBSYSTEM_DEF(announce)
 		__announce_arrival_simple(name, rank, spawnpoint.msg, announce_freq)
 
 /datum/controller/subsystem/announce/proc/__announce_arrival_simple(name, rank = "visitor", join_message = "has arrived on the [station_name()]", frequency)
-	GLOB.global_announcer.autosay("[name], [rank], [join_message].", get_announcement_computer(), frequency)
+	GLOB.global_announcer.autosay("[name], [rank], [join_message].", "Arrivals Announcement Computer", frequency)
 
 /datum/controller/subsystem/announce/proc/__announce(announce_type, text, title, sender, sound_override, msg_sanitized, do_newscast, zlevels)
 	var/message = null

--- a/code/modules/mob/new_player/new_player.dm
+++ b/code/modules/mob/new_player/new_player.dm
@@ -442,7 +442,7 @@
 		if(character.mind.role_alt_title)
 			rank = character.mind.role_alt_title
 		// can't use their name here, since cyborg namepicking is done post-spawn, so we'll just say "A new Cyborg has arrived"/"A new Android has arrived"/etc.
-		GLOB.global_announcer.autosay("A new[rank ? " [rank]" : " visitor" ] [join_message ? join_message : "has arrived"].", get_announcement_computer())
+		GLOB.global_announcer.autosay("A new[rank ? " [rank]" : " visitor" ] [join_message ? join_message : "has arrived"].", "Arrivals Announcement Computer")
 		log_and_message_admins("has joined the round as [character.mind.assigned_role].", character)
 
 /mob/new_player/proc/LateChoices()

--- a/code/procs/announce.dm
+++ b/code/procs/announce.dm
@@ -14,16 +14,6 @@
 	// Format currently matches that of newscaster feeds: Registered Name (Assigned Rank)
 	return I.assignment ? "[I.registered_name] ([I.assignment])" : I.registered_name
 
-/proc/get_announcement_computer(announcer = "Arrivals Announcement Computer")
-	if(length(ai_list))
-		var/list/mob/living/silicon/ai/valid_AIs = list()
-		for(var/mob/living/silicon/ai/AI in ai_list)
-			if(!AI.is_ic_dead())
-				valid_AIs.Add(AI)
-		if(length(valid_AIs))
-			announcer = pick(valid_AIs)
-	return announcer
-
 /proc/get_announcement_frequency(datum/job/job)
 	// During red alert all jobs are announced on main frequency.
 	var/decl/security_state/security_state = decls_repository.get_decl(GLOB.using_map.security_state)


### PR DESCRIPTION
Resolves #12359

<details>
<summary>Чейнджлог</summary>

```yml
🆑
bugfix: Имплант уведомления о смерти Дезмонда Джонсона должен перестать воровать роль аннонсера.
/🆑
```

</details>

- [x] Pull Request полностью завершен, мне не нужна помощь чтобы его закончить.
- [x] Я внимательно прочитал(-а) все свои изменения и багов в них не нашёл(-ла).
- [x] Я запускал(-а) сервер со своими изменениями локально и все протестировал(-а).
- [x] Я ознакомился(-ась) c [Guide to Contribute](https://github.com/ChaoticOnyx/OnyxBay/blob/dev/docs/contributing.md).
