### PR TITLE
Fix autoconnect solar_control

### DIFF
--- a/code/modules/power/power.dm
+++ b/code/modules/power/power.dm
@@ -2,9 +2,12 @@
 // POWER MACHINERY BASE CLASS
 //////////////////////////////
 
-#define CONNECT_NETWORK_FAIL           0  /// Failed to connect to the network
-#define CONNECT_NETWORK_SUCCESS        1  /// Successfully connected the machinery to the network
-#define CONNECT_NETWORK_DELAYED_PROC   2  /// Successfully connected the machinery to the network, but will run the after_connect_to_network procedure afterward
+/// Failed to connect to the network
+#define CONNECT_NETWORK_FAIL 0
+/// Successfully connected the machinery to the network
+#define CONNECT_NETWORK_SUCCESS 1
+/// Successfully connected the machinery to the network, but will run the after_connect_to_network procedure afterward
+#define CONNECT_NETWORK_DELAYED_PROC 2
 
 /////////////////////////////
 // Definitions

--- a/code/modules/power/power.dm
+++ b/code/modules/power/power.dm
@@ -2,9 +2,9 @@
 // POWER MACHINERY BASE CLASS
 //////////////////////////////
 
-#define CONNECT_NETWORK_FAIL           0  // Failed to connect to the network
-#define CONNECT_NETWORK_SUCCESS        1  // Successfully connected the machinery to the network
-#define CONNECT_NETWORK_DELAYED_PROC   2  // Successfully connected the machinery to the network, but will run the after_connect_to_network procedure afterward
+#define CONNECT_NETWORK_FAIL           0  /// Failed to connect to the network
+#define CONNECT_NETWORK_SUCCESS        1  /// Successfully connected the machinery to the network
+#define CONNECT_NETWORK_DELAYED_PROC   2  /// Successfully connected the machinery to the network, but will run the after_connect_to_network procedure afterward
 
 /////////////////////////////
 // Definitions
@@ -225,21 +225,18 @@
 		else
 			continue
 
-	var/list/pending_machinery
-	LAZYINITLIST(pending_machinery)
+	var/list/pending_machinery = list()
 
 	//now that the powernet is set, connect found machines to it
 	for(var/obj/machinery/power/PM in found_machines)
 		var/to_return = PM.connect_to_network()
 		if(to_return == CONNECT_NETWORK_FAIL) //couldn't find a node on its turf...
 			PM.disconnect_from_network() //... so disconnect if already on a powernet
-		if(to_return == CONNECT_NETWORK_DELAYED_PROC) //find a node on its turf, but need start proc in this machinery.powernet
+		else if(to_return == CONNECT_NETWORK_DELAYED_PROC) //need start add proc after connect machinery to powernet
 			pending_machinery += PM
 
-	if(pending_machinery.len)
-		for(var/obj/machinery/power/PM in pending_machinery)
-			PM.after_connect_to_network() //start proc in this machinery.powernet
-		pending_machinery.Cut()
+	for(var/obj/machinery/power/PM in pending_machinery)
+		PM.after_connect_to_network() //start proc in this machinery.powernet
 
 //Merge two powernets, the bigger (in cable length term) absorbing the other
 /proc/merge_powernets(datum/powernet/net1, datum/powernet/net2)

--- a/code/modules/power/solar.dm
+++ b/code/modules/power/solar.dm
@@ -529,7 +529,6 @@ var/list/solars_list = list()
 	return ..() == CONNECT_NETWORK_FAIL ? CONNECT_NETWORK_FAIL : CONNECT_NETWORK_DELAYED_PROC
 
 /obj/machinery/power/solar_control/autostart/after_connect_to_network()
-	..()
 	autoconnect()
 
 /obj/machinery/power/solar_control/autostart/proc/autoconnect()

--- a/code/modules/power/solar.dm
+++ b/code/modules/power/solar.dm
@@ -347,12 +347,6 @@ var/list/solars_list = list()
 	set_panels(cdir)
 	updateDialog()
 
-
-/obj/machinery/power/solar_control/Initialize()
-	. = ..()
-	if(!connect_to_network()) return
-	set_panels(cdir)
-
 /obj/machinery/power/solar_control/on_update_icon()
 	ClearOverlays()
 	if(stat & NOPOWER)
@@ -531,12 +525,11 @@ var/list/solars_list = list()
 /obj/machinery/power/solar_control/autostart
 	track = 2 // Auto tracking mode
 
-/obj/machinery/power/solar_control/autostart/Initialize()
-	. = ..()
-	return INITIALIZE_HINT_LATELOAD
+/obj/machinery/power/solar_control/autostart/connect_to_network()
+	return ..() == CONNECT_NETWORK_FAIL ? CONNECT_NETWORK_FAIL : CONNECT_NETWORK_DELAYED_PROC
 
-/obj/machinery/power/solar_control/autostart/LateInitialize()
-	. = ..()
+/obj/machinery/power/solar_control/autostart/after_connect_to_network()
+	..()
 	autoconnect()
 
 /obj/machinery/power/solar_control/autostart/proc/autoconnect()


### PR DESCRIPTION
Небольшой фикс автоподключения соляров.

Проблема была в том что:
1. Сначала Initialized Atoms subsystem
2. После него Initialized Machines subsystem

Network кабелей инициализируется во 2-ом пункте, а подключиться машинерия к network пытается в 1-ом.
В этой доработке соляры будут подключаться только после инициализации network в процедуре /obj/machinery/power/proc/after_connect_to_network()

<details>
<summary>Чейнджлог</summary>

🆑Devyashka
bugfix: Панели на спутнике снова включаются сами при старте.
/🆑

</details>

- [x] Pull Request полностью завершен, мне не нужна помощь чтобы его закончить.
- [x] Я внимательно прочитал все свои изменения и багов в них не нашел.
- [x] Я запускал сервер со своими изменениями локально и все протестировал.
- [x] Я ознакомился c [Guide to Contribute](https://github.com/ChaoticOnyx/OnyxBay/blob/dev/docs/contributing.md).
