### PR TITLE
Tweaking poise once again, removing poise immunity from knockdowns

### DIFF
--- a/code/game/objects/items.dm
+++ b/code/game/objects/items.dm
@@ -639,7 +639,6 @@ var/list/global/slot_flags_enumeration = list(
 			return TRUE
 	H.visible_message(SPAN("warning", "[H] falls down, unable to keep balance!"))
 	H.apply_effect(5, WEAKEN, 0)
-	H.poise_immunity(3)
 	return canremove ? TRUE : FALSE
 
 /obj/item/proc/get_loc_turf()

--- a/code/modules/mob/living/carbon/human/human_defense.dm
+++ b/code/modules/mob/living/carbon/human/human_defense.dm
@@ -135,8 +135,6 @@ meteor_act
 				visible_message("<b>[src]</b> collapses!", SPAN("warning", "You collapse from shock!"))
 			Stun(reduced_tasing)
 			Weaken(reduced_tasing + 1) // Getting up after being tased is not instant, adding 1 tick of unstunned crawling
-			if(poise <= 0)
-				poise_immunity(min(reduced_tasing, 3))
 
 
 //////////////////////
@@ -443,7 +441,6 @@ meteor_act
 						visible_message(SPAN("danger", "[src] [species.knockout_message]"))
 						custom_pain("Your head's definitely gonna hurt tomorrow.", 30, affecting = affecting)
 						apply_effect((I.mod_weight*15), PARALYZE, (blocked/2))
-						poise_immunity(3)
 
 					else if(prob(effective_force))
 						visible_message(SPAN("danger", "[src] looks momentarily disoriented."), SPAN("danger", "You see stars."))
@@ -453,7 +450,6 @@ meteor_act
 					if(poise <= effective_force/3*I.mod_weight)
 						visible_message(SPAN("danger", "[src] has been knocked down!"))
 						apply_effect(min((I.mod_weight * 3), 4), WEAKEN, (blocked/2))
-						poise_immunity(2)
 
 				if(BP_L_HAND, BP_R_HAND) //Knocking someone down by smashing their hands? Hell no.
 					if(poise <= effective_force/3*I.mod_weight)
@@ -529,7 +525,6 @@ meteor_act
 					visible_message(SPAN("danger", "[src] [species.knockout_message]"))
 					custom_pain("Your head's <B>definitely</B> gonna hurt tomorrow.", 30, affecting = affecting)
 					apply_effect((I.mod_weight*20), PARALYZE, (blocked/2))
-					poise_immunity(3)
 
 				else if(prob(effective_force))
 					visible_message(SPAN("danger", "[src] looks momentarily disoriented."), SPAN("danger", "You see stars."))
@@ -559,7 +554,6 @@ meteor_act
 				if(poise <= effective_force/3*I.mod_weight)
 					visible_message(SPAN("danger", "[src] has been knocked down!"))
 					apply_effect((I.mod_weight*3.5), WEAKEN, (blocked/2))
-					poise_immunity(2)
 
 				else if(prob(effective_force))
 					var/turf/T = get_step(get_turf(src), get_dir(get_turf(user), get_turf(src)))
@@ -571,13 +565,11 @@ meteor_act
 					else
 						visible_message(SPAN("danger", "[src] bumps into \the [T]!"))
 						apply_effect(effective_force * 0.4, WEAKEN, (blocked/2))
-						poise_immunity(2)
 
 			if(BP_L_FOOT, BP_R_FOOT)
 				if(poise <= effective_force*I.mod_reach)
 					visible_message(SPAN("danger", "[user] takes [src] down with their [I.name]!"))
 					apply_effect((I.mod_reach*5), WEAKEN, blocked)
-					poise_immunity(2)
 
 	if(effective_force <= 0)
 		return 0
@@ -737,7 +729,6 @@ meteor_act
 				visible_message(SPAN("warning", "[defender] falls down, unable to keep balance!"))
 				defender.apply_effect(3, WEAKEN, 0)
 				defender.useblock_off()
-				defender.poise_immunity(2)
 	return 1
 
 //Src (defender) blocks attacking_mob's (attacker) punch/generic attack with their weapon_def
@@ -787,7 +778,6 @@ meteor_act
 				visible_message(SPAN("warning", "[defender] falls down, unable to keep balance!"))
 				defender.apply_effect(3, WEAKEN, 0)
 				defender.useblock_off()
-				defender.poise_immunity(2)
 	return 1
 
 
@@ -872,7 +862,6 @@ meteor_act
 	damage_poise(poisedamage * pd_mult)
 	if(poise <= 25 && !prob(poise * 3))
 		apply_effect(max(3, (poisedamage * pd_mult / 4)), WEAKEN)
-		poise_immunity(2)
 		if(!lying)
 			visible_message(SPAN("danger", "[src] goes down under the impact of \the [P]!"))
 
@@ -938,7 +927,6 @@ meteor_act
 						visible_message(SPAN("warning", "[src] falls down, unable to keep balance!"))
 						apply_effect(2, WEAKEN, 0)
 						useblock_off()
-						poise_immunity(1)
 					return
 
 

--- a/code/modules/mob/living/carbon/human/life.dm
+++ b/code/modules/mob/living/carbon/human/life.dm
@@ -1030,18 +1030,19 @@
 		poise = poise_pool
 		poise_icon?.icon_state = "[round((poise/poise_pool) * 50)]"
 		return
-	var/pregen = 5
+	var/base_pregen = poise_pool * 0.1
+	var/pregen = base_pregen
 
 	for(var/obj/item/grab/G in list(get_active_hand(), get_inactive_hand()))
-		pregen -= 1.25
+		pregen -= base_pregen * 0.25
 
 	if(blocking)
-		pregen -= 2.5
+		pregen -= base_pregen * 0.5
 
 	if(lying)
-		pregen += 2.5
+		pregen += base_pregen * 0.5
 
-	poise = between(0, poise+pregen, poise_pool)
+	poise = between(0, poise + pregen, poise_pool)
 
 	poise_icon?.icon_state = "[round((poise/poise_pool) * 50)]"
 

--- a/code/modules/mob/living/carbon/human/species/species.dm
+++ b/code/modules/mob/living/carbon/human/species/species.dm
@@ -684,7 +684,6 @@ The slots that you can use are found in items_clothing.dm and are the inventory 
 		if(prob(100-target.poise*6.5))
 			target.visible_message("<span class='danger'>[attacker] has pushed [target]!</span>")
 			target.apply_effect(5, WEAKEN, armor_check)
-			target.poise_immunity(2)
 		else
 			target.visible_message("<span class='warning'>[attacker] attempted to push [target]!</span>")
 		return


### PR DESCRIPTION
```yml
🆑
balance: Откат механики poise immunity. Как показала практика, механика плохо сочетается с темпом боёвки.
balance: Устойчивость теперь восстанавливается в процентных значениях. Следовательно, у мобов с высоким запасом устойчивости она будет восстанавливаться за то же время, что и у мобов со стандартным запасом.
/🆑
```

- [x] Pull Request полностью завершен, мне не нужна помощь чтобы его закончить.
- [x] Я внимательно прочитал(-а) все свои изменения и багов в них не нашёл(-ла).
- [x] Я запускал(-а) сервер со своими изменениями локально и все протестировал(-а).
- [x] Я ознакомился(-ась) c [Guide to Contribute](https://github.com/ChaoticOnyx/OnyxBay/blob/dev/docs/contributing.md).
