### PR TITLE
fix(slot_machine): the ability to unanchored it from the floor

### DIFF
--- a/code/game/machinery/slot_machine.dm
+++ b/code/game/machinery/slot_machine.dm
@@ -161,7 +161,7 @@
 		pay_with_card(I, W, user)
 
 	update_icon()
-	return TRUE
+	return FALSE
 
 /obj/machinery/slot_machine/proc/pay_with_card(obj/item/card/id/I, obj/item/ID_container, mob/user)
 	if(I == ID_container || ID_container == null)

--- a/code/game/machinery/slot_machine.dm
+++ b/code/game/machinery/slot_machine.dm
@@ -125,12 +125,12 @@
 	update_icon()
 
 /obj/machinery/slot_machine/attackby(obj/item/W, mob/user)
-	if(pay(W, user))
-		return
 	if((obj_flags & OBJ_FLAG_ANCHORABLE) && isWrench(W))
 		if(wrench_floor_bolts(user))
 			update_standing_icon()
 			power_change()
+		return
+	if(pay(W, user))
 		return
 	else if(W.force >= 10)
 		user.visible_message(SPAN("danger", "\The [src] has been [pick(W.attack_verb)] with [W] by [user]!"))
@@ -161,7 +161,7 @@
 		pay_with_card(I, W, user)
 
 	update_icon()
-	return FALSE
+	return TRUE
 
 /obj/machinery/slot_machine/proc/pay_with_card(obj/item/card/id/I, obj/item/ID_container, mob/user)
 	if(I == ID_container || ID_container == null)


### PR DESCRIPTION
Не уверен на счёт того, насколько фикс правильный, однако благодаря нему автомат теперь можно открутить, но спрайт выглядит немного странно в лежачем положение:

![FixSlotMachine1](https://github.com/user-attachments/assets/edfe598c-b3e3-45b4-9e49-ecd57c5e662b)

![FixSlotMachine2](https://github.com/user-attachments/assets/2eca30a1-2b2b-4494-9944-8ad979e056ef)

![FixSlotMachine3](https://github.com/user-attachments/assets/28e16ba9-c40d-4d24-8b4a-8490142299de)

<details>
<summary>Чейнджлог</summary>

```yml
🆑ilyadobr
bugfix: Слот машину теперь можно открутить от пола с помощью гаечного ключа.
/🆑
```

</details>

- [x] Pull Request полностью завершен, мне не нужна помощь чтобы его закончить.
- [ ] Я внимательно прочитал(-а) все свои изменения и багов в них не нашёл(-ла).
- [x] Я запускал(-а) сервер со своими изменениями локально и все протестировал(-а).
- [x] Я ознакомился(-ась) c [Guide to Contribute](https://github.com/ChaoticOnyx/OnyxBay/blob/dev/docs/contributing.md).
