### PR TITLE
tweak(human life, skrell species): sane cold-blooded & skrell temperatures

### DIFF
--- a/code/modules/mob/living/carbon/human/life.dm
+++ b/code/modules/mob/living/carbon/human/life.dm
@@ -918,7 +918,7 @@
 				//TODO: precalculate all of this stuff when the species datum is created
 				var/base_temperature = species.body_temperature
 				if(base_temperature == null) //some species don't have a set metabolic temperature
-					base_temperature = (getSpeciesOrSynthTemp(HEAT_LEVEL_1) + getSpeciesOrSynthTemp(COLD_LEVEL_1))/2
+					base_temperature = (species.cold_discomfort_level + species.heat_discomfort_level)/2
 
 				var/temp_step
 				if(bodytemperature >= base_temperature)

--- a/code/modules/mob/living/carbon/human/species/station/station.dm
+++ b/code/modules/mob/living/carbon/human/species/station/station.dm
@@ -225,7 +225,7 @@
 	default_eye_color = "#ffffff"
 	organs_icon = 'icons/mob/human_races/organs/skrell.dmi'
 
-	cold_level_1 = 280 //Default 260 - Lower is better
+	cold_level_1 = 260 //Default 260 - Lower is better
 	cold_level_2 = 220 //Default 200
 	cold_level_3 = 130 //Default 120
 
@@ -233,8 +233,8 @@
 	heat_level_2 = 650 //Default 500
 	heat_level_3 = 1100 //Default 1000
 
-	cold_discomfort_level = 295 //16.85C, not more because they will have a constant messages
-	heat_discomfort_level = 375 //101.85C
+	cold_discomfort_level = 290 //16.85C, not more because they will have a constant messages
+	heat_discomfort_level = 315 //41.85C
 
 	reagent_tag = IS_SKRELL
 


### PR DESCRIPTION
- Изменён рассчёт `base_temperature` для хладнокровных (`base_temperature = null`) рас. Теперь это среднее арифметическое `cold_discomfort_level` и `heat_discomfort_level`.
- Изменены значения комфортных температур у скреллов:
- - Минимальная комфортная температура: **295 K -> 290 K** (кто-то десять лет назад обсчитался при переводе из цельсия в кельвины)
- - Максимальная комфортная температура: **375 K -> 315 K**
- - Первый порог замерзания `cold_level_1`: **280 K -> 260 K**
- - Всё это сделано для того, чтобы скреллы при комнатной температуре не имели постоянный эффект холода и, как следствие, постоянный оверлей на экране. Поскольку скреллы хладнокровные, куртки им не помогали.

fix https://github.com/ChaoticOnyx/OnyxBay/issues/13218

<details>
<summary>Чейнджлог</summary>

```yml
🆑
tweak: Скреллы больше не будут постоянно мёрзнуть при комнатной температуре (293,15 K или 20 C), но всё ещё чувствительнее людей к низким температурам, а также стали немного более чувствительными к теплу.
/🆑
```

</details>

- [x] Pull Request полностью завершен, мне не нужна помощь чтобы его закончить.
- [x] Я внимательно прочитал(-а) все свои изменения и багов в них не нашёл(-ла).
- [x] Я запускал(-а) сервер со своими изменениями локально и все протестировал(-а).
- [x] Я ознакомился(-ась) c [Guide to Contribute](https://github.com/ChaoticOnyx/OnyxBay/blob/dev/docs/contributing.md).
