### PR TITLE
fix(merchant): adding [station_name()] to the illegal license warning

### DIFF
--- a/code/game/jobs/job_controller.dm
+++ b/code/game/jobs/job_controller.dm
@@ -503,8 +503,8 @@ var/global/datum/controller/occupations/job_master
 		to_chat(H, "<b>To speak on your department's radio channel use :h. For the use of other channels, examine your headset.</b>")
 
 		if(rank == "Merchant" && GLOB.merchant_illegalness)
-			to_chat(H, SPAN_DANGER("<b>Your trading license is a forgery. Trading on NSS \"Exodus\" is illegal!</b>"))
-			H.mind.store_memory("Your trading license is a forgery. Trading on NSS \"Exodus\" is illegal.")
+			to_chat(H, SPAN_DANGER("<b>Your trading license is a forgery. Trading on [station_name()] is illegal!</b>"))
+			H.mind.store_memory("Your trading license is a forgery. Trading on [station_name()] is illegal.")
 
 		if(job.req_admin_notify)
 			to_chat(H, "<b>You are playing a job that is important for Game Progression. If you have to disconnect, please notify the admins via adminhelp.</b>")


### PR DESCRIPTION
Добавил прок [station_name()] в оповещение о том, что лицензия мерчантов испорченная/нелегальная.
До этого в оповещение использовалось название только станции Исход. Теперь же там будут использоваться названия станции, для которой, собственно, эта лицензия и выдавалась.

Тесты проводились на карте Example, которая имеет наименование "BAD Station"

<details>
<summary>До:</summary>

Предупреждение в чате
![Fix-Merchant3](https://github.com/user-attachments/assets/4df91341-1944-4149-99b5-2b8b8d61fbad)
Заметка в Notes'ах
![Fix-Merchant4](https://github.com/user-attachments/assets/5706f63c-92f8-4424-9db8-49a3a4e055e7)

</details> 

<details>
<summary>После:</summary>

Предупреждение в чате
![Fix-Merchant1](https://github.com/user-attachments/assets/5e7098c6-1aee-46b1-a046-54c7ddb6d1b5)
Заметка в Notes'ах
![Fix-Merchant2](https://github.com/user-attachments/assets/ed732c5b-0920-4295-80ab-2b65210a12fe)

</details> 

- [x] Pull Request полностью завершен, мне не нужна помощь чтобы его закончить.
- [x] Я внимательно прочитал(-а) все свои изменения и багов в них не нашёл(-ла).
- [x] Я запускал(-а) сервер со своими изменениями локально и все протестировал(-а).
- [x] Я ознакомился(-ась) c [Guide to Contribute](https://github.com/ChaoticOnyx/OnyxBay/blob/dev/docs/contributing.md).
