### PR TITLE
tweak(reagent-containters): players can ALT+CLICK to switch transfer amount

### DIFF
--- a/code/modules/reagents/reagent_containers.dm
+++ b/code/modules/reagents/reagent_containers.dm
@@ -203,6 +203,24 @@
 		return ..()
 
 /obj/item/reagent_containers/AltClick(mob/user)
+	if(!CanPhysicallyInteract(user))
+		return
+	if(!possible_transfer_amounts)
+		return
+
+	var/list/modes = list()
+	for(var/mode in params2list(possible_transfer_amounts))
+		modes += text2num(mode)
+
+	var/current_index = modes.Find(amount_per_transfer_from_this)
+	if(current_index == modes.len)
+		amount_per_transfer_from_this = modes[1]
+	else
+		amount_per_transfer_from_this = modes[current_index + 1]
+
+	to_chat(user, SPAN("notice", "You set the next amount per tranfser from \the [name]: <b>[amount_per_transfer_from_this]<b>"))
+
+/obj/item/reagent_containers/CtrlAltClick(mob/user)
 	if(possible_transfer_amounts)
 		if(CanPhysicallyInteract(user))
 			set_APTFT()


### PR DESCRIPTION
title

<details>
<summary>Чейнджлог</summary>

```yml
🆑
tweak: ALT+CLICK по всему, что может переливать, теперь циклически переключает режим (количество единиц для переливания)
tweak: Предыдущее окошко с выбором количества переливания на ALT+CLICK было изменено на CTRL+ALT+CLICK
/🆑
```

</details>

- [x] Pull Request полностью завершен, мне не нужна помощь чтобы его закончить.
- [x] Я внимательно прочитал(-а) все свои изменения и багов в них не нашёл(-ла).
- [x] Я запускал(-а) сервер со своими изменениями локально и все протестировал(-а).
- [x] Я ознакомился(-ась) c [Guide to Contribute](https://github.com/ChaoticOnyx/OnyxBay/blob/dev/docs/contributing.md).
