### PR TITLE
tweak: make boombox & dusty_tape buyable

### DIFF
--- a/code/modules/client/preference_setup/loadout/lists/utility.dm
+++ b/code/modules/client/preference_setup/loadout/lists/utility.dm
@@ -53,7 +53,7 @@
 		<b>Be careful!</b> Don't use it to play music/sounds which can be annoying for other players. Admins can erase your music if they consider it unacceptable or even ban you for abusing it.
 	"}
 	path = /obj/item/music_tape/custom
-	patron_tier = PATREON_SCIENTIST
+	price = 250
 
 /datum/gear/utility/boombox
 	display_name = "boombox"
@@ -64,5 +64,4 @@
 	"}
 	path = /obj/item/music_player/boombox
 	flags = GEAR_HAS_COLOR_SELECTION
-	patron_tier = PATREON_ASSISTANT
-	cost = 4
+	price = 100


### PR DESCRIPTION
Теперь кастомную кассету и бумбокс можно купить за 250 и 100 опиксов соответственно.

<details>
<summary>Чейнджлог</summary>

```yml
🆑
tweak: Dusty Tape и boombox доступны к покупке в лодауте, во вкладке utility.
/🆑
```

</details>

- [x] Pull Request полностью завершен, мне не нужна помощь чтобы его закончить.
- [x] Я внимательно прочитал(-а) все свои изменения и багов в них не нашёл(-ла).
- [x] Я запускал(-а) сервер со своими изменениями локально и все протестировал(-а).
- [x] Я ознакомился(-ась) c [Guide to Contribute](https://github.com/ChaoticOnyx/OnyxBay/blob/dev/docs/contributing.md).
