### PR TITLE
tweak(last words): exclude drones

### DIFF
--- a/code/datums/elements/last_words.dm
+++ b/code/datums/elements/last_words.dm
@@ -23,7 +23,7 @@ GLOBAL_LIST_EMPTY(last_words)
 	if(new_stat != DEAD || !L.is_ooc_dead())
 		return
 
-	if(!length(L.logging[INDIVIDUAL_SAY_LOG]) || (L.loc?.z in GLOB.using_map.get_levels_with_trait(ZTRAIT_CENTCOM)))
+	if(!length(L.logging[INDIVIDUAL_SAY_LOG]) || (L.loc?.z in GLOB.using_map.get_levels_with_trait(ZTRAIT_CENTCOM)) || istype(L, /mob/living/silicon/robot/drone))
 		detach(L)
 		return
 


### PR DESCRIPTION
- Последние слова дронов больше не будут записываться для раундэнда.
- В частности, исправляет то, что последние слова управляемого ИИ дрона туда попадали. Но дроны в целом являются либо куклами ИИ из фабрикатора, либо развлечением для гостов с законом не взаимодействовать с персоналом, поэтому их слова, думаю, можно не записывать в целом.

<details>
<summary>Чейнджлог</summary>

```yml
🆑
bugfix: Последние слова дронов ИИ больше не будут попадать в раундэндовый список.
/🆑
```

</details>

- [x] Pull Request полностью завершен, мне не нужна помощь чтобы его закончить.
- [x] Я внимательно прочитал(-а) все свои изменения и багов в них не нашёл(-ла).
- [x] Я запускал(-а) сервер со своими изменениями локально и все протестировал(-а).
- [x] Я ознакомился(-ась) c [Guide to Contribute](https://github.com/ChaoticOnyx/OnyxBay/blob/dev/docs/contributing.md).
