### PR TITLE
Makes smart fridges and kitchen appliances movable

### DIFF
--- a/code/game/machinery/kitchen/cooking_machines/_cooker.dm
+++ b/code/game/machinery/kitchen/cooking_machines/_cooker.dm
@@ -19,6 +19,8 @@
 	density = 1
 	anchored = 1
 	idle_power_usage = 5 WATTS
+	obj_flags = OBJ_FLAG_ANCHORABLE
+	pull_slowdown = PULL_SLOWDOWN_HEAVY
 
 	var/on_icon						// Icon state used when cooking.
 	var/off_icon					// Icon state used when not cooking.
@@ -78,6 +80,11 @@
 	if(product_status() != NO_PRODUCT)
 		to_chat(user, SPAN_WARNING("There is no more space in \the [src]. \A [thing_inside] is already there!"))
 		return 0
+
+	if((obj_flags & OBJ_FLAG_ANCHORABLE) && isWrench(I)) //TODO
+		if(wrench_floor_bolts(user))
+			power_change()
+		return
 
 	var/mob/living/inserted_mob
 	var/obj/item/reagent_containers/food/check

--- a/code/game/machinery/kitchen/smartfridge.dm
+++ b/code/game/machinery/kitchen/smartfridge.dm
@@ -8,6 +8,8 @@
 	layer = BELOW_OBJ_LAYER
 	density = 1
 	anchored = 1
+	obj_flags = OBJ_FLAG_ANCHORABLE
+	pull_slowdown = PULL_SLOWDOWN_HEAVY
 	idle_power_usage = 5 WATTS
 	active_power_usage = 100 WATTS
 	atom_flags = ATOM_FLAG_NO_REACT
@@ -262,6 +264,11 @@
 	if(isMultitool(O) || isWirecutter(O))
 		if(panel_open)
 			attack_hand(user)
+		return
+
+	if((obj_flags & OBJ_FLAG_ANCHORABLE) && isWrench(O))
+		if(wrench_floor_bolts(user))
+			power_change()
 		return
 
 	if(stat & NOPOWER)


### PR DESCRIPTION
Добавляет отсутствующую ранее возможность откручивать умные холодильники (smart fridge) и кухонные приборы (griddle, deep fryer, oven, candy machine, cereal maker)

Затрагивает #9982, но не фиксит его

<details>
<summary>Чейнджлог</summary>

```yml
🆑
rscadd: Холодильники и кухонные приборы теперь можно откручивать.
/🆑
```

</details>

- [ ] Pull Request полностью завершен, мне не нужна помощь чтобы его закончить.
- [ ] Я внимательно прочитал(-а) все свои изменения и багов в них не нашёл(-ла).
- [x] Я запускал(-а) сервер со своими изменениями локально и все протестировал(-а).
- [x] Я ознакомился(-ась) c [Guide to Contribute](https://github.com/ChaoticOnyx/OnyxBay/blob/dev/docs/contributing.md).
