### PR TITLE
Верб 'Select Module' у РИГов теперь получил радиальное меню.

### DIFF
--- a/code/modules/clothing/spacesuits/rig/rig_verbs.dm
+++ b/code/modules/clothing/spacesuits/rig/rig_verbs.dm
@@ -189,7 +189,6 @@
 	speech.engage()
 
 /obj/item/rig/verb/select_module()
-
 	set name = "Select Module"
 	set desc = "Selects a module as your primary system."
 	set category = "Powersuit"
@@ -211,18 +210,31 @@
 
 	var/list/selectable = list()
 	for(var/obj/item/rig_module/module in installed_modules)
-		if(module.selectable)
-			selectable |= module
+		selectable |= module
 
-	var/obj/item/rig_module/module = input("Which module do you wish to select?") as null|anything in selectable
+	var/list/module_choices = list()
+	for(var/obj/item/rig_module/M in selectable)
+		module_choices[M] = make_item_radial_menu_button(M)
 
-	if(!istype(module))
-		selected_module = null
-		to_chat(usr, "<span class='info'><b>Primary system is now: deselected.</b></span>")
-		return
 
-	selected_module = module
-	to_chat(usr, "<span class='info'><b>Primary system is now: [selected_module.interface_name].</b></span>")
+	var/obj/item/rig_module/chosen_module = show_radial_menu(usr, src, module_choices, "rig_module_selection")
+
+	if(chosen_module)
+		if(chosen_module == selected_module && chosen_module.usable) // if you choose module again engage it (e.g. stun lethal for egun module)
+			selected_module.engage()
+			to_chat(usr, "<span class='info'><b>Engaging selected system: [selected_module.interface_name].</b></span>")
+		if(chosen_module.toggleable)
+			if(chosen_module.active)
+				to_chat(usr, "<span class='info'><b>You attempt to deactivate \the [chosen_module.interface_name].</b></span>")
+				chosen_module.deactivate()
+			else
+				to_chat(usr, "<span class='info'><b>You attempt to activate \the [chosen_module.interface_name].</b></span>")
+				chosen_module.activate()	
+		else
+			selected_module = chosen_module
+			to_chat(usr, "<span class='info'><b>Primary system is now: [selected_module.interface_name].</b></span>")
+	else
+		to_chat(usr, "<span class='info'><b>No module selected.</b></span>")
 
 /obj/item/rig/verb/toggle_module()
 

--- a/code/modules/clothing/spacesuits/rig/rig_verbs.dm
+++ b/code/modules/clothing/spacesuits/rig/rig_verbs.dm
@@ -189,6 +189,7 @@
 	speech.engage()
 
 /obj/item/rig/verb/select_module()
+
 	set name = "Select Module"
 	set desc = "Selects a module as your primary system."
 	set category = "Powersuit"
@@ -216,25 +217,24 @@
 	for(var/obj/item/rig_module/M in selectable)
 		module_choices[M] = make_item_radial_menu_button(M)
 
-
 	var/obj/item/rig_module/chosen_module = show_radial_menu(usr, src, module_choices, "rig_module_selection")
 
 	if(chosen_module)
 		if(chosen_module == selected_module && chosen_module.usable) // if you choose module again engage it (e.g. stun lethal for egun module)
 			selected_module.engage()
-			to_chat(usr, "<span class='info'><b>Engaging selected system: [selected_module.interface_name].</b></span>")
+			to_chat(usr, SPAN_INFO("<b>Engaging selected system: [selected_module.interface_name].</b>"))
 		if(chosen_module.toggleable)
 			if(chosen_module.active)
-				to_chat(usr, "<span class='info'><b>You attempt to deactivate \the [chosen_module.interface_name].</b></span>")
+				to_chat(usr, SPAN_INFO("<b>You attempt to deactivate \the [chosen_module.interface_name].</b>"))
 				chosen_module.deactivate()
 			else
-				to_chat(usr, "<span class='info'><b>You attempt to activate \the [chosen_module.interface_name].</b></span>")
+				to_chat(usr, SPAN_INFO("<b>You attempt to activate \the [chosen_module.interface_name].</b>"))
 				chosen_module.activate()	
 		else
 			selected_module = chosen_module
-			to_chat(usr, "<span class='info'><b>Primary system is now: [selected_module.interface_name].</b></span>")
+			to_chat(usr, SPAN_INFO("<b>Primary system is now: [selected_module.interface_name].</b>"))
 	else
-		to_chat(usr, "<span class='info'><b>No module selected.</b></span>")
+		to_chat(usr, SPAN_INFO("<b>No module selected.</b>"))
 
 /obj/item/rig/verb/toggle_module()
 

--- a/code/modules/clothing/spacesuits/rig/rig_verbs.dm
+++ b/code/modules/clothing/spacesuits/rig/rig_verbs.dm
@@ -222,19 +222,20 @@
 	if(chosen_module)
 		if(chosen_module == selected_module && chosen_module.usable) // if you choose module again engage it (e.g. stun lethal for egun module)
 			selected_module.engage()
-			to_chat(usr, SPAN_INFO("<b>Engaging selected system: [selected_module.interface_name].</b>"))
+			show_splash_text(usr, SPAN_INFO("<b>Engaging: [selected_module.interface_name].</b>") ,SPAN_INFO("<b>Engaging selected system: [selected_module.interface_name].</b>"))
+			return
 		if(chosen_module.toggleable)
 			if(chosen_module.active)
-				to_chat(usr, SPAN_INFO("<b>You attempt to deactivate \the [chosen_module.interface_name].</b>"))
+				show_splash_text(usr, SPAN_INFO("<b>Deactivating: \the [chosen_module.interface_name].</b>"), SPAN_INFO("<b>You attempt to deactivate \the [chosen_module.interface_name].</b>"))
 				chosen_module.deactivate()
 			else
-				to_chat(usr, SPAN_INFO("<b>You attempt to activate \the [chosen_module.interface_name].</b>"))
+				show_splash_text(usr, SPAN_INFO("<b>Activating: \the [chosen_module.interface_name].</b>"), SPAN_INFO("<b>You attempt to activate \the [chosen_module.interface_name].</b>"))
 				chosen_module.activate()	
 		else
 			selected_module = chosen_module
-			to_chat(usr, SPAN_INFO("<b>Primary system is now: [selected_module.interface_name].</b>"))
+			show_splash_text(usr, SPAN_INFO("<b>Primary system: [selected_module.interface_name].</b>"), SPAN_INFO("<b>Primary system is now: [selected_module.interface_name].</b>"))
 	else
-		to_chat(usr, SPAN_INFO("<b>No module selected.</b>"))
+		show_splash_text(usr, SPAN_INFO("<b>No module selected.</b>"), SPAN_INFO("<b>No module selected.</b>"))
 
 /obj/item/rig/verb/toggle_module()
 

--- a/code/modules/clothing/spacesuits/rig/rig_verbs.dm
+++ b/code/modules/clothing/spacesuits/rig/rig_verbs.dm
@@ -222,20 +222,20 @@
 	if(chosen_module)
 		if(chosen_module == selected_module && chosen_module.usable) // if you choose module again engage it (e.g. stun lethal for egun module)
 			selected_module.engage()
-			show_splash_text(usr, SPAN_INFO("<b>Engaging: [selected_module.interface_name].</b>") ,SPAN_INFO("<b>Engaging selected system: [selected_module.interface_name].</b>"))
+			show_splash_text(usr, "engaging [selected_module.interface_name].", SPAN_INFO("<b>Engaging selected system: [selected_module.interface_name].</b>"))
 			return
 		if(chosen_module.toggleable)
 			if(chosen_module.active)
-				show_splash_text(usr, SPAN_INFO("<b>Deactivating: \the [chosen_module.interface_name].</b>"), SPAN_INFO("<b>You attempt to deactivate \the [chosen_module.interface_name].</b>"))
+				show_splash_text(usr, "deactivating \the [chosen_module.interface_name].", SPAN_INFO("<b>You attempt to deactivate \the [chosen_module.interface_name].</b>"))
 				chosen_module.deactivate()
 			else
-				show_splash_text(usr, SPAN_INFO("<b>Activating: \the [chosen_module.interface_name].</b>"), SPAN_INFO("<b>You attempt to activate \the [chosen_module.interface_name].</b>"))
+				show_splash_text(usr, "activating \the [chosen_module.interface_name].", SPAN_INFO("<b>You attempt to activate \the [chosen_module.interface_name].</b>"))
 				chosen_module.activate()	
 		else
 			selected_module = chosen_module
-			show_splash_text(usr, SPAN_INFO("<b>Primary system: [selected_module.interface_name].</b>"), SPAN_INFO("<b>Primary system is now: [selected_module.interface_name].</b>"))
+			show_splash_text(usr, "primary system [selected_module.interface_name].", SPAN_INFO("<b>Primary system is now: [selected_module.interface_name].</b>"))
 	else
-		show_splash_text(usr, SPAN_INFO("<b>No module selected.</b>"), SPAN_INFO("<b>No module selected.</b>"))
+		show_splash_text(usr, "no module selected.", SPAN_INFO("<b>No module selected.</b>"))
 
 /obj/item/rig/verb/toggle_module()
 

--- a/interface/skin.dmf
+++ b/interface/skin.dmf
@@ -546,6 +546,12 @@ macro "hotkeymode"
 		name = "CTRL+H"
 		command = "holster"
 	elem
+		name = "V"
+		command = "select-module"
+	elem
+		name = "CTRL+V"
+		command = "select-module"
+	elem
 		name = "J"
 		command = "toggle-gun-mode"
 	elem


### PR DESCRIPTION

https://github.com/user-attachments/assets/08209921-2e35-4a06-88d6-8f1c47ffc382


Радиальное меню у ригов. При нажатии на верб теперь на мобе на котором надет РИГ будет высвечиваться радиальное меню.
Модули которые пихаются в СКМ будут пихаться в СКМ.
Модули которые активируются по нажатию будут активироваться по нажатию.
Если модуль имеет несколько стейтов (скажем, как у егана - стан и летал), то повторное нажатие на этот же модуль переключит режим.
Стоило выпилить пару лишних вербов но пусть пока что поваляется в этом виде ради фидбека.
Плюс, надо прикрутить макрос на Select-Module, но я не понял как, ибо когда менял skin.dmf оно долбило окно игры и чат. Пока что можно обойтись немного костыльным решением, добавить макрос самому через кнопки в верхнем-левом углу игры и нажав ПКМ на окошечко.

<details>
<summary>Чейнджлог</summary>

```yml
🆑Roxreic
tweak: Верб РИГа Select-Module во вкладке Powersuit получил радиальное меню. Макрос поставьте себе через меню Macros в левом верхнем углу окошка игры нажав ПКМ..
/🆑
```

</details>

- [x] Pull Request полностью завершен, мне не нужна помощь чтобы его закончить.
- [x] Я внимательно прочитал(-а) все свои изменения и багов в них не нашёл(-ла).
- [x] Я запускал(-а) сервер со своими изменениями локально и все протестировал(-а).
- [x] Я ознакомился(-ась) c [Guide to Contribute](https://github.com/ChaoticOnyx/OnyxBay/blob/dev/docs/contributing.md).
