### PR TITLE
Add restricted roles for assassinate contract, add contracts number limit

### DIFF
--- a/code/game/gamemodes/traitor/contracts.dm
+++ b/code/game/gamemodes/traitor/contracts.dm
@@ -58,6 +58,7 @@ GLOBAL_LIST_INIT(syndicate_factions, list(
 	var/reason
 	var/list/reason_list = list()
 	var/datum/contract_organization/organization
+	var/list/wanted_jobs = list()
 
 /datum/antag_contract/New(datum/contract_organization/contract_organization, reason, datum/mind/target)
 	ASSERT(intent)
@@ -102,6 +103,16 @@ GLOBAL_LIST_INIT(syndicate_factions, list(
 	if(!H?.species)
 		return FALSE
 	return !!(H.species.species_flags & SPECIES_FLAG_NO_ANTAG_TARGET)
+
+/datum/antag_contract/proc/skip_unwanted_job(datum/mind/H)
+	var/datum/job/title = job_master.GetJob(H.assigned_role)
+	if(wanted_jobs.len)
+		if(title in wanted_jobs)
+			return FALSE
+		else
+			return TRUE
+	else
+		return FALSE
 
 /datum/antag_contract/proc/create_contract(new_reason, target)
 	return
@@ -400,6 +411,7 @@ GLOBAL_LIST_INIT(syndicate_factions, list(
 	var/weakref/alternative_target // obj/item
 	var/weakref/H // mob/living/carbon/human
 	var/full_reward_mod = 1.5
+	wanted_jobs = list(/datum/job/captain,/datum/job/hop,/datum/job/rd,/datum/job/chief_engineer,/datum/job/cmo,/datum/job/hos, /datum/job/warden, /datum/job/detective, /datum/job/qm)
 
 /datum/antag_contract/item/assassinate/New(datum/contract_organization/contract_organization, reason, datum/mind/target)
 	organization = contract_organization
@@ -438,7 +450,7 @@ GLOBAL_LIST_INIT(syndicate_factions, list(
 
 			target_real_name = _H.real_name
 			target_mind = candidate_mind
-			if(skip_antag_role() || skip_unwanted_species(_H))
+			if(skip_antag_role() || skip_unwanted_species(_H) || skip_unwanted_job(_H))
 				target_mind = null
 				_H = null
 				continue

--- a/code/game/gamemodes/traitor/contracts.dm
+++ b/code/game/gamemodes/traitor/contracts.dm
@@ -106,7 +106,7 @@ GLOBAL_LIST_INIT(syndicate_factions, list(
 
 /datum/antag_contract/proc/skip_unwanted_job(datum/mind/H)
 	var/datum/job/title = job_master.GetJob(H.assigned_role)
-	if(wanted_jobs.len)
+	if(length(wanted_jobs))
 		if(title in wanted_jobs)
 			return FALSE
 		else

--- a/code/game/gamemodes/traitor/fixer.dm
+++ b/code/game/gamemodes/traitor/fixer.dm
@@ -25,8 +25,15 @@
 		set_next_think(world.time + time_to_next_contract)
 
 /datum/contract_fixer/think()
-	create_random_contract(1)
-	set_next_think(world.time + time_to_next_contract)
+	if(!contract_list_overfilled())
+		create_random_contract(1)
+		set_next_think(world.time + time_to_next_contract)
+
+/datum/contract_fixer/proc/contract_list_overfilled()
+	if(GLOB.all_contracts.len > (6 + round(SSticker.minds.len / 5)))
+		return TRUE
+	else
+		return FALSE
 
 /datum/contract_fixer/proc/create_random_contract(count = 1)
 	while(count--)

--- a/code/game/gamemodes/traitor/fixer.dm
+++ b/code/game/gamemodes/traitor/fixer.dm
@@ -25,7 +25,7 @@
 		set_next_think(world.time + time_to_next_contract)
 
 /datum/contract_fixer/think()
-	if(!contract_list_overfilled())
+	if(!contract_list_closed())
 		create_random_contract(1)
 	set_next_think(world.time + time_to_next_contract)
 

--- a/code/game/gamemodes/traitor/fixer.dm
+++ b/code/game/gamemodes/traitor/fixer.dm
@@ -27,10 +27,10 @@
 /datum/contract_fixer/think()
 	if(!contract_list_overfilled())
 		create_random_contract(1)
-		set_next_think(world.time + time_to_next_contract)
+	set_next_think(world.time + time_to_next_contract)
 
-/datum/contract_fixer/proc/contract_list_overfilled()
-	if(GLOB.all_contracts.len > (6 + round(SSticker.minds.len / 5)))
+/datum/contract_fixer/proc/contract_list_closed()
+	if(length(GLOB.all_contracts) > (6 + round(length(SSticker.minds) / 5)))
 		return TRUE
 	else
 		return FALSE
@@ -43,11 +43,11 @@
 /datum/contract_organization
 	var/name = "This is bug!"
 	var/list/datum/antag_contract/contracts = list()
-	var/intents // what contracts organization prefers?
+	var/intentz // what contracts organization prefers?
 	var/datum/contract_fixer/holder
 
 /datum/contract_organization/New(datum/contract_fixer/CF)
-	ASSERT(intents)
+	ASSERT(intentz)
 	holder = CF
 	holder.organizations.Add(src)
 	holder.organizations_by_name[name] = src
@@ -67,7 +67,7 @@
 		var/datum/antag_contract/C = new contract_type(src)
 		if(!C)
 			continue
-		var/not_avaliable = (intents ^ C.intent)
+		var/not_avaliable = (intentz ^ C.intent)
 		if(not_avaliable && prob(25))
 			not_avaliable = FALSE
 		if(!C.can_place() || not_avaliable)
@@ -113,22 +113,22 @@
 
 /datum/contract_organization/syndicate/tti
 	name = "Trauma Team Interspace"
-	intents = CONTRACT_IMPACT_SOCIAL | CONTRACT_IMPACT_OPERATION
+	intentz = CONTRACT_IMPACT_SOCIAL | CONTRACT_IMPACT_OPERATION
 /datum/contract_organization/syndicate/ms
 	name = "MiliSpace"
-	intents = CONTRACT_IMPACT_MILITARY | CONTRACT_IMPACT_HIJACK
+	intentz = CONTRACT_IMPACT_MILITARY | CONTRACT_IMPACT_HIJACK
 /datum/contract_organization/syndicate/bs
 	name = "Biospacenica"
-	intents = CONTRACT_IMPACT_SOCIAL
+	intentz = CONTRACT_IMPACT_SOCIAL
 /datum/contract_organization/syndicate/kt
 	name = "Kang Too"
-	intents = CONTRACT_IMPACT_SOCIAL | CONTRACT_IMPACT_OPERATION | CONTRACT_IMPACT_MILITARY
+	intentz = CONTRACT_IMPACT_SOCIAL | CONTRACT_IMPACT_OPERATION | CONTRACT_IMPACT_MILITARY
 /datum/contract_organization/syndicate/nv
 	name = "NovaPlasma"
-	intents = CONTRACT_IMPACT_SOCIAL | CONTRACT_IMPACT_OPERATION
+	intentz = CONTRACT_IMPACT_SOCIAL | CONTRACT_IMPACT_OPERATION
 /datum/contract_organization/syndicate/dt
 	name = "Dynamoon Technologies"
-	intents = CONTRACT_IMPACT_SOCIAL | CONTRACT_IMPACT_HIJACK
+	intentz = CONTRACT_IMPACT_SOCIAL | CONTRACT_IMPACT_HIJACK
 /datum/contract_organization/syndicate/ns
 	name = "NanoSaka"
-	intents = CONTRACT_IMPACT_SOCIAL | CONTRACT_IMPACT_OPERATION | CONTRACT_IMPACT_MILITARY | CONTRACT_IMPACT_HIJACK
+	intentz = CONTRACT_IMPACT_SOCIAL | CONTRACT_IMPACT_OPERATION | CONTRACT_IMPACT_MILITARY | CONTRACT_IMPACT_HIJACK


### PR DESCRIPTION
Контракты на убийство выдаются только на глав, квартермейстера и старших офицеров СБ. Общее количество доступных контрактов не может превысить лимит (6 + количество игроков/5).

Поправлен баг с неправильной выдачей контрактов от разных фракций. Там у организаций использовалась побитовая переменная intents, которая уже была обьявлена глобально, что приводило к неправильной работе выдачи контрактов.

<details>
<summary>Чейнджлог</summary>

```yml
🆑
balance: Контракты на убийство выдаются только на глав и СБ. Общее число активных контрактов ограничено.
/🆑
```

</details>

- [x] Pull Request полностью завершен, мне не нужна помощь чтобы его закончить.
- [x] Я внимательно прочитал(-а) все свои изменения и багов в них не нашёл(-ла).
- [x] Я запускал(-а) сервер со своими изменениями локально и все протестировал(-а).
- [x] Я ознакомился(-ась) c [Guide to Contribute](https://github.com/ChaoticOnyx/OnyxBay/blob/dev/docs/contributing.md).
