### PR TITLE
fix(cyborgs): fix synthetics craft

### DIFF
--- a/code/modules/materials/material_sheets.dm
+++ b/code/modules/materials/material_sheets.dm
@@ -40,7 +40,8 @@
 		obj_flags &= (~OBJ_FLAG_CONDUCTIBLE)
 
 	matter = material.get_matter()
-	craft_tool = material.craft_tool
+	if(!uses_charge)
+		craft_tool = material.craft_tool
 	update_strings()
 
 	if(material.reagent_path)


### PR DESCRIPTION
Синтезаторы ресов киборгов больше не берут переменную craft_tools из их материала, а значит не будут требовать сварку для крафта.

close #11976 

<details>
<summary>Чейнджлог</summary>

```yml
🆑BaraBara
bugfix: Дроны и киборги снова могут строить
/🆑
```

</details>

- [x] Pull Request полностью завершен, мне не нужна помощь чтобы его закончить.
- [ ] Я внимательно прочитал(-а) все свои изменения и багов в них не нашёл(-ла).
- [ ] Я запускал(-а) сервер со своими изменениями локально и все протестировал(-а).
- [x] Я ознакомился(-ась) c [Guide to Contribute](https://github.com/ChaoticOnyx/OnyxBay/blob/dev/docs/contributing.md).
