### PR TITLE
fix(coctail_stick) Correct glass addition icon

### DIFF
--- a/code/modules/reagents/reagent_containers/vessel/glass/extras.dm
+++ b/code/modules/reagents/reagent_containers/vessel/glass/extras.dm
@@ -57,7 +57,7 @@
 /obj/item/glass_extra/cocktail_stick
 	name = "stick"
 	desc = "This goes in a glass."
-	glass_addition = "cocktail_stick"
+	glass_addition = "stick"
 	glass_desc = "There is a stick in the glass."
 	icon_state = "cocktail_stick"
 


### PR DESCRIPTION
Теперь будут подтягиваться правильные иконки.

fix #12990

<details>
<summary>Чейнджлог</summary>

```yml
🆑
bugfix: Теперь в коктейли снова можно вставлять палочки.
/🆑
```

</details>

- [x] Pull Request полностью завершен, мне не нужна помощь чтобы его закончить.
- [x] Я внимательно прочитал(-а) все свои изменения и багов в них не нашёл(-ла).
- [x] Я запускал(-а) сервер со своими изменениями локально и все протестировал(-а).
- [x] Я ознакомился(-ась) c [Guide to Contribute](https://github.com/ChaoticOnyx/OnyxBay/blob/dev/docs/contributing.md).
