### PR TITLE
fix(secure_door_assembly): fix craft of blast doors

### DIFF
--- a/code/game/objects/structures/secure_door_assembly.dm
+++ b/code/game/objects/structures/secure_door_assembly.dm
@@ -75,12 +75,12 @@
 	if(!WT.use_tool(src, user, delay = 4 SECONDS, amount = 5))
 		return
 
-	to_chat(user, SPAN_NOTICE("You dissasembled \the [src] a!"))
-	new /obj/item/stack/material/steel(loc, 10)
+	to_chat(user, SPAN_NOTICE("You dissasembled \the [src]!"))
+	new material_path(loc, 10)
 	qdel(src)
 
 /obj/structure/secure_door_assembly/wrench_floor_bolts(mob/user, delay = 40)
-	if(state > STATE_UNANCHORED)
+	if(state > STATE_EMPTY)
 		return
 
 	. = ..()

--- a/code/game/objects/structures/secure_door_assembly.dm
+++ b/code/game/objects/structures/secure_door_assembly.dm
@@ -71,7 +71,7 @@
 	return ..()
 
 /obj/structure/secure_door_assembly/proc/deconstruct_assembly(obj/item/weldingtool/WT, mob/user)
-	user.visible_message("[user] dissassembles \the [src] .", "You start to dissassemble \the [src] .")
+	user.visible_message("[user] dissassembles \the [src].", "You start to dissassemble \the [src].")
 	if(!WT.use_tool(src, user, delay = 4 SECONDS, amount = 5))
 		return
 


### PR DESCRIPTION
Я такой тупой блин класс.

Пофиксил баг который не позволял разобрать бластерные дуры и теперь из них выпадает пласталь, а не сталь.

- [x] Pull Request полностью завершен, мне не нужна помощь чтобы его закончить.
- [x] Я внимательно прочитал(-а) все свои изменения и багов в них не нашёл(-ла).
- [x] Я запускал(-а) сервер со своими изменениями локально и все протестировал(-а).
- [x] Я ознакомился(-ась) c [Guide to Contribute](https://github.com/ChaoticOnyx/OnyxBay/blob/dev/docs/contributing.md).
