### PR TITLE
Более читаемые оповещения о смерти

### DIFF
--- a/code/game/objects/items/implants/implants/death_alarm.dm
+++ b/code/game/objects/items/implants/implants/death_alarm.dm
@@ -1,6 +1,6 @@
 /obj/item/implant/death_alarm
 	name = "death alarm implant"
-	desc = "An alarm which monitors host vital signs and transmits a radio message upon death."
+	desc = "An implant which monitors its host's vital signs and transmits a radio message upon death."
 	origin_tech = list(TECH_MATERIAL = 1, TECH_BIO = 2, TECH_DATA = 1)
 	known = 1
 	var/mobname = "Will Robinson"
@@ -43,14 +43,14 @@
 		location = t?.name
 	var/death_message
 	if(!cause || !location)
-		death_message = "A message from [name] has been received. [mobname] has died-zzzzt in-in-in..."
+		death_message = "[mobname] has died-zzzzt in-in-in..."
 	else
-		var/additional_info = " The neural lace signature not found in the body."
+		var/additional_info = " No neural lace signature detected in the body."
 		var/mob/living/carbon/human/H = imp_in
 		var/obj/item/organ/internal/stack/S = H?.internal_organs_by_name[BP_STACK]
 		if(istype(S))
-			additional_info = " The neural lace signature found in the body."
-		death_message = "A message from [name] has been received. [mobname] has died in [location]![additional_info]"
+			additional_info = " A neural lace signature has been detected in the body!"
+		death_message = "[mobname] has died in [location]![additional_info]"
 	set_next_think(0)
 
 	for(var/channel in list("Security", "Medical", "Command"))

--- a/code/modules/mob/living/silicon/robot/robot_upgrades.dm
+++ b/code/modules/mob/living/silicon/robot/robot_upgrades.dm
@@ -674,7 +674,7 @@
 
 /obj/item/borg/upgrade/death_alarm
 	name = "death alarm module"
-	desc = "An alarm which monitors cyborg signals and transmits a radio message upon destruction."
+	desc = "A module which monitors a cyborg's status and transmits a radio message upon destruction."
 	icon_state = "cyborg_upgrade1"
 	origin_tech = list(TECH_MATERIAL = 2, TECH_DATA = 2)
 	var/mob/living/silicon/robot/host = null
@@ -690,9 +690,9 @@
 		var/area/default = world.area
 		location = initial(default.name)
 
-	var/death_message = "Message from [name] acquired successful. [host] has been destroyed in [location]!"
+	var/death_message = "[host] has been destroyed in [location]!"
 	if(!cause)
-		death_message = "Message from [name] acquired successful. [host] has been destroyed-zzzzt in-in-in..."
+		death_message = "[host] has been destroyed-zzzzt in-in-in..."
 	var/obj/item/robot_module/CH = host.module
 	for(var/channel in CH.channels)
 		if (channel != "Science")
@@ -721,10 +721,10 @@
 		activate("emp")	//let's shout that this borg is dead
 	if(severity == 1)
 		if(prob(60) && !broken)	//small chance of obvious meltdown
-			to_chat(host, "<span class='warning'>Your's \the [src] stopped recive signals!</span>")
+			to_chat(host, SPAN_WARNING("Your \the [src] stopped receiving signals!"))
 			broken = 1
 			name = "melted circuit"
-			desc = "Charred circuit. Wonder what that used to be..."
+			desc = "A charred circuit. Wonder what that used to be..."
 			set_next_think(0)
 
 /obj/item/borg/upgrade/death_alarm/action(mob/living/silicon/robot/R)


### PR DESCRIPTION
Как я понял, в какой-то момент весьма давно сделали так, чтобы оповещение о смерти объявлял ИИ, если он есть, вследствие чего в сами оповещения было добавлено это "`A message from [name] has been received...`".

Потом там была куча каких-то изменений, но, так или иначе, теперь ИИ больше не объявляет оповещения, а делает это сам имплант. Но это предложение в оповещениях осталось, что есть чутка информационный мусор, и уже давно резало мне глаза при игре на враче или СБшнике. Наконец-то дошли руки обрезать его, и заодно немного подправил английский в паре мест в импланте/модуле оповещения о смерти, ну и один `<span> -> SPAN()`.

Не тестил на локалке, но тут буквально только строки редактированы, билд компилится, так что сойдёт.

<details>
<summary>Чейнджлог</summary>

```yml
🆑TheUnknownOne
spellcheck: Немного изменён текст оповещений о смерти от соответствующего импланта и модуля для киборгов.
/🆑
```

</details>

- [x] Pull Request полностью завершен, мне не нужна помощь чтобы его закончить.
- [x] Я внимательно прочитал все свои изменения и багов в них не нашёл.
- [x] Я запускал сервер со своими изменениями локально и все протестировал.
- [x] Я ознакомился c [Guide to Contribute](https://github.com/ChaoticOnyx/OnyxBay/blob/dev/docs/contributing.md).
