### PR TITLE
fix(posibrain): fixes wrong parent organ

### DIFF
--- a/code/modules/mob/organs/internal/posibrain.dm
+++ b/code/modules/mob/organs/internal/posibrain.dm
@@ -9,9 +9,9 @@
 
 	override_organic_icon = FALSE
 
-	vital = FALSE
+	vital = TRUE
 	organ_tag = BP_POSIBRAIN
-	parent_organ = BP_CHEST
+	parent_organ = BP_HEAD
 
 	origin_tech = list(TECH_ENGINEERING = 4, TECH_MATERIAL = 4, TECH_BLUESPACE = 2, TECH_DATA = 4)
 


### PR DESCRIPTION
Resolves #12236

<details>
<summary>Чейнджлог</summary>

```yml
🆑
bugfix: Позитронный мозг переехал из туловища в голову. Жизненно важные органы синтов снова задеваются при повреждении головы.
/🆑
```

</details>

- [x] Pull Request полностью завершен, мне не нужна помощь чтобы его закончить.
- [x] Я внимательно прочитал(-а) все свои изменения и багов в них не нашёл(-ла).
- [x] Я запускал(-а) сервер со своими изменениями локально и все протестировал(-а).
- [x] Я ознакомился(-ась) c [Guide to Contribute](https://github.com/ChaoticOnyx/OnyxBay/blob/dev/docs/contributing.md).
