### PR TITLE
revert(sprites): return door1 and door0 to their places

### DIFF
--- a/code/game/machinery/doors/door.dm
+++ b/code/game/machinery/doors/door.dm
@@ -363,9 +363,9 @@
 
 /obj/machinery/door/on_update_icon()
 	if(density)
-		icon_state = "door_closed"
+		icon_state = "door1"
 	else
-		icon_state = "door_open"
+		icon_state = "door0"
 	return
 
 
@@ -398,7 +398,7 @@
 	operating = TRUE
 
 	do_animate("opening")
-	icon_state = "door_opening"
+	icon_state = "door0"
 	set_opacity(FALSE)
 	if(filler)
 		filler.set_opacity(opacity)


### PR DESCRIPTION
Что-то не учёл, что у нас некоторые двери всё ещё используют систему door1 и door0, от чего "шлюзы" в церкви и на шаттле потеряли спрайты. По хорошему надо какую-нибудь одну систему выбрать, но пока что лучшее решение вернуть всё как было изначально.

- [x] Pull Request полностью завершен, мне не нужна помощь чтобы его закончить.
- [x] Я внимательно прочитал(-а) все свои изменения и багов в них не нашёл(-ла).
- [x] Я запускал(-а) сервер со своими изменениями локально и все протестировал(-а).
- [x] Я ознакомился(-ась) c [Guide to Contribute](https://github.com/ChaoticOnyx/OnyxBay/blob/dev/docs/contributing.md).
