### PR TITLE
fix(boxes): removed large tubes from light boxes

### DIFF
--- a/code/game/objects/items/storage/boxes.dm
+++ b/code/game/objects/items/storage/boxes.dm
@@ -501,8 +501,7 @@
 /obj/item/storage/box/lights/tubes
 	name = "box of replacement tubes"
 	icon_state = "lighttube"
-	startswith = list(/obj/item/light/tube = 17,
-					/obj/item/light/tube/large = 4)
+	startswith = list(/obj/item/light/tube = 21)
 
 /obj/item/storage/box/lights/tubes/empty
 	startswith = null
@@ -510,8 +509,7 @@
 /obj/item/storage/box/lights/mixed
 	name = "box of replacement lights"
 	icon_state = "lightmixed"
-	startswith = list(/obj/item/light/tube = 12,
-					/obj/item/light/tube/large = 4,
+	startswith = list(/obj/item/light/tube = 16,
 					/obj/item/light/bulb = 5)
 
 /obj/item/storage/box/lights/mixed/empty


### PR DESCRIPTION
Убрал из коробок с лампами(box of replacement lights и box of replacement tubes) большие лампы (large light tube). Теперь все лампы адекватно помещаются в коробку.

fixes #7097


<details>
<summary>Чейнджлог</summary>

```yml
🆑
bugfix: Коробки с лампами теперь адекватно вмещают в себя лампы.
/🆑
```

</details>


- [x] Pull Request полностью завершен, мне не нужна помощь чтобы его закончить.
- [x] Я внимательно прочитал(-а) все свои изменения и багов в них не нашёл(-ла).
- [x] Я запускал(-а) сервер со своими изменениями локально и все протестировал(-а).
- [x] Я ознакомился(-ась) c [Guide to Contribute](https://github.com/ChaoticOnyx/OnyxBay/blob/dev/docs/contributing.md).
