### PR TITLE
Makes poise more dynamic

### DIFF
--- a/code/game/objects/items.dm
+++ b/code/game/objects/items.dm
@@ -638,7 +638,8 @@ var/list/global/slot_flags_enumeration = list(
 			H.visible_message(SPAN("warning", "[H]'s [src] flies off!"))
 			return TRUE
 	H.visible_message(SPAN("warning", "[H] falls down, unable to keep balance!"))
-	H.apply_effect(3, WEAKEN, 0)
+	H.apply_effect(5, WEAKEN, 0)
+	H.poise_immunity(3)
 	return canremove ? TRUE : FALSE
 
 /obj/item/proc/get_loc_turf()

--- a/code/modules/mob/living/carbon/human/body_build.dm
+++ b/code/modules/mob/living/carbon/human/body_build.dm
@@ -38,6 +38,7 @@ var/global/datum/body_build/default_body_build = new
 	var/poise_pool         = HUMAN_DEFAULT_POISE
 	var/stomach_capacity   = STOMACH_CAPACITY_NORMAL
 	var/ambiguous_gender   = FALSE // If TRUE, both females and females will be PLURAL if there's no beard and their groin is covered
+	var/melee_modifier     = 1.0
 
 	var/list/equip_adjust
 	var/list/equip_overlays = list()
@@ -92,6 +93,7 @@ var/global/datum/body_build/default_body_build = new
 
 	stomach_capacity   = STOMACH_CAPACITY_LOW
 	poise_pool         = HUMAN_LOW_POISE
+	melee_modifier     = 0.75 // It's kinda hard to club people when you're two times thinner than a regular person.
 
 	equip_adjust = list(
 		"slot_l_hand" = list(
@@ -225,7 +227,8 @@ var/global/datum/body_build/default_body_build = new
 	movespeed_modifier = /datum/movespeed_modifier/bodybuild/fat
 	equipment_modifier = 0.5
 	poise_pool         = HUMAN_HIGH_POISE
-	ambiguous_gender = TRUE
+	ambiguous_gender   = TRUE
+	melee_modifier     = 1.15 // Force is acceleration times MASS, so...
 
 
 /datum/body_build/slim/alt/tajaran //*sigh. I regret of doing this.
@@ -310,7 +313,7 @@ var/global/datum/body_build/default_body_build = new
 	movespeed_modifier = /datum/movespeed_modifier/bodybuild/fat
 	equipment_modifier = 0.5
 	poise_pool         = HUMAN_HIGH_POISE
-	ambiguous_gender = TRUE
+	ambiguous_gender   = TRUE
 
 /datum/body_build/unathi
 	name                 = SPECIES_UNATHI
@@ -337,6 +340,7 @@ var/global/datum/body_build/default_body_build = new
 	dam_mask             = 'icons/mob/human_races/masks/dam_mask_lizard.dmi'
 
 	poise_pool         = HUMAN_HIGH_POISE
+	melee_modifier     = 1.15
 
 /datum/body_build/vox
 	name                 = "Vox"
@@ -390,6 +394,7 @@ var/global/datum/body_build/default_body_build = new
 	stomach_capacity   = STOMACH_CAPACITY_LOW
 
 	equipment_modifier = -0.5
+	melee_modifier     = 1.25 // Monke muscles are no joke
 
 /datum/body_build/xenomorph
 	name                 = "Xenomorph"

--- a/code/modules/mob/living/carbon/human/human_defense.dm
+++ b/code/modules/mob/living/carbon/human/human_defense.dm
@@ -518,8 +518,7 @@ meteor_act
 
 	if(istype(user,/mob/living/carbon/human))
 		var/mob/living/carbon/human/A = user
-		if(A.body_build.name == "Slim" || A.body_build.name == "Slim Alt")
-			effective_force *= 0.8
+		effective_force *= A.body_build.melee_modifier
 
 	effective_force *= round((100-blocked)/100, 0.01)
 

--- a/code/modules/mob/living/carbon/human/human_defines.dm
+++ b/code/modules/mob/living/carbon/human/human_defines.dm
@@ -118,6 +118,12 @@
 	var/innate_heal = 1
 	var/shock_stage
 
+	var/poise_pool = HUMAN_DEFAULT_POISE
+	var/poise = HUMAN_DEFAULT_POISE
+	var/poise_immune_until = 0
+	var/blocking_hand = 0 // 0 for main hand, 1 for offhand
+	var/last_block = 0
+
 	var/obj/item/grab/current_grab_type 	// What type of grab they use when they grab someone.
 	var/skin_state = SKIN_NORMAL
 	var/no_pain = 0

--- a/code/modules/mob/living/carbon/human/species/species.dm
+++ b/code/modules/mob/living/carbon/human/species/species.dm
@@ -678,12 +678,13 @@ The slots that you can use are found in items_clothing.dm and are the inventory 
 	//target.visible_message("Debug \[DISARM\]: [target] lost [round(4.0+4.0*((100-effective_armor)/100),0.1)] poise ([target.poise]/[target.poise_pool])") // Debug Message
 
 	//var/randn = rand(1, 100)
-	if(!(species_flags & SPECIES_FLAG_NO_SLIP) && target.poise <= 20 && !prob(target.poise*4.5) && !target.lying)
+	if(!(species_flags & SPECIES_FLAG_NO_SLIP) && target.poise <= 20 && !prob(target.poise*4.5) && !target.check_poise_immunity())
 		var/armor_check = target.run_armor_check(affecting, "melee")
 		playsound(target.loc, 'sound/weapons/thudswoosh.ogg', 50, 1, -1)
 		if(prob(100-target.poise*6.5))
 			target.visible_message("<span class='danger'>[attacker] has pushed [target]!</span>")
-			target.apply_effect(4, WEAKEN, armor_check)
+			target.apply_effect(5, WEAKEN, armor_check)
+			target.poise_immunity(2)
 		else
 			target.visible_message("<span class='warning'>[attacker] attempted to push [target]!</span>")
 		return

--- a/code/modules/mob/living/carbon/human/unarmed_attack.dm
+++ b/code/modules/mob/living/carbon/human/unarmed_attack.dm
@@ -54,7 +54,7 @@ var/global/list/sparring_attack_cache = list()
 
 	//target.visible_message("Debug \[UNARMED\]: [target] lost [round(attack_damage*0.5 + attack_damage*0.5*((100-effective_armor)/100),0.1)] poise ([target.poise]/[target.poise_pool])") // Debug Message
 
-	if(attack_damage >= 5 && armor < 100 && !(target == user) && target.poise <= attack_damage*3)
+	if(attack_damage >= 5 && armor < 100 && target != user && target.poise <= attack_damage*3 && !target.check_poise_immunity())
 		switch(zone) // strong punches can have effects depending on where they hit
 			if(BP_HEAD, BP_EYES, BP_MOUTH)
 				// Induce blurriness

--- a/code/modules/mob/mob_helpers.dm
+++ b/code/modules/mob/mob_helpers.dm
@@ -83,7 +83,7 @@
 
 //The base miss chance for the different defence zones
 var/list/global/base_miss_chance = list(
-	BP_HEAD = 35,
+	BP_HEAD = 40,
 	BP_CHEST = 10,
 	BP_GROIN = 20,
 	BP_L_LEG = 30,

--- a/code/modules/mob/mob_helpers.dm
+++ b/code/modules/mob/mob_helpers.dm
@@ -83,7 +83,7 @@
 
 //The base miss chance for the different defence zones
 var/list/global/base_miss_chance = list(
-	BP_HEAD = 25,
+	BP_HEAD = 35,
 	BP_CHEST = 10,
 	BP_GROIN = 20,
 	BP_L_LEG = 30,

--- a/code/modules/spells/general/gastrocnemius_magic.dm
+++ b/code/modules/spells/general/gastrocnemius_magic.dm
@@ -32,7 +32,7 @@
 			to_chat(L, SPAN("danger", "You are sent flying!"))
 		if(ishuman(L))
 			var/mob/living/carbon/human/H = L
-			H.damage_poise(25)
+			H.damage_poise(25, TRUE)
 
 	var/turf/T = get_turf(user)
 	T.ex_act(rand(2, 3))

--- a/code/modules/spells/hand/biceps_magic.dm
+++ b/code/modules/spells/hand/biceps_magic.dm
@@ -25,7 +25,7 @@
 	user.make_grab(user, H, GRAB_QUICKCHOKE)
 	user.zone_sel.selecting = saved_zone_sel
 
-	H.damage_poise(25)
+	H.damage_poise(25, TRUE)
 
 	to_chat(H, SPAN("warning", "It looks like you're in trouble."))
 	return TRUE

--- a/code/modules/spells/hand/deltoid_magic.dm
+++ b/code/modules/spells/hand/deltoid_magic.dm
@@ -39,7 +39,7 @@
 		H.apply_damage(rand(20, 40), BRUTE, affecting)
 		H.Weaken(8)
 		H.Stun(4)
-		H.damage_poise(30)
+		H.damage_poise(30, TRUE)
 		playsound(H.loc, SFX_FIGHTING_PUNCH, rand(80, 100), 1, -1)
 
 	H.throw_at(get_edge_target_turf(H, throw_dir), 5, 1)


### PR DESCRIPTION
Делаем устойчивость более динамичной. Больше Сифу, меньше стамины.

```yml
🆑
balance: Обновлена механика устойчивости (Poise). Теперь если космонавтик падает из-за закончившейся устойчивости - он восстанавливает запас устойчивости и получает короткое окно неуязвимости к урону по устойчивости (не распространяется на трату устойчивости на собственные атаки), но сами нокдауны длятся дольше.
balance: Унатхи, обезьяны и толстяки теперь немного больнее бьют оружием в ближнем бою.
/🆑
```

- [x] Pull Request полностью завершен, мне не нужна помощь чтобы его закончить.
- [x] Я внимательно прочитал(-а) все свои изменения и багов в них не нашёл(-ла).
- [x] Я запускал(-а) сервер со своими изменениями локально и все протестировал(-а).
- [x] Я ознакомился(-ась) c [Guide to Contribute](https://github.com/ChaoticOnyx/OnyxBay/blob/dev/docs/contributing.md).
