### PR TITLE
tweak(ce rig): add heat protection to CE's rig

### DIFF
--- a/code/modules/clothing/spacesuits/rig/suits/station.dm
+++ b/code/modules/clothing/spacesuits/rig/suits/station.dm
@@ -135,6 +135,7 @@
 	desc = "An advanced powersuit that protects against hazardous, low pressure environments. Shines with a high polish. Appears compatible with the physiology of most species."
 	icon_state = "ce_rig"
 	armor = list(melee = 80, bullet = 70, laser = 60, energy = 65, bomb = 45, bio = 100)
+	max_heat_protection_temperature = FIRESUIT_MAX_HEAT_PROTECTION_TEMPERATURE
 	online_slowdown = 0
 	offline_slowdown = 0
 	offline_vision_restriction = TINT_HEAVY


### PR DESCRIPTION
- РИГу СЕ добавлена защита от высоких температур, как у атмосферного скафандра. При горении человек в РИГе теперь не будет получать урон.

fix #1701 

<details>
<summary>Чейнджлог</summary>

```yml
🆑TheUnknownOne
tweak: РИГ СЕ теперь снова защищает от высоких температур и огня.
/🆑
```

</details>

- [x] Pull Request полностью завершен, мне не нужна помощь чтобы его закончить.
- [x] Я внимательно прочитал(-а) все свои изменения и багов в них не нашёл(-ла).
- [x] Я запускал(-а) сервер со своими изменениями локально и все протестировал(-а).
- [x] Я ознакомился(-ась) c [Guide to Contribute](https://github.com/ChaoticOnyx/OnyxBay/blob/dev/docs/contributing.md).
