### PR TITLE
fix(chem_grenade): sets proper-sized vessels

### DIFF
--- a/code/game/objects/items/grenades/chem_grenade.dm
+++ b/code/game/objects/items/grenades/chem_grenade.dm
@@ -210,10 +210,10 @@
 
 /obj/item/grenade/chem_grenade/metalfoam/Initialize()
 	. = ..()
-	var/obj/item/reagent_containers/vessel/beaker/B1 = new(src)
+	var/obj/item/reagent_containers/vessel/bottle/chemical/big/B1 = new(src)
 	B1.reagents.add_reagent(/datum/reagent/aluminum, 300)
 
-	var/obj/item/reagent_containers/vessel/beaker/B2 = new(src)
+	var/obj/item/reagent_containers/vessel/bottle/chemical/big/B2 = new(src)
 	B2.reagents.add_reagent(/datum/reagent/foaming_agent, 100)
 	B2.reagents.add_reagent(/datum/reagent/acid/polyacid, 100)
 
@@ -230,13 +230,14 @@
 
 /obj/item/grenade/chem_grenade/incendiary/Initialize()
 	. = ..()
-	var/obj/item/reagent_containers/vessel/beaker/B1 = new(src)
+	var/obj/item/reagent_containers/vessel/bottle/chemical/big/B1 = new(src)
 	B1.reagents.add_reagent(/datum/reagent/aluminum, 150)
-	B1.reagents.add_reagent(/datum/reagent/fuel, 400)
+	B1.reagents.add_reagent(/datum/reagent/fuel, 350)
 
-	var/obj/item/reagent_containers/vessel/beaker/B2 = new(src)
+	var/obj/item/reagent_containers/vessel/bottle/chemical/big/B2 = new(src)
 	B2.reagents.add_reagent(/datum/reagent/toxin/plasma, 150)
 	B2.reagents.add_reagent(/datum/reagent/acid, 150)
+	B1.reagents.add_reagent(/datum/reagent/fuel, 50)
 
 	detonator = new /obj/item/device/assembly_holder/timer_igniter(src)
 
@@ -251,11 +252,11 @@
 
 /obj/item/grenade/chem_grenade/antiweed/Initialize()
 	. = ..()
-	var/obj/item/reagent_containers/vessel/beaker/B1 = new(src)
+	var/obj/item/reagent_containers/vessel/bottle/chemical/big/B1 = new(src)
 	B1.reagents.add_reagent(/datum/reagent/toxin/plantbgone, 250)
 	B1.reagents.add_reagent(/datum/reagent/potassium, 250)
 
-	var/obj/item/reagent_containers/vessel/beaker/B2 = new(src)
+	var/obj/item/reagent_containers/vessel/bottle/chemical/big/B2 = new(src)
 	B2.reagents.add_reagent(/datum/reagent/phosphorus, 250)
 	B2.reagents.add_reagent(/datum/reagent/sugar, 250)
 
@@ -272,10 +273,10 @@
 
 /obj/item/grenade/chem_grenade/cleaner/Initialize()
 	. = ..()
-	var/obj/item/reagent_containers/vessel/beaker/B1 = new(src)
+	var/obj/item/reagent_containers/vessel/bottle/chemical/big/B1 = new(src)
 	B1.reagents.add_reagent(/datum/reagent/surfactant, 400)
 
-	var/obj/item/reagent_containers/vessel/beaker/B2 = new(src)
+	var/obj/item/reagent_containers/vessel/bottle/chemical/big/B2 = new(src)
 	B2.reagents.add_reagent(/datum/reagent/water, 400)
 	B2.reagents.add_reagent(/datum/reagent/space_cleaner, 100)
 
@@ -292,14 +293,14 @@
 
 /obj/item/grenade/chem_grenade/teargas/Initialize()
 	. = ..()
-	var/obj/item/reagent_containers/vessel/beaker/large/B1 = new(src)
+	var/obj/item/reagent_containers/vessel/bottle/chemical/big/B1 = new(src)
 	B1.reagents.add_reagent(/datum/reagent/phosphorus, 200)
 	B1.reagents.add_reagent(/datum/reagent/potassium, 200)
-	B1.reagents.add_reagent(/datum/reagent/capsaicin/condensed, 200)
+	B1.reagents.add_reagent(/datum/reagent/capsaicin/condensed, 100)
 
-	var/obj/item/reagent_containers/vessel/beaker/large/B2 = new(src)
+	var/obj/item/reagent_containers/vessel/bottle/chemical/big/B2 = new(src)
 	B2.reagents.add_reagent(/datum/reagent/sugar, 200)
-	B2.reagents.add_reagent(/datum/reagent/capsaicin/condensed, 400)
+	B2.reagents.add_reagent(/datum/reagent/capsaicin/condensed, 300)
 
 	detonator = new /obj/item/device/assembly_holder/timer_igniter(src)
 
@@ -314,8 +315,8 @@
 
 /obj/item/grenade/chem_grenade/apple/Initialize()
 	. = ..()
-	var/obj/item/reagent_containers/vessel/beaker/B1 = new(src)
-	var/obj/item/reagent_containers/vessel/beaker/B2 = new(src)
+	var/obj/item/reagent_containers/vessel/bottle/chemical/B1 = new(src)
+	var/obj/item/reagent_containers/vessel/bottle/chemical/B2 = new(src)
 
 	B1.reagents.add_reagent(/datum/reagent/potassium, 200)
 


### PR DESCRIPTION
```yml
🆑
bugfix: Исправлена ошибка, из-за которой в пресетовых химических гранатах использовались слишком маленькие сосуды, в которые не влезали все стартовые реагенты. Например, в чистящей гранате в принципе не содержалось чистящее средство, т.к. всё место было занято водой и азосурфактантом.
/🆑
```

- [x] Pull Request полностью завершен, мне не нужна помощь чтобы его закончить.
- [x] Я внимательно прочитал(-а) все свои изменения и багов в них не нашёл(-ла).
- [x] Я запускал(-а) сервер со своими изменениями локально и все протестировал(-а).
- [x] Я ознакомился(-ась) c [Guide to Contribute](https://github.com/ChaoticOnyx/OnyxBay/blob/dev/docs/contributing.md).
