### PR TITLE
fix(RUST): fixing RUST control consoles and fuel compressor fix and tweaks

### DIFF
--- a/code/modules/power/fusion/core/core_control.dm
+++ b/code/modules/power/fusion/core/core_control.dm
@@ -5,6 +5,7 @@
 	light_color = COLOR_ORANGE
 	idle_power_usage = 250 WATTS
 	active_power_usage = 500 WATTS
+	circuit = /obj/item/circuitboard/fusion_core_control
 
 	var/id_tag
 	var/scan_range = 25
@@ -18,6 +19,7 @@
 			id_tag = new_ident
 			cur_viewed_device = null
 		return
+
 	else
 		return ..()
 
@@ -27,6 +29,7 @@
 /obj/machinery/computer/fusion_core_control/attack_hand(mob/user)
 	if(..())
 		return
+
 	add_fingerprint(user)
 	interact(user)
 
@@ -142,7 +145,7 @@
 		var/idx = Clamp(text2num(href_list["toggle_active"]), 1, connected_devices.len)
 		cur_viewed_device = connected_devices[idx]
 		updateUsrDialog()
-		return 1
+		return TRUE
 
 	//All HREFs from this point on require a device anyways.
 	if(!cur_viewed_device || !check_core_status(cur_viewed_device) || cur_viewed_device.id_tag != id_tag || get_dist(src, cur_viewed_device) > scan_range)
@@ -151,13 +154,13 @@
 	if(href_list["goto_scanlist"])
 		cur_viewed_device = null
 		updateUsrDialog()
-		return 1
+		return TRUE
 
 	if(href_list["toggle_active"])
 		if(!cur_viewed_device.Startup()) //Startup() whilst the device is active will return null.
 			cur_viewed_device.Shutdown()
 		updateUsrDialog()
-		return 1
+		return TRUE
 
 	if(href_list["str"])
 		var/val = text2num(href_list["str"])
@@ -166,8 +169,8 @@
 		else
 			cur_viewed_device.set_strength(cur_viewed_device.field_strength + val)
 		updateUsrDialog()
-		return 1
+		return TRUE
 
 //Returns 1 if the machine can be interacted with via this console.
 /obj/machinery/computer/fusion_core_control/proc/check_core_status(obj/machinery/power/fusion_core/C)
-	. = 1
+	. = TRUE

--- a/code/modules/power/fusion/core/core_field.dm
+++ b/code/modules/power/fusion/core/core_field.dm
@@ -28,7 +28,8 @@
 		/obj/item/projectile,
 		/obj/effect,
 		/obj/structure/cable,
-		/obj/machinery/atmospherics
+		/obj/machinery/atmospherics,
+		/obj/machinery/air_sensor
 		)
 
 	var/light_min_range = 2
@@ -143,7 +144,7 @@
 
 	check_instability()
 	Radiate()
-	
+
 	set_next_think(world.time + 1 SECOND)
 
 /obj/effect/fusion_em_field/proc/check_instability()

--- a/code/modules/power/fusion/fuel_assembly/fuel_compressor.dm
+++ b/code/modules/power/fusion/fuel_assembly/fuel_compressor.dm
@@ -11,8 +11,7 @@
 		/obj/item/circuitboard/fusion_fuel_compressor = 1,
 		/obj/item/stock_parts/manipulator/pico = 2,
 		/obj/item/stock_parts/matter_bin/super = 2,
-		/obj/item/stock_parts/console_screen = 1,
-		/obj/item/stack/cable_coil{amount = 5}
+		/obj/item/stock_parts/console_screen = 1
 	)
 
 /obj/machinery/fusion_fuel_compressor/MouseDrop_T(atom/movable/target, mob/user)

--- a/code/modules/power/fusion/fuel_assembly/fuel_compressor.dm
+++ b/code/modules/power/fusion/fuel_assembly/fuel_compressor.dm
@@ -7,17 +7,12 @@
 	atom_flags = ATOM_FLAG_CLIMBABLE
 	turf_height_offset = 23
 
-/obj/machinery/fusion_fuel_compressor/Initialize()
-	. = ..()
-	component_parts = list(
-		new /obj/item/circuitboard/fusion_fuel_compressor(src),
-		new /obj/item/stock_parts/manipulator/pico(src),
-		new /obj/item/stock_parts/manipulator/pico(src),
-		new /obj/item/stock_parts/matter_bin/super(src),
-		new /obj/item/stock_parts/matter_bin/super(src),
-		new /obj/item/stock_parts/console_screen(src),
-		new /obj/item/stack/cable_coil(src, 5))
-	RefreshParts()
+	component_types = list(
+		/obj/item/stock_parts/manipulator/pico = 2,
+		/obj/item/stock_parts/matter_bin/super = 2,
+		/obj/item/stock_parts/console_screen = 1,
+		/obj/item/stack/cable_coil = 5
+	)
 
 /obj/machinery/fusion_fuel_compressor/MouseDrop_T(atom/movable/target, mob/user)
 	if(user.incapacitated() || !user.Adjacent(src))

--- a/code/modules/power/fusion/fuel_assembly/fuel_compressor.dm
+++ b/code/modules/power/fusion/fuel_assembly/fuel_compressor.dm
@@ -38,7 +38,7 @@
 	if(do_fuel_compression(thing, user))
 		return
 
-	..()
+	return ..()
 
 /obj/machinery/fusion_fuel_compressor/proc/do_fuel_compression(obj/item/thing, mob/user)
 	if(istype(thing) && thing.reagents && thing.reagents.total_volume && thing.is_open_container())

--- a/code/modules/power/fusion/fuel_assembly/fuel_compressor.dm
+++ b/code/modules/power/fusion/fuel_assembly/fuel_compressor.dm
@@ -8,10 +8,11 @@
 	turf_height_offset = 23
 
 	component_types = list(
+		/obj/item/circuitboard/fusion_fuel_compressor = 1,
 		/obj/item/stock_parts/manipulator/pico = 2,
 		/obj/item/stock_parts/matter_bin/super = 2,
 		/obj/item/stock_parts/console_screen = 1,
-		/obj/item/stack/cable_coil = 5
+		/obj/item/stack/cable_coil{amount = 5}
 	)
 
 /obj/machinery/fusion_fuel_compressor/MouseDrop_T(atom/movable/target, mob/user)

--- a/code/modules/power/fusion/fuel_assembly/fuel_compressor.dm
+++ b/code/modules/power/fusion/fuel_assembly/fuel_compressor.dm
@@ -2,50 +2,83 @@
 	name = "fuel compressor"
 	icon = 'icons/obj/machines/power/fusion.dmi'
 	icon_state = "fuel_compressor1"
-	density = 1
-	anchored = 1
-	layer = 4
+	density = TRUE
+	anchored = TRUE
+	atom_flags = ATOM_FLAG_CLIMBABLE
+	turf_height_offset = 23
+
+/obj/machinery/fusion_fuel_compressor/Initialize()
+	. = ..()
+	component_parts = list(
+		new /obj/item/circuitboard/fusion_fuel_compressor(src),
+		new /obj/item/stock_parts/manipulator/pico(src),
+		new /obj/item/stock_parts/manipulator/pico(src),
+		new /obj/item/stock_parts/matter_bin/super(src),
+		new /obj/item/stock_parts/matter_bin/super(src),
+		new /obj/item/stock_parts/console_screen(src),
+		new /obj/item/stack/cable_coil(src, 5))
+	RefreshParts()
 
 /obj/machinery/fusion_fuel_compressor/MouseDrop_T(atom/movable/target, mob/user)
 	if(user.incapacitated() || !user.Adjacent(src))
 		return
+
+	if(target == user)
+		. = ..()
+
 	return do_fuel_compression(target, user)
 
 /obj/machinery/fusion_fuel_compressor/attackby(obj/item/thing, mob/user)
-	return do_fuel_compression(thing, user) || ..()
+	if(default_deconstruction_screwdriver(user, thing))
+		return
+
+	if(default_deconstruction_crowbar(user, thing))
+		return
+
+	if(do_fuel_compression(thing, user))
+		return
+
+	..()
 
 /obj/machinery/fusion_fuel_compressor/proc/do_fuel_compression(obj/item/thing, mob/user)
 	if(istype(thing) && thing.reagents && thing.reagents.total_volume && thing.is_open_container())
 		if(thing.reagents.reagent_list.len > 1)
 			to_chat(user, "<span class='warning'>The contents of \the [thing] are impure and cannot be used as fuel.</span>")
-			return 1
+			return TRUE
+
 		if(thing.reagents.total_volume < 50)
 			to_chat(user, "<span class='warning'>You need at least fifty units of material to form a fuel rod.</span>")
-			return 1
+			return TRUE
+
 		var/datum/reagent/R = thing.reagents.reagent_list[1]
 		visible_message("<span class='notice'>\The [src] compresses the contents of \the [thing] into a new fuel assembly.</span>")
 		var/obj/item/fuel_assembly/F = new(get_turf(src), R.type, R.color)
 		thing.reagents.remove_reagent(R.type, R.volume)
 		user.pick_or_drop(F)
-		return 1
+		return TRUE
+
 	else if(istype(thing, /obj/machinery/power/supermatter/shard))
 		var/obj/item/fuel_assembly/F = new(get_turf(src), MATERIAL_SUPERMATTER)
 		visible_message("<span class='notice'>\The [src] compresses the \[thing] into a new fuel assembly.</span>")
 		qdel(thing)
 		user.pick_or_drop(F)
-		return 1
+		return TRUE
+
 	else if(istype(thing, /obj/item/stack/material))
 		var/obj/item/stack/material/M = thing
 		var/material/mat = M.get_material()
 		if(!mat.is_fusion_fuel)
 			to_chat(user, "<span class='warning'>It would be pointless to make a fuel rod out of [mat.use_name].</span>")
-			return
+			return TRUE
+
 		if(M.get_amount() < 25)
 			to_chat(user, "<span class='warning'>You need at least 25 [mat.sheet_plural_name] to make a fuel rod.</span>")
-			return
+			return TRUE
+
 		var/obj/item/fuel_assembly/F = new(get_turf(src), mat.name)
 		visible_message("<span class='notice'>\The [src] compresses the [mat.use_name] into a new fuel assembly.</span>")
 		M.use(25)
 		user.pick_or_drop(F)
-		return 1
-	return 0
+		return TRUE
+
+	return FALSE

--- a/code/modules/power/fusion/fuel_assembly/fuel_control.dm
+++ b/code/modules/power/fusion/fuel_assembly/fuel_control.dm
@@ -5,6 +5,7 @@
 	light_color = COLOR_ORANGE
 	idle_power_usage = 250 WATTS
 	active_power_usage = 500 WATTS
+	circuit = /obj/item/circuitboard/fusion_fuel_control
 
 	var/id_tag
 	var/scan_range = 25
@@ -15,6 +16,7 @@
 /obj/machinery/computer/fusion_fuel_control/attack_hand(mob/user)
 	if(..())
 		return
+
 	add_fingerprint(user)
 	interact(user)
 
@@ -78,7 +80,7 @@
 
 /obj/machinery/computer/fusion_fuel_control/Topic(href, href_list)
 	if(..())
-		return 1
+		return TRUE
 
 	if(href_list["toggle_injecting"])
 		var/obj/machinery/fusion_fuel_injector/I = locate(href_list["toggle_injecting"])

--- a/code/modules/power/fusion/fusion_circuits.dm
+++ b/code/modules/power/fusion/fusion_circuits.dm
@@ -12,7 +12,6 @@
 							/obj/item/stock_parts/manipulator/pico = 2,
 							/obj/item/stock_parts/matter_bin/super = 2,
 							/obj/item/stock_parts/console_screen = 1,
-							/obj/item/stack/cable_coil = 5
 							)
 
 /obj/item/circuitboard/fusion_fuel_control

--- a/code/modules/power/fusion/gyrotron/gyrotron_control.dm
+++ b/code/modules/power/fusion/gyrotron/gyrotron_control.dm
@@ -5,6 +5,7 @@
 	light_color = COLOR_BLUE
 	idle_power_usage = 250 WATTS
 	active_power_usage = 500 WATTS
+	circuit = /obj/item/circuitboard/gyrotron_control
 
 	var/id_tag
 	var/scan_range = 25
@@ -63,30 +64,32 @@
 		return
 
 	if(href_list["modifypower"])
-		var/new_val = input("Enter new emission power level (1 - 50)", "Modifying power level", G.mega_energy) as num
+		var/new_val = input("Enter new emission power level (1 - 10)", "Modifying power level", G.mega_energy) as num
 		if(!new_val)
 			to_chat(usr, "<span class='warning'>That's not a valid number.</span>")
-			return 1
-		G.mega_energy = Clamp(new_val, 1, 50)
+			return TRUE
+
+		G.mega_energy = Clamp(new_val, 1, 10)
 		G.change_power_consumption(G.mega_energy * 1500, POWER_USE_ACTIVE)
 		updateUsrDialog()
-		return 1
+		return TRUE
 
 	if(href_list["modifyrate"])
 		var/new_val = input("Enter new emission delay between 1 and 10 seconds.", "Modifying emission rate", G.rate) as num
 		if(!new_val)
 			to_chat(usr, "<span class='warning'>That's not a valid number.</span>")
-			return 1
+			return TRUE
+
 		G.rate = Clamp(new_val, 1, 10)
 		updateUsrDialog()
-		return 1
+		return TRUE
 
 	if(href_list["toggle"])
 		G.activate(usr)
 		updateUsrDialog()
-		return 1
+		return TRUE
 
-	return 0
+	return FALSE
 
 /obj/machinery/computer/gyrotron_control/attackby(obj/item/W, mob/user)
 	if(isMultitool(W))

--- a/code/modules/power/fusion/gyrotron/gyrotron_control.dm
+++ b/code/modules/power/fusion/gyrotron/gyrotron_control.dm
@@ -64,7 +64,7 @@
 		return
 
 	if(href_list["modifypower"])
-		var/new_val = input("Enter new emission power level (1 - 10)", "Modifying power level", G.mega_energy) as num
+		var/new_val = input("Enter new emission power level (1 - 50)", "Modifying power level", G.mega_energy) as num
 		if(!new_val)
 			to_chat(usr, "<span class='warning'>That's not a valid number.</span>")
 			return TRUE

--- a/code/modules/power/fusion/gyrotron/gyrotron_control.dm
+++ b/code/modules/power/fusion/gyrotron/gyrotron_control.dm
@@ -69,7 +69,7 @@
 			to_chat(usr, "<span class='warning'>That's not a valid number.</span>")
 			return TRUE
 
-		G.mega_energy = Clamp(new_val, 1, 10)
+		G.mega_energy = Clamp(new_val, 1, 50)
 		G.change_power_consumption(G.mega_energy * 1500, POWER_USE_ACTIVE)
 		updateUsrDialog()
 		return TRUE


### PR DESCRIPTION
Из компрессора теперь выпадают запчасти при разборке и на него можно залезть, починил разборку консолей раста, поле раста больше не должно цеплять газовый сенсор в реакторной.
<details>
<summary>Чейнджлог</summary>

```yml
🆑
bugfix: Консоли РАСТа теперь можно разобрать и починить
bugfix: Из топливного компрессора теперь выпадают детали при разборке
bugfix: Поле РАСТа больше не цепляет газовый сенсор в реакторной
/🆑
```

</details>

- [x] Pull Request полностью завершен, мне не нужна помощь чтобы его закончить.
- [x] Я внимательно прочитал(-а) все свои изменения и багов в них не нашёл(-ла).
- [ ] Я запускал(-а) сервер со своими изменениями локально и все протестировал(-а).
- [x] Я ознакомился(-ась) c [Guide to Contribute](https://github.com/ChaoticOnyx/OnyxBay/blob/dev/docs/contributing.md).
