### PR TITLE
tweak(combat): Бойтесь оружия

### DIFF
--- a/code/modules/mob/living/carbon/human/human_defense.dm
+++ b/code/modules/mob/living/carbon/human/human_defense.dm
@@ -50,7 +50,7 @@ meteor_act
 	// Internal damage
 	// Some day we should make internals deal with blunt and sharp damage differently, but for now it's like this, if 'blocked' is non-zero, then the projectile's already lost its SHARP/EDGE flags and thus we cut the damage accordingly
 	if(length(organ.internal_organs))
-		var/internal_damage_prob = 90 * blocked_mult(blocked) // 70% for a naked dude/armor fail, 35% if one armor layer's succeeded, etc.
+		var/internal_damage_prob = 90 * blocked_mult(blocked) // 90% for a naked dude/armor fail, 58% if one armor layer's succeeded, etc.
 
 		// If our bodypart is a pile of shredded meat then it doesn't protect organs well
 		if(organ.damage > organ.max_damage)

--- a/code/modules/mob/living/carbon/human/human_defense.dm
+++ b/code/modules/mob/living/carbon/human/human_defense.dm
@@ -50,7 +50,7 @@ meteor_act
 	// Internal damage
 	// Some day we should make internals deal with blunt and sharp damage differently, but for now it's like this, if 'blocked' is non-zero, then the projectile's already lost its SHARP/EDGE flags and thus we cut the damage accordingly
 	if(length(organ.internal_organs))
-		var/internal_damage_prob = 70 * blocked_mult(blocked) // 70% for a naked dude/armor fail, 35% if one armor layer's succeeded, etc.
+		var/internal_damage_prob = 90 * blocked_mult(blocked) // 70% for a naked dude/armor fail, 35% if one armor layer's succeeded, etc.
 
 		// If our bodypart is a pile of shredded meat then it doesn't protect organs well
 		if(organ.damage > organ.max_damage)
@@ -59,18 +59,19 @@ meteor_act
 		if(prob(internal_damage_prob))
 			var/penetrating_damage = P.damage * P.penetration_modifier * PROJECTILE_INTERNAL_DAMAGE_MULT * blocked_mult(blocked)
 			if(organ.encased && !(organ.status & ORGAN_BROKEN))
-				penetrating_damage *= 0.75 // Ribs and skulls somewhat protect
+				penetrating_damage *= 0.8 // Ribs and skulls somewhat protect
 
 			var/list/victims = list()
-			var/list/possible_victims = shuffle(organ.internal_organs.Copy())
+//			var/list/possible_victims = shuffle(organ.internal_organs.Copy())
 
-			for(var/obj/item/organ/internal/I in possible_victims)
-				if(I.damage < I.max_damage && (prob((sqrt(I.relative_size) * 10) * (1 / max(1, victims.len)))))
+			for(var/obj/item/organ/internal/I in organ.internal_organs)
+				if(I.damage < I.max_damage && (prob(I.relative_size)*2))
 					victims += I
+					internal_damage_prob += I.relative_size
 
 			if(length(victims))
 				for(var/obj/item/organ/internal/victim in victims)
-					victim.take_internal_damage(penetrating_damage / victims.len)
+					victim.take_internal_damage(penetrating_damage*3)
 
 	// Embed or sever artery, only happens if the projectile's successfully bypassed armor
 	if(!blocked && !(species.species_flags & SPECIES_FLAG_NO_EMBED) && prob(PROJECTILE_EMBED_CHANCE) && P.can_embed())

--- a/code/modules/mob/organs/external/_external_damage.dm
+++ b/code/modules/mob/organs/external/_external_damage.dm
@@ -104,7 +104,7 @@ obj/item/organ/external/take_general_damage(amount, silent = FALSE)
 		var/organ_damage_threshold = 5
 		if(sharp)
 			organ_damage_threshold *= 0.5
-		var/organ_damage_prob = 6.25 * damage_amt/organ_damage_threshold //more damage, higher chance to damage
+		var/organ_damage_prob = 7 * damage_amt/organ_damage_threshold //more damage, higher chance to damage
 		if(sharp)
 			organ_damage_prob *= 1.5
 		if(cur_damage >= 15)
@@ -123,7 +123,7 @@ obj/item/organ/external/take_general_damage(amount, silent = FALSE)
 				brute /= 2
 				if(laser)
 					burn /= 3
-				damage_amt /= 2
+				damage_amt *= 2
 				victim.take_internal_damage(damage_amt)
 
 	if(status & ORGAN_BROKEN && brute)

--- a/code/modules/mob/organs/external/_external_damage.dm
+++ b/code/modules/mob/organs/external/_external_damage.dm
@@ -123,7 +123,7 @@ obj/item/organ/external/take_general_damage(amount, silent = FALSE)
 				brute /= 2
 				if(laser)
 					burn /= 3
-				damage_amt *= 2
+				damage_amt /= 2
 				victim.take_internal_damage(damage_amt)
 
 	if(status & ORGAN_BROKEN && brute)

--- a/code/modules/mob/organs/internal/brain.dm
+++ b/code/modules/mob/organs/internal/brain.dm
@@ -4,6 +4,8 @@
 	name = "\improper Brain"
 	desc = "A piece of juicy meat found in a person's head."
 
+	relative_size = 65
+
 	food_organ_type = /obj/item/reagent_containers/food/organ/brain
 
 	var/damage_threshold_value

--- a/code/modules/mob/organs/internal/eyes.dm
+++ b/code/modules/mob/organs/internal/eyes.dm
@@ -6,7 +6,7 @@
 	organ_tag = BP_EYES
 	parent_organ = BP_HEAD
 	surface_accessible = TRUE
-	relative_size = 10
+	relative_size = 5
 	var/plasma_guard = 0
 	var/list/eye_colour = list(0,0,0)
 	var/innate_flash_protection = 0

--- a/code/modules/mob/organs/internal/heart.dm
+++ b/code/modules/mob/organs/internal/heart.dm
@@ -8,7 +8,7 @@
 	var/heartbeat = 0
 	var/beat_sound = 'sound/effects/singlebeat.ogg'
 	var/tmp/next_blood_squirt = 0
-	relative_size = 15
+	relative_size = 20
 	max_damage = 50
 	min_bruised_damage = 15
 	min_broken_damage = 35

--- a/code/modules/mob/organs/internal/liver.dm
+++ b/code/modules/mob/organs/internal/liver.dm
@@ -8,7 +8,7 @@
 	min_bruised_damage = 25
 	min_broken_damage = 45 // Also the amount of toxic damage it can store
 	max_damage = 70
-	relative_size = 60
+	relative_size = 45
 	var/tox_filtering = 0
 
 /obj/item/organ/internal/liver/robotize()

--- a/code/modules/mob/organs/internal/lungs.dm
+++ b/code/modules/mob/organs/internal/lungs.dm
@@ -8,7 +8,7 @@
 	min_bruised_damage = 25
 	min_broken_damage = 50
 	max_damage = 100
-	relative_size = 60
+	relative_size = 65
 
 	var/active_breathing = 1
 


### PR DESCRIPTION
Дисклеймер: я не кодер, все мои изменения в код внесены путём ударов головой об клавиатуру

Кратко: человечки убиваются melee и projectile оружием во много раз быстрее. 

Подробно: 
- оружие ближнего боя было почти не тронуто
- изменены относительные размеры внутренних органов, например мозг "стал больше", а глаза меньше, соотв. чаще всего будет наноситься урон мозгу, а не глазам (что супер логично, ведь мозг занимает много места в черепной коробке)
- получается, что шанс выбора внутреннего органа для нанесения дамага прожектайлом зависит от относительного размера внутреннего органа, раньше же было рандомно
- всё так же остаётся шанс не нанести урон внутренним органам
- увеличен урон по внутренним органам
- как пример: c20r в упор в голову убивает с двух пулек чаще всего; 357-ой револьвер (да и мне кажется любое огнестрельное и лазерное оружие) может убить в голову в упор с 1 выстрела, но может и не убить;

Лично мне результат понравился и интересно, как оно будет играться с такими изменениями в раундах с игроками. И можно для эксперимента запустить данную ветку на денёк.

<details>
<summary>Чейнджлог</summary>

```yml
🆑
experiment: Сражения космонавтов будут оканчиваться быстрее и летальнее. 
/🆑
```

</details>

- [x] Pull Request полностью завершен, мне не нужна помощь чтобы его закончить.
- [x] Я внимательно прочитал(-а) все свои изменения и багов в них не нашёл(-ла).
- [x] Я запускал(-а) сервер со своими изменениями локально и все протестировал(-а).
- [x] Я ознакомился(-ась) c [Guide to Contribute](https://github.com/ChaoticOnyx/OnyxBay/blob/dev/docs/contributing.md).
