### PR TITLE
fix(storage): there really is more room in the combat medical kit

### DIFF
--- a/code/game/objects/items/storage/firstaid.dm
+++ b/code/game/objects/items/storage/firstaid.dm
@@ -104,6 +104,7 @@
 	icon_state = "firstaid-bezerk"
 	item_state = "firstaid-advanced"
 	storage_slots = 9 // Tacticoolness makes it more spaceous
+	max_storage_space = null
 
 	startswith = list(
 		/obj/item/stack/medical/advanced/bruise_pack,


### PR DESCRIPTION

<details>
<summary>Чейнджлог</summary>

```yml
🆑ilyadobr
bugfix: Теперь в комбат аптечке доступны два дополнительных слота на постоянной основе.
/🆑
```

</details>

- [x] Pull Request полностью завершен, мне не нужна помощь чтобы его закончить.
- [x] Я внимательно прочитал(-а) все свои изменения и багов в них не нашёл(-ла).
- [x] Я запускал(-а) сервер со своими изменениями локально и все протестировал(-а).
- [x] Я ознакомился(-ась) c [Guide to Contribute](https://github.com/ChaoticOnyx/OnyxBay/blob/dev/docs/contributing.md).
