### PR TITLE
Revert "tweak(syringe): added ability to set APTFT"

### DIFF
--- a/code/modules/reagents/reagent_containers.dm
+++ b/code/modules/reagents/reagent_containers.dm
@@ -16,7 +16,7 @@
 	set category = "Object"
 	set src in usr
 
-	var/N = tgui_input_list(usr, "Amount per transfer from this:", "[src]", cached_number_list_decode(possible_transfer_amounts))
+	var/N = input("Amount per transfer from this:","[src]") as null|anything in cached_number_list_decode(possible_transfer_amounts)
 	if(N)
 		amount_per_transfer_from_this = N
 

--- a/code/modules/reagents/reagent_containers/syringes.dm
+++ b/code/modules/reagents/reagent_containers/syringes.dm
@@ -12,7 +12,7 @@
 	icon_state = "0"
 	matter = list(MATERIAL_GLASS = 150)
 	amount_per_transfer_from_this = 5
-	possible_transfer_amounts = "5;10;15"
+	possible_transfer_amounts = null
 	volume = 15
 	w_class = ITEM_SIZE_TINY
 	slot_flags = SLOT_EARS
@@ -21,7 +21,7 @@
 	var/mode = SYRINGE_DRAW
 	var/image/filling //holds a reference to the current filling overlay
 	var/visible_name = "a syringe"
-	var/time = 25
+	var/time = 30
 	var/stabby = TRUE
 	var/starting_label = null
 	var/package_state = "package"
@@ -103,7 +103,7 @@
 			syringestab(target, user)
 			return
 		if(reagents && reagents.total_volume)
-			to_chat(user, SPAN_NOTICE("You spurt out the contents of \the [src] onto [target].")) //They are on harm intent, aka wanting to spill it.
+			to_chat(user, "<span class='notice'>You spurt out the contents of \the [src] onto [target].</span>") //They are on harm intent, aka wanting to spill it.
 			reagents.splash(target, reagents.total_volume)
 			mode = SYRINGE_DRAW
 			update_icon()
@@ -158,33 +158,33 @@
 
 /obj/item/reagent_containers/syringe/proc/drawReagents(atom/target, mob/user)
 	if(!reagents.get_free_space())
-		to_chat(user, SPAN_WARNING("The syringe is full."))
+		to_chat(user, "<span class='warning'>The syringe is full.</span>")
 		mode = SYRINGE_INJECT
 		return
 
 	if(ismob(target))//Blood!
 		if(reagents.has_reagent(/datum/reagent/blood))
-			to_chat(user, SPAN_NOTICE("There is already a blood sample in this syringe."))
+			to_chat(user, "<span class='notice'>There is already a blood sample in this syringe.</span>")
 			return
 		if(istype(target, /mob/living/carbon))
 			if(istype(target, /mob/living/carbon/metroid))
-				to_chat(user, SPAN_WARNING("You are unable to locate any blood."))
+				to_chat(user, "<span class='warning'>You are unable to locate any blood.</span>")
 				return
 			var/amount = reagents.get_free_space()
 			var/mob/living/carbon/T = target
 			if(!T.dna)
-				to_chat(user, SPAN_WARNING("You are unable to locate any blood."))
+				to_chat(user, "<span class='warning'>You are unable to locate any blood.</span>")
 				CRASH("[T] \[[T.type]\] was missing their dna datum!")
 
-			var/injtime = time
+			var/injtime = time //Taking a blood sample through a hardsuit takes longer due to needing to find a port.
 			var/allow = T.can_inject(user, check_zone(user.zone_sel.selecting))
 			if(!allow)
 				return
 			if(allow == INJECTION_PORT)
 				injtime *= 2
-				user.visible_message(SPAN_WARNING("\The [user] begins hunting for an injection port on [target]'s suit!"))
+				user.visible_message("<span class='warning'>\The [user] begins hunting for an injection port on [target]'s suit!</span>")
 			else
-				user.visible_message(SPAN_WARNING("\The [user] is trying to take a blood sample from [target]."))
+				user.visible_message("<span class='warning'>\The [user] is trying to take a blood sample from [target].</span>")
 
 			user.setClickCooldown(DEFAULT_QUICK_COOLDOWN)
 			user.do_attack_animation(target)
@@ -193,21 +193,21 @@
 				return
 
 			T.take_blood(src, amount)
-			to_chat(user, SPAN_NOTICE("You take a blood sample from [target]."))
+			to_chat(user, "<span class='notice'>You take a blood sample from [target].</span>")
 			for(var/mob/O in viewers(4, user))
-				O.show_message(SPAN_NOTICE("[user] takes a blood sample from [target]."), 1)
+				O.show_message("<span class='notice'>[user] takes a blood sample from [target].</span>", 1)
 
 	else //if not mob
 		if(!target.reagents.total_volume)
-			to_chat(user, SPAN_NOTICE("[target] is empty."))
+			to_chat(user, "<span class='notice'>[target] is empty.</span>")
 			return
 
 		if(!target.is_open_container() && !istype(target, /obj/structure/reagent_dispensers) && !istype(target, /obj/item/backwear/reagent) && !istype(target, /obj/item/metroid_extract) && !istype(target, /obj/item/metroidcrossbeaker))
-			to_chat(user, SPAN_NOTICE("You cannot directly remove reagents from this object."))
+			to_chat(user, "<span class='notice'>You cannot directly remove reagents from this object.</span>")
 			return
 
 		var/trans = target.reagents.trans_to_obj(src, amount_per_transfer_from_this)
-		to_chat(user, SPAN_NOTICE("You fill the syringe with [trans] units of the solution."))
+		to_chat(user, "<span class='notice'>You fill the syringe with [trans] units of the solution.</span>")
 		update_icon()
 
 	if(!reagents.get_free_space())
@@ -216,17 +216,17 @@
 
 /obj/item/reagent_containers/syringe/proc/injectReagents(atom/target, mob/user)
 	if(!reagents.total_volume)
-		to_chat(user, SPAN_NOTICE("The syringe is empty."))
+		to_chat(user, "<span class='notice'>The syringe is empty.</span>")
 		mode = SYRINGE_DRAW
 		return
 	if(istype(target, /obj/item/implantcase/chem))
 		return
 
 	if(!target.is_open_container() && !ismob(target) && !istype(target, /obj/item/reagent_containers/food) && !istype(target, /obj/item/metroid_extract) && !istype(target, /obj/item/clothing/mask/smokable/cigarette) && !istype(target, /obj/item/storage/fancy/cigarettes))
-		to_chat(user, SPAN_NOTICE("You cannot directly fill this object."))
+		to_chat(user, "<span class='notice'>You cannot directly fill this object.</span>")
 		return
 	if(!target.reagents.get_free_space())
-		to_chat(user, SPAN_NOTICE("[target] is full."))
+		to_chat(user, "<span class='notice'>[target] is full.</span>")
 		return
 
 	if(isliving(target))
@@ -234,7 +234,7 @@
 		return
 
 	var/trans = reagents.trans_to(target, amount_per_transfer_from_this)
-	to_chat(user, SPAN_NOTICE("You inject \the [target] with [trans] units of the solution. \The [src] now contains [src.reagents.total_volume] units."))
+	to_chat(user, "<span class='notice'>You inject \the [target] with [trans] units of the solution. \The [src] now contains [src.reagents.total_volume] units.</span>")
 	if(reagents.total_volume <= 0 && mode == SYRINGE_INJECT)
 		mode = SYRINGE_DRAW
 		update_icon()
@@ -251,15 +251,15 @@
 		trackTarget = target
 
 	if(target != user)
-		var/injtime = time + amount_per_transfer_from_this // in deciseconds, 25 + 5/10/15 (depends on transfer amount)
+		var/injtime = time //Injecting through a hardsuit takes longer due to needing to find a port.
 		var/allow = target.can_inject(user, check_zone(user.zone_sel.selecting))
 		if(!allow)
 			return
 		if(allow == INJECTION_PORT)
 			injtime *= 2
-			user.visible_message(SPAN_WARNING("\The [user] begins hunting for an injection port on [target]'s suit!"))
+			user.visible_message("<span class='warning'>\The [user] begins hunting for an injection port on [target]'s suit!</span>")
 		else
-			user.visible_message(SPAN_WARNING("\The [user] is trying to inject [target] with [visible_name]!"))
+			user.visible_message("<span class='warning'>\The [user] is trying to inject [target] with [visible_name]!</span>")
 
 		user.setClickCooldown(DEFAULT_QUICK_COOLDOWN)
 		user.do_attack_animation(trackTarget)
@@ -275,9 +275,9 @@
 	if(target != user)
 		var/contained = reagentlist()
 		admin_inject_log(user, target, src, contained, trans)
-		user.visible_message(SPAN_WARNING("\the [user] injects \the [target] with [visible_name]!"), SPAN_NOTICE("You inject \the [target] with [trans] units of the solution. \The [src] now contains [src.reagents.total_volume] units."))
+		user.visible_message("<span class='warning'>\the [user] injects \the [target] with [visible_name]!</span>", "<span class='notice'>You inject \the [target] with [trans] units of the solution. \The [src] now contains [src.reagents.total_volume] units.</span>")
 	else
-		to_chat(user, SPAN_NOTICE("You inject yourself with [trans] units of the solution. \The [src] now contains [src.reagents.total_volume] units."))
+		to_chat(user, "<span class='notice'>You inject yourself with [trans] units of the solution. \The [src] now contains [src.reagents.total_volume] units.</span>")
 
 	if(reagents.total_volume <= 0 && mode == SYRINGE_INJECT)
 		mode = SYRINGE_DRAW
@@ -293,7 +293,7 @@
 		var/obj/item/organ/external/affecting = H.get_organ(target_zone)
 
 		if (!affecting || affecting.is_stump())
-			to_chat(user, SPAN_DANGER("They are missing that limb!"))
+			to_chat(user, "<span class='danger'>They are missing that limb!</span>")
 			return
 
 		var/hit_area = affecting.name
@@ -303,17 +303,17 @@
 
 		if(target != user && H.get_flat_armor(target_zone, "melee") > 5 && prob(50))
 			for(var/mob/O in viewers(world.view, user))
-				O.show_message((SPAN_DANGER("[user] tries to stab [target] in \the [hit_area] with [src.name], but the attack is deflected by armor!")), 1)
+				O.show_message(text("<span class='danger'>[user] tries to stab [target] in \the [hit_area] with [src.name], but the attack is deflected by armor!</span>"), 1)
 			qdel(src)
 
 			admin_attack_log(user, target, "Attacked using \a [src]", "Was attacked with \a [src]", "used \a [src] to attack")
 			return
 
-		user.visible_message(SPAN_DANGER("[user] stabs [target] in \the [hit_area] with [src.name]!"))
+		user.visible_message("<span class='danger'>[user] stabs [target] in \the [hit_area] with [src.name]!</span>")
 		affecting.take_external_damage(3)
 
 	else
-		user.visible_message(SPAN_DANGER("[user] stabs [target] with [src.name]!"))
+		user.visible_message("<span class='danger'>[user] stabs [target] with [src.name]!</span>")
 		target.take_organ_damage(3)// 7 is the same as crowbar punch
 	user.setClickCooldown(src.update_attack_cooldown())
 	user.do_attack_animation(target)
@@ -486,12 +486,12 @@
 	time = 300
 
 /obj/item/reagent_containers/syringe/ld50_syringe/syringestab(mob/living/carbon/target, mob/living/carbon/user)
-	to_chat(user, SPAN_NOTICE("This syringe is too big to stab someone with it."))
+	to_chat(user, "<span class='notice'>This syringe is too big to stab someone with it.</span>")
 	return // No instant injecting
 
 /obj/item/reagent_containers/syringe/ld50_syringe/drawReagents(target, mob/user)
 	if(ismob(target)) // No drawing 60 units of blood at once
-		to_chat(user, SPAN_NOTICE("This needle isn't designed for drawing blood."))
+		to_chat(user, "<span class='notice'>This needle isn't designed for drawing blood.</span>")
 		return
 	..()
 


### PR DESCRIPTION
Reverts ChaoticOnyx/OnyxBay#11277

**Обязательно ревертать вместе с #11254, иначе данный реверт бессмысленнен**

>Ну и конечно же поменял одну строчку чтобы нас меньше корежило от старого инпута.

Как бы эта фича не старалась улучшить качество жизни людей в медбее, на деле же ввод лекарств и прочего через шприц людям стало гораздо.. Нет, в разы сложнее. Выборка количества жидкостей это гораздо более длительный процесс, чем определённое количество кликов по банке шприцом (до трёх раз). Если ты наплевал на это и ставишь 15 кубиков, ты теряешь точность и лишние кубики жидкости. Абсолютно не вижу ничего полезного в этой фиче. Не знаю, дайте людям проголосовать за неё, за ревёрт, что угодно. Шприцы стали абсолютно неудобными и я уверен что я далеко не один такой.