### PR TITLE
fix(id.icon_states): prevent invisible IDs

### DIFF
--- a/code/game/antagonist/outsider/deathsquad.dm
+++ b/code/game/antagonist/outsider/deathsquad.dm
@@ -62,7 +62,7 @@ GLOBAL_DATUM_INIT(deathsquad, /datum/antagonist/deathsquad, new)
 	var/obj/item/card/id/id = create_id("Death Commando", player)
 	if(id)
 		id.access |= get_all_station_access()
-		id.icon_state = "centcom"
+		id.icon_state = "card_centcom"
 	create_radio(DTH_FREQ, player)
 
 /datum/antagonist/deathsquad/update_antag_mob(datum/mind/player)

--- a/code/modules/admin/verbs/debug.dm
+++ b/code/modules/admin/verbs/debug.dm
@@ -164,11 +164,11 @@
 			if(istype(H.wear_id, /obj/item/device/pda))
 				var/obj/item/device/pda/pda = H.wear_id
 				id = pda.id
-			id.icon_state = "gold"
+			id.icon_state = "card_gold"
 			id.access = get_all_accesses()
 		else
 			var/obj/item/card/id/id = new /obj/item/card/id(M);
-			id.icon_state = "gold"
+			id.icon_state = "card_gold"
 			id.access = get_all_accesses()
 			id.registered_name = H.real_name
 			id.assignment = "Captain"


### PR DESCRIPTION
В #12989 забыли в паре мест, где изменяется `icon_state` у карточки, поменять название спрайта на новое. Из-за этого при использовании педального верба Grant Full Access и при одевании космонавтов в эквип дедсадовца ИД-карточки оказывались невидимыми.

<details>
<summary>Чейнджлог</summary>

```yml
🆑TheUnknownOne
bugfix: Исправлен баг, из-за которого в некоторых случаях ИД-карточки становились невидимыми.
/🆑
```

</details>

- [x] Pull Request полностью завершен, мне не нужна помощь чтобы его закончить.
- [x] Я внимательно прочитал(-а) все свои изменения и багов в них не нашёл(-ла).
- [ ] Я запускал(-а) сервер со своими изменениями локально и все протестировал(-а).
- [x] Я ознакомился(-ась) c [Guide to Contribute](https://github.com/ChaoticOnyx/OnyxBay/blob/dev/docs/contributing.md).
