### PR TITLE
feat(sound player): non-spatial sounds

### DIFF
--- a/code/datums/sound_player.dm
+++ b/code/datums/sound_player.dm
@@ -21,11 +21,11 @@ GLOBAL_DATUM_INIT(sound_player, /decl/sound_player, new)
 
 
 //This can be called if either we're doing whole sound setup ourselves or it will be as part of from-file sound setup
-/decl/sound_player/proc/PlaySoundDatum(atom/source, sound_id, sound/sound, range, prefer_mute, datum/client_preference/preference, streaming, is_3d)
+/decl/sound_player/proc/PlaySoundDatum(atom/source, sound_id, sound/sound, range, prefer_mute, datum/client_preference/preference, streaming, is_spatial = TRUE)
 	var/token_type = isnum(sound.environment) ? /datum/sound_token : /datum/sound_token/static_environment
-	return new token_type(source, sound_id, sound, range, prefer_mute, preference, streaming, is_3d)
+	return new token_type(source, sound_id, sound, range, prefer_mute, preference, streaming, is_spatial)
 
-/decl/sound_player/proc/PlayLoopingSound(atom/source, sound_id, sound, volume, range, falloff = 1, echo, frequency, prefer_mute, datum/client_preference/preference, streaming, is_3d)
+/decl/sound_player/proc/PlayLoopingSound(atom/source, sound_id, sound, volume, range, falloff = 1, echo, frequency, prefer_mute, datum/client_preference/preference, streaming, is_spatial = TRUE)
 	var/sound/S = istype(sound, /sound) ? sound : new(sound)
 	S.environment = 0 // Ensures a 3D effect even if x/y offset happens to be 0 the first time it's played
 	S.volume  = volume
@@ -34,7 +34,7 @@ GLOBAL_DATUM_INIT(sound_player, /decl/sound_player, new)
 	S.frequency = frequency
 	S.repeat = TRUE
 
-	return PlaySoundDatum(source, sound_id, S, range, prefer_mute, preference, streaming, is_3d)
+	return PlaySoundDatum(source, sound_id, S, range, prefer_mute, preference, streaming, is_spatial)
 
 /decl/sound_player/proc/PrivStopSound(datum/sound_token/sound_token)
 	var/channel = sound_token.sound.channel
@@ -80,13 +80,13 @@ GLOBAL_DATUM_INIT(sound_player, /decl/sound_player, new)
 	var/sound_id       // The associated sound id, used for cleanup
 	var/status = 0     // Paused, muted, running? Global for all listeners
 	var/listener_status// Paused, muted, running? Specific for the given listener.
-	var/is_3d = TRUE
+	var/is_spatial = TRUE
 	var/const/SOUND_STOPPED = 0x8000
 	var/datum/client_preference/preference
 	var/datum/proximity_trigger/square/proxy_listener
 	var/list/can_be_heard_from
 
-/datum/sound_token/New(atom/source, sound_id, sound/sound, range = 4, prefer_mute = FALSE, datum/client_preference/preference, streaming, is_3d)
+/datum/sound_token/New(atom/source, sound_id, sound/sound, range = 4, prefer_mute = FALSE, datum/client_preference/preference, streaming, is_spatial = TRUE)
 	..()
 	if(!istype(source))
 		CRASH("Invalid sound source: [log_info_line(source)]")
@@ -103,7 +103,7 @@ GLOBAL_DATUM_INIT(sound_player, /decl/sound_player, new)
 	src.sound       = sound
 	src.sound_id    = sound_id
 	src.preference  = preference
-	src.is_3d       = is_3d
+	src.is_spatial       = is_spatial
 
 	if(streaming) // Streams music
 		src.status |= SOUND_STREAM
@@ -237,7 +237,7 @@ GLOBAL_DATUM_INIT(sound_player, /decl/sound_player, new)
 	else if(prefer_mute)
 		listener_status[listener] &= ~SOUND_MUTE
 
-	if(is_3d)
+	if(is_spatial)
 		sound.x = source_turf.x - listener_turf.x
 		sound.z = source_turf.y - listener_turf.y
 		sound.y = 1

--- a/code/datums/sound_player.dm
+++ b/code/datums/sound_player.dm
@@ -21,11 +21,11 @@ GLOBAL_DATUM_INIT(sound_player, /decl/sound_player, new)
 
 
 //This can be called if either we're doing whole sound setup ourselves or it will be as part of from-file sound setup
-/decl/sound_player/proc/PlaySoundDatum(atom/source, sound_id, sound/sound, range, prefer_mute, datum/client_preference/preference, streaming)
+/decl/sound_player/proc/PlaySoundDatum(atom/source, sound_id, sound/sound, range, prefer_mute, datum/client_preference/preference, streaming, is_3d)
 	var/token_type = isnum(sound.environment) ? /datum/sound_token : /datum/sound_token/static_environment
-	return new token_type(source, sound_id, sound, range, prefer_mute, preference, streaming)
+	return new token_type(source, sound_id, sound, range, prefer_mute, preference, streaming, is_3d)
 
-/decl/sound_player/proc/PlayLoopingSound(atom/source, sound_id, sound, volume, range, falloff = 1, echo, frequency, prefer_mute, datum/client_preference/preference, streaming)
+/decl/sound_player/proc/PlayLoopingSound(atom/source, sound_id, sound, volume, range, falloff = 1, echo, frequency, prefer_mute, datum/client_preference/preference, streaming, is_3d)
 	var/sound/S = istype(sound, /sound) ? sound : new(sound)
 	S.environment = 0 // Ensures a 3D effect even if x/y offset happens to be 0 the first time it's played
 	S.volume  = volume
@@ -34,7 +34,7 @@ GLOBAL_DATUM_INIT(sound_player, /decl/sound_player, new)
 	S.frequency = frequency
 	S.repeat = TRUE
 
-	return PlaySoundDatum(source, sound_id, S, range, prefer_mute, preference, streaming)
+	return PlaySoundDatum(source, sound_id, S, range, prefer_mute, preference, streaming, is_3d)
 
 /decl/sound_player/proc/PrivStopSound(datum/sound_token/sound_token)
 	var/channel = sound_token.sound.channel
@@ -80,12 +80,13 @@ GLOBAL_DATUM_INIT(sound_player, /decl/sound_player, new)
 	var/sound_id       // The associated sound id, used for cleanup
 	var/status = 0     // Paused, muted, running? Global for all listeners
 	var/listener_status// Paused, muted, running? Specific for the given listener.
+	var/is_3d = TRUE
 	var/const/SOUND_STOPPED = 0x8000
 	var/datum/client_preference/preference
 	var/datum/proximity_trigger/square/proxy_listener
 	var/list/can_be_heard_from
 
-/datum/sound_token/New(atom/source, sound_id, sound/sound, range = 4, prefer_mute = FALSE, datum/client_preference/preference, streaming)
+/datum/sound_token/New(atom/source, sound_id, sound/sound, range = 4, prefer_mute = FALSE, datum/client_preference/preference, streaming, is_3d)
 	..()
 	if(!istype(source))
 		CRASH("Invalid sound source: [log_info_line(source)]")
@@ -102,6 +103,7 @@ GLOBAL_DATUM_INIT(sound_player, /decl/sound_player, new)
 	src.sound       = sound
 	src.sound_id    = sound_id
 	src.preference  = preference
+	src.is_3d       = is_3d
 
 	if(streaming) // Streams music
 		src.status |= SOUND_STREAM
@@ -235,9 +237,15 @@ GLOBAL_DATUM_INIT(sound_player, /decl/sound_player, new)
 	else if(prefer_mute)
 		listener_status[listener] &= ~SOUND_MUTE
 
-	sound.x = source_turf.x - listener_turf.x
-	sound.z = source_turf.y - listener_turf.y
-	sound.y = 1
+	if(is_3d)
+		sound.x = source_turf.x - listener_turf.x
+		sound.z = source_turf.y - listener_turf.y
+		sound.y = 1
+	else
+		sound.x = 0
+		sound.z = 0
+		sound.y = 0
+
 	// Far as I can tell from testing, sound priority just doesn't work.
 	// Sounds happily steal channels from each other no matter what.
 	sound.priority = Clamp(255 - distance, 0, 255)

--- a/code/game/machinery/jukebox.dm
+++ b/code/game/machinery/jukebox.dm
@@ -253,7 +253,7 @@
 	if(!spamcheck && prob(RICKROLL_PROBABILITY))
 		lock_rickroll()
 	// Jukeboxes cheat massively and actually don't share id. This is only done because it's music rather than ambient noise.
-	sound_token = GLOB.sound_player.PlayLoopingSound(src, sound_id, current_track.GetTrack(), volume = volume, range = 7, falloff = 3, prefer_mute = TRUE, preference = /datum/client_preference/play_jukeboxes, streaming = TRUE, is_3d = FALSE)
+	sound_token = GLOB.sound_player.PlayLoopingSound(src, sound_id, current_track.GetTrack(), volume = volume, range = 7, falloff = 3, prefer_mute = TRUE, preference = /datum/client_preference/play_jukeboxes, streaming = TRUE, is_spatial = FALSE)
 
 	playing = 1
 	update_use_power(POWER_USE_ACTIVE)

--- a/code/game/machinery/jukebox.dm
+++ b/code/game/machinery/jukebox.dm
@@ -253,7 +253,7 @@
 	if(!spamcheck && prob(RICKROLL_PROBABILITY))
 		lock_rickroll()
 	// Jukeboxes cheat massively and actually don't share id. This is only done because it's music rather than ambient noise.
-	sound_token = GLOB.sound_player.PlayLoopingSound(src, sound_id, current_track.GetTrack(), volume = volume, range = 7, falloff = 3, prefer_mute = TRUE, preference = /datum/client_preference/play_jukeboxes, streaming = TRUE)
+	sound_token = GLOB.sound_player.PlayLoopingSound(src, sound_id, current_track.GetTrack(), volume = volume, range = 7, falloff = 3, prefer_mute = TRUE, preference = /datum/client_preference/play_jukeboxes, streaming = TRUE, is_3d = FALSE)
 
 	playing = 1
 	update_use_power(POWER_USE_ACTIVE)


### PR DESCRIPTION
- Возможность проигрывать не трёхмерные звуки добавлена в `sound_player`.
- Музыка, играющая из джукбокса, теперь не трёхмерный звук.

<details>
<summary>Чейнджлог</summary>

```yml
🆑TheUnknownOne
tweak: Проигрываемая джукбоксом музыка теперь не трёхмерный звук: она не будет сдвигаться при вашем перемещении относительно джукбокса, а всегда будет играть, как эмбиент.
/🆑
```

</details>

- [x] Pull Request полностью завершен, мне не нужна помощь чтобы его закончить.
- [x] Я внимательно прочитал(-а) все свои изменения и багов в них не нашёл(-ла).
- [x] Я запускал(-а) сервер со своими изменениями локально и все протестировал(-а).
- [x] Я ознакомился(-ась) c [Guide to Contribute](https://github.com/ChaoticOnyx/OnyxBay/blob/dev/docs/contributing.md).
