### PR TITLE
tweak(recharger): wall chargers accept magazines from lawgiver

### DIFF
--- a/code/game/machinery/recharger.dm
+++ b/code/game/machinery/recharger.dm
@@ -212,7 +212,7 @@
 	icon = 'icons/obj/stationobjs.dmi'
 	icon_state = "wrecharger0"
 	active_power_usage = 50 KILO WATTS	//It's more specialized than the standalone recharger (guns and batons only) so make it more powerful
-	allowed_devices = list(/obj/item/gun/magnetic/railgun, /obj/item/gun/energy, /obj/item/melee/baton, /obj/item/cell/ammo/charge)
+	allowed_devices = list(/obj/item/gun/magnetic/railgun, /obj/item/gun/energy, /obj/item/melee/baton, /obj/item/cell/ammo/charge, /obj/item/ammo_magazine/lawgiver)
 	icon_state_charged = "wrecharger2"
 	icon_state_charging = "wrecharger1"
 	icon_state_idle = "wrecharger0"


### PR DESCRIPTION
Настенные зарядники на самом деле предназначались исключительно для, собственно, энергетического оружия и шоковой дубинки, и только, однако раз Тоби сказал что туда можно помещать на зарядку _/obj/item/cell/ammo/charge_, не вижу причин почему сюда же нельзя дополнить магазин для Лавгивера.

close #12432

<details>
<summary>Чейнджлог</summary>

```yml
🆑ilyadobr
bugfix: Теперь магазины от Лавгивера помещаются в настенные зарядники.
/🆑
```

</details>

- [x] Pull Request полностью завершен, мне не нужна помощь чтобы его закончить.
- [x] Я внимательно прочитал(-а) все свои изменения и багов в них не нашёл(-ла).
- [x] Я запускал(-а) сервер со своими изменениями локально и все протестировал(-а).
- [x] Я ознакомился(-ась) c [Guide to Contribute](https://github.com/ChaoticOnyx/OnyxBay/blob/dev/docs/contributing.md).
