### PR TITLE
fix(flechette): ammo usage

### DIFF
--- a/code/datums/uplink/categories/ammunition.dm
+++ b/code/datums/uplink/categories/ammunition.dm
@@ -99,4 +99,4 @@
 	name = "Flechette Magazine"
 	item_cost = 3
 	antag_roles = list(MODE_NUKE)
-	path = /obj/item/magnetic_ammo
+	path = /obj/item/rcd_ammo/magnetic_ammo

--- a/code/game/objects/items/storage/belt.dm
+++ b/code/game/objects/items/storage/belt.dm
@@ -173,7 +173,7 @@
 		/obj/item/gun/projectile/pistol/vp78,
 		/obj/item/taperoll,
 		/obj/item/device/holowarrant,
-		/obj/item/magnetic_ammo,
+		/obj/item/rcd_ammo/magnetic_ammo,
 		/obj/item/device/radio,
 		/obj/item/material/knife,
 		/obj/item/material/butterfly,

--- a/code/modules/clothing/under/accessories/storage.dm
+++ b/code/modules/clothing/under/accessories/storage.dm
@@ -162,7 +162,7 @@
 		/obj/item/clothing/mask/smokable,
 		/obj/item/screwdriver,
 		/obj/item/device/multitool,
-		/obj/item/magnetic_ammo,
+		/obj/item/rcd_ammo/magnetic_ammo,
 		/obj/item/ammo_magazine,
 		/obj/item/net_shell,
 		/obj/item/reagent_containers/vessel/beaker/vial

--- a/code/modules/projectiles/ammunition/magnetic.dm
+++ b/code/modules/projectiles/ammunition/magnetic.dm
@@ -1,13 +1,13 @@
-/obj/item/magnetic_ammo
+/obj/item/rcd_ammo/magnetic_ammo
 	name = "flechette magazine"
 	desc = "A magazine containing steel flechettes."
 	icon = 'icons/obj/ammo.dmi'
 	icon_state = "5.56"
+	item_state = "syringe_kit"
 	w_class = ITEM_SIZE_SMALL
 	matter = list(MATERIAL_STEEL = 1800)
 	origin_tech = list(TECH_COMBAT = 1)
-	var/remaining = 9
+	ammoamt = 9
 
-/obj/item/magnetic_ammo/ex_act(severity)
-	. = ..()
-	. += "There [(remaining == 1)? "is" : "are"] [remaining] flechette\s left!"
+/obj/item/rcd_ammo/magnetic_ammo/get_ammo_desc()
+	return "There [(ammoamt == 1)? "is" : "are"] [ammoamt] flechette\s left!"

--- a/code/modules/projectiles/guns/magnetic/magnetic_railgun.dm
+++ b/code/modules/projectiles/guns/magnetic/magnetic_railgun.dm
@@ -97,9 +97,9 @@
 	slowdown_held = 0
 	slowdown_worn = 0
 	power_cost = 100
-	load_type = /obj/item/magnetic_ammo
+	load_type = /obj/item/rcd_ammo/magnetic_ammo
 	projectile_type = /obj/item/projectile/bullet/magnetic/flechette
-	loaded = /obj/item/magnetic_ammo
+	loaded = /obj/item/rcd_ammo/magnetic_ammo
 	wielded_item_state = "z8carbine-wielded"
 
 	firemodes = list(

--- a/code/modules/rcd/ammo.dm
+++ b/code/modules/rcd/ammo.dm
@@ -16,7 +16,10 @@
 	. = ..()
 
 	if(get_dist(src, user) <= 1)
-		. += SPAN("notice", "It has [ammoamt] unit\s of matter left.")
+		. += SPAN("notice", get_ammo_desc())
+
+/obj/item/rcd_ammo/proc/get_ammo_desc()
+	return "It has [ammoamt] unit\s of matter left."
 
 /obj/item/rcd_ammo/large
 	name = "high-capacity matter cartridge"


### PR DESCRIPTION
проблема была в проках у railgun, которые смотрели количество патронов у типа `/obj/item/rcd_ammo`, в то время как у флешета патроны это `/obj/item/magnetic_ammo`

Примечание к тем, кто будет **ревьювить**: Да, пришлось сделать патроны подтипом rcd_ammo, но это связанно с тем, что сам флешет является сыном рейлгана, у которого всё очень строго привязано к использованию патронов rcd_ammo. Можно было бы переопределить код просмотра кол-ва патронов и его использование, но в таком случае это ctrl+c ctrl+v, что не очень здорово выглядит. 

<details>
<summary>Чейнджлог</summary>

```yml
🆑
bugfix: Исправлено использование патронов у флешета
/🆑
```

</details>

- [x] Pull Request полностью завершен, мне не нужна помощь чтобы его закончить.
- [x] Я внимательно прочитал(-а) все свои изменения и багов в них не нашёл(-ла).
- [x] Я запускал(-а) сервер со своими изменениями локально и все протестировал(-а).
- [x] Я ознакомился(-ась) c [Guide to Contribute](https://github.com/ChaoticOnyx/OnyxBay/blob/dev/docs/contributing.md).
