### PR TITLE
fix(rig): incorrect display of helmet sprites

### DIFF
--- a/code/modules/clothing/head.dm
+++ b/code/modules/clothing/head.dm
@@ -37,6 +37,10 @@
 	var/cache_key = "[light_overlay]_[species_name]"
 	if(on && light_overlay_cache[cache_key] && slot == slot_head_str)
 		ret.AddOverlays(light_overlay_cache[cache_key])
+	if(item_state_slots && item_state_slots[slot])
+		ret.icon_state = item_state_slots[slot]
+	else
+		ret.icon_state = icon_state
 	return ret
 
 /obj/item/clothing/head/attack_self(mob/user)

--- a/code/modules/clothing/spacesuits/spacesuits.dm
+++ b/code/modules/clothing/spacesuits/spacesuits.dm
@@ -5,10 +5,7 @@
 /obj/item/clothing/head/helmet/space
 	name = "Space helmet"
 	icon_state = "space"
-	item_state_slots = list(
-		slot_l_hand_str = "s_helmet",
-		slot_r_hand_str = "s_helmet",
-		)
+	item_state = "space"
 	desc = "A special helmet designed for work in a hazardous, low-pressure environment."
 	item_flags = ITEM_FLAG_STOPPRESSUREDAMAGE | ITEM_FLAG_THICKMATERIAL | ITEM_FLAG_AIRTIGHT
 	flags_inv = BLOCKHAIR

--- a/code/modules/clothing/spacesuits/spacesuits.dm
+++ b/code/modules/clothing/spacesuits/spacesuits.dm
@@ -5,7 +5,10 @@
 /obj/item/clothing/head/helmet/space
 	name = "Space helmet"
 	icon_state = "space"
-	item_state = "space"
+	item_state_slots = list(
+		slot_l_hand_str = "s_helmet",
+		slot_r_hand_str = "s_helmet",
+		)
 	desc = "A special helmet designed for work in a hazardous, low-pressure environment."
 	item_flags = ITEM_FLAG_STOPPRESSUREDAMAGE | ITEM_FLAG_THICKMATERIAL | ITEM_FLAG_AIRTIGHT
 	flags_inv = BLOCKHAIR


### PR DESCRIPTION
Не уверен на счёт того, насколько фикс правильный. Однако благодаря нему РИГовские шлемы стали нормально подгружаться на космонавтике.

<details>
<summary>Чейнджлог</summary>

```yml
🆑ilyadobr
bugfix: РИГовские шлемы теперь должны нормально отображаться.
/🆑
```

</details>


- [x] Pull Request полностью завершен, мне не нужна помощь чтобы его закончить.
- [ ] Я внимательно прочитал(-а) все свои изменения и багов в них не нашёл(-ла).
- [x] Я запускал(-а) сервер со своими изменениями локально и все протестировал(-а).
- [x] Я ознакомился(-ась) c [Guide to Contribute](https://github.com/ChaoticOnyx/OnyxBay/blob/dev/docs/contributing.md).
