### PR TITLE
fix(vampire): fixes vampire

### DIFF
--- a/code/game/gamemodes/vampire/powers/bloodheal.dm
+++ b/code/game/gamemodes/vampire/powers/bloodheal.dm
@@ -62,7 +62,7 @@
 
 		for(var/obj/item/organ/external/current_organ in organs)
 			for(var/datum/wound/wound in current_organ.wounds)
-				wound.embedded_objects.Cut()
+				LAZYCLEARLIST(wound.embedded_objects)
 
 			// remove embedded objects and drop them on the floor
 			for(var/obj/implanted_object in current_organ.implants)

--- a/code/game/gamemodes/vampire/powers/embrace.dm
+++ b/code/game/gamemodes/vampire/powers/embrace.dm
@@ -21,17 +21,25 @@
 	var/mob/living/carbon/human/T = G.affecting
 	if(!vampire.can_affect(T, check_thrall = FALSE))
 		return
+
 	if(!T.client)
 		to_chat(my_mob, SPAN("warning", "[T] is a mindless husk. The Veil has no purpose for them."))
 		return
-	if(T.stat == 2)
+
+	if(T.is_ic_dead())
 		to_chat(my_mob, SPAN("warning", "[T]'s body is broken and damaged beyond salvation. You have no use for them."))
 		return
+
 	if(T.isSynthetic() || T.species.species_flags & SPECIES_FLAG_NO_BLOOD)
 		to_chat(my_mob, SPAN("warning", "[T] has no blood and can not be affected by your powers!"))
 		return
+
 	if(vampire.vamp_status & VAMP_DRAINING)
 		to_chat(my_mob, SPAN("warning", "Your fangs are already sunk into a victim's neck!"))
+		return
+
+	if(jobban_isbanned(T, MODE_VAMPIRE))
+		to_chat(my_mob, SPAN_WARNING("[T]'s mind is tainted. They cannot be forced into a blood bond."))
 		return
 
 	if(T.mind.vampire)
@@ -66,7 +74,7 @@
 	to_chat(T, SPAN("notice", "You are currently being turned into a vampire. You will die in the course of this, but you will be revived by the end. Please do not ghost out of your body until the process is complete."))
 
 	while(do_mob(my_mob, T, 50))
-		if (!my_mob.mind.vampire)
+		if(!my_mob.mind.vampire)
 			to_chat(my_mob, SPAN("alert", "Your fangs have disappeared!"))
 			return
 		if (!T.vessel.get_reagent_amount(/datum/reagent/blood))
@@ -74,6 +82,20 @@
 			break
 
 		T.vessel.remove_reagent(/datum/reagent/blood, 50)
+
+	if(!istype(T))
+		vampire.vamp_status &= ~VAMP_DRAINING
+		return
+
+	if(T.isSynthetic() || T.species.species_flags & SPECIES_FLAG_NO_BLOOD)
+		to_chat(my_mob, SPAN("warning", "[T] has no blood and can not be affected by your powers!"))
+		vampire.vamp_status &= ~VAMP_DRAINING
+		return
+
+	if(jobban_isbanned(T, MODE_VAMPIRE))
+		to_chat(my_mob, SPAN_WARNING("[T]'s mind is tainted. They cannot be forced into a blood bond."))
+		vampire.vamp_status &= ~VAMP_DRAINING
+		return
 
 	T.revive()
 

--- a/code/game/gamemodes/vampire/powers/enthrall.dm
+++ b/code/game/gamemodes/vampire/powers/enthrall.dm
@@ -22,13 +22,20 @@
 	if(!istype(T) || T.isSynthetic())
 		to_chat(my_mob, SPAN("warning", "[T] is not a creature you can enthrall."))
 		return
+
 	if(!vampire.can_affect(T, TRUE, TRUE))
 		return
-	if (!T.client || !T.mind)
+
+	if(!T.client || !T.mind)
 		to_chat(my_mob, SPAN("warning", "[T]'s mind is empty and useless. They cannot be forced into a blood bond."))
 		return
+
 	if(vampire.vamp_status & VAMP_DRAINING)
 		to_chat(my_mob, SPAN("warning", "Your fangs are already sunk into a victim's neck!"))
+		return
+
+	if(jobban_isbanned(T, MODE_THRALL))
+		to_chat(my_mob, SPAN_WARNING("[T]'s mind is tainted. They cannot be forced into a blood bond."))
 		return
 
 	my_mob.visible_message(SPAN("danger", "[my_mob] tears the flesh on their wrist, and holds it up to [T]. In a gruesome display, [T] starts lapping up the blood that's oozing from the fresh wound."),\
@@ -38,6 +45,17 @@
 	if(!do_mob(my_mob, T, 50))
 		my_mob.visible_message(SPAN("warning", "[my_mob] yanks away their hand from [T]'s mouth as they're interrupted, the wound quickly sealing itself!"),\
 							   SPAN("danger", "You are interrupted!"))
+		return
+
+	if(!istype(T) || T.isSynthetic())
+		to_chat(my_mob, SPAN("warning", "[T] is not a creature you can enthrall."))
+		return
+
+	if(!vampire.can_affect(T, TRUE, TRUE))
+		return
+
+	if(!T.client || !T.mind)
+		to_chat(my_mob, SPAN("warning", "[T]'s mind is empty and useless. They cannot be forced into a blood bond."))
 		return
 
 	to_chat(T, SPAN("danger", "Your mind blanks as you finish feeding from [my_mob]'s wrist."))

--- a/code/game/gamemodes/vampire/vampire_datum.dm
+++ b/code/game/gamemodes/vampire/vampire_datum.dm
@@ -35,6 +35,11 @@
 
 /datum/vampire/New(mob/_M)
 	..()
+	if(!istype(_M))
+		util_crash_with("Vampire datum was initialised without `var/my_mob`. Shit is fucked.")
+		qdel_self()
+		return
+
 	my_mob = _M
 	set_next_think(world.time + 1 SECOND)
 
@@ -104,6 +109,10 @@
 
 /datum/vampire/proc/set_up_organs()
 	if(vamp_status & VAMP_ISTHRALL)
+		return
+
+	if(!istype(my_mob))
+		util_crash_with("Vampire datum was initialised without `var/my_mob`. Shit is fucked.")
 		return
 
 	blood_usable = 30


### PR DESCRIPTION
Вылезла пара очень неприятных рантаймов. Скорее всего - следствие попытки завампирить заджобаненного игрока.

Меня пугает лишь одно - по непонятным причинам в датуме вампира, сука, исчезла ссылка на самого вампира.

```
Runtime in code/game/gamemodes/vampire/powers/alertness.dm, line 23: Cannot modify null.stealth.
Runtime in code/game/gamemodes/vampire/vampire_datum.dm, line 111: Cannot modify null.does_not_breathe.
Runtime in code/game/gamemodes/vampire/powers/revitalise.dm, line 24: Cannot read null.status_flags Runtime in code/game/gamemodes/vampire/powers/darkvision.dm, line 23: Cannot modify null.seeDarkness.
Runtime in code/game/gamemodes/vampire/vampire_datum.dm, line 203: Cannot read null.ability_master
```
<details>
<summary>Чейнджлог</summary>

```yml
🆑
bugfix: Пара фиксов вампиров.
/🆑
```

</details>

- [x] Pull Request полностью завершен, мне не нужна помощь чтобы его закончить.
- [x] Я внимательно прочитал(-а) все свои изменения и багов в них не нашёл(-ла).
- [x] Я запускал(-а) сервер со своими изменениями локально и все протестировал(-а).
- [x] Я ознакомился(-ась) c [Guide to Contribute](https://github.com/ChaoticOnyx/OnyxBay/blob/dev/docs/contributing.md).
