### PR TITLE
fix(gun): accelerator sprite in hand didn't load before the update

### DIFF
--- a/code/modules/projectiles/guns/energy/accelerator.dm
+++ b/code/modules/projectiles/guns/energy/accelerator.dm
@@ -2,6 +2,7 @@
 	name = "accelerator shotgun"
 	desc = "A NanoTrasen UPA \"Shepherd\". It synthesizes unstable particles and accelerates them, effectively shooting \"temporary\" bullets without using any ammunition besides electric power."
 	icon_state = "phazer"
+	item_state = "phazer"
 	modifystate = "phazer"
 	improper_held_icon = TRUE
 	wielded_item_state = TRUE
@@ -64,6 +65,7 @@
 	name = "accelerator pistol"
 	desc = "An experimental NanoTrasen UPA \"Wingman\", based on the famous VP78. While being almost just as powerful as its larger counterpart, it is as small as a regular pistol."
 	icon_state = "phazer_pistol"
+	item_state = "phazer_pistol"
 	modifystate = "phazer_pistol"
 	improper_held_icon = FALSE
 	wielded_item_state = FALSE


### PR DESCRIPTION
Как показала практика, item_state в данном месте всё же необходим. Думал что обойдусь только modifystate, однако оказалось что без item_state'а пистолет имеет спрайт "gun" в руке, пока из него не сделать выстрел, то есть пока спрайт не обновиться, совершив определённый цикл в коде. 

В данном виде должно работать корректнее.

Чейнджлог не нужен, никто думаю не заметит разницы.

- [x] Pull Request полностью завершен, мне не нужна помощь чтобы его закончить.
- [x] Я внимательно прочитал(-а) все свои изменения и багов в них не нашёл(-ла).
- [ ] Я запускал(-а) сервер со своими изменениями локально и все протестировал(-а).
- [x] Я ознакомился(-ась) c [Guide to Contribute](https://github.com/ChaoticOnyx/OnyxBay/blob/dev/docs/contributing.md).
