### PR TITLE
balance: nuke and heist min player raise, changeling initial spawn number is one

### DIFF
--- a/code/game/antagonist/station/changeling.dm
+++ b/code/game/antagonist/station/changeling.dm
@@ -13,7 +13,7 @@ GLOBAL_DATUM_INIT(changelings, /datum/antagonist/changeling, new)
 	welcome_text = "Use say \",g message\" to communicate with your fellow changelings. Remember: you get all of their absorbed DNA if you absorb them."
 	flags = ANTAG_SUSPICIOUS | ANTAG_RANDSPAWN | ANTAG_VOTABLE
 	antaghud_indicator = "hudchangeling"
-
+	initial_spawn_target = 1
 	faction = "changeling"
 
 /datum/antagonist/changeling/Initialize()

--- a/code/game/gamemodes/heist/heist.dm
+++ b/code/game/gamemodes/heist/heist.dm
@@ -5,7 +5,7 @@
 /datum/game_mode/heist
 	name = "Heist"
 	config_tag = "heist"
-	required_players = 12
+	required_players = 16
 	required_enemies = 3
 	round_description = "An unidentified bluespace signature has slipped into close sensor range and is approaching!"
 	extended_round_description = "The Company's majority control of plasma in Nyx has marked the \

--- a/code/game/gamemodes/nuclear/nuclear.dm
+++ b/code/game/gamemodes/nuclear/nuclear.dm
@@ -12,7 +12,7 @@ var/list/nuke_disks = list()
 		colony of sizable population and considerable wealth causes it to often be the target of various \
 		attempts of robbery, fraud and other malicious actions."
 	config_tag = "nuke"
-	required_players = 15
+	required_players = 20
 	required_enemies = 1
 	end_on_antag_death = 1
 	var/nuke_off_station = 0 //Used for tracking if the syndies actually haul the nuke to the station


### PR DESCRIPTION
Увеличено требование количества игроков для нюки до 20 и для воксов до 16.
Генокрады теперь спавнятся в количестве 1 штука в начале раунда. Больше генокрадов будет спавнится сторителлером, если сила станции будет позволять.

<details>
<summary>Чейнджлог</summary>

```yml
🆑
balance: Нюка и воксы требуют больше игроков для старта режима.
balance: Генокрад спавнится один раундстартом.
/🆑
```

</details>

- [x] Pull Request полностью завершен, мне не нужна помощь чтобы его закончить.
- [x] Я внимательно прочитал(-а) все свои изменения и багов в них не нашёл(-ла).
- [x] Я запускал(-а) сервер со своими изменениями локально и все протестировал(-а).
- [x] Я ознакомился(-ась) c [Guide to Contribute](https://github.com/ChaoticOnyx/OnyxBay/blob/dev/docs/contributing.md).
