### PR TITLE
tweak(surplus-rifles): Жоский бафф винтовок

### DIFF
--- a/code/datums/supplypacks/security.dm
+++ b/code/datums/supplypacks/security.dm
@@ -414,15 +414,17 @@
 					/obj/item/gun/projectile/bolt_action/mauser = 2,
 					/obj/item/ammo_magazine/c792 = 4
 					)
-	cost = 40
+	cost = 100
 	containertype = /obj/structure/closet/crate/secure
 	containername = "\improper Surplus Firearms"
 	access = access_security
+	security_level = SUPPLY_SECURITY_ELEVATED
 
 /decl/hierarchy/supply_pack/security/surplusammo
 	name = "Misc - Surplus ammo"
 	contains = list(/obj/item/ammo_magazine/c792 = 8)
-	cost = 10
+	cost = 20
 	containertype = /obj/structure/closet/crate/secure
 	containername = "\improper Surplus Ammo"
 	access = access_security
+	security_level = SUPPLY_SECURITY_ELEVATED

--- a/code/modules/projectiles/projectile/bullets.dm
+++ b/code/modules/projectiles/projectile/bullets.dm
@@ -266,7 +266,7 @@
 	armor_penetration = 50
 
 /obj/item/projectile/bullet/rifle/a792
-	damage = 35
+	damage = 50
 	armor_penetration = 50
 
 /obj/item/projectile/bullet/rifle/a145


### PR DESCRIPTION
Увеличен урон для патрона 7.92 с 35 до 50 (у матебы 60, с тем же армор пенетрейшн и большим уроном по поизу). Винтовки можно начать заказывать только при синем коде. Ящик стоит 100 вместо 40. Ящик с патронами для них стоит 20 вместо 10.

<details>
<summary>Чейнджлог</summary>

```yml
🆑
balance: Винтовки с продольно-скользящим затвором получили свой бафф. 
/🆑
```

</details>

- [x] Pull Request полностью завершен, мне не нужна помощь чтобы его закончить.
- [x] Я внимательно прочитал(-а) все свои изменения и багов в них не нашёл(-ла).
- [x] Я запускал(-а) сервер со своими изменениями локально и все протестировал(-а).
- [x] Я ознакомился(-ась) c [Guide to Contribute](https://github.com/ChaoticOnyx/OnyxBay/blob/dev/docs/contributing.md).
