### PR TITLE
fix(character setup): newcommers message now shows properly

### DIFF
--- a/code/_helpers/warnings.dm
+++ b/code/_helpers/warnings.dm
@@ -23,7 +23,7 @@ SUBSYSTEM_DEF(warnings)
 	ASSERT(type)
 	ASSERT(options)
 	if (!(C.key in shown_warnings_this_round[type]) && (shown_warnings[type][C.key] < WARNINGS_REPEAT_TIMES))
-		var/message = config.texts[type]
+		var/message = config.texts.vars[type]
 		show_browser(C, message, options)
 		shown_warnings_this_round[type].Add(C.key)
 		if(!shown_warnings[type][C.key])


### PR DESCRIPTION
К сожалению, Byond не является джава скриптом и просто так скобочки использовать нельзя.

<details>
<summary>Чейнджлог</summary>

```yml
🆑
bugfix: Сообщение для нового игрока снова выводится.
/🆑
```

</details>

- [x] Pull Request полностью завершен, мне не нужна помощь чтобы его закончить.
- [x] Я внимательно прочитал(-а) все свои изменения и багов в них не нашёл(-ла).
- [x] Я запускал(-а) сервер со своими изменениями локально и все протестировал(-а).
- [x] Я ознакомился(-ась) c [Guide to Contribute](https://github.com/ChaoticOnyx/OnyxBay/blob/dev/docs/contributing.md).
