### PR TITLE
tweak(toxLoss): reduces cap, buffs sleepers

### DIFF
--- a/code/__defines/mobs.dm
+++ b/code/__defines/mobs.dm
@@ -429,8 +429,8 @@ GLOBAL_LIST_INIT(organ_tag_to_name, list(
 #define TOXLOSS_SEVERE   50
 #define TOXLOSS_CRITICAL 75
 #define TOXLOSS_LETHAL   100
-#define TOXLOSS_SOFTCAP  150
-#define TOXLOSS_HARDCAP  200
+#define TOXLOSS_SOFTCAP  125
+#define TOXLOSS_HARDCAP  150
 
 #define HUMAN_POWER_NONE    "None"
 #define HUMAN_POWER_SPIT    "Spit"

--- a/code/game/machinery/Sleeper.dm
+++ b/code/game/machinery/Sleeper.dm
@@ -17,7 +17,7 @@
 	var/filtering = 0
 	var/pump
 	var/filtering_strength = 5
-	var/list/possible_filtering = list(5, 7.5, 10, 15)
+	var/list/possible_filtering = list(7.5, 10.0, 15.0, 25.0)
 	var/list/possible_stasis = list(list(1, 2, 5),
 									list(1, 2, 5, 10),
 									list(1, 2, 5, 10, 15),


### PR DESCRIPTION
```yml
🆑
balance: Понижен лимит токсического урона с 560 до 420, пациенты с критическим отравлением стабилизируются быстрее.
balance: Усилен диализ в слиперах. Раньше - 5.0 мл/тик со стоковым манипулятором и 15 мл/тик с наилучшим. Теперь - 7.5 и 25 мл/тик соответственно.
/🆑
```

- [x] Pull Request полностью завершен, мне не нужна помощь чтобы его закончить.
- [x] Я внимательно прочитал(-а) все свои изменения и багов в них не нашёл(-ла).
- [x] Я запускал(-а) сервер со своими изменениями локально и все протестировал(-а).
- [x] Я ознакомился(-ась) c [Guide to Contribute](https://github.com/ChaoticOnyx/OnyxBay/blob/dev/docs/contributing.md).
