### PR TITLE
feat(admin): Ring Unready verb

### DIFF
--- a/code/modules/admin/admin.dm
+++ b/code/modules/admin/admin.dm
@@ -979,6 +979,33 @@ var/global/floorIsLava = 0
 		alert("[M.name] is not prisoned.")
 	feedback_add_details("admin_verb","UP") //If you are copy-pasting this, ensure the 2nd parameter is unique to the new proc!
 
+/datum/admins/proc/ring_unready()
+	set category = "Server"
+	set desc = "(Pre-round only) Send an audio and text notification to all non-ready players."
+	set name = "Ring Unready"
+
+	if(!check_rights(R_SERVER))
+		return
+
+	if(GAME_STATE > RUNLEVEL_LOBBY)
+		to_chat(usr, "Ring Unready is only available during the pre-round lobby.")
+		return
+
+	var/secs_to_roundstart = round(SSticker.pregame_timeleft / 10)
+	var/players_rung = 0
+
+	for(var/mob/new_player/player in GLOB.player_list)
+		if(player.ready)
+			continue
+
+		to_chat(player, "<font size = '6'>READY UP! The round is starting in [secs_to_roundstart] seconds!</font>")
+		sound_to(player, sound('sound/effects/adminhelp.ogg'))
+		players_rung++
+
+	to_chat(usr, "[players_rung] unready players notified.")
+
+	feedback_add_details("admin_verb","RING") //If you are copy-pasting this, ensure the 2nd parameter is unique to the new proc!
+
 ////////////////////////////////////////////////////////////////////////////////////////////////ADMIN HELPER PROCS
 
 /proc/is_special_character(character) // returns 1 for special characters and 2 for heroes of gamemode

--- a/code/modules/admin/admin_verbs.dm
+++ b/code/modules/admin/admin_verbs.dm
@@ -168,6 +168,7 @@ var/list/admin_verbs_server = list(
 	/datum/admins/proc/changemap,
 	/datum/admins/proc/delay,
 	/datum/admins/proc/toggleaban,
+	/datum/admins/proc/ring_unready,
 	/client/proc/everyone_random,
 	/datum/admins/proc/toggleAI,
 	/client/proc/cmd_admin_delete,		// delete an instance/object/mob/etc,


### PR DESCRIPTION
- Новый верб для педалей -- `Ring Unready`. Доступен только в лобби до начала раунда. Отправляет всем незадекларившимся и не вышедшим в обсерв игрокам текстовое и звуковое оповещение с указанием времени до начала раунда. Подойдёт для случаев, когда долго стояла задержка раундстарта, и многие игроки могут сидеть со свёрнутой игрой, не зная, что раунд уже начинается.

<details>
<summary>Чейнджлог</summary>

```yml
🆑TheUnknownOne
admin: Для педалей добавлен верб Ring Unready, отправляющий всем незадекларившимся игрокам оповещение. Доступен только до начала раунда.
/🆑
```

</details>

- [x] Pull Request полностью завершен, мне не нужна помощь чтобы его закончить.
- [x] Я внимательно прочитал(-а) все свои изменения и багов в них не нашёл(-ла).
- [x] Я запускал(-а) сервер со своими изменениями локально и все протестировал(-а).
- [x] Я ознакомился(-ась) c [Guide to Contribute](https://github.com/ChaoticOnyx/OnyxBay/blob/dev/docs/contributing.md).
