### PR TITLE
tweak(Machinery_AltClick) Beaker detaching

### DIFF
--- a/code/game/machinery/Sleeper.dm
+++ b/code/game/machinery/Sleeper.dm
@@ -216,6 +216,39 @@
 			stasis = text2num(href_list["stasis"])
 			return TOPIC_REFRESH
 
+/obj/machinery/sleeper/AltClick(mob/user)
+	if(!issilicon(user))
+		if(!user.Adjacent(get_turf(src)))
+			return
+
+		if(!can_use(user))
+			to_chat(user, SPAN("notice", "You cannot remove [beaker.name]."))
+			return
+
+	if(beaker)
+		grab_beaker(user)
+	else
+		to_chat(user, SPAN("notice", "\The [src] does not have a beaker in it."))
+
+/obj/machinery/sleeper/proc/grab_beaker(mob/user)
+	if(!beaker)
+		return
+
+	if(issilicon(user))
+		beaker.dropInto(loc)
+	else
+		user.pick_or_drop(beaker, get_turf(src))
+
+	to_chat(user, SPAN("notice", "You remove the [beaker.name] from the [name]."))
+	beaker = null
+	toggle_filter()
+	toggle_pump()
+	for(var/obj/item/reagent_containers/vessel/beaker/A in component_parts)
+		component_parts -= A
+	update_icon()
+	if(!(stat & (BROKEN|NOPOWER)))
+		playsound(src, clicksound, clickvol)
+
 /obj/machinery/sleeper/attack_ai(mob/user)
 	return attack_hand(user)
 

--- a/code/game/machinery/Sleeper.dm
+++ b/code/game/machinery/Sleeper.dm
@@ -217,37 +217,11 @@
 			return TOPIC_REFRESH
 
 /obj/machinery/sleeper/AltClick(mob/user)
-	if(!issilicon(user))
-		if(!user.Adjacent(get_turf(src)))
-			return
-
-		if(!can_use(user))
-			to_chat(user, SPAN("notice", "You cannot remove [beaker.name]."))
-			return
-
-	if(beaker)
-		grab_beaker(user)
-	else
-		to_chat(user, SPAN("notice", "\The [src] does not have a beaker in it."))
-
-/obj/machinery/sleeper/proc/grab_beaker(mob/user)
-	if(!beaker)
-		return
-
-	if(issilicon(user))
-		beaker.dropInto(loc)
-	else
-		user.pick_or_drop(beaker, get_turf(src))
-
-	to_chat(user, SPAN("notice", "You remove the [beaker.name] from the [name]."))
-	beaker = null
-	toggle_filter()
-	toggle_pump()
-	for(var/obj/item/reagent_containers/vessel/beaker/A in component_parts)
-		component_parts -= A
-	update_icon()
-	if(!(stat & (BROKEN|NOPOWER)))
-		playsound(src, clicksound, clickvol)
+	if(grab_container(user, &beaker))
+		toggle_filter()
+		toggle_pump()
+		for(var/obj/item/reagent_containers/vessel/beaker/A in component_parts)
+			component_parts -= A
 
 /obj/machinery/sleeper/attack_ai(mob/user)
 	return attack_hand(user)

--- a/code/game/machinery/camera/camera.dm
+++ b/code/game/machinery/camera/camera.dm
@@ -337,7 +337,7 @@
 	camera_alarm.clearAlarm(loc, src)
 
 //if false, then the camera is listed as DEACTIVATED and cannot be used
-/obj/machinery/camera/proc/can_use()
+/obj/machinery/camera/can_use()
 	if(!status)
 		return 0
 	if(stat & (EMPED|BROKEN))

--- a/code/game/machinery/cryo.dm
+++ b/code/game/machinery/cryo.dm
@@ -265,32 +265,7 @@
 	return
 
 /obj/machinery/atmospherics/unary/cryo_cell/AltClick(mob/user)
-	if(!issilicon(user))
-		if(!user.Adjacent(get_turf(src)))
-			return
-
-		if(!can_use(user))
-			to_chat(user, SPAN("notice", "You cannot remove [beaker.name]."))
-			return
-
-	if(beaker)
-		grab_beaker(user)
-	else
-		to_chat(user, SPAN("notice", "\The [src] does not have a beaker in it."))
-
-/obj/machinery/atmospherics/unary/cryo_cell/proc/grab_beaker(mob/user)
-	if(!beaker)
-		return
-
-	if(issilicon(user))
-		beaker.dropInto(get_step(loc, SOUTH))
-	else
-		user.pick_or_drop(beaker, get_step(loc, SOUTH))
-
-	to_chat(user, SPAN("notice", "You remove the [beaker.name] from the [name]."))
-	beaker = null
-	if(!(stat & (BROKEN|NOPOWER)))
-		playsound(src, clicksound, clickvol)
+	grab_container(user, &beaker, get_step(loc, SOUTH))
 
 /obj/machinery/atmospherics/unary/cryo_cell/on_update_icon()
 	ClearOverlays()

--- a/code/game/machinery/cryo.dm
+++ b/code/game/machinery/cryo.dm
@@ -289,7 +289,8 @@
 
 	to_chat(user, SPAN("notice", "You remove the [beaker.name] from the [name]."))
 	beaker = null
-	playsound(src, clicksound, clickvol)
+	if(!(stat & (BROKEN|NOPOWER)))
+		playsound(src, clicksound, clickvol)
 
 /obj/machinery/atmospherics/unary/cryo_cell/on_update_icon()
 	ClearOverlays()

--- a/code/game/machinery/cryo.dm
+++ b/code/game/machinery/cryo.dm
@@ -283,7 +283,7 @@
 		return
 
 	if(issilicon(user))
-		beaker:dropInto(get_step(loc, SOUTH))
+		beaker.dropInto(get_step(loc, SOUTH))
 	else
 		user.pick_or_drop(beaker, get_step(loc, SOUTH))
 

--- a/code/game/machinery/cryo.dm
+++ b/code/game/machinery/cryo.dm
@@ -264,6 +264,33 @@
 			user.visible_message(SPAN("notice", "\The [user] places \the [M] into \the [src]."), SPAN("notice", "You place \the [M] into \the [src]."))
 	return
 
+/obj/machinery/atmospherics/unary/cryo_cell/AltClick(mob/user)
+	if(!issilicon(user))
+		if(!user.Adjacent(get_turf(src)))
+			return
+
+		if(!can_use(user))
+			to_chat(user, SPAN("notice", "You cannot remove [beaker.name]."))
+			return
+
+	if(beaker)
+		grab_beaker(user)
+	else
+		to_chat(user, SPAN("notice", "\The [src] does not have a beaker in it."))
+
+/obj/machinery/atmospherics/unary/cryo_cell/proc/grab_beaker(mob/user)
+	if(!beaker)
+		return
+
+	if(issilicon(user))
+		beaker:dropInto(get_step(loc, SOUTH))
+	else
+		user.pick_or_drop(beaker, get_step(loc, SOUTH))
+
+	to_chat(user, SPAN("notice", "You remove the [beaker.name] from the [name]."))
+	beaker = null
+	playsound(src, clicksound, clickvol)
+
 /obj/machinery/atmospherics/unary/cryo_cell/on_update_icon()
 	ClearOverlays()
 	var/overlays_state = 0

--- a/code/game/machinery/machinery.dm
+++ b/code/game/machinery/machinery.dm
@@ -239,7 +239,7 @@ Class Procs:
 		if(!user.Adjacent(get_turf(src)))
 			return FALSE
 	else
-		if(stat & (BROKEN|NOPOWER))
+		if(inoperable())
 			to_chat(user, SPAN("notice", "\The [src] is not functional"))
 			return FALSE
 
@@ -261,7 +261,7 @@ Class Procs:
 	*container = null
 	update_icon()
 
-	if(!(stat & (BROKEN|NOPOWER)))
+	if(operable())
 		playsound(src, clicksound, clickvol)
 
 	return TRUE

--- a/code/game/machinery/machinery.dm
+++ b/code/game/machinery/machinery.dm
@@ -235,16 +235,17 @@ Class Procs:
 	return (stat & (POWEROFF|NOPOWER|BROKEN|additional_flags))
 
 /obj/machinery/proc/grab_container(mob/user, obj/item/reagent_containers/container, atom/drop_loc = loc)
-	if(issilicon(user))
+	if(!issilicon(user))
+		if(!user.Adjacent(get_turf(src)))
+			return FALSE
+	else
 		if(stat & (BROKEN|NOPOWER))
 			to_chat(user, SPAN("notice", "\The [src] is not functional"))
 			return FALSE
-	else
-		if(!user.Adjacent(get_turf(src)))
-			return FALSE
-		if(!can_use(user))
-			to_chat(user, SPAN("notice", "You cannot remove [container.name]."))
-			return FALSE
+
+	if(!can_use(user))
+		to_chat(user, SPAN("notice", "You cannot remove [container.name]."))
+		return FALSE
 
 	if(!*container)
 		to_chat(user, SPAN("notice", "\The [src] does not have a [istype(src, /obj/machinery/chemical_dispenser) ? "container" : "beaker"] in it."))
@@ -268,7 +269,7 @@ Class Procs:
 /obj/machinery/proc/can_use(mob/user)
 	if(user.stat || user.restrained() || user.paralysis || user.stunned || user.weakened)
 		return 0
-	if(in_range(src, user))
+	if(issilicon(user) || Adjacent(user))
 		return 1
 	else
 		return 0

--- a/code/game/machinery/machinery.dm
+++ b/code/game/machinery/machinery.dm
@@ -234,6 +234,37 @@ Class Procs:
 /obj/machinery/proc/inoperable(additional_flags = 0)
 	return (stat & (POWEROFF|NOPOWER|BROKEN|additional_flags))
 
+/obj/machinery/proc/grab_container(mob/user, obj/item/reagent_containers/container, atom/drop_loc = loc)
+	if(issilicon(user))
+		if(stat & (BROKEN|NOPOWER))
+			to_chat(user, SPAN("notice", "\The [src] is not functional"))
+			return FALSE
+	else
+		if(!user.Adjacent(get_turf(src)))
+			return FALSE
+		if(!can_use(user))
+			to_chat(user, SPAN("notice", "You cannot remove [container.name]."))
+			return FALSE
+
+	if(!*container)
+		to_chat(user, SPAN("notice", "\The [src] does not have a [istype(src, /obj/machinery/chemical_dispenser) ? "container" : "beaker"] in it."))
+		return FALSE
+
+	if(issilicon(user))
+		container.dropInto(drop_loc)
+	else
+		user.pick_or_drop(*container, get_turf(user))
+
+	to_chat(user, SPAN("notice", "You remove [container.name] from \the [src]"))
+
+	*container = null
+	update_icon()
+
+	if(!(stat & (BROKEN|NOPOWER)))
+		playsound(src, clicksound, clickvol)
+
+	return TRUE
+
 /obj/machinery/proc/can_use(mob/user)
 	if(user.stat || user.restrained() || user.paralysis || user.stunned || user.weakened)
 		return 0

--- a/code/game/machinery/machinery.dm
+++ b/code/game/machinery/machinery.dm
@@ -268,11 +268,11 @@ Class Procs:
 
 /obj/machinery/proc/can_use(mob/user)
 	if(user.stat || user.restrained() || user.paralysis || user.stunned || user.weakened)
-		return 0
+		return FALSE
 	if(issilicon(user) || Adjacent(user))
-		return 1
+		return TRUE
 	else
-		return 0
+		return FALSE
 
 /obj/machinery/CanUseTopic(mob/user)
 	if(stat & BROKEN)

--- a/code/game/machinery/machinery.dm
+++ b/code/game/machinery/machinery.dm
@@ -234,6 +234,14 @@ Class Procs:
 /obj/machinery/proc/inoperable(additional_flags = 0)
 	return (stat & (POWEROFF|NOPOWER|BROKEN|additional_flags))
 
+/obj/machinery/proc/can_use(mob/user)
+	if(user.stat || user.restrained() || user.paralysis || user.stunned || user.weakened)
+		return 0
+	if(in_range(src, user))
+		return 1
+	else
+		return 0
+
 /obj/machinery/CanUseTopic(mob/user)
 	if(stat & BROKEN)
 		return STATUS_CLOSE

--- a/code/modules/power/apc.dm
+++ b/code/modules/power/apc.dm
@@ -832,7 +832,7 @@
 	return wires.IsIndexCut(wireIndex)
 
 
-/obj/machinery/power/apc/proc/can_use(mob/user as mob, loud = 0) //used by attack_hand() and Topic()
+/obj/machinery/power/apc/can_use(mob/user as mob, loud = 0) //used by attack_hand() and Topic()
 	if (user.stat)
 		to_chat(user, "<span class='warning'>You must be conscious to use [src]!</span>")
 		return 0

--- a/code/modules/reagents/Chemistry-Machinery.dm
+++ b/code/modules/reagents/Chemistry-Machinery.dm
@@ -100,7 +100,7 @@
 		return
 
 	if(issilicon(user))
-		beaker:dropInto(loc)
+		beaker.dropInto(loc)
 	else
 		user.pick_or_drop(beaker, get_turf(src))
 
@@ -567,7 +567,7 @@
 		return
 
 	if(issilicon(user))
-		beaker:dropInto(loc)
+		beaker.dropInto(loc)
 	else
 		user.pick_or_drop(beaker, get_turf(src))
 

--- a/code/modules/reagents/Chemistry-Machinery.dm
+++ b/code/modules/reagents/Chemistry-Machinery.dm
@@ -82,34 +82,8 @@
 				return
 
 /obj/machinery/chem_master/AltClick(mob/user)
-	if(!issilicon(user))
-		if(!user.Adjacent(get_turf(src)))
-			return
-
-		if(!can_use(user))
-			to_chat(user, SPAN("notice", "You cannot remove [beaker.name]."))
-			return
-
-	if(beaker)
-		grab_beaker(user)
-	else
-		to_chat(user, SPAN("notice", "\The [src] does not have a beaker in it."))
-
-/obj/machinery/chem_master/proc/grab_beaker(mob/user)
-	if(!beaker)
-		return
-
-	if(issilicon(user))
-		beaker.dropInto(loc)
-	else
-		user.pick_or_drop(beaker, get_turf(src))
-
-	to_chat(user, SPAN("notice", "You remove the [beaker.name] from the [name]."))
-	beaker = null
-	reagents.clear_reagents()
-	update_icon()
-	if(!(stat & (BROKEN|NOPOWER)))
-		playsound(src, clicksound, clickvol)
+	if(grab_container(user, &beaker))
+		reagents.clear_reagents()
 
 /obj/machinery/chem_master/attackby(obj/item/W, mob/user)
 	if(default_deconstruction_screwdriver(user, W))
@@ -555,29 +529,7 @@
 	if(!user.Adjacent(get_turf(src)))
 		return
 		
-	if(!can_use(user))
-		to_chat(user, SPAN("notice", "You cannot remove [beaker.name]."))
-		return
-
-	if(beaker)
-		grab_beaker(user)
-	else
-		to_chat(user, SPAN("notice", "\The [src] does not have a beaker in it."))
-
-/obj/machinery/reagentgrinder/proc/grab_beaker(mob/user)
-	if(!beaker)
-		return
-
-	if(issilicon(user))
-		beaker.dropInto(loc)
-	else
-		user.pick_or_drop(beaker, get_turf(src))
-
-	to_chat(user, SPAN("notice", "You remove the [beaker.name] from the [name]."))
-	beaker = null
-	update_icon()
-	if(!(stat & (BROKEN|NOPOWER)))
-		playsound(src, clicksound, clickvol)
+	grab_container(user, &beaker)
 
 /obj/machinery/reagentgrinder/proc/show_choices(mob/user)
 	if(!length(choices))

--- a/code/modules/reagents/Chemistry-Machinery.dm
+++ b/code/modules/reagents/Chemistry-Machinery.dm
@@ -108,6 +108,8 @@
 	beaker = null
 	reagents.clear_reagents()
 	update_icon()
+	if(!(stat & (BROKEN|NOPOWER)))
+		playsound(src, clicksound, clickvol)
 
 /obj/machinery/chem_master/attackby(obj/item/W, mob/user)
 	if(default_deconstruction_screwdriver(user, W))
@@ -574,6 +576,8 @@
 	to_chat(user, SPAN("notice", "You remove the [beaker.name] from the [name]."))
 	beaker = null
 	update_icon()
+	if(!(stat & (BROKEN|NOPOWER)))
+		playsound(src, clicksound, clickvol)
 
 /obj/machinery/reagentgrinder/proc/show_choices(mob/user)
 	if(!length(choices))

--- a/code/modules/reagents/Chemistry-Machinery.dm
+++ b/code/modules/reagents/Chemistry-Machinery.dm
@@ -87,13 +87,13 @@
 			return
 
 		if(!can_use(user))
-			to_chat(user, "<span class='notice'>You cannot remove [beaker.name].</span>")
+			to_chat(user, SPAN("notice", "You cannot remove [beaker.name]."))
 			return
 
 	if(beaker)
 		grab_beaker(user)
 	else
-		to_chat(user, "<span class='notice'>\The [src] does not have a beaker in it.</span>")
+		to_chat(user, SPAN("notice", "\The [src] does not have a beaker in it."))
 
 /obj/machinery/chem_master/proc/grab_beaker(mob/M)
 	if(!beaker)
@@ -554,13 +554,13 @@
 		return
 		
 	if(!can_use(user))
-		to_chat(user, "<span class='notice'>You cannot remove [beaker.name].</span>")
+		to_chat(user, SPAN("notice", "You cannot remove [beaker.name]."))
 		return
 
 	if(beaker)
 		grab_beaker(user)
 	else
-		to_chat(user, "<span class='notice'>\The [src] does not have a beaker in it.</span>")
+		to_chat(user, SPAN("notice", "\The [src] does not have a beaker in it."))
 
 /obj/machinery/reagentgrinder/proc/grab_beaker(mob/M)
 	if(!beaker)

--- a/code/modules/reagents/Chemistry-Machinery.dm
+++ b/code/modules/reagents/Chemistry-Machinery.dm
@@ -95,16 +95,16 @@
 	else
 		to_chat(user, SPAN("notice", "\The [src] does not have a beaker in it."))
 
-/obj/machinery/chem_master/proc/grab_beaker(mob/M)
+/obj/machinery/chem_master/proc/grab_beaker(mob/user)
 	if(!beaker)
 		return
 
-	if(issilicon(M))
+	if(issilicon(user))
 		beaker:dropInto(loc)
 	else
-		M.pick_or_drop(beaker, get_turf(src))
+		user.pick_or_drop(beaker, get_turf(src))
 
-	to_chat(M, SPAN("notice", "You remove the [beaker.name] from the [name]."))
+	to_chat(user, SPAN("notice", "You remove the [beaker.name] from the [name]."))
 	beaker = null
 	reagents.clear_reagents()
 	update_icon()
@@ -562,16 +562,16 @@
 	else
 		to_chat(user, SPAN("notice", "\The [src] does not have a beaker in it."))
 
-/obj/machinery/reagentgrinder/proc/grab_beaker(mob/M)
+/obj/machinery/reagentgrinder/proc/grab_beaker(mob/user)
 	if(!beaker)
 		return
 
-	if(issilicon(M))
+	if(issilicon(user))
 		beaker:dropInto(loc)
 	else
-		M.pick_or_drop(beaker, get_turf(src))
+		user.pick_or_drop(beaker, get_turf(src))
 
-	to_chat(M, SPAN("notice", "You remove the [beaker.name] from the [name]."))
+	to_chat(user, SPAN("notice", "You remove the [beaker.name] from the [name]."))
 	beaker = null
 	update_icon()
 

--- a/code/modules/reagents/Chemistry-Machinery.dm
+++ b/code/modules/reagents/Chemistry-Machinery.dm
@@ -81,6 +81,34 @@
 				qdel(src)
 				return
 
+/obj/machinery/chem_master/AltClick(mob/user)
+	if(!issilicon(user))
+		if(!user.Adjacent(get_turf(src)))
+			return
+
+		if(!can_use(user))
+			to_chat(user, "<span class='notice'>You cannot remove [beaker.name].</span>")
+			return
+
+	if(beaker)
+		grab_beaker(user)
+	else
+		to_chat(user, "<span class='notice'>\The [src] does not have a beaker in it.</span>")
+
+/obj/machinery/chem_master/proc/grab_beaker(mob/M)
+	if(!beaker)
+		return
+
+	if(issilicon(M))
+		beaker:dropInto(loc)
+	else
+		M.pick_or_drop(beaker, get_turf(src))
+
+	to_chat(M, SPAN("notice", "You remove the [beaker.name] from the [name]."))
+	beaker = null
+	reagents.clear_reagents()
+	update_icon()
+
 /obj/machinery/chem_master/attackby(obj/item/W, mob/user)
 	if(default_deconstruction_screwdriver(user, W))
 		return
@@ -520,6 +548,32 @@
 		//Calling attack_hand(user) to make ensure no functionality is missed.
 		//If attack_hand is updated, this segment won't have to be updated as well.
 		return attack_hand(user)
+
+/obj/machinery/reagentgrinder/AltClick(mob/user)
+	if(!user.Adjacent(get_turf(src)))
+		return
+		
+	if(!can_use(user))
+		to_chat(user, "<span class='notice'>You cannot remove [beaker.name].</span>")
+		return
+
+	if(beaker)
+		grab_beaker(user)
+	else
+		to_chat(user, "<span class='notice'>\The [src] does not have a beaker in it.</span>")
+
+/obj/machinery/reagentgrinder/proc/grab_beaker(mob/M)
+	if(!beaker)
+		return
+
+	if(issilicon(M))
+		beaker:dropInto(loc)
+	else
+		M.pick_or_drop(beaker, get_turf(src))
+
+	to_chat(M, SPAN("notice", "You remove the [beaker.name] from the [name]."))
+	beaker = null
+	update_icon()
 
 /obj/machinery/reagentgrinder/proc/show_choices(mob/user)
 	if(!length(choices))

--- a/code/modules/reagents/dispenser/dispenser2.dm
+++ b/code/modules/reagents/dispenser/dispenser2.dm
@@ -75,6 +75,33 @@
 	cartridges -= label
 	SSnano.update_uis(src)
 
+/obj/machinery/chemical_dispenser/AltClick(mob/user)
+	if(!issilicon(user))
+		if(!user.Adjacent(get_turf(src)))
+			return
+
+		if(!can_use(user))
+			to_chat(user, "<span class='notice'>You cannot remove [container.name].</span>")
+			return
+
+	if(container)
+		grab_container(user)
+	else
+		to_chat(user, "<span class='notice'>\The [src] does not have a container in it.</span>")
+
+/obj/machinery/chemical_dispenser/proc/grab_container(mob/M)
+	if(!container)
+		return
+
+	if(issilicon(M))
+		container:dropInto(loc)
+	else
+		M.pick_or_drop(container, get_turf(src))
+
+	to_chat(M, SPAN("notice", "You remove the [container.name] from the [name]."))
+	container = null
+	update_icon()
+
 /obj/machinery/chemical_dispenser/attackby(obj/item/W, mob/user)
 	if(default_deconstruction_crowbar(user, W))
 		return

--- a/code/modules/reagents/dispenser/dispenser2.dm
+++ b/code/modules/reagents/dispenser/dispenser2.dm
@@ -76,33 +76,7 @@
 	SSnano.update_uis(src)
 
 /obj/machinery/chemical_dispenser/AltClick(mob/user)
-	if(!issilicon(user))
-		if(!user.Adjacent(get_turf(src)))
-			return
-
-		if(!can_use(user))
-			to_chat(user, SPAN("notice", "You cannot remove [container.name]."))
-			return
-
-	if(container)
-		grab_container(user)
-	else
-		to_chat(user, SPAN("notice", "\The [src] does not have a container in it."))
-
-/obj/machinery/chemical_dispenser/proc/grab_container(mob/user)
-	if(!container)
-		return
-
-	if(issilicon(user))
-		container.dropInto(loc)
-	else
-		user.pick_or_drop(container, get_turf(src))
-
-	to_chat(user, SPAN("notice", "You remove the [container.name] from the [name]."))
-	container = null
-	update_icon()
-	if(!(stat & (BROKEN|NOPOWER)))
-		playsound(src, clicksound, clickvol)
+	grab_container(user, &container)
 
 /obj/machinery/chemical_dispenser/attackby(obj/item/W, mob/user)
 	if(default_deconstruction_crowbar(user, W))

--- a/code/modules/reagents/dispenser/dispenser2.dm
+++ b/code/modules/reagents/dispenser/dispenser2.dm
@@ -89,16 +89,16 @@
 	else
 		to_chat(user, SPAN("notice", "\The [src] does not have a container in it."))
 
-/obj/machinery/chemical_dispenser/proc/grab_container(mob/M)
+/obj/machinery/chemical_dispenser/proc/grab_container(mob/user)
 	if(!container)
 		return
 
-	if(issilicon(M))
+	if(issilicon(user))
 		container:dropInto(loc)
 	else
-		M.pick_or_drop(container, get_turf(src))
+		user.pick_or_drop(container, get_turf(src))
 
-	to_chat(M, SPAN("notice", "You remove the [container.name] from the [name]."))
+	to_chat(user, SPAN("notice", "You remove the [container.name] from the [name]."))
 	container = null
 	update_icon()
 

--- a/code/modules/reagents/dispenser/dispenser2.dm
+++ b/code/modules/reagents/dispenser/dispenser2.dm
@@ -94,7 +94,7 @@
 		return
 
 	if(issilicon(user))
-		container:dropInto(loc)
+		container.dropInto(loc)
 	else
 		user.pick_or_drop(container, get_turf(src))
 

--- a/code/modules/reagents/dispenser/dispenser2.dm
+++ b/code/modules/reagents/dispenser/dispenser2.dm
@@ -101,6 +101,8 @@
 	to_chat(user, SPAN("notice", "You remove the [container.name] from the [name]."))
 	container = null
 	update_icon()
+	if(!(stat & (BROKEN|NOPOWER)))
+		playsound(src, clicksound, clickvol)
 
 /obj/machinery/chemical_dispenser/attackby(obj/item/W, mob/user)
 	if(default_deconstruction_crowbar(user, W))

--- a/code/modules/reagents/dispenser/dispenser2.dm
+++ b/code/modules/reagents/dispenser/dispenser2.dm
@@ -81,13 +81,13 @@
 			return
 
 		if(!can_use(user))
-			to_chat(user, "<span class='notice'>You cannot remove [container.name].</span>")
+			to_chat(user, SPAN("notice", "You cannot remove [container.name]."))
 			return
 
 	if(container)
 		grab_container(user)
 	else
-		to_chat(user, "<span class='notice'>\The [src] does not have a container in it.</span>")
+		to_chat(user, SPAN("notice", "\The [src] does not have a container in it."))
 
 /obj/machinery/chemical_dispenser/proc/grab_container(mob/M)
 	if(!container)


### PR DESCRIPTION
Добавлена возможность достать емкость с помощью АльтКлика из такой машинерии, как:
- Сhemical dispenser
- ChemMaster 3000
- All-In-One Grinder
- The cryo cell
- The sleeper
- Soft Drink Dispenser
- Booze Dispenser

close #6059

<details>
<summary>Чейнджлог</summary>

```yml
🆑
tweak: Возможность с помощью АльтКлика достать емкость из химических раздатчиков, миксеров, крио капсул, слиперов и барных автоматов.
/🆑
```

</details>

- [x] Pull Request полностью завершен, мне не нужна помощь чтобы его закончить.
- [x] Я внимательно прочитал(-а) все свои изменения и багов в них не нашёл(-ла).
- [x] Я запускал(-а) сервер со своими изменениями локально и все протестировал(-а).
- [x] Я ознакомился(-ась) c [Guide to Contribute](https://github.com/ChaoticOnyx/OnyxBay/blob/dev/docs/contributing.md).
