### PR TITLE
Правильное сообщение при катапультировании ММИ

### DIFF
--- a/code/modules/mob/organs/external/head.dm
+++ b/code/modules/mob/organs/external/head.dm
@@ -36,7 +36,7 @@
 	if(BP_IS_ROBOTIC(src) && disintegrate == DROPLIMB_BURN)
 		var/obj/item/organ/internal/cerebrum/mmi/MMI = owner.internal_organs_by_name[BP_BRAIN]
 		if(istype(MMI))
-			MMI.visible_message(SPAN_DANGER("You see a bright flash as you get catapulted out of your body. You feel disoriented, which must be normal since you're just a brain in a can."), SPAN_NOTICE("[owner]'s head ejects an MMI!"))
+			MMI.visible_message(SPAN_NOTICE("[owner]'s head ejects an MMI!"), SPAN_DANGER("You see a bright flash as you get catapulted out of your body. You feel disoriented, which must be normal since you're just a brain in a can."))
 			MMI.removed()
 	return ..()
 


### PR DESCRIPTION
При гибе головы синта ММИ катапультируется с сопутствующим сообщением. Но в отвечающем за это `visible_message()` аргументы стояли в неправильном порядке, из-за чего всем вокруг показывалось сообщение, которое должно показываться только самому синту, а сообщение для окружающих показывалось синту. Теперь исправлено.

Иссуи не нашёл.

- [x] Pull Request полностью завершен, мне не нужна помощь чтобы его закончить.
- [x] Я внимательно прочитал(-а) все свои изменения и багов в них не нашёл(-ла).
- [ ] Я запускал(-а) сервер со своими изменениями локально и все протестировал(-а).
- [x] Я ознакомился(-ась) c [Guide to Contribute](https://github.com/ChaoticOnyx/OnyxBay/blob/dev/docs/contributing.md).
