### PR TITLE
rscadd: Headstamp

### DIFF
--- a/code/game/objects/structures/watercloset.dm
+++ b/code/game/objects/structures/watercloset.dm
@@ -341,6 +341,7 @@
 			if(istype(head))
 				head.forehead_graffiti = null
 				head.graffiti_style = null
+				head.forehead_stamps.Cut()
 		else
 			if(M.wear_mask)						//if the mob is not human, it cleans the mask without asking for bitflags
 				if(M.wear_mask.clean_blood())

--- a/code/modules/mob/organs/external/head.dm
+++ b/code/modules/mob/organs/external/head.dm
@@ -24,8 +24,13 @@
 
 	var/forehead_graffiti
 	var/graffiti_style
+	var/list/forehead_stamps = list()
 
 	var/skull_path = /obj/item/skull
+
+	New()
+		. = ..()
+		forehead_stamps = list()
 
 /obj/item/organ/external/head/droplimb(clean, disintegrate = DROPLIMB_EDGE, ignore_children, silent)
 	if(BP_IS_ROBOTIC(src) && disintegrate == DROPLIMB_BURN)
@@ -80,6 +85,31 @@
 			graffiti_style = style
 			if(owner)
 				log_and_message_admins("has written something on [owner]'s ([owner.ckey]) head: \"[graffiti]\".", penman)
+
+/obj/item/organ/external/head/proc/apply_stamp(stamp_name, stamper)
+	if(!forehead_stamps)
+		forehead_stamps = list()
+	if(!(stamp_name in forehead_stamps))
+		forehead_stamps += stamp_name
+		if(owner == stamper)
+			to_chat(stamper, "<span class='notice'>You stamped yourself with '[stamp_name]'.</span>")
+		else
+			to_chat(stamper,"<span class='notice'>You stamp [owner]'s forehead with '[stamp_name]'!</span>")
+			to_chat(owner, "<span class='notice'>[stamper] stamped your forehead with '[stamp_name]'!</span>")
+			to_chat(stamper, "[stamper] stamps [owner]'s forehead with '[stamp_name]'.", stamper, owner)
+
+/mob/living/carbon/human/proc/wash_forehead()
+	var/obj/item/organ/external/head/head = get_organ(BP_HEAD)
+	if(head && head.forehead_stamps && head.forehead_stamps.len > 0)
+		to_chat(src,"<span class='warning'>The stamps on your head is washed away by shower.</span>")
+		head.forehead_stamps.Cut()
+
+/mob/living/carbon/human/examine(mob/user, infix)
+	. = ..()
+	var/obj/item/organ/external/head/head = get_organ(BP_HEAD)
+	if(head && head.forehead_stamps && head.forehead_stamps.len > 0)
+		for(var/stamp in head.forehead_stamps)
+			. += SPAN_NOTICE("[src] has a [stamp] stamped on their forehead!")
 
 /obj/item/organ/external/head/get_agony_multiplier()
 	return (owner && owner.headcheck(organ_tag)) ? 1.50 : 1

--- a/code/modules/mob/organs/external/head.dm
+++ b/code/modules/mob/organs/external/head.dm
@@ -28,7 +28,7 @@
 
 	var/skull_path = /obj/item/skull
 
-	New()
+/obj/item/organ/external/head/New()
 		. = ..()
 		forehead_stamps = list()
 
@@ -101,12 +101,11 @@
 		else
 			to_chat(stamper,"<span class='notice'>You stamp [owner]'s forehead with '[stamp_name]'!</span>")
 			to_chat(owner, "<span class='notice'>[stamper] stamped your forehead with '[stamp_name]'!</span>")
-			to_chat(stamper, "[stamper] stamps [owner]'s forehead with '[stamp_name]'.", stamper, owner)
+			to_chat(stamper, "<span class = 'notice'>[stamper] stamps [owner]'s forehead with '[stamp_name]'.</span>", stamper, owner)
 
 /mob/living/carbon/human/proc/wash_forehead()
 	var/obj/item/organ/external/head/head = get_organ(BP_HEAD)
 	if(head && head.forehead_stamps && head.forehead_stamps.len > 0)
-		to_chat(src,"<span class='warning'>The stamps on your head is washed away by shower.</span>")
 		head.forehead_stamps.Cut()
 
 /mob/living/carbon/human/examine(mob/user, infix)

--- a/code/modules/mob/organs/external/head.dm
+++ b/code/modules/mob/organs/external/head.dm
@@ -87,8 +87,13 @@
 				log_and_message_admins("has written something on [owner]'s ([owner.ckey]) head: \"[graffiti]\".", penman)
 
 /obj/item/organ/external/head/proc/apply_stamp(stamp_name, stamper)
+	if(owner && (owner.wear_mask || owner.head))
+		to_chat(stamper, "<span class='notice'>[owner]'s forehead is covered up.</span>")
+		return
+
 	if(!forehead_stamps)
 		forehead_stamps = list()
+
 	if(!(stamp_name in forehead_stamps))
 		forehead_stamps += stamp_name
 		if(owner == stamper)
@@ -108,8 +113,10 @@
 	. = ..()
 	var/obj/item/organ/external/head/head = get_organ(BP_HEAD)
 	if(head && head.forehead_stamps && head.forehead_stamps.len > 0)
+		var/gender_pronoun = src.gender == "male" ? "He" : "She"
+		var/posessive_pronoun = src.gender == "male" ? "his" : "her"
 		for(var/stamp in head.forehead_stamps)
-			. += SPAN_NOTICE("[src] has a [stamp] stamped on their forehead!")
+			. += SPAN_NOTICE("[gender_pronoun] has a [stamp] stamped on [posessive_pronoun] forehead!")
 
 /obj/item/organ/external/head/get_agony_multiplier()
 	return (owner && owner.headcheck(organ_tag)) ? 1.50 : 1

--- a/code/modules/paperwork/stamps.dm
+++ b/code/modules/paperwork/stamps.dm
@@ -19,7 +19,7 @@
 				head.apply_stamp(src.name, user)
 				return TRUE
 			else
-				to_chat(user, "You can't stamp on that!")
+				to_chat(user, "<span class = 'notice'>You can't stamp on that!</span>")
 				return FALSE
 	return ..()
 

--- a/code/modules/paperwork/stamps.dm
+++ b/code/modules/paperwork/stamps.dm
@@ -10,6 +10,19 @@
 	matter = list(MATERIAL_STEEL = 60)
 	attack_verb = list("stamped")
 
+/obj/item/stamp/attack(mob/living/M, mob/living/user, target_zone)
+	if(user.a_intent == I_HURT && target_zone == BP_HEAD)
+		if(ishuman(M))
+			var/mob/living/carbon/human/H = M
+			var/obj/item/organ/external/head/head = H.get_organ(BP_HEAD)
+			if(head)
+				head.apply_stamp(src.name, user)
+				return TRUE
+			else
+				to_chat(user, "You can't stamp on that!")
+				return FALSE
+	return ..()
+
 /obj/item/stamp/captain
 	name = "captain's rubber stamp"
 	icon_state = "stamp-cap"


### PR DESCRIPTION
Харм-интент с прицелом в голову и печатью в руке позволяет поставить печать на лоб, если не надет головной убор или маска. Смыть штамп можно в душе.

close #5197

<details>
<summary>Чейнджлог</summary>

```yml
🆑
rscadd: Харм клик с печатью в руке на голову куклы позволяет ставить штамп на лоб, смывается в душе.
/🆑
```

</details>

- [x] Pull Request полностью завершен, мне не нужна помощь чтобы его закончить.
- [x] Я внимательно прочитал(-а) все свои изменения и багов в них не нашёл(-ла).
- [x] Я запускал(-а) сервер со своими изменениями локально и все протестировал(-а).
- [x] Я ознакомился(-ась) c [Guide to Contribute](https://github.com/ChaoticOnyx/OnyxBay/blob/dev/docs/contributing.md).
