### PR TITLE
Fixes finger lockpick initialization

### DIFF
--- a/code/game/gamemodes/changeling/helpcode/items.dm
+++ b/code/game/gamemodes/changeling/helpcode/items.dm
@@ -98,7 +98,8 @@
 	canremove = FALSE
 	force_drop = TRUE
 
-/obj/item/finger_lockpick/New()
+/obj/item/finger_lockpick/Initialize()
+	. = ..()
 	if(ismob(loc))
 		to_chat(loc, SPAN("changeling", "We shape our finger to fit inside electronics, and are ready to force them open."))
 


### PR DESCRIPTION
Runtime in code/__std/util.dm, line 3: GC: -- finger lockpick | /obj/item/finger_lockpick was deleted before initalization --

- [x] Pull Request полностью завершен, мне не нужна помощь чтобы его закончить.
- [x] Я внимательно прочитал(-а) все свои изменения и багов в них не нашёл(-ла).
- [ ] Я запускал(-а) сервер со своими изменениями локально и все протестировал(-а).
- [x] Я ознакомился(-ась) c [Guide to Contribute](https://github.com/ChaoticOnyx/OnyxBay/blob/dev/docs/contributing.md).
