### PR TITLE
fix(clippers): disabling randicon

### DIFF
--- a/code/modules/hydroponics/trays/tray_tools.dm
+++ b/code/modules/hydroponics/trays/tray_tools.dm
@@ -7,6 +7,7 @@
 	icon = 'icons/obj/hydroponics_items.dmi'
 	icon_state = "plantclippers"
 	item_state = "plantclippers"
+	randicon = FALSE
 
 /obj/item/device/analyzer/plant_analyzer
 	name = "plant analyzer"


### PR DESCRIPTION
Randicon это параметр для кусачек, отвечающий за то, чтобы у него менялся спрайт между двумя вариантами (красным и жёлтым). По умолчанию он включённый, и, внезапно, был также включённым для секаторов, который в свою очередь унаследовал это от кусачек, чем вызывал проблемы. Данный фикс должен исправить это.

close #12999

<details>
<summary>Чейнджлог</summary>

```yml
🆑ilyadobr
bugfix: У секатора из ботаники теперь не пропадает спрайт.
/🆑
```

</details>

- [x] Pull Request полностью завершен, мне не нужна помощь чтобы его закончить.
- [x] Я внимательно прочитал(-а) все свои изменения и багов в них не нашёл(-ла).
- [x] Я запускал(-а) сервер со своими изменениями локально и все протестировал(-а).
- [x] Я ознакомился(-ась) c [Guide to Contribute](https://github.com/ChaoticOnyx/OnyxBay/blob/dev/docs/contributing.md).
