### PR TITLE
fix(lighting): makes light fixtures' glow colored

### DIFF
--- a/code/modules/power/lighting.dm
+++ b/code/modules/power/lighting.dm
@@ -147,6 +147,7 @@
 	idle_power_usage = 2 WATTS
 	active_power_usage = 20 WATTS
 	power_channel = STATIC_LIGHT //Lights are calc'd via area so they dont need to be in the machine list
+	glow_colored = TRUE
 
 	/// Whether light is currently turned on.
 	var/on = TRUE


### PR DESCRIPTION
glow_colored был подрублен не у светильников а у лампочек, бывает

до 
<img width="375" height="250" alt="image" src="https://github.com/user-attachments/assets/e1ccd74a-d1c2-4027-bcae-b7dc8c7f889e" />
после
<img width="463" height="367" alt="image" src="https://github.com/user-attachments/assets/644dec7c-183d-457c-8e5c-a2be9f413a20" />

как заставить хелайты не быть такими яркими и белыми я так и не понял, у меня голова болит от этих ваших матриц
<img width="368" height="423" alt="image" src="https://github.com/user-attachments/assets/e5c3b6d0-7599-4f28-a88b-f22a7519890a" />


- [ ] Pull Request полностью завершен, мне не нужна помощь чтобы его закончить.
- [ ] Я внимательно прочитал(-а) все свои изменения и багов в них не нашёл(-ла).
- [ ] Я запускал(-а) сервер со своими изменениями локально и все протестировал(-а).
- [ ] Я ознакомился(-ась) c [Guide to Contribute](https://github.com/ChaoticOnyx/OnyxBay/blob/dev/docs/contributing.md).
