### PR TITLE
tweaks(hud, tajaran species): flash vulnerability for NVGs and intense HUD vulnerability for tajaran

### DIFF
--- a/code/modules/clothing/glasses/hud.dm
+++ b/code/modules/clothing/glasses/hud.dm
@@ -102,6 +102,7 @@
 	matrix_icon = "night"
 	darkness_view = 7
 	see_invisible = SEE_INVISIBLE_NOLIGHTING
+	flash_protection = FLASH_PROTECTION_REDUCED
 	origin_tech = list(TECH_MAGNET = 2)
 
 /obj/item/device/hudmatrix/night/Initialize()

--- a/code/modules/mob/living/carbon/human/species/station/station.dm
+++ b/code/modules/mob/living/carbon/human/species/station/station.dm
@@ -165,6 +165,15 @@
 		return tail_slim
 	return ..()
 
+/datum/species/tajaran/handle_vision(mob/living/carbon/human/H)
+	..()
+	if(H.eyecheck() < FLASH_PROTECTION_NONE && !H.eye_blind)
+		var/obj/item/organ/internal/eyes/E = H.internal_organs_by_name[BP_EYES]
+		E.damage += 1
+		if(prob(40))
+			H.flash_eyes()
+			to_chat(H, SPAN_DANGER("Your eyes hurt from the intensified light!"))
+
 /datum/species/skrell
 	name = SPECIES_SKRELL
 	name_plural = SPECIES_SKRELL


### PR DESCRIPTION
- ПНВ теперь повышает уязвимость к флешкам у носителя.
- Таяры теперь имеют уязвимость к термал-очкам и ПНВ. При ношении таярой этих ХУДов она будет получать урон по глазам с шансом на вспышку (ослепление от усиленного света).
- - Примечание: технически, это происходит, когда у персонажа понижена защита от вспышек -- но снизить её может только ношение термалов или ПНВ.

<details>
<summary>Чейнджлог</summary>

```yml
🆑TheUnknownOne
tweak: При ношении ПНВ вы теперь будете более уязвимы к вспышкам.
/🆑
```

</details>

- [x] Pull Request полностью завершен, мне не нужна помощь чтобы его закончить.
- [x] Я внимательно прочитал(-а) все свои изменения и багов в них не нашёл(-ла).
- [x] Я запускал(-а) сервер со своими изменениями локально и все протестировал(-а).
- [x] Я ознакомился(-ась) c [Guide to Contribute](https://github.com/ChaoticOnyx/OnyxBay/blob/dev/docs/contributing.md).
