### PR TITLE
Fixes non-carbon mobs bumps causing recursion

### DIFF
--- a/code/modules/mob/living/bot/bot.dm
+++ b/code/modules/mob/living/bot/bot.dm
@@ -227,7 +227,7 @@
 		if(!istype(D, /obj/machinery/door/firedoor) && !istype(D, /obj/machinery/door/blast) && D.check_access(botcard))
 			D.open()
 	else
-		..()
+		return ..()
 
 /mob/living/bot/emag_act(remaining_charges, mob/user)
 	return 0

--- a/code/modules/mob/living/bot/mulebot.dm
+++ b/code/modules/mob/living/bot/mulebot.dm
@@ -200,11 +200,11 @@
 	..()
 
 /mob/living/bot/mulebot/Bump(mob/living/carbon/human/M)
-	if(!safety && istype(M))
+	. = ..()
+	if(. && !safety && istype(M))
 		visible_message("<span class='warning'>[src] knocks over [M]!</span>")
 		M.Stun(8)
 		M.Weaken(5)
-	..()
 
 /mob/living/bot/mulebot/proc/runOver(mob/living/carbon/human/H)
 	if(istype(H)) // No safety checks - WILL run over lying humans. Stop ERPing in the maint!

--- a/code/modules/mob/living/carbon/carbon.dm
+++ b/code/modules/mob/living/carbon/carbon.dm
@@ -402,10 +402,10 @@
 
 /mob/living/carbon/Bump(atom/movable/AM, yes)
 	if(now_pushing || !yes)
-		return
-	..()
-	if(istype(AM, /mob/living/carbon) && prob(10))
-		src.spread_disease_to(AM, "Contact")
+		return FALSE
+	. = ..()
+	if(. && istype(AM, /mob/living/carbon) && prob(10))
+		spread_disease_to(AM, "Contact")
 
 /mob/living/carbon/slip(slipped_on, stun_duration = 8)
 	var/area/A = get_area(src)

--- a/code/modules/mob/living/carbon/xenobiological/xenobiological.dm
+++ b/code/modules/mob/living/carbon/xenobiological/xenobiological.dm
@@ -104,9 +104,10 @@
 	return tally + config.movement.metroid_delay
 
 /mob/living/carbon/metroid/Bump(atom/movable/AM as mob|obj, yes)
-	if ((!(yes) || now_pushing))
-		return
-	now_pushing = 1
+	if((!(yes) || now_pushing))
+		return FALSE
+
+	now_pushing = TRUE
 
 	if(isobj(AM) && !client && powerlevel > 0)
 		var/probab = 10
@@ -129,16 +130,16 @@
 		if(is_adult)
 			if(istype(tmob, /mob/living/carbon/human))
 				if(prob(90))
-					now_pushing = 0
-					return
+					now_pushing = FALSE
+					return TRUE
 		else
 			if(istype(tmob, /mob/living/carbon/human))
-				now_pushing = 0
-				return
+				now_pushing = FALSE
+				return TRUE
 
-	now_pushing = 0
+	now_pushing = FALSE
 
-	..()
+	return ..()
 
 /mob/living/carbon/metroid/Allow_Spacemove()
 	return 1

--- a/code/modules/mob/living/living.dm
+++ b/code/modules/mob/living/living.dm
@@ -78,9 +78,10 @@
 	return ..()
 
 /mob/living/Bump(atom/movable/AM, yes)
+	if(now_pushing || !yes || !loc)
+		return FALSE
+
 	spawn(0)
-		if ((!( yes ) || now_pushing) || !loc)
-			return
 		if(!istype(AM, /mob/living/bot/mulebot))
 			now_pushing = 1
 		if (istype(AM, /mob/living))
@@ -211,6 +212,8 @@
 						start_pulling(AM, TRUE)
 
 				now_pushing = 0
+
+	return TRUE
 
 /proc/swap_density_check(mob/swapper, mob/swapee)
 	var/turf/T = get_turf(swapper)


### PR DESCRIPTION
```yml
🆑
bugfix: Исправлен баг, из-за которого толкание объектов в стену любыми мобами, кроме людей, вызывало рекурсию и приводило к жутчайшим лагам.
/🆑
```

- [x] Pull Request полностью завершен, мне не нужна помощь чтобы его закончить.
- [x] Я внимательно прочитал(-а) все свои изменения и багов в них не нашёл(-ла).
- [x] Я запускал(-а) сервер со своими изменениями локально и все протестировал(-а).
- [x] Я ознакомился(-ась) c [Guide to Contribute](https://github.com/ChaoticOnyx/OnyxBay/blob/dev/docs/contributing.md).
