### PR TITLE
fix(player_panel) Rudimentary transformation correct spawning species

### DIFF
--- a/code/modules/admin/admin.dm
+++ b/code/modules/admin/admin.dm
@@ -161,12 +161,12 @@ var/global/floorIsLava = 0
 				<A href='?src=\ref[src];simplemake=human;species=Xenomorph Queen;mob=\ref[M]'>Queen</A> \] |
 				\[ Crew: <A href='?src=\ref[src];simplemake=human;mob=\ref[M]'>Human</A>
 				<A href='?src=\ref[src];simplemake=human;species=Unathi;mob=\ref[M]'>Unathi</A>
-				<A href='?src=\ref[src];simplemake=human;species=Tajaran;mob=\ref[M]'>Tajaran</A>
+				<A href='?src=\ref[src];simplemake=human;species=Tajara;mob=\ref[M]'>Tajaran</A>
 				<A href='?src=\ref[src];simplemake=human;species=Skrell;mob=\ref[M]'>Skrell</A>
 				<A href='?src=\ref[src];simplemake=human;species=Trottine;mob=\ref[M]'>Trottine</A>
 				<A href='?src=\ref[src];simplemake=human;species=Vox;mob=\ref[M]'>Vox</A> \] | \[
 				<A href='?src=\ref[src];simplemake=nymph;mob=\ref[M]'>Nymph</A>
-				<A href='?src=\ref[src];simplemake=human;species='Diona';mob=\ref[M]'>Diona</A> \] |
+				<A href='?src=\ref[src];simplemake=human;species=Diona;mob=\ref[M]'>Diona</A> \] |
 				\[ metroid: <A href='?src=\ref[src];simplemake=metroid;mob=\ref[M]'>Baby</A>,
 				<A href='?src=\ref[src];simplemake=adultmetroid;mob=\ref[M]'>Adult</A> \]
 				<A href='?src=\ref[src];simplemake=monkey;mob=\ref[M]'>Monkey</A> |

--- a/code/modules/mob/mob_transformation_simple.dm
+++ b/code/modules/mob/mob_transformation_simple.dm
@@ -24,9 +24,9 @@
 
 	var/mob/M
 	if(isturf(location))
-		M = new new_type( location )
+		M = new new_type(location, subspecies)
 	else
-		M = new new_type( src.loc )
+		M = new new_type(src.loc, subspecies)
 
 	if(!M || !ismob(M))
 		to_chat(usr, "Type path is not a mob (new_type = [new_type]) in change_mob_type(). Contact a coder.")
@@ -47,10 +47,6 @@
 		mind.transfer_to(M)
 	else
 		M.key = key
-
-	if(subspecies && istype(M,/mob/living/carbon/human))
-		var/mob/living/carbon/human/H = M
-		H.set_species(subspecies)
 
 	if(delete_old_mob)
 		QDEL_IN(src, 1)

--- a/code/modules/mob/mob_transformation_simple.dm
+++ b/code/modules/mob/mob_transformation_simple.dm
@@ -24,9 +24,9 @@
 
 	var/mob/M
 	if(isturf(location))
-		M = new new_type(location, subspecies)
+		M = new new_type(location, new_species = subspecies)
 	else
-		M = new new_type(src.loc, subspecies)
+		M = new new_type(src.loc, new_species = subspecies)
 
 	if(!M || !ismob(M))
 		to_chat(usr, "Type path is not a mob (new_type = [new_type]) in change_mob_type(). Contact a coder.")


### PR DESCRIPTION
Теперь плеер панель будет правильно выставлять species у мобов, таяры будут спавниться со спрайтом таяр, а не людей, а дион теперь в принципе будет возможно заспавнить, ведь до этого просто вылезала ошибка "This can only be used on instances of type /mob"

<details>
<summary>Чейнджлог</summary>

```yml
🆑
admin: Теперь Player Panel корректно спавнит Таяр и Дион
/🆑
```

</details>

- [x] Pull Request полностью завершен, мне не нужна помощь чтобы его закончить.
- [x] Я внимательно прочитал(-а) все свои изменения и багов в них не нашёл(-ла).
- [x] Я запускал(-а) сервер со своими изменениями локально и все протестировал(-а).
- [x] Я ознакомился(-ась) c [Guide to Contribute](https://github.com/ChaoticOnyx/OnyxBay/blob/dev/docs/contributing.md).
