### PR TITLE
Removes lack of performance, adds performance

### DIFF
--- a/code/controllers/master.dm
+++ b/code/controllers/master.dm
@@ -178,7 +178,8 @@ GLOBAL_REAL(Master, /datum/controller/master) = new
 	// Initialize subsystems.
 	current_ticklimit = config.general.tick_limit_mc_init
 	for (var/datum/controller/subsystem/SS in subsystems)
-		if (SS.flags & SS_NO_INIT)
+		if(SS.flags & SS_NO_INIT)
+			SS.initialized = TRUE // set initialized to TRUE, because the value of initialized may still be checked on SS_NO_INIT subsystems as an "is this ready" check
 			continue
 		SS.Initialize(REALTIMEOFDAY)
 		CHECK_TICK

--- a/code/game/area/areas.dm
+++ b/code/game/area/areas.dm
@@ -259,6 +259,8 @@ var/list/mob/living/forced_ambiance_list = new
 	play_ambience(L)
 
 /area/proc/play_ambience(mob/living/L, custom_period = 1 MINUTES)
+	set waitfor = FALSE
+
 	if(!L.client) //Why play the ambient without a client?
 		return
 	// Ambience goes down here -- make sure to list each area seperately for ease of adding things in later, thanks! Note: areas adjacent to each other should have the same sounds to prevent cutoff when possible.- LastyScratch

--- a/code/game/machinery/doors/airlock.dm
+++ b/code/game/machinery/doors/airlock.dm
@@ -264,8 +264,8 @@ About the new airlock wires panel:
 	. = ..()
 	if(.)
 		hasShocked = 1
-		sleep(10)
-		hasShocked = 0
+		spawn(1 SECOND)
+			hasShocked = 0
 
 /obj/machinery/door/airlock/on_update_icon(keep_light = 0)
 	if(!keep_light)


### PR DESCRIPTION
- помечаем контроллеры с SS_NO_INIT как инициализированные, а то когда-нибудь за жопу укусит
- /area/proc/play_ambience() дорогой шо пиздец и вызывается в лайфе хуманов, спасибо но ждать его больше не будем
- /obj/machinery/door/airlock/shock() тоже может вызваться в лайфе мобов, а там слип торчал

---

- [x] Pull Request полностью завершен, мне не нужна помощь чтобы его закончить.
- [x] Я внимательно прочитал(-а) все свои изменения и багов в них не нашёл(-ла).
- [x] Я запускал(-а) сервер со своими изменениями локально и все протестировал(-а).
- [x] Я ознакомился(-ась) c [Guide to Contribute](https://github.com/ChaoticOnyx/OnyxBay/blob/dev/docs/contributing.md).
