### PR TITLE
Allows pushing without interrupting pulls

### DIFF
--- a/code/datums/movement/mob.dm
+++ b/code/datums/movement/mob.dm
@@ -184,6 +184,10 @@
 			return
 		. = max(., G.grab_slowdown())
 
+/datum/movement_handler/mob/delay/proc/InstantUpdateGlideSize()
+	var/supposed_delay = max(1, mob.movement_delay() + GetGrabSlowdown())
+	host.set_glide_size(DELAY2GLIDESIZE(supposed_delay))
+
 // Stop effect
 /datum/movement_handler/mob/stop_effect/DoMove()
 	if(MayMove() == MOVEMENT_STOP)

--- a/code/modules/mob/living/living.dm
+++ b/code/modules/mob/living/living.dm
@@ -151,44 +151,65 @@
 		spawn(0)
 			..()
 			var/saved_dir = AM.dir
-			if (!istype(AM, /atom/movable) || AM.anchored || AM.atom_flags & ATOM_FLAG_UNPUSHABLE)
+
+			if(!istype(AM, /atom/movable) || AM.anchored || AM.atom_flags & ATOM_FLAG_UNPUSHABLE)
 				if(confused && prob(50) && m_intent == M_RUN && !lying)
 					var/obj/machinery/disposal/D = AM
+
 					if(istype(D) && !(D.stat & BROKEN))
 						Weaken(6)
 						playsound(AM, 'sound/effects/clang.ogg', 75)
 						visible_message(SPAN_WARNING("[src] falls into \the [AM]!"), SPAN_WARNING("You fall into \the [AM]!"))
-						if (client)
+
+						if(client)
 							client.perspective = EYE_PERSPECTIVE
 							client.eye = src
+
 						forceMove(AM)
 					else
 						Weaken(2)
 						playsound(loc, SFX_FIGHTING_PUNCH, rand(80, 100), 1, -1)
 						visible_message(SPAN_WARNING("[src] [pick("ran", "slammed")] into \the [AM]!"))
+
 					src.apply_damage(5, BRUTE)
 				return
+
 			if (!now_pushing)
 				now_pushing = 1
 
 				var/t = get_dir(src, AM)
-				if (istype(AM, /obj/structure/window))
+
+				if(istype(AM, /obj/structure/window))
 					for(var/obj/structure/window/win in get_step(AM,t))
 						now_pushing = 0
 						return
-				step(AM, t)
-				if (istype(AM, /mob/living))
+
+				var/pulled_pushing = (AM.pulledby == src && pulling == AM)
+				if(pulled_pushing)
+					step_glide(AM, t, AM.glide_size)
+				else
+					step(AM, t)
+
+				if(istype(AM, /mob/living))
 					var/mob/living/tmob = AM
 					if(istype(tmob.buckled, /obj/structure/bed))
 						if(!tmob.buckled.anchored)
-							step(tmob.buckled, t)
+							step_glide(tmob.buckled, t, tmob.buckled.glide_size)
+
 				if(ishuman(AM))
 					var/mob/living/carbon/human/M = AM
 					for(var/obj/item/grab/G in M.grabbed_by)
 						step(G.assailant, get_dir(G.assailant, AM))
 						G.adjust_position()
+
 				if(saved_dir)
 					AM.set_dir(saved_dir)
+
+				if(pulled_pushing)
+					step_glide(src, t, glide_size)
+					if(pulling != AM)
+						start_pulling(AM, TRUE)
+
 				now_pushing = 0
 
 /proc/swap_density_check(mob/swapper, mob/swapee)

--- a/code/modules/mob/mob.dm
+++ b/code/modules/mob/mob.dm
@@ -631,9 +631,14 @@
 
 /mob/proc/stop_pulling()
 	if(pulling)
+		pulling.set_glide_size(8)
 		unregister_signal(pulling, SIGNAL_QDELETING)
 		pulling.pulledby = null
 		pulling = null
+
+		var/datum/movement_handler/mob/delay/delay = GetMovementHandler(/datum/movement_handler/mob/delay)
+		if(delay)
+			delay.InstantUpdateGlideSize()
 
 	if(pullin)
 		pullin.icon_state = "pull0"
@@ -694,6 +699,10 @@
 
 	register_signal(AM, SIGNAL_QDELETING, nameof(.proc/stop_pulling))
 	update_pull_slowdown(AM)
+	var/datum/movement_handler/mob/delay/delay = GetMovementHandler(/datum/movement_handler/mob/delay)
+	if(delay)
+		delay.InstantUpdateGlideSize()
+	AM.set_glide_size(glide_size)
 
 	if(ishuman(AM))
 		var/mob/living/carbon/human/H = AM


### PR DESCRIPTION

https://github.com/ChaoticOnyx/OnyxBay/assets/45202681/4d4df6d5-915f-4987-b61e-7cd40417904d

```yml
🆑
bugfix: Космонавтики на каталках больше не дёргаются во время движения.
bugfix: У объектов после пулла больше не ломается глайд.
tweak: Теперь запулленые объекты можно толкать, не прерывая пулл.
/🆑
```

- [x] Pull Request полностью завершен, мне не нужна помощь чтобы его закончить.
- [x] Я внимательно прочитал(-а) все свои изменения и багов в них не нашёл(-ла).
- [x] Я запускал(-а) сервер со своими изменениями локально и все протестировал(-а).
- [x] Я ознакомился(-ась) c [Guide to Contribute](https://github.com/ChaoticOnyx/OnyxBay/blob/dev/docs/contributing.md).
