### PR TITLE
fix(rig chestpiece): fix xenos on-mob icons not working

### DIFF
--- a/code/modules/clothing/spacesuits/rig/rig_pieces.dm
+++ b/code/modules/clothing/spacesuits/rig/rig_pieces.dm
@@ -37,6 +37,7 @@
 
 /obj/item/clothing/suit/space/rig
 	name = "chestpiece"
+	item_state = null // Otherwise RIG chestpieces always just use human icons. Why? No bloody clue. ~TheUnknownOne
 	allowed = list(/obj/item/device/flashlight,/obj/item/tank,/obj/item/device/suit_cooling_unit)
 	body_parts_covered = UPPER_TORSO|LOWER_TORSO|LEGS|ARMS
 	heat_protection =    UPPER_TORSO|LOWER_TORSO|LEGS|ARMS


### PR DESCRIPTION
- Исправлен баг чуть ли не полуторагодичной давности, из-за которого надетые на ксеноса нагрудники РИГов использовали спрайты для людей, а не для данного ксеноса. Вызывается это установкой `item_state` у `/obj/item/clothing/suit/space` и исправилось, в данном случае, просто установкой у объекта нагрудника РИГа этой переменной на null. Рантаймов нет в обоих случаях. Почему оно так работает -- я не знаю, но фикс есть фикс. Может, когда-нибудь в будущем кто-то сделает более элегантно. 

close #13315

<details>
<summary>Чейнджлог</summary>

```yml
🆑
bugfix: Исправлен странный баг, из-за которого РИГи на ксеносах иногда выглядели, будто надеты на человека.
/🆑
```

</details>

- [x] Pull Request полностью завершен, мне не нужна помощь чтобы его закончить.
- [x] Я внимательно прочитал(-а) все свои изменения и багов в них не нашёл(-ла).
- [x] Я запускал(-а) сервер со своими изменениями локально и все протестировал(-а).
- [x] Я ознакомился(-ась) c [Guide to Contribute](https://github.com/ChaoticOnyx/OnyxBay/blob/dev/docs/contributing.md).
