### PR TITLE
Removes lack of dynamic climbing

### DIFF
--- a/code/game/atoms.dm
+++ b/code/game/atoms.dm
@@ -585,14 +585,14 @@ its easier to just keep the beam vertical.
 			return A
 	return 0
 
-/atom/proc/do_climb(mob/living/user)
+/atom/proc/do_climb(mob/living/user, climb_time = 2 SECONDS)
 	if(!can_climb(user))
 		return
 
 	user.visible_message(SPAN_WARNING("\The [user] starts climbing onto \the [src]!"))
 	LAZYDISTINCTADD(climbers, user)
 
-	if(!do_after(user,(issmall(user) ? 30 : 50), src))
+	if(!do_after(user,(user.get_climb_speed() * climb_time), src))
 		LAZYREMOVE(climbers, user)
 		return
 

--- a/code/game/objects/objs.dm
+++ b/code/game/objects/objs.dm
@@ -20,6 +20,7 @@
 	var/rad_resist_type = /datum/rad_resist/none
 	hitby_sound = 'sound/effects/metalhit2.ogg'
 	var/turf_height_offset = 0
+	var/climb_delay = 2 SECONDS // Default for everything. Doesn't make the thing climbable on its own, it still requires ATOM_FLAG_CLIMBABLE.
 
 /obj/Initialize()
 	. = ..()
@@ -232,3 +233,6 @@
 	pull_slowdown = new_slowdown
 	if(pulledby)
 		pulledby.update_pull_slowdown()
+
+/obj/do_climb(mob/living/user)
+	return ..(user, climb_delay)

--- a/code/game/objects/structures/barricade/material.dm
+++ b/code/game/objects/structures/barricade/material.dm
@@ -7,6 +7,7 @@
 
 	atom_flags = ATOM_FLAG_CLIMBABLE
 	turf_height_offset = 3 // It looks so shitty I dunno what offset to use. 3 will go for now I guess. ~ TobyThorne
+	climb_delay = 5 SECONDS // Matching the old delay. RIP fatties.
 
 	/// Reference to a material datum this object was made from.
 	var/material/material

--- a/code/game/objects/structures/crates_lockers/largecrate.dm
+++ b/code/game/objects/structures/crates_lockers/largecrate.dm
@@ -7,6 +7,7 @@
 	atom_flags = ATOM_FLAG_CLIMBABLE
 	pull_slowdown = PULL_SLOWDOWN_HEAVY
 	turf_height_offset = 22
+	climb_delay = 4 SECONDS // It's tall AF.
 
 /obj/structure/largecrate/Initialize()
 	. = ..()

--- a/code/game/objects/structures/geltanks.dm
+++ b/code/game/objects/structures/geltanks.dm
@@ -8,6 +8,7 @@
 	pull_sound = SFX_PULL_MACHINE
 	pull_slowdown = PULL_SLOWDOWN_LIGHT
 	turf_height_offset = 25
+	climb_delay = 3 SECONDS
 	var/capacity_max = 300
 	var/capacity = 300
 	var/gel_type = "unknown"

--- a/code/game/objects/structures/janicart.dm
+++ b/code/game/objects/structures/janicart.dm
@@ -7,6 +7,7 @@
 	density = 1
 	atom_flags = ATOM_FLAG_OPEN_CONTAINER | ATOM_FLAG_CLIMBABLE
 	pull_slowdown = PULL_SLOWDOWN_LIGHT
+	climb_delay = 3 SECONDS
 	//copypaste sorry
 	var/amount_per_transfer_from_this = 5 //shit I dunno, adding this so syringes stop runtime erroring. --NeoFite
 	var/obj/item/storage/bag/trash/mybag	= null

--- a/code/game/objects/structures/mop_bucket.dm
+++ b/code/game/objects/structures/mop_bucket.dm
@@ -11,6 +11,7 @@
 	atom_flags = ATOM_FLAG_OPEN_CONTAINER
 	pull_slowdown = PULL_SLOWDOWN_TINY
 	turf_height_offset = 14
+	climb_delay = 1 SECONDS
 	var/amount_per_transfer_from_this = 5	//shit I dunno, adding this so syringes stop runtime erroring. --NeoFite
 
 

--- a/code/game/objects/structures/railing.dm
+++ b/code/game/objects/structures/railing.dm
@@ -11,6 +11,7 @@
 	throwpass = 1
 	can_buckle = 1
 	buckle_require_restraints = 1
+	climb_delay = 2 SECONDS
 	var/health = 40
 	var/maxhealth = 40
 	var/check = 0
@@ -261,7 +262,7 @@
 	user.visible_message("<span class='warning'>\The [user] starts climbing over \the [src]!</span>")
 	LAZYDISTINCTADD(climbers, user)
 
-	if(!do_after(user,(issmall(user) ? 30 : 50), src))
+	if(!do_after(user, (user.get_climb_speed() * climb_delay), src))
 		LAZYREMOVE(climbers, user)
 		return
 

--- a/code/modules/mob/living/carbon/human/body_build.dm
+++ b/code/modules/mob/living/carbon/human/body_build.dm
@@ -39,6 +39,7 @@ var/global/datum/body_build/default_body_build = new
 	var/stomach_capacity   = STOMACH_CAPACITY_NORMAL
 	var/ambiguous_gender   = FALSE // If TRUE, both females and females will be PLURAL if there's no beard and their groin is covered
 	var/melee_modifier     = 1.0
+	var/climb_speed        = 1.0 // Climbing tables, etc.; lower is faster
 
 	var/list/equip_adjust
 	var/list/equip_overlays = list()
@@ -229,6 +230,7 @@ var/global/datum/body_build/default_body_build = new
 	poise_pool         = HUMAN_HIGH_POISE
 	ambiguous_gender   = TRUE
 	melee_modifier     = 1.15 // Force is acceleration times MASS, so...
+	climb_speed        = 2.5 // You're a landwhale; not a, what, tablewhale?
 
 
 /datum/body_build/slim/alt/tajaran //*sigh. I regret of doing this.
@@ -259,6 +261,7 @@ var/global/datum/body_build/default_body_build = new
 	dam_mask             = 'icons/mob/human_races/masks/dam_mask_tajaran_slim.dmi'
 
 	equipment_modifier = -0.5
+	climb_speed = 0.75
 
 /datum/body_build/tajaran
 	name                 = "Tajaran"
@@ -283,6 +286,7 @@ var/global/datum/body_build/default_body_build = new
 		"slot_r_hand"    = 'icons/mob/onmob/items/righthand.dmi'
 		)
 	dam_mask             = 'icons/mob/human_races/masks/dam_mask_tajaran.dmi'
+	climb_speed = 0.75
 
 /datum/body_build/tajaran/fat
 	name                 = "Fat Tajaran"
@@ -314,6 +318,7 @@ var/global/datum/body_build/default_body_build = new
 	equipment_modifier = 0.5
 	poise_pool         = HUMAN_HIGH_POISE
 	ambiguous_gender   = TRUE
+	climb_speed        = 1.0 // Even a OH-LAWD-CHONK-BOI-fat cat is at least as agile as a normal human
 
 /datum/body_build/unathi
 	name                 = SPECIES_UNATHI
@@ -395,6 +400,7 @@ var/global/datum/body_build/default_body_build = new
 
 	equipment_modifier = -0.5
 	melee_modifier     = 1.25 // Monke muscles are no joke
+	climb_speed        = 0.5
 
 /datum/body_build/xenomorph
 	name                 = "Xenomorph"
@@ -404,3 +410,4 @@ var/global/datum/body_build/default_body_build = new
 	bandages_icon        =  null
 
 	poise_pool         = HUMAN_MAX_POISE
+	climb_speed        = 0.5 // Realistically, they should be able to jog along walls and ceilings, effectively ignoring four-legged thingies, but let's keep things at least somewhat balanced.

--- a/code/modules/mob/living/carbon/human/human_helpers.dm
+++ b/code/modules/mob/living/carbon/human/human_helpers.dm
@@ -372,3 +372,29 @@
 
 /mob/living/carbon/human/is_eligible_for_antag_spawn(antag_id)
 	return species ? species.is_eligible_for_antag_spawn(antag_id) : TRUE // No species = no problems, assuming ourselves to be a baseline human being
+
+mob/living/carbon/human/get_climb_speed()
+	. = 1.0
+
+	if(body_build?.climb_speed)
+		. = body_build.climb_speed
+	else
+		. = ..()
+
+	var/area/area = get_area(src)
+	if(shoes && (shoes.item_flags & ITEM_FLAG_NOSLIP) && istype(shoes, /obj/item/clothing/shoes/magboots))
+		. *= 2.0 // Magboots are pain in the ass
+	else if(!area || !area.has_gravity())
+		. *= 0.25 // Zero G is fun
+		return
+
+	if(isSynthetic())
+		. *= 1.5 // Fullsteel fucks are heavy
+
+	// Check hands for additional difficulties
+	if(l_hand?.w_class >= ITEM_SIZE_NORMAL && r_hand?.w_class >= ITEM_SIZE_NORMAL)
+		. *= 2.5 // Pure pain
+	else if(l_hand?.w_class >= ITEM_SIZE_NORMAL || r_hand?.w_class >= ITEM_SIZE_NORMAL)
+		. *= 1.5 // Less pain
+
+	return

--- a/code/modules/mob/mob_helpers.dm
+++ b/code/modules/mob/mob_helpers.dm
@@ -757,3 +757,8 @@ var/list/intents = list(I_HELP,I_DISARM,I_GRAB,I_HURT)
 	animate(C, pixel_x=recoil_x, pixel_y=recoil_y, time=1, easing=SINE_EASING|EASE_OUT, flags=ANIMATION_PARALLEL|ANIMATION_RELATIVE)
 	sleep(2)
 	animate(C, pixel_x=0, pixel_y=0, time=3, easing=SINE_EASING|EASE_IN)
+
+/mob/proc/get_climb_speed()
+	if(issmall(src))
+		return 0.6
+	return 1.0

--- a/code/modules/reagents/reagent_dispenser.dm
+++ b/code/modules/reagents/reagent_dispenser.dm
@@ -102,6 +102,7 @@
 	atom_flags = ATOM_FLAG_CLIMBABLE
 	filling_overlay_levels = 7
 	turf_height_offset = 25
+	climb_delay = 3 SECONDS
 
 /obj/structure/reagent_dispensers/fueltank
 	name = "fueltank"
@@ -114,6 +115,7 @@
 	atom_flags = ATOM_FLAG_CLIMBABLE
 	filling_overlay_levels = 6
 	turf_height_offset = 25
+	climb_delay = 3 SECONDS
 
 /obj/structure/reagent_dispensers/fueltank/Destroy()
 	QDEL_NULL(rig)
@@ -279,6 +281,7 @@
 	initial_reagent_types = list(/datum/reagent/toxin/fertilizer/compost = 1)
 	atom_flags = ATOM_FLAG_CLIMBABLE
 	turf_height_offset = 25
+	climb_delay = 3 SECONDS
 
 /obj/structure/reagent_dispensers/composttank/attackby(obj/item/W, mob/user)
 	src.add_fingerprint(user)

--- a/code/modules/tables/tables.dm
+++ b/code/modules/tables/tables.dm
@@ -9,6 +9,7 @@
 	layer = TABLE_LAYER
 	throwpass = 1
 	turf_height_offset = 12
+	climb_delay = 2 SECONDS
 
 	rad_resist_type = /datum/rad_resist/none
 
@@ -46,6 +47,7 @@
 
 		if(reinforced)
 			maxhealth += reinforced.integrity / 2
+			climb_delay = 3 SECONDS // Reinforced tables are harder to climb. Somehow.
 
 	health += maxhealth - old_maxhealth
 

--- a/code/modules/tables/tables.dm
+++ b/code/modules/tables/tables.dm
@@ -9,7 +9,7 @@
 	layer = TABLE_LAYER
 	throwpass = 1
 	turf_height_offset = 12
-	climb_delay = 2 SECONDS
+	climb_delay = 1.5 SECONDS
 
 	rad_resist_type = /datum/rad_resist/none
 
@@ -47,7 +47,9 @@
 
 		if(reinforced)
 			maxhealth += reinforced.integrity / 2
-			climb_delay = 3 SECONDS // Reinforced tables are harder to climb. Somehow.
+			climb_delay = 2.5 SECONDS // Reinforced tables are harder to climb. Somehow.
+		else
+			climb_delay = 1.5 SECONDS
 
 	health += maxhealth - old_maxhealth
 


### PR DESCRIPTION
```yml
🆑
tweak: Улучшена механика залезания на объекты. Раньше залезание всегда занимало 5 секунд, для любого объекта и моба. Теперь залезание стало быстрее (1.5 секунды для обычых столов, 2.5 для укреплённых, 3 секунды для баков, 5 секунд для баррикад), но на время влияют различные факторы: раса и бодибилд (таяры залезают немного быстрее, макаки и ксеноморфы - намного быстрее, жирдяи - ахахахахаха), гравитация и магбутсы (без гравитации залезание почти мгновенное, с магбутсами - гораздо дольше), наличие больших предметов в руках (одна занятая рука - небольшое замедление, обе руки заняты - логичнее сначала сложить предметы на стол, а потом лезть самому). 
/🆑
```

- [x] Pull Request полностью завершен, мне не нужна помощь чтобы его закончить.
- [x] Я внимательно прочитал(-а) все свои изменения и багов в них не нашёл(-ла).
- [x] Я запускал(-а) сервер со своими изменениями локально и все протестировал(-а).
- [x] Я ознакомился(-ась) c [Guide to Contribute](https://github.com/ChaoticOnyx/OnyxBay/blob/dev/docs/contributing.md).
