### PR TITLE
Fix(announce): fixed a typo in the text

### DIFF
--- a/code/controllers/subsystems/supply.dm
+++ b/code/controllers/subsystems/supply.dm
@@ -129,7 +129,7 @@ SUBSYSTEM_DEF(supply)
 	var/announce = FALSE
 	announce = prob(chance) || force
 	if(announce)
-		SSannounce.play_station_announce(/datum/announce/suspicious_cargo, title_override = "[GLOB.using_map.company_name] Cargo Security Departament")
+		SSannounce.play_station_announce(/datum/announce/suspicious_cargo, title_override = "[GLOB.using_map.company_name] Cargo Security Department")
 
 //Buyin
 /datum/controller/subsystem/supply/proc/buy()


### PR DESCRIPTION
Исправлена опечатка, с "Departament" на "Department". Это надо, чтоб ошибка в слове не выбивала игрока из РП процесса.

fix #13281

<details>
<summary>Чейнджлог</summary>

```yml
🆑 Accoll
bugfix: Исправлена опечатка в тексте анонса, с "Departament" на "Department"
/🆑
```

</details>

- [x] Pull Request полностью завершен, мне не нужна помощь чтобы его закончить.
- [x] Я внимательно прочитал(-а) все свои изменения и багов в них не нашёл(-ла).
- [ ] Я запускал(-а) сервер со своими изменениями локально и все протестировал(-а).
- [x] Я ознакомился(-ась) c [Guide to Contribute](https://github.com/ChaoticOnyx/OnyxBay/blob/dev/docs/contributing.md).
