### PR TITLE
feat(soul): add more BoH interactions & add SM consume sounds

### DIFF
--- a/baystation12.dme
+++ b/baystation12.dme
@@ -3006,6 +3006,7 @@
 #include "code\modules\splash_text\splash_text.dm"
 #include "code\modules\supermatter\setup_supermatter.dm"
 #include "code\modules\supermatter\supermatter.dm"
+#include "code\modules\supermatter\supermatter_act.dm"
 #include "code\modules\synthesized_instruments\echo_editor.dm"
 #include "code\modules\synthesized_instruments\env_editor.dm"
 #include "code\modules\synthesized_instruments\event_manager.dm"

--- a/code/__defines/sound.dm
+++ b/code/__defines/sound.dm
@@ -352,6 +352,7 @@
 #define SFX_THUNDER                 "thunder"
 #define SFX_SHOE_COVERS             "shoe_covers"
 #define SFX_GLASSES_CLINK           "glasses_clink"
+#define SFX_SUPERMATTER             "supermatter"
 
 // FOOTSTEPS
 #define SFX_DISTANT_MOVEMENT        "distant_movement"

--- a/code/_global_vars/sfx.dm
+++ b/code/_global_vars/sfx.dm
@@ -1688,6 +1688,9 @@ GLOBAL_LIST_INIT(sfx_list, list(
 	SFX_GLASSES_CLINK = list(
 		'sound/items/glasses_clink.ogg'
 	),
+	SFX_SUPERMATTER = list(
+		'sound/effects/supermatter.ogg',
+	),
 	// DEVICES
 	SFX_GEIGER_LOW = list(
 		'sound/effects/geiger/geiger_low_1.ogg',

--- a/code/modules/supermatter/supermatter.dm
+++ b/code/modules/supermatter/supermatter.dm
@@ -493,6 +493,10 @@
 
 	user.rad_act(new /datum/radiation_source(new /datum/radiation/preset/supermatter(4), src))
 
+/obj/machinery/power/supermatter/supermatter_act()
+	qdel_self()
+	return TRUE
+
 /obj/machinery/power/supermatter/throw_impact(atom/hit_atom, speed, target_zone)
 	. = ..()
 	if (hit_atom.density)
@@ -506,23 +510,26 @@
 		AM.visible_message("<span class=\"warning\">\The [AM] slams into \the [src] inducing a resonance... \his body starts to glow and catch flame before flashing into ash.</span>",\
 		"<span class=\"danger\">You slam into \the [src] as your ears are filled with unearthly ringing. Your last thought is \"Oh, fuck.\"</span>",\
 		"<span class=\"warning\">You hear an uneartly ringing, then what sounds like a shrilling kettle as you are washed with a wave of heat.</span>")
+	else if(!grav_pulling) //To prevent spam, detonating supermatter does not indicate non-mobs being destroyed
+		AM.visible_message("<span class=\"warning\">\The [AM] smacks into \the [src] and rapidly flashes to ash.</span>",\
+		"<span class=\"warning\">You hear a loud crack as you are washed with a wave of heat.</span>")
 
-	Consume(AM, silent = isliving(AM))
+	Consume(AM)
 
 #define SUPERMATTER_MIN_THROW_DIST 1
 #define SUPERMATTER_MAX_THROW_DIST 3
 
 /obj/machinery/power/supermatter/proc/Consume(atom/victim, silent = FALSE)
 	if (istype(victim, /obj/machinery/power/supermatter))
-		var/atom/movable/movable_victim = victim
-		movable_victim.throw_at(get_edge_target_turf(movable_victim, get_dir(src, movable_victim)), rand(SUPERMATTER_MIN_THROW_DIST, SUPERMATTER_MAX_THROW_DIST), 1)
-		movable_victim.visible_message(SPAN_WARNING("\The [movable_victim] briefly lights up and instantly starts flying in the opposite direction."))
+		var/obj/machinery/power/supermatter/supermatter_victim = victim
+		if (config.misc.meme_content)
+			supermatter_victim.throw_at(get_edge_target_turf(supermatter_victim, get_dir(src, supermatter_victim)), rand(SUPERMATTER_MIN_THROW_DIST, SUPERMATTER_MAX_THROW_DIST), 1)
+			supermatter_victim.visible_message(SPAN_WARNING("\The [supermatter_victim] briefly lights up and instantly starts flying in the opposite direction."))
+		else
+			power += supermatter_victim.power
+
+	if (!victim.supermatter_act())
 		return
-
-	if (!grav_pulling && !silent) // To prevent spam, detonating supermatter does not indicate non-mobs being destroyed.
-		victim.visible_message(SPAN_WARNING("\The [victim] comes into contact with \the [src] and rapidly flashes to ash."))
-
-	victim.supermatter_act()
 
 	if (ismob(victim))
 		power += 400

--- a/code/modules/supermatter/supermatter.dm
+++ b/code/modules/supermatter/supermatter.dm
@@ -519,7 +519,7 @@
 #define SUPERMATTER_MIN_THROW_DIST 1
 #define SUPERMATTER_MAX_THROW_DIST 3
 
-/obj/machinery/power/supermatter/proc/Consume(atom/victim, silent = FALSE)
+/obj/machinery/power/supermatter/proc/Consume(atom/victim)
 	if (istype(victim, /obj/machinery/power/supermatter))
 		var/obj/machinery/power/supermatter/supermatter_victim = victim
 		if (config.misc.meme_content)

--- a/code/modules/supermatter/supermatter_act.dm
+++ b/code/modules/supermatter/supermatter_act.dm
@@ -1,14 +1,17 @@
 /atom/proc/supermatter_act()
 	CAN_BE_REDEFINED(TRUE)
-	return
+	return FALSE
 
 /mob/supermatter_act()
 	dust()
+	return TRUE
 
 /obj/supermatter_act()
 	new /obj/effect/decal/cleanable/ash(loc)
 	qdel_self()
+	return TRUE
 
 /turf/simulated/wall/supermatter_act()
 	new /obj/effect/decal/cleanable/ash(src)
 	dismantle_wall(no_product = TRUE)
+	return TRUE

--- a/code/modules/supermatter/supermatter_act.dm
+++ b/code/modules/supermatter/supermatter_act.dm
@@ -1,0 +1,14 @@
+/atom/proc/supermatter_act()
+	CAN_BE_REDEFINED(TRUE)
+	return
+
+/mob/supermatter_act()
+	dust()
+
+/obj/supermatter_act()
+	new /obj/effect/decal/cleanable/ash(loc)
+	qdel_self()
+
+/turf/simulated/wall/supermatter_act()
+	new /obj/effect/decal/cleanable/ash(src)
+	dismantle_wall(no_product = TRUE)


### PR DESCRIPTION
Очередной тейк на тему нескучных суперматерий и мемов в игре.

<details>
<summary>Чейнджлог</summary>

```yml
🆑
tweak: Изменено поведение суперматерии при поглощении другой суперематерии, поведение определеятся настройкой мемов вконфиге.
soundadd: Добавлены новые звуки при уничтожении чего-либо суперматерией. 
rscadd: Добавлены новые исходы при попытке убрать блюспейс сумку внутрь блюспейс сумки, при включенных мемах в конфиге снова появилась возможность создать сингулярность.
/🆑
```

</details>

- [x] Pull Request полностью завершен, мне не нужна помощь чтобы его закончить.
- [x] Я внимательно прочитал(-а) все свои изменения и багов в них не нашёл(-ла).
- [x] Я запускал(-а) сервер со своими изменениями локально и все протестировал(-а).
- [x] Я ознакомился(-ась) c [Guide to Contribute](https://github.com/ChaoticOnyx/OnyxBay/blob/dev/docs/contributing.md).
