### PR TITLE
fix(mop, tobacco): various fixes

### DIFF
--- a/code/game/objects/items/smokables/pipes.dm
+++ b/code/game/objects/items/smokables/pipes.dm
@@ -38,7 +38,7 @@
 	if(ismob(loc))
 		var/mob/living/M = loc
 		if (!nomessage)
-			to_chat(M, "<span class='notice'>Your [name] goes out, and you empty the ash.</span>")
+			to_chat(M, SPAN_NOTICE("Your [name] goes out, and you empty the ash."))
 
 
 // Actually i take this from cigarette, but... who cares?
@@ -70,13 +70,13 @@
 
 /obj/item/clothing/mask/smokable/pipe/attack_self(mob/user)
 	if(lit == 1)
-		user.visible_message("<span class='notice'>[user] puts out [src].</span>", "<span class='notice'>You put out [src].</span>")
+		user.visible_message(SPAN_NOTICE("[user] puts out [src]."), SPAN_NOTICE("You put out [src]."))
 		lit = 0
 		update_icon()
 		set_next_think(0)
 	else if(smoketime)
 		var/turf/location = get_turf(user)
-		user.visible_message("<span class='notice'>[user] empties out [src].</span>", "<span class='notice'>You empty out [src].</span>")
+		user.visible_message(SPAN_NOTICE("[user] empties out [src]."), SPAN_NOTICE("You empty out [src]."))
 		new /obj/effect/decal/cleanable/ash(location)
 		smoketime = 0
 		reagents.clear_reagents()
@@ -100,6 +100,7 @@
 		smoketime = 180
 		if(G.reagents)
 			G.reagents.trans_to_obj(src, G.reagents.total_volume)
+		user.visible_message(SPAN_NOTICE("[user] stuffs [src] with [G]."), SPAN_NOTICE("You stuff [src] with [G]."))
 		SetName("[G.name]-packed [initial(name)]")
 		qdel(G)
 

--- a/code/game/objects/items/smokables/rolling.dm
+++ b/code/game/objects/items/smokables/rolling.dm
@@ -88,53 +88,33 @@
 	. = ..()
 	bitesize = 3
 
-/obj/item/reagent_containers/food/tobacco/generic/Initialize()
-	. = ..()
-	reagents.add_reagent(/datum/reagent/tobacco, 4)
+/obj/item/reagent_containers/food/tobacco/generic
+	startswith = list(/datum/reagent/tobacco = 4)
 
 /obj/item/reagent_containers/food/tobacco/cherry
 	desc = "A small pile of dried and grinded herbs. Smells of cherries."
 	icon_state = "tpile_cherry"
-
-/obj/item/reagent_containers/food/tobacco/cherry/Initialize()
-	. = ..()
-	reagents.add_reagent(/datum/reagent/tobacco, 3)
-	reagents.add_reagent(/datum/reagent/nutriment/cherryjelly, 2)
+	startswith = list(/datum/reagent/tobacco = 3, /datum/reagent/nutriment/cherryjelly = 2)
 
 /obj/item/reagent_containers/food/tobacco/menthol
 	desc = "A small pile of dried and grinded herbs. Smells of mint."
 	icon_state = "tpile_menthol"
-
-/obj/item/reagent_containers/food/tobacco/menthol/Initialize()
-	. = ..()
-	reagents.add_reagent(/datum/reagent/tobacco, 3)
-	reagents.add_reagent(/datum/reagent/menthol, 2)
+	startswith = list(/datum/reagent/tobacco = 3, /datum/reagent/menthol = 2)
 
 /obj/item/reagent_containers/food/tobacco/chocolate
 	desc = "A small pile of dried and grinded herbs. Smells of cocoa."
 	icon_state = "tpile_chocolate"
-
-/obj/item/reagent_containers/food/tobacco/chocolate/Initialize()
-	. = ..()
-	reagents.add_reagent(/datum/reagent/tobacco, 3)
-	reagents.add_reagent(/datum/reagent/nutriment/coco, 2)
+	startswith = list(/datum/reagent/tobacco = 3, /datum/reagent/nutriment/coco = 2)
 
 /obj/item/reagent_containers/food/tobacco/premium
 	desc = "A small pile of evenly dried and finely grounded herbs. Smells of quality."
 	icon_state = "tpile_premium"
-
-/obj/item/reagent_containers/food/tobacco/premium/Initialize()
-	. = ..()
-	reagents.add_reagent(/datum/reagent/tobacco/fine, 4)
+	startswith = list(/datum/reagent/tobacco/fine = 4)
 
 /obj/item/reagent_containers/food/tobacco/contraband
 	desc = "A suspicious pile of dried and grinded herbs. Smells of something barely legal."
 	icon_state = "tpile_contraband"
-
-/obj/item/reagent_containers/food/tobacco/contraband/Initialize()
-	. = ..()
-	reagents.add_reagent(/datum/reagent/tobacco, 2)
-	reagents.add_reagent(/datum/reagent/thc, 4)
+	startswith = list(/datum/reagent/tobacco = 2, /datum/reagent/thc = 4)
 
 // Packs
 /obj/item/storage/tobaccopack

--- a/code/game/objects/structures/janicart.dm
+++ b/code/game/objects/structures/janicart.dm
@@ -34,34 +34,34 @@
 		mybag = I
 		update_icon()
 		updateUsrDialog()
-		to_chat(user, "<span class='notice'>You put [I] into [src].</span>")
+		to_chat(user, SPAN_NOTICE("You put [I] into [src]."))
 
 	else if(istype(I, /obj/item/mop))
 		if(I.reagents.total_volume < I.reagents.maximum_volume)	//if it's not completely soaked we assume they want to wet it, otherwise store it
 			if(reagents.total_volume < 1)
-				to_chat(user, "<span class='warning'>[src] is out of water!</span>")
+				to_chat(user, SPAN_WARNING("[src] is out of water!"))
 			else
 				reagents.trans_to_obj(I, I.reagents.maximum_volume)
-				to_chat(user, "<span class='notice'>You wet [I] in [src].</span>")
+				to_chat(user, SPAN_NOTICE("You wet [I] in [src]."))
 				playsound(loc, 'sound/effects/slosh.ogg', 25, 1)
 				return
 		if(!mymop && user.drop(I, src))
 			mymop = I
 			update_icon()
 			updateUsrDialog()
-			to_chat(user, "<span class='notice'>You put [I] into [src].</span>")
+			to_chat(user, SPAN_NOTICE("You put [I] into [src]."))
 
 	else if(istype(I, /obj/item/reagent_containers/spray) && !myspray && user.drop(I, src))
 		myspray = I
 		update_icon()
 		updateUsrDialog()
-		to_chat(user, "<span class='notice'>You put [I] into [src].</span>")
+		to_chat(user, SPAN_NOTICE("You put [I] into [src]."))
 
 	else if(istype(I, /obj/item/device/lightreplacer) && !myreplacer && user.drop(I, src))
 		myreplacer = I
 		update_icon()
 		updateUsrDialog()
-		to_chat(user, "<span class='notice'>You put [I] into [src].</span>")
+		to_chat(user, SPAN_NOTICE("You put [I] into [src]."))
 
 	else if(istype(I, /obj/item/caution))
 		if(signs < 4)
@@ -70,9 +70,9 @@
 			signs++
 			update_icon()
 			updateUsrDialog()
-			to_chat(user, "<span class='notice'>You put [I] into [src].</span>")
+			to_chat(user, SPAN_NOTICE("You put [I] into [src]."))
 		else
-			to_chat(user, "<span class='notice'>[src] can't hold any more signs.</span>")
+			to_chat(user, SPAN_NOTICE("[src] can't hold any more signs."))
 
 	else if(istype(I, /obj/item/reagent_containers/vessel))
 		var/obj/item/reagent_containers/vessel/V = I
@@ -205,14 +205,14 @@
 	if(istype(I, /obj/item/mop))
 		if(reagents.total_volume > 1)
 			reagents.trans_to_obj(I, 2)
-			to_chat(user, "<span class='notice'>You wet [I] in the [callme].</span>")
+			to_chat(user, SPAN_NOTICE("You wet [I] in the [callme]."))
 			playsound(loc, 'sound/effects/slosh.ogg', 25, 1)
 		else
-			to_chat(user, "<span class='notice'>This [callme] is out of water!</span>")
+			to_chat(user, SPAN_NOTICE("This [callme] is out of water!"))
 	else if(istype(I, /obj/item/key))
 		to_chat(user, "Hold [I] in one of your hands while you drive this [callme].")
 	else if(istype(I, /obj/item/storage/bag/trash) && !mybag && user.drop(I, src))
-		to_chat(user, "<span class='notice'>You hook the trashbag onto the [callme].</span>")
+		to_chat(user, SPAN_NOTICE("You hook the trashbag onto the [callme]."))
 		mybag = I
 
 
@@ -231,7 +231,7 @@
 		step(src, direction)
 		update_mob()
 	else
-		to_chat(user, "<span class='notice'>You'll need the keys in one of your hands to drive this [callme].</span>")
+		to_chat(user, SPAN_NOTICE("You'll need the keys in one of your hands to drive this [callme]."))
 
 
 /obj/structure/bed/chair/janicart/Move(newloc, direct)
@@ -288,7 +288,7 @@
 	if(buckled_mob)
 		if(prob(85))
 			return buckled_mob.bullet_act(Proj)
-	visible_message("<span class='warning'>[Proj] ricochets off the [callme]!</span>")
+	visible_message(SPAN_WARNING("[Proj] ricochets off the [callme]!"))
 
 
 /obj/item/key

--- a/code/game/objects/structures/mop_bucket.dm
+++ b/code/game/objects/structures/mop_bucket.dm
@@ -32,7 +32,7 @@
 			return
 
 		else
-			reagents.trans_to_obj(I, 5)
+			reagents.trans_to_obj(I, 50)
 			show_splash_text(user, "you wet the mop!", SPAN("notice", "You wet \the [I] in \the [src]."))
 			playsound(loc, 'sound/effects/slosh.ogg', 25, 1)
 			return

--- a/code/modules/reagents/reagent_containers/vessel/unsorted.dm
+++ b/code/modules/reagents/reagent_containers/vessel/unsorted.dm
@@ -77,7 +77,7 @@
 		if(reagents.total_volume < 1)
 			show_splash_text(user, "no water!", SPAN("warning", "\The [src] is empty!"))
 		else
-			reagents.trans_to_obj(D, 5)
+			reagents.trans_to_obj(D, 50)
 			show_splash_text(user, "you wet the mop!", SPAN("notice", "You wet \the [D] in \the [src]."))
 			playsound(loc, 'sound/effects/slosh.ogg', 25, 1)
 		return


### PR DESCRIPTION
- Швабра теперь получает 50 юнитов реагентов при окунании её в ведро, а не 5.
- Кучки табака не имели внутри себя реагентов из-за того, что `recalc_max_volume()` ставил им объём реагентов на 0. Исправлено переносом списка начальных реагентов для табака в `startswith`.
- При наполнении курительной трубки табаком выводится соответствующее сообщение.
- `<span> -> SPAN()`

close #13152 
close #13243 
close #13264 

<details>
<summary>Чейнджлог</summary>

```yml
🆑TheUnknownOne
bugfix: Швабра вновь полноценно смачивается при окунании в ведро.
bugfix: Трубку, кальян и табачные самокрутки снова можно нормально курить. Есть табак и добавлять в него яд теперь тоже можно.
/🆑
```

</details>

- [x] Pull Request полностью завершен, мне не нужна помощь чтобы его закончить.
- [x] Я внимательно прочитал(-а) все свои изменения и багов в них не нашёл(-ла).
- [x] Я запускал(-а) сервер со своими изменениями локально и все протестировал(-а).
- [x] Я ознакомился(-ась) c [Guide to Contribute](https://github.com/ChaoticOnyx/OnyxBay/blob/dev/docs/contributing.md).
