### PR TITLE
Removes lack of grahbowboyevckah

### DIFF
--- a/code/modules/mob/grab/grab_datum.dm
+++ b/code/modules/mob/grab/grab_datum.dm
@@ -288,7 +288,7 @@
 
 	//assailant.visible_message("Debug: p_diff = [p_diff] | breakability = [breakability]") //Debug message
 
-	if(prob(p_diff))
+	if(p_diff > assailant.poise && prob(p_diff))
 		if(can_downgrade_on_resist && !prob(p_diff))
 			affecting.visible_message(SPAN("warning", "[affecting] has loosened [assailant]'s grip!"))
 			assailant.setClickCooldown(10)

--- a/code/modules/mob/grab/grab_datum.dm
+++ b/code/modules/mob/grab/grab_datum.dm
@@ -265,14 +265,14 @@
 		p_mult -= 0.1
 	if(affecting.confused)
 		p_mult -= 0.1
-	if(!affecting.lying)
-		p_mult += 0.1
+	if(affecting.lying)
+		p_mult -= 0.1
 
 	//if(break_strength < 1)
 	//	to_chat(G.assailant, "<span class='warning'>You try to break free but feel that unless something changes, you'll never escape!</span>")
 	//	return
 
-	var/p_lost = (5.5 + affecting.poise/10 - assailant.poise/20) * p_mult
+	var/p_lost = round((5.5 + affecting.poise/10 - assailant.poise/15) * p_mult, 0.1)
 	assailant.damage_poise(p_lost)
 	affecting.damage_poise(2.0)
 

--- a/code/modules/mob/grab/grab_datum.dm
+++ b/code/modules/mob/grab/grab_datum.dm
@@ -272,7 +272,7 @@
 	//	to_chat(G.assailant, "<span class='warning'>You try to break free but feel that unless something changes, you'll never escape!</span>")
 	//	return
 
-	var/p_lost = round((5.5 + affecting.poise/10 - assailant.poise/15) * p_mult, 0.1)
+	var/p_lost = round((5.0 + affecting.poise/10 - assailant.poise/15) * p_mult, 0.1)
 	assailant.damage_poise(p_lost)
 	affecting.damage_poise(2.0)
 
@@ -288,7 +288,7 @@
 
 	//assailant.visible_message("Debug: p_diff = [p_diff] | breakability = [breakability]") //Debug message
 
-	if(p_diff > assailant.poise || prob(p_diff))
+	if(prob(p_diff))
 		if(can_downgrade_on_resist && !prob(p_diff))
 			affecting.visible_message(SPAN("warning", "[affecting] has loosened [assailant]'s grip!"))
 			assailant.setClickCooldown(10)

--- a/code/modules/mob/grab/normal/norm_kill.dm
+++ b/code/modules/mob/grab/normal/norm_kill.dm
@@ -13,6 +13,7 @@
 	same_tile = 1
 	force_danger = 1
 	restrains = 1
+	breakability = 5
 
 	downgrade_on_action = 1
 	downgrade_on_move = 1
@@ -34,10 +35,10 @@
 		affecting.Stun(2)
 
 	if((MUTATION_HULK in G.assailant.mutations) || (MUTATION_STRONG in G.assailant.mutations))
-		affecting.adjustOxyLoss(3)
+		affecting.adjustOxyLoss(5)
 		affecting.Stun(2)
 	else
-		affecting.adjustOxyLoss(1)
+		affecting.adjustOxyLoss(3)
 
 	affecting.apply_effect(STUTTER, 5) //It will hamper your voice, being choked and all.
 	affecting.losebreath = max(affecting.losebreath + 2, 3)

--- a/code/modules/mob/grab/normal/norm_neck.dm
+++ b/code/modules/mob/grab/normal/norm_neck.dm
@@ -18,6 +18,7 @@
 	force_danger = 1
 	restrains = 1
 	ladder_carry = 1
+	breakability = 5
 
 	icon_state = "kill"
 

--- a/code/modules/mob/grab/normal/norm_struggle.dm
+++ b/code/modules/mob/grab/normal/norm_struggle.dm
@@ -16,8 +16,6 @@
 	grab_slowdown = 10
 	upgrade_cooldown = 20
 
-	can_downgrade_on_resist = 0
-
 	icon_state = "reinforce"
 
 	break_chance_table = list(5, 20, 30, 80, 100)


### PR DESCRIPTION
```yml
🆑
experiment: Астрологи объявили неделю грабобоёвки: грабы тратят меньше стамины, успешный резист не мгновенно ломает свежий синий граб, а сбрасывает его до жёлтого, из красного граба сложнее вырваться, баффнуто удушение.
/🆑
```

- [x] Pull Request полностью завершен, мне не нужна помощь чтобы его закончить.
- [x] Я внимательно прочитал(-а) все свои изменения и багов в них не нашёл(-ла).
- [x] Я запускал(-а) сервер со своими изменениями локально и все протестировал(-а).
- [x] Я ознакомился(-ась) c [Guide to Contribute](https://github.com/ChaoticOnyx/OnyxBay/blob/dev/docs/contributing.md).
