### PR TITLE
Fix(chemistry): add 'return' to function .splash

### DIFF
--- a/code/modules/reagents/Chemistry-Holder.dm
+++ b/code/modules/reagents/Chemistry-Holder.dm
@@ -353,7 +353,7 @@ GLOBAL_DATUM_INIT(temp_reagents_holder, /obj, new)
 	if(spill)
 		splash(target.loc, spill, multiplier, copy, min_spill, max_spill)
 
-	trans_to(target, amount, multiplier, copy)
+	return trans_to(target, amount, multiplier, copy)
 
 /datum/reagents/proc/trans_type_to(atom/target, type, amount = 1)
 	if (!target || !target.reagents || !target.simulated)


### PR DESCRIPTION
Метод splash() ничего не возвращает, из-за чего в 75 строке dropper переменная trans остается пустой. Решение - добавить return в splash() перед trans_to(). 
Спасибо bocchouli, что объяснил где проблема.

fix #13258 

<details>
<summary>Чейнджлог</summary>

```yml
🆑 Accoll
bugfix: Теперь Dropper знает сколько мл. вещества он отдает.
/🆑
```

</details>

- [x] Pull Request полностью завершен, мне не нужна помощь чтобы его закончить.
- [x] Я внимательно прочитал(-а) все свои изменения и багов в них не нашёл(-ла).
- [x] Я запускал(-а) сервер со своими изменениями локально и все протестировал(-а).
- [x] Я ознакомился(-ась) c [Guide to Contribute](https://github.com/ChaoticOnyx/OnyxBay/blob/dev/docs/contributing.md).
