### PR TITLE
Add Rimworld-like personal energy shield into uplink

### DIFF
--- a/code/datums/uplink/categories/devices and tools.dm
+++ b/code/datums/uplink/categories/devices and tools.dm
@@ -117,8 +117,8 @@
 
 /datum/uplink_item/item/tools/personal_shield
 	name = "Personal Shield"
-	desc = "This small device creates defensive shield around the user, protecting them for a few shots. Rechargable."
-	item_cost = 4
+	desc = "This small device creates defensive shield around the user, protecting both them and their enemies for a few shots. Rechargable."
+	item_cost = 8
 	path = /obj/item/device/personal_shield
 
 /datum/uplink_item/item/tools/advemag

--- a/code/datums/uplink/categories/devices and tools.dm
+++ b/code/datums/uplink/categories/devices and tools.dm
@@ -115,6 +115,12 @@
 	item_cost = 4
 	path = /obj/item/card/emag
 
+/datum/uplink_item/item/tools/personal_shield
+	name = "Personal Shield"
+	desc = "This small device creates defensive shield around the user, protecting them for a few shots. Rechargable."
+	item_cost = 4
+	path = /obj/item/device/personal_shield
+
 /datum/uplink_item/item/tools/advemag
 	name = "Advanced Cryptographic Sequencer"
 	desc = "This sophisticated piece of equipment allows you to quite literally open anything: doors, lockers, crates and other things. \

--- a/code/datums/uplink/categories/devices and tools.dm
+++ b/code/datums/uplink/categories/devices and tools.dm
@@ -118,7 +118,7 @@
 /datum/uplink_item/item/tools/personal_shield
 	name = "Personal Shield"
 	desc = "This small device creates defensive shield around the user, protecting both them and their enemies for a few shots. Rechargable."
-	item_cost = 8
+	item_cost = 6
 	path = /obj/item/device/personal_shield
 
 /datum/uplink_item/item/tools/advemag

--- a/code/game/machinery/recharger.dm
+++ b/code/game/machinery/recharger.dm
@@ -12,7 +12,7 @@
 	var/list/allowed_devices = list(
 		/obj/item/gun/energy, /obj/item/gun/magnetic/railgun, /obj/item/melee/baton, /obj/item/cell,
 		/obj/item/modular_computer/, /obj/item/device/suit_sensor_jammer, /obj/item/computer_hardware/battery_module,
-		/obj/item/shield_diffuser, /obj/item/clothing/mask/smokable/ecig, /obj/item/shield/barrier, /obj/item/ammo_magazine/lawgiver
+		/obj/item/shield_diffuser, /obj/item/clothing/mask/smokable/ecig, /obj/item/shield/barrier, /obj/item/device/personal_shield, /obj/item/ammo_magazine/lawgiver
 	)
 	var/icon_state_charged = "recharger2"
 	var/icon_state_charging = "recharger1"
@@ -121,6 +121,9 @@
 			cell = C.battery_module.battery
 		else if(istype(charging, /obj/item/gun/energy))
 			var/obj/item/gun/energy/E = charging
+			cell = E.power_supply
+		else if(istype(charging, /obj/item/device/personal_shield))
+			var/obj/item/device/personal_shield/E = charging
 			cell = E.power_supply
 		else if(istype(charging, /obj/item/computer_hardware/battery_module))
 			var/obj/item/computer_hardware/battery_module/BM = charging

--- a/code/game/objects/auras/personal_shields/personal_shield.dm
+++ b/code/game/objects/auras/personal_shields/personal_shield.dm
@@ -10,12 +10,19 @@
 	new /obj/effect/sparks(user.loc)
 	to_chat(user,"<span class='notice'>You feel your body prickle as \the [src] comes online.</span>")
 
-/obj/aura/personal_shield/bullet_act(obj/item/projectile/P, def_zone)
-	user.visible_message("<span class='warning'>\The [user]'s [src.name] flashes before \the [P] can hit them!</span>")
-	new /obj/effect/shield_impact(user.loc)
-	playsound(user,'sound/effects/bamf.ogg',40,1)
-	new /obj/effect/sparks(user.loc)
-	return AURA_FALSE|AURA_CANCEL
+/obj/aura/personal_shield/bullet_act(obj/item/projectile/P, def_zone, mob/A)
+	if(user != A)
+		user.visible_message("<span class='warning'>\The [user]'s [src.name] flashes before \the [P] can hit them!</span>")
+		new /obj/effect/shield_impact(user.loc)
+		playsound(user,'sound/effects/bamf.ogg',40,1)
+		new /obj/effect/sparks(user.loc)
+		return AURA_FALSE|AURA_CANCEL
+	else
+		user.visible_message("<span class='warning'>\The [user]'s [src.name] flashes reflecting \the [P] back at them!</span>")
+		new /obj/effect/shield_impact(user.loc)
+		playsound(user,'sound/effects/fighting/energyblock.ogg',40,1)
+		new /obj/effect/sparks(user.loc)
+		return AURA_FALSE|AURA_CANCEL
 
 /obj/aura/personal_shield/hitby(atom/movable/M, speed, nomsg)
 	new /obj/effect/shield_impact(user.loc)

--- a/code/game/objects/auras/personal_shields/personal_shield.dm
+++ b/code/game/objects/auras/personal_shields/personal_shield.dm
@@ -1,29 +1,41 @@
 /obj/aura/personal_shield
 	name = "personal shield"
+	icon = 'icons/effects/effects.dmi'
+	icon_state = "shield-old"
+	layer = BELOW_PROJECTILE_LAYER
 
 /obj/aura/personal_shield/New(mob/living/user)
 	..()
-	playsound(user,'sound/weapons/flash.ogg',35,1)
+	playsound(user,'sound/effects/EMPulse.ogg',35,1)
+	new /obj/effect/sparks(user.loc)
 	to_chat(user,"<span class='notice'>You feel your body prickle as \the [src] comes online.</span>")
 
 /obj/aura/personal_shield/bullet_act(obj/item/projectile/P, def_zone)
 	user.visible_message("<span class='warning'>\The [user]'s [src.name] flashes before \the [P] can hit them!</span>")
 	new /obj/effect/shield_impact(user.loc)
-	playsound(user,'sound/effects/basscannon.ogg',35,1)
+	playsound(user,'sound/effects/bamf.ogg',40,1)
+	new /obj/effect/sparks(user.loc)
+	return AURA_FALSE|AURA_CANCEL
+
+/obj/aura/personal_shield/hitby(atom/movable/M, speed, nomsg)
+	new /obj/effect/shield_impact(user.loc)
+	playsound(user,'sound/effects/bamf.ogg',40,1)
+	new /obj/effect/sparks(user.loc)
 	return AURA_FALSE|AURA_CANCEL
 
 /obj/aura/personal_shield/Destroy()
 	to_chat(user,"<span class='warning'>\The [src] goes offline!</span>")
 	playsound(user,'sound/mecha/internaldmgalarm.ogg',25,1)
+	new /obj/effect/sparks(user.loc)
 	return ..()
 
 /obj/aura/personal_shield/device
 	var/obj/item/device/personal_shield/shield
 
-/obj/aura/personal_shield/device/bullet_act()
+/obj/aura/personal_shield/device/bullet_act(obj/item/projectile/P)
 	. = ..()
 	if(shield)
-		shield.take_charge()
+		shield.take_charge(P.damage)
 
 /obj/aura/personal_shield/device/New(mob/living/user, user_shield)
 	..()

--- a/code/game/objects/items/devices/personal_shield.dm
+++ b/code/game/objects/items/devices/personal_shield.dm
@@ -17,8 +17,14 @@
 	. = ..()
 	power_supply = new /obj/item/cell/device/variable(src, max_shots*charge_cost)
 
+/obj/item/device/personal_shield/is_active(mob/living/user)
+	var/act = FALSE
+	for(var//obj/item/device/personal_shield/a in user.contents)
+		if(a.active)
+			act = TRUE
+
 /obj/item/device/personal_shield/attack_self(mob/living/user)
-	if(power_supply.charge && !active)
+	if(power_supply.charge && !is_active(user))
 		active = TRUE
 		shield = new(user,src)
 		holder = user

--- a/code/game/objects/items/devices/personal_shield.dm
+++ b/code/game/objects/items/devices/personal_shield.dm
@@ -6,7 +6,7 @@
 	var/obj/aura/personal_shield/device/shield
 	var/obj/item/cell/power_supply //What type of power cell this uses
 	var/charge_cost = 20 //How much energy is needed to fire.
-	var/max_shots = 15 //Determines the capacity of the weapon's power cell. Specifying a cell_type overrides this value.
+	var/max_shots = 7 //Determines the capacity of the weapon's power cell. Specifying a cell_type overrides this value.
 	w_class = ITEM_SIZE_SMALL
 	var/active = FALSE
 	var/mob/living/holder = null

--- a/code/game/objects/items/devices/personal_shield.dm
+++ b/code/game/objects/items/devices/personal_shield.dm
@@ -6,7 +6,7 @@
 	var/obj/aura/personal_shield/device/shield
 	var/obj/item/cell/power_supply //What type of power cell this uses
 	var/charge_cost = 20 //How much energy is needed to fire.
-	var/max_shots = 7 //Determines the capacity of the weapon's power cell. Specifying a cell_type overrides this value.
+	var/max_shots = 5 //Determines the capacity of the weapon's power cell. Specifying a cell_type overrides this value.
 	w_class = ITEM_SIZE_SMALL
 	var/active = FALSE
 	var/mob/living/holder = null
@@ -17,13 +17,16 @@
 	. = ..()
 	power_supply = new /obj/item/cell/device/variable(src, max_shots*charge_cost)
 
-/obj/item/device/personal_shield/is_active(mob/living/user)
+/obj/item/device/personal_shield/proc/is_active(mob/living/user)
 	var/act = FALSE
-	for(var//obj/item/device/personal_shield/a in user.contents)
+	for(var/obj/item/device/personal_shield/a in user.contents)
 		if(a.active)
 			act = TRUE
+	return act
 
 /obj/item/device/personal_shield/attack_self(mob/living/user)
+	playsound(user, 'sound/effects/weapons/energy/toggle_mode1.ogg', 25, 1)
+	spawn(5)
 	if(power_supply.charge && !is_active(user))
 		active = TRUE
 		shield = new(user,src)
@@ -32,10 +35,11 @@
 		QDEL_NULL(shield)
 		active = FALSE
 		holder = null
+		playsound(user,'sound/mecha/internaldmgalarm.ogg',25,1)
 
 /obj/item/device/personal_shield/Move()
 	..()
-	if(holder && get_turf(holder) != get_turf(src))
+	if(holder && !(src in holder.contents))
 		QDEL_NULL(shield)
 		active = FALSE
 		holder = null
@@ -43,14 +47,14 @@
 
 /obj/item/device/personal_shield/forceMove()
 	..()
-	if(holder && get_turf(holder) != get_turf(src))
+	if(holder && !(src in holder.contents))
 		QDEL_NULL(shield)
 		active = FALSE
 		holder = null
 	return
 
 /obj/item/device/personal_shield/proc/take_charge(cost)
-	if(!power_supply.checked_use(cost))
+	if(!power_supply.use(cost) && cost)
 		QDEL_NULL(shield)
 		active = FALSE
 		holder = null

--- a/code/game/objects/items/devices/personal_shield.dm
+++ b/code/game/objects/items/devices/personal_shield.dm
@@ -3,36 +3,62 @@
 	desc = "Truely a life-saver: this device protects its user from being hit by objects moving very, very fast, though only for a few shots."
 	icon = 'icons/obj/device.dmi'
 	icon_state = "batterer"
-	var/uses = 5
 	var/obj/aura/personal_shield/device/shield
+	var/obj/item/cell/power_supply //What type of power cell this uses
+	var/charge_cost = 20 //How much energy is needed to fire.
+	var/max_shots = 15 //Determines the capacity of the weapon's power cell. Specifying a cell_type overrides this value.
+	w_class = ITEM_SIZE_SMALL
+	var/active = FALSE
+	var/mob/living/holder = null
+	item_flags = ITEM_FLAG_IS_BELT
+	slot_flags = SLOT_BELT
+
+/obj/item/device/personal_shield/Initialize()
+	. = ..()
+	power_supply = new /obj/item/cell/device/variable(src, max_shots*charge_cost)
 
 /obj/item/device/personal_shield/attack_self(mob/living/user)
-	if(uses)
+	if(power_supply.charge && !active)
+		active = TRUE
 		shield = new(user,src)
+		holder = user
 	else
 		QDEL_NULL(shield)
+		active = FALSE
+		holder = null
 
 /obj/item/device/personal_shield/Move()
-	QDEL_NULL(shield)
-	return ..()
+	..()
+	if(holder && get_turf(holder) != get_turf(src))
+		QDEL_NULL(shield)
+		active = FALSE
+		holder = null
+	return
 
 /obj/item/device/personal_shield/forceMove()
-	QDEL_NULL(shield)
-	return ..()
-
-/obj/item/device/personal_shield/proc/take_charge()
-	if(!--uses)
+	..()
+	if(holder && get_turf(holder) != get_turf(src))
 		QDEL_NULL(shield)
-		to_chat(loc,"<span class='danger'>\The [src] begins to spark as it breaks!</span>")
+		active = FALSE
+		holder = null
+	return
+
+/obj/item/device/personal_shield/proc/take_charge(cost)
+	if(!power_supply.checked_use(cost))
+		QDEL_NULL(shield)
+		active = FALSE
+		holder = null
+		to_chat(loc,"<span class='danger'>\The [src] begins to spark!</span>")
 		update_icon()
 		return
 
 /obj/item/device/personal_shield/on_update_icon()
-	if(uses)
+	if(power_supply.charge)
 		icon_state = "batterer"
 	else
 		icon_state = "battererburnt"
 
 /obj/item/device/personal_shield/Destroy()
 	QDEL_NULL(shield)
+	QDEL_NULL(power_supply)
 	return ..()

--- a/code/game/objects/items/devices/uplink_random_lists.dm
+++ b/code/game/objects/items/devices/uplink_random_lists.dm
@@ -70,6 +70,7 @@ var/list/uplink_random_selections_
 	items += new /datum/uplink_random_item(/datum/uplink_item/item/tools/encryptionkey_radio)
 	items += new /datum/uplink_random_item(/datum/uplink_item/item/tools/encryptionkey_binary)
 	items += new /datum/uplink_random_item(/datum/uplink_item/item/tools/emag, 100, 50)
+	items += new /datum/uplink_random_item(/datum/uplink_item/item/tools/personal_shield, 100, 50)
 	items += new /datum/uplink_random_item(/datum/uplink_item/item/tools/clerical)
 	items += new /datum/uplink_random_item(/datum/uplink_item/item/tools/space_suit, 50, 10)
 	items += new /datum/uplink_random_item(/datum/uplink_item/item/stealth_items/thermal)

--- a/code/modules/mob/living/carbon/human/human_defense.dm
+++ b/code/modules/mob/living/carbon/human/human_defense.dm
@@ -890,6 +890,9 @@ meteor_act
 
 //this proc handles being hit by a thrown atom
 /mob/living/carbon/human/hitby(atom/movable/AM, speed = THROWFORCE_SPEED_DIVISOR)
+	if(!aura_check(AURA_TYPE_THROWN, AM, speed))
+		return
+
 	if(isobj(AM))
 		var/obj/O = AM
 		if(in_throw_mode && !get_active_hand() && speed >= THROWFORCE_SPEED_DIVISOR)	//empty active hand and we're in throw mode

--- a/code/modules/projectiles/gun.dm
+++ b/code/modules/projectiles/gun.dm
@@ -293,6 +293,10 @@
 			break
 
 		fired = TRUE
+		if(ismob(firer))
+			var/mob/living/A = firer
+			if(!A.aura_check(AURA_TYPE_BULLET, projectile, target_zone))
+				break
 		process_accuracy(projectile, firer, target, i, held_twohanded)
 
 		if(pointblank)

--- a/code/modules/projectiles/gun.dm
+++ b/code/modules/projectiles/gun.dm
@@ -295,8 +295,9 @@
 		fired = TRUE
 		if(ismob(firer))
 			var/mob/living/A = firer
-			if(!A.aura_check(AURA_TYPE_BULLET, projectile, target_zone))
-				break
+			if(!A.aura_check(AURA_TYPE_BULLET, projectile, target_zone, firer))
+				target = firer
+				targloc = get_turf(target)
 		process_accuracy(projectile, firer, target, i, held_twohanded)
 
 		if(pointblank)


### PR DESCRIPTION
Добавил персональный энергощит в аплинк. Можно положить в карман или на пояс. Держит примерно 3 выстрела из лазерной винтовки. Стоит 6 телекристаллов. Перезаряжается в заряднике. При включенном щите снаряды владельца отражаются в него же.

<details>
<summary>Чейнджлог</summary>

```yml
🆑
tweak: Добавлен энерго-щит в аплинк, который можно носить на поясе. Блокирует выстрелы врага и отражает выстрелы владельца.
/🆑
```

</details>

- [x] Pull Request полностью завершен, мне не нужна помощь чтобы его закончить.
- [x] Я внимательно прочитал(-а) все свои изменения и багов в них не нашёл(-ла).
- [x] Я запускал(-а) сервер со своими изменениями локально и все протестировал(-а).
- [x] Я ознакомился(-ась) c [Guide to Contribute](https://github.com/ChaoticOnyx/OnyxBay/blob/dev/docs/contributing.md).
