### PR TITLE
fix(screen/storage/Click()) Correct double row behavior

### DIFF
--- a/code/_onclick/hud/screen_objects.dm
+++ b/code/_onclick/hud/screen_objects.dm
@@ -89,13 +89,19 @@
 		var/list/PM = params2list(params)
 		var/list/screen_loc_params = splittext(PM["screen-loc"], ",")
 		var/list/screen_loc_X = splittext(screen_loc_params[1], ":")
+		var/list/screen_loc_Y = splittext(screen_loc_params[2], ":")
 		var/click_x = text2num(screen_loc_X[1]) * WORLD_ICON_SIZE + text2num(screen_loc_X[2]) - 144
+		var/click_y = text2num(screen_loc_Y[1]) * WORLD_ICON_SIZE + text2num(screen_loc_Y[2]) - 144
+		var/rows = round((S.contents.len-1)/7)
+		if(!rows)
+			click_y += WORLD_ICON_SIZE
 
-		for(var/i = 1, i <= S.storage_ui.click_border_start.len, i++)
-			if(S.storage_ui.click_border_start[i] <= click_x && click_x <= S.storage_ui.click_border_end[i] && i <= S.contents.len)
-				I = S.contents[i]
-				I?.Click(location, control, params)
-				return
+		for(var/i = 1, i <= S.contents.len, i++)
+			if(S.storage_ui.click_border["x"]["start"][i] <= click_x && click_x <= S.storage_ui.click_border["x"]["end"][i])
+				if(S.storage_ui.click_border["y"]["start"][i] >= click_y && click_y >= S.storage_ui.click_border["y"]["end"][i])
+					I = S.contents[i]
+					I?.Click(location, control, params)
+					return
 
 	return TRUE
 

--- a/code/_onclick/hud/screen_objects.dm
+++ b/code/_onclick/hud/screen_objects.dm
@@ -90,15 +90,12 @@
 		var/list/screen_loc_params = splittext(PM["screen-loc"], ",")
 		var/list/screen_loc_X = splittext(screen_loc_params[1], ":")
 		var/list/screen_loc_Y = splittext(screen_loc_params[2], ":")
-		var/click_x = text2num(screen_loc_X[1]) * WORLD_ICON_SIZE + text2num(screen_loc_X[2]) - 144
-		var/click_y = text2num(screen_loc_Y[1]) * WORLD_ICON_SIZE + text2num(screen_loc_Y[2]) - 144
-		var/rows = round((S.contents.len-1)/7)
-		if(!rows)
-			click_y += WORLD_ICON_SIZE
+		var/click_x = text2num(screen_loc_X[1])*WORLD_ICON_SIZE + text2num(screen_loc_X[2]) - 4.5*WORLD_ICON_SIZE
+		var/click_y = text2num(screen_loc_Y[1])*WORLD_ICON_SIZE + text2num(screen_loc_Y[2]) - 2.5*WORLD_ICON_SIZE
 
 		for(var/i = 1, i <= S.contents.len, i++)
 			if(S.storage_ui.click_border["x"]["start"][i] <= click_x && click_x <= S.storage_ui.click_border["x"]["end"][i])
-				if(S.storage_ui.click_border["y"]["start"][i] >= click_y && click_y >= S.storage_ui.click_border["y"]["end"][i])
+				if(S.storage_ui.click_border["y"]["start"][i] <= click_y && click_y <= S.storage_ui.click_border["y"]["end"][i])
 					I = S.contents[i]
 					I?.Click(location, control, params)
 					return

--- a/code/game/objects/items/storage/storage_ui/default.dm
+++ b/code/game/objects/items/storage/storage_ui/default.dm
@@ -215,11 +215,11 @@
 		O.maptext = ""
 		O.hud_layerise()
 
-		click_border["x"]["start"] += (cx - 4) * 32
-		click_border["x"]["end"] += (cx - 4) * 32 + 32
+		click_border["x"]["start"] += (cx - 4) * WORLD_ICON_SIZE
+		click_border["x"]["end"] += (cx - 4) * WORLD_ICON_SIZE + WORLD_ICON_SIZE
 
-		click_border["y"]["start"] += (cy - 2-rows) * 32
-		click_border["y"]["end"] += (cy - 2-rows) * 32 - 32
+		click_border["y"]["start"] += (cy - 2) * WORLD_ICON_SIZE
+		click_border["y"]["end"] += (cy - 2) * WORLD_ICON_SIZE + WORLD_ICON_SIZE
 
 		cx++
 		if (cx > (4+cols))
@@ -259,7 +259,7 @@
 		click_border["x"]["end"].Add(endpoint)
 
 		click_border["y"]["start"].Add(0)
-		click_border["y"]["end"].Add(-WORLD_ICON_SIZE)
+		click_border["y"]["end"].Add(WORLD_ICON_SIZE)
 
 		stored_start.SetTransform(offset_x = startpoint)
 		stored_end.SetTransform(offset_x = endpoint - stored_cap_width)

--- a/code/game/objects/items/storage/storage_ui/default.dm
+++ b/code/game/objects/items/storage/storage_ui/default.dm
@@ -192,8 +192,10 @@
 
 //This proc determins the size of the inventory to be displayed. Please touch it only if you know what you're doing.
 /datum/storage_ui/default/proc/slot_orient_objs()
-	click_border_start.Cut()
-	click_border_end.Cut()
+	click_border["x"]["start"].Cut()
+	click_border["x"]["end"].Cut()
+	click_border["y"]["start"].Cut()
+	click_border["y"]["end"].Cut()
 
 	var/adjusted_contents = storage.contents.len
 	var/row_num = 0
@@ -212,8 +214,12 @@
 		O.screen_loc = "[cx]:16,[cy]:16"
 		O.maptext = ""
 		O.hud_layerise()
-		click_border_start += (cx - 4) * 32
-		click_border_end += (cx - 4) * 32 + 32
+
+		click_border["x"]["start"] += (cx - 4) * 32
+		click_border["x"]["end"] += (cx - 4) * 32 + 32
+
+		click_border["y"]["start"] += (cy - 2-rows) * 32
+		click_border["y"]["end"] += (cy - 2-rows) * 32 - 32
 
 		cx++
 		if (cx > (4+cols))
@@ -229,8 +235,11 @@
 	var/stored_cap_width = 4 //length of sprite for start and end of the box representing the stored item
 	var/storage_width = min( round( 224 * storage.max_storage_space/baseline_max_storage_space ,1) ,284) //length of sprite for the box representing total storage space
 
-	click_border_start.Cut()
-	click_border_end.Cut()
+	click_border["x"]["start"].Cut()
+	click_border["x"]["end"].Cut()
+	click_border["y"]["start"].Cut()
+	click_border["y"]["end"].Cut()
+
 	storage_start.ClearOverlays()
 
 	storage_continue.SetTransform(scale_x = (storage_width - storage_cap_width * 2 + 3) / 32)
@@ -246,8 +255,11 @@
 		startpoint = endpoint + 1
 		endpoint += storage_width * O.get_storage_cost()/storage.max_storage_space
 
-		click_border_start.Add(startpoint)
-		click_border_end.Add(endpoint)
+		click_border["x"]["start"].Add(startpoint)
+		click_border["x"]["end"].Add(endpoint)
+
+		click_border["y"]["start"].Add(0)
+		click_border["y"]["end"].Add(-WORLD_ICON_SIZE)
 
 		stored_start.SetTransform(offset_x = startpoint)
 		stored_end.SetTransform(offset_x = endpoint - stored_cap_width)

--- a/code/game/objects/items/storage/storage_ui/storage_ui.dm
+++ b/code/game/objects/items/storage/storage_ui/storage_ui.dm
@@ -1,8 +1,9 @@
 /datum/storage_ui
 	var/obj/item/storage/storage
-	var/list/click_border_start = list()
-	var/list/click_border_end = list()
-
+	var/list/click_border = list(
+		"x" = list("start" = list(), "end" = list()),
+		"y" = list("start" = list(), "end" = list())
+	)
 
 /datum/storage_ui/New(storage)
 	src.storage = storage


### PR DESCRIPTION
Теперь при клике учитывается ось Y.

fix #13023

<details>
<summary>Чейнджлог</summary>

```yml
🆑
bugfix: Исправлена ошибка из-за которой при клике на ячейку нижнего ряда хирургического набора, доставался инструмент, находящийся в ячейке выше.
/🆑
```

</details>

- [x] Pull Request полностью завершен, мне не нужна помощь чтобы его закончить.
- [x] Я внимательно прочитал(-а) все свои изменения и багов в них не нашёл(-ла).
- [x] Я запускал(-а) сервер со своими изменениями локально и все протестировал(-а).
- [x] Я ознакомился(-ась) c [Guide to Contribute](https://github.com/ChaoticOnyx/OnyxBay/blob/dev/docs/contributing.md).
