### PR TITLE
feat(admin): staff notices for deaths and players joining

### DIFF
--- a/code/modules/client/client_procs.dm
+++ b/code/modules/client/client_procs.dm
@@ -218,6 +218,9 @@
 	// Load EAMS data
 	SSeams.CollectDataForClient(src)
 
+	var/age = isnum(player_age) ? player_age : 0
+	message_staff("[src] ([age < 10 ? "<font color='#ff0000'>[age]</font>" : age]) has connected.")
+
 	setup_preferences()
 	view_size = new(src, get_screen_size(TRUE))
 

--- a/code/modules/mob/death.dm
+++ b/code/modules/mob/death.dm
@@ -90,11 +90,10 @@
 		SSticker.mode.check_win()
 	to_chat(src, SPAN_DEADSAY("[show_dead_message]"))
 
-	if(!client)
-		return TRUE
+	if(client)
+		var/turf/death_turf = get_turf(src)
+		var/death_turf_descriptor = "[death_turf.loc] \[[death_turf.x],[death_turf.y],[death_turf.z]\]"
+		log_and_message_staff("has died in [death_turf_descriptor]", src, death_turf)
 
-	var/turf/death_turf = get_turf(src)
-	var/death_turf_descriptor = "[death_turf.loc] \[[death_turf.x],[death_turf.y],[death_turf.z]\]"
-	log_and_message_staff("has died in [death_turf_descriptor]", src, death_turf)
 	return TRUE
 

--- a/code/modules/mob/death.dm
+++ b/code/modules/mob/death.dm
@@ -55,7 +55,7 @@
 /mob/proc/death(gibbed, deathmessage = "seizes up and falls limp...", show_dead_message = "You have died.")
 
 	if(is_ooc_dead())
-		return 0
+		return FALSE
 
 	facing_dir = null
 
@@ -88,5 +88,13 @@
 
 	if(SSticker.mode)
 		SSticker.mode.check_win()
-	to_chat(src,"<span class='deadsay'>[show_dead_message]</span>")
-	return 1
+	to_chat(src, SPAN_DEADSAY("[show_dead_message]"))
+
+	if(!client)
+		return TRUE
+
+	var/turf/death_turf = get_turf(src)
+	var/death_turf_descriptor = "[death_turf.loc] \[[death_turf.x],[death_turf.y],[death_turf.z]\]"
+	log_and_message_staff("has died in [death_turf_descriptor]", src, death_turf)
+	return TRUE
+


### PR DESCRIPTION
- Педали теперь получают сообщение при смерти моба с клиентом (то есть, если за него играет или играл игрок). Смерть таких мобов также логируется с точными его координатами в этот момент.
- Педали будут получать сообщение при заходе игрока на сервер с указанием возраста его аккаунта (прошедших дней с даты первого захода на сервер).
- - Если возраст аккаунта меньше 10, то он выделяется красным цветом.
- - Если БД не работает (`player_age` не число), то в этом оповещении будет всегда показываться нулевой возраст.

<img width="426" height="34" alt="image" src="https://github.com/user-attachments/assets/e1c7843b-ce3d-46a6-8b76-e092dbad5fb8" />

<img width="853" height="106" alt="image" src="https://github.com/user-attachments/assets/8a7e9326-f483-4782-a4b9-1027aee5c26c" />

- [x] Pull Request полностью завершен, мне не нужна помощь чтобы его закончить.
- [x] Я внимательно прочитал(-а) все свои изменения и багов в них не нашёл(-ла).
- [x] Я запускал(-а) сервер со своими изменениями локально и все протестировал(-а).
- [x] Я ознакомился(-ась) c [Guide to Contribute](https://github.com/ChaoticOnyx/OnyxBay/blob/dev/docs/contributing.md).
