### PR TITLE
fix(code): the correct name of the icon_state's bluespace tech. card

### DIFF
--- a/code/modules/admin/bluespace_tech.dm
+++ b/code/modules/admin/bluespace_tech.dm
@@ -321,7 +321,8 @@
 
 //ID
 /obj/item/card/id/bluespace_tech
-	icon_state = "centcom"
+	icon_state = "card_centcom"
+	item_state = "card_centcom"
 	desc = "An ID straight from Central Command. This one looks highly classified."
 
 /obj/item/card/id/bluespace_tech/Initialize()


### PR DESCRIPTION

close #13060

<details>
<summary>Чейнджлог</summary>

```yml
🆑ilyadobr
bugfix: Блюспейс техники снова имеют спрайт ID карточек.
/🆑
```

</details>

- [x] Pull Request полностью завершен, мне не нужна помощь чтобы его закончить.
- [x] Я внимательно прочитал(-а) все свои изменения и багов в них не нашёл(-ла).
- [ ] Я запускал(-а) сервер со своими изменениями локально и все протестировал(-а).
- [x] Я ознакомился(-ась) c [Guide to Contribute](https://github.com/ChaoticOnyx/OnyxBay/blob/dev/docs/contributing.md).
