### PR TITLE
fix(mech): repairing

### DIFF
--- a/code/game/mecha/mecha.dm
+++ b/code/game/mecha/mecha.dm
@@ -868,12 +868,11 @@
 		if(!WT.use_tool(src, user, amount = 1))
 			return
 
-		if(!hasInternalDamage(MECHA_INT_TANK_BREACH))
+		if(hasInternalDamage(MECHA_INT_TANK_BREACH))
+			clearInternalDamage(MECHA_INT_TANK_BREACH)
+			to_chat(user, SPAN_NOTICE("You repair the damaged gas tank."))
+			user.setClickCooldown(DEFAULT_ATTACK_COOLDOWN)
 			return
-
-		clearInternalDamage(MECHA_INT_TANK_BREACH)
-		to_chat(user, SPAN_NOTICE("You repair the damaged gas tank."))
-		user.setClickCooldown(DEFAULT_ATTACK_COOLDOWN)
 
 		if(health < initial(health))
 			to_chat(user, SPAN_NOTICE("You repair some damage to [src.name]."))


### PR DESCRIPTION
Почему-то при ревёрте ТГуи проебалась проверка на нарушение целостности баллона (с кислородом, как я понял) у меха, из-за чего не давало чинить ни баллон, ни самого меха.

<details>
<summary>Чейнджлог</summary>

```yml
🆑
bugfix: Мехов вновь можно чинить
/🆑
```

</details>

- [x] Pull Request полностью завершен, мне не нужна помощь чтобы его закончить.
- [x] Я внимательно прочитал(-а) все свои изменения и багов в них не нашёл(-ла).
- [x] Я запускал(-а) сервер со своими изменениями локально и все протестировал(-а).
- [x] Я ознакомился(-ась) c [Guide to Contribute](https://github.com/ChaoticOnyx/OnyxBay/blob/dev/docs/contributing.md).
