### PR TITLE
feat(supermatter): add lack of unstable supermatter fun REDUX

### DIFF
--- a/code/modules/supermatter/supermatter.dm
+++ b/code/modules/supermatter/supermatter.dm
@@ -71,7 +71,7 @@
 	var/grav_pulling = 0
 	// Time in ticks between delamination ('exploding') and exploding (as in the actual boom)
 	var/pull_time = 300
-	var/explosion_power_modifier = 9
+	var/explosion_power_modifier = 0
 
 	var/emergency_issued = 0
 
@@ -106,11 +106,17 @@
 
 	var/datum/radiation_source/rad_source = null
 
+	var/is_unstable_and_fun = FALSE
+
 	is_poi = TRUE
 
 /obj/machinery/power/supermatter/Initialize()
 	. = ..()
 	uid = gl_uid++
+	if(prob(50))
+		is_unstable_and_fun = TRUE
+	if(!explosion_power_modifier)
+		explosion_power_modifier = rand(1, 30)
 
 /obj/machinery/power/supermatter/proc/handle_admin_warnings()
 	if(disable_adminwarn)
@@ -314,7 +320,7 @@
 	if(!istype(L)) 	//We are in a crate or somewhere that isn't turf, if we return to turf resume processing but for now.
 		return  //Yeah just stop.
 
-	if(damage > explosion_point)
+	if((damage > explosion_point) || (is_unstable_and_fun && prob(1)))
 		if(!exploded)
 			if(!istype(L, /turf/space))
 				announce_warning()


### PR DESCRIPTION
Помните https://github.com/ChaoticOnyx/OnyxBay/pull/3159 ? А я помню, вот, впилил ее опять. Но можно не читать тот ПР - формулы удалось оптимизировать, значительно ужав количество кода, но оставив тот же уровень ВЕСЕЛЬЯ.

```yml
🆑
rscadd: Теперь инженеры могут выбрать между обычной материей и "нестабильной", параметры которой генерируются каждый раунд случайно. Открой этот киндерсюрприз и посмотри, что выпало тебе! Объявлена неделя проебов материи. Осторожно: выбор осуществляется путём молитв и размышлений.
/🆑
```

- [x] Pull Request полностью завершен, мне не нужна помощь чтобы его закончить.
- [x] Я внимательно прочитал(-а) все свои изменения и багов в них не нашёл(-ла).
- [x] Я запускал(-а) сервер со своими изменениями локально и все протестировал(-а).
- [x] Я ознакомился(-ась) c [Guide to Contribute](https://github.com/ChaoticOnyx/OnyxBay/blob/dev/docs/contributing.md).
