### PR TITLE
fix(cargo): right crate for accelerators guns

### DIFF
--- a/code/datums/supplypacks/security.dm
+++ b/code/datums/supplypacks/security.dm
@@ -209,7 +209,7 @@
 	contains = list(/obj/item/gun/energy/accelerator = 2,
 					/obj/item/gun/energy/accelerator/pistol = 2)
 	cost = 60
-	containertype = /obj/structure/closet/crate/secure
+	containertype = /obj/structure/closet/crate/secure/weapon
 	containername = "\improper Accelerator weapons crate"
 	access = access_security
 	security_level = SUPPLY_SECURITY_ELEVATED


### PR DESCRIPTION
Вместо серого и _скучного ящика_ теперь "**настоящий тактически-зелёный боевой ящик 3000**".

Исправил тип ящика на корректный.

- [x] Pull Request полностью завершен, мне не нужна помощь чтобы его закончить.
- [x] Я внимательно прочитал(-а) все свои изменения и багов в них не нашёл(-ла).
- [ ] Я запускал(-а) сервер со своими изменениями локально и все протестировал(-а).
- [x] Я ознакомился(-ась) c [Guide to Contribute](https://github.com/ChaoticOnyx/OnyxBay/blob/dev/docs/contributing.md).
