### PR TITLE
tweak(tajaran species): make siikmaas the default lang

### DIFF
--- a/code/modules/mob/living/carbon/human/species/station/station.dm
+++ b/code/modules/mob/living/carbon/human/species/station/station.dm
@@ -99,8 +99,8 @@
 	burn_mod =  1.15
 	gluttonous = GLUT_TINY
 	num_alternate_languages = 2
-	secondary_langs = list(LANGUAGE_SIIK_TAJR)
-	additional_langs = list(LANGUAGE_SIIK_MAAS)
+	secondary_langs = list(LANGUAGE_SIIK_MAAS)
+	additional_langs = list(LANGUAGE_SIIK_TAJR)
 	name_language = LANGUAGE_SIIK_MAAS
 	health_hud_intensity = 1.75
 


### PR DESCRIPTION
Уже шут знает сколько лет у нас [по лору](https://wiki.ss13.ru/index.php?title=%D0%A2%D0%B0%D1%8F%D1%80%D0%B0%D0%BD#.D0.AF.D0.B7.D1.8B.D0.BA) Сиик'маас -- родной язык таяран, а Сиик'таяр -- вторичный язык жестов. Но в билде при смене расы на таяру по умолчанию добавляется именно Сиик'таяр. Сукбесит, поменял на то, как по идее оно должно было быть.

<details>
<summary>Чейнджлог</summary>

```yml
🆑TheUnknownOne
tweak: Стандартным языком для таяр теперь является Сиик'маас. Это повлияет только на создание новых персонажей (Сиик'маас будет автоматически добавляться при смене расы на таяру, вместо Сиик'таяра).
/🆑
```

</details>

- [x] Pull Request полностью завершен, мне не нужна помощь чтобы его закончить.
- [x] Я внимательно прочитал(-а) все свои изменения и багов в них не нашёл(-ла).
- [x] Я запускал(-а) сервер со своими изменениями локально и все протестировал(-а).
- [x] Я ознакомился(-ась) c [Guide to Contribute](https://github.com/ChaoticOnyx/OnyxBay/blob/dev/docs/contributing.md).
