### PR TITLE
tweak(human life): tweak freezing overlay mechanic

### DIFF
--- a/code/modules/mob/living/carbon/human/life.dm
+++ b/code/modules/mob/living/carbon/human/life.dm
@@ -940,19 +940,17 @@
 
 					if(bodytemperature <= getSpeciesOrSynthTemp(COLD_LEVEL_1))
 						bodytemp.icon_state = "temp-4"
-						overlay_fullscreen("temperature", /atom/movable/screen/fullscreen/frost, 4)
-					else if(bodytemperature <= base_temperature - temp_step*3)
+						overlay_fullscreen("temperature", /atom/movable/screen/fullscreen/frost, min(ceil((getSpeciesOrSynthTemp(COLD_LEVEL_1) - bodytemperature) / 5), 4))
+						return 1
+					if(bodytemperature <= base_temperature - temp_step*3)
 						bodytemp.icon_state = "temp-3"
-						overlay_fullscreen("temperature", /atom/movable/screen/fullscreen/frost, 3)
 					else if(bodytemperature <= base_temperature - temp_step*2)
 						bodytemp.icon_state = "temp-2"
-						overlay_fullscreen("temperature", /atom/movable/screen/fullscreen/frost, 2)
 					else if(bodytemperature <= base_temperature - temp_step*1)
 						bodytemp.icon_state = "temp-1"
-						overlay_fullscreen("temperature", /atom/movable/screen/fullscreen/frost, 1)
 					else
 						bodytemp.icon_state = "temp0"
-						clear_fullscreen("temperature")
+					clear_fullscreen("temperature")
 	return 1
 
 /mob/living/carbon/human/handle_hud_icons_health()

--- a/code/modules/mob/living/carbon/human/life.dm
+++ b/code/modules/mob/living/carbon/human/life.dm
@@ -941,16 +941,18 @@
 					if(bodytemperature <= getSpeciesOrSynthTemp(COLD_LEVEL_1))
 						bodytemp.icon_state = "temp-4"
 						overlay_fullscreen("temperature", /atom/movable/screen/fullscreen/frost, min(ceil((getSpeciesOrSynthTemp(COLD_LEVEL_1) - bodytemperature) / 5), 4))
-						return 1
-					if(bodytemperature <= base_temperature - temp_step*3)
+					else if(bodytemperature <= base_temperature - temp_step*3)
 						bodytemp.icon_state = "temp-3"
+						clear_fullscreen("temperature")
 					else if(bodytemperature <= base_temperature - temp_step*2)
 						bodytemp.icon_state = "temp-2"
+						clear_fullscreen("temperature")
 					else if(bodytemperature <= base_temperature - temp_step*1)
 						bodytemp.icon_state = "temp-1"
+						clear_fullscreen("temperature")
 					else
 						bodytemp.icon_state = "temp0"
-					clear_fullscreen("temperature")
+						clear_fullscreen("temperature")
 	return 1
 
 /mob/living/carbon/human/handle_hud_icons_health()


### PR DESCRIPTION
- Поскольку оверлей замерзания плохо работал для скреллов с их чувствительностью к температуре, его механика была переработана.
- Теперь оверлей появляется только при понижении температуры ниже минимальной комфортной для данной расы, и становится отчётливее каждые 5 градусов ниже комфортного значения. Максимальная отчётливость достигается на -20 градусах от комфортного значения.

fix #13218

<details>
<summary>Чейнджлог</summary>

```yml
🆑
bugfix: Скреллы больше не страдают перманентно от оверлея замерзания.
tweak: Оверлей замерзания теперь будет появляться только при понижении температуры ниже минимального комфортного её значения для вашей расы.
/🆑
```

</details>

- [x] Pull Request полностью завершен, мне не нужна помощь чтобы его закончить.
- [x] Я внимательно прочитал(-а) все свои изменения и багов в них не нашёл(-ла).
- [x] Я запускал(-а) сервер со своими изменениями локально и все протестировал(-а).
- [x] Я ознакомился(-ась) c [Guide to Contribute](https://github.com/ChaoticOnyx/OnyxBay/blob/dev/docs/contributing.md).
