### PR TITLE
tweak(misc suits): armor & allowed for hos's coat

### DIFF
--- a/code/modules/clothing/suits/miscellaneous.dm
+++ b/code/modules/clothing/suits/miscellaneous.dm
@@ -704,6 +704,27 @@
 	item_state = "hosformal"
 	body_parts_covered = UPPER_TORSO|LOWER_TORSO|ARMS
 
+	allowed = list(
+		/obj/item/ammo_magazine,
+		/obj/item/ammo_casing,
+		/obj/item/clothing/head/helmet,
+		/obj/item/clothing/mask/gas,
+		/obj/item/device/radio,
+		/obj/item/device/flashlight,
+		/obj/item/grenade,
+		/obj/item/gun/energy,
+		/obj/item/gun/projectile,
+		/obj/item/gun/charge,
+		/obj/item/gun/magnetic,
+		/obj/item/gun/launcher/grenade,
+		/obj/item/handcuffs,
+		/obj/item/melee/baton,
+		/obj/item/reagent_containers/spray/pepper
+	)
+
+	armor = list(melee = 70, bullet = 110, laser = 100, energy = 35, bomb = 55, bio = 20)
+	siemens_coefficient = 0.6
+
 /obj/item/clothing/suit/yuri
 	name = "yuri initiate coat"
 	desc = "Yuri is master! Sponsored by DonkSoft Co."


### PR DESCRIPTION
- Донатному официальному пальто ХоСа добавлены список вешаемых на его держатель предметов, броня и электропроводимость, идентичные оным у обычного бронепальто ХоСа. Это донатный предмет, с которым можно заспавниться только за ХоСа, так что почему нет?

<details>
<summary>Чейнджлог</summary>

```yml
🆑TheUnknownOne
tweak: Официальное пальто ХоСа, доступное в лодауте за опиксы, получило держатель и броню, равную обычному пальто ХоСа.
/🆑
```

</details>

- [x] Pull Request полностью завершен, мне не нужна помощь чтобы его закончить.
- [x] Я внимательно прочитал(-а) все свои изменения и багов в них не нашёл(-ла).
- [x] Я запускал(-а) сервер со своими изменениями локально и все протестировал(-а).
- [x] Я ознакомился(-ась) c [Guide to Contribute](https://github.com/ChaoticOnyx/OnyxBay/blob/dev/docs/contributing.md).
