### PR TITLE
tweak(synthetic): emp_act fix and damage rebalance

### DIFF
--- a/code/modules/mob/organs/external/_external.dm
+++ b/code/modules/mob/organs/external/_external.dm
@@ -179,13 +179,13 @@
 	var/burn_damage = 0
 	switch (severity)
 		if (1)
-			burn_damage = 15
+			burn_damage = 28
 		if (2)
-			burn_damage = 7
+			burn_damage = 18
 		if (3)
-			burn_damage = 3
+			burn_damage = 13
 
-	var/mult = BP_IS_ROBOTIC(src) + BP_IS_ASSISTED(src)
+	var/mult = round((BP_IS_ROBOTIC(src) + BP_IS_ASSISTED(src)) / 1000)
 	burn_damage *= mult/burn_mod //ignore burn mod for EMP damage
 
 	var/power = 4 - severity //stupid reverse severity


### PR DESCRIPTION
Короче смысл в том, что формула неправильно расчитывала урон и накидывала синтетикам 16 тысяч урона, смешно гибая их, с данными правками ионка (большая) будет с шансом 50% либо гибать конечности им, либо просто оставляя неработаспособными

<details>
<summary>Чейнджлог</summary>

```yml
🆑
balance: Ионки больше не гибают синтетиков, только их конечности с некоторым шансом
/🆑
```

</details>

- [x] Pull Request полностью завершен, мне не нужна помощь чтобы его закончить.
- [x] Я внимательно прочитал(-а) все свои изменения и багов в них не нашёл(-ла).
- [x] Я запускал(-а) сервер со своими изменениями локально и все протестировал(-а).
- [x] Я ознакомился(-ась) c [Guide to Contribute](https://github.com/ChaoticOnyx/OnyxBay/blob/dev/docs/contributing.md).
