### PR TITLE
tweak(organs): boosts livers'n'kidneys

### DIFF
--- a/code/modules/mob/living/carbon/human/human_organs.dm
+++ b/code/modules/mob/living/carbon/human/human_organs.dm
@@ -471,7 +471,7 @@
 		if(K)
 			detox_efficiency = K.detox_efficiency
 		else
-			detox_efficiency = -1.0
+			detox_efficiency = -0.5
 
 	// High hydratation boosts detox efficiency (if applicible), low hydration slows it down or halts it completely.
 	switch(hydration)

--- a/code/modules/mob/organs/internal/normal/kidneys.dm
+++ b/code/modules/mob/organs/internal/normal/kidneys.dm
@@ -28,12 +28,19 @@
 		return
 
 	detox_efficiency = 0.5
-	// Technically, ceases toxloss healing function. Lore-wise, still filters out the body's natural toxic buildup, but can't handle anything beyond that.
-	if(is_bruised())
-		detox_efficiency -= 0.5
-	// Causes the body's natural toxic buildup to... build up.
-	if(is_broken())
-		detox_efficiency -= 0.5
+	if(status & ORGAN_DEAD) // Causes the body's natural toxic buildup to... build up.
+		detox_efficiency *= -1
+	else if(is_broken()) // Technically, ceases toxloss healing function. Lore-wise, still filters out the body's natural toxic buildup, but can't handle anything beyond that.
+		detox_efficiency = 0
+	else if(is_bruised()) // Halves the healing potential, we'll only get intoxicated when completely dehydrated.
+		detox_efficiency *= 0.5
+
+	else
+
+/obj/item/organ/internal/kidneys/die()
+	..()
+	if(status & ORGAN_DEAD)
+		detox_efficiency = -0.5
 
 /obj/item/organ/internal/kidneys/proc/process_hydration()
 	if(!owner)

--- a/code/modules/mob/organs/internal/normal/liver.dm
+++ b/code/modules/mob/organs/internal/normal/liver.dm
@@ -75,7 +75,7 @@
 		filtering_efficiency -= 1
 	// That's where we're in trouble.
 	if(is_broken())
-		filtering_efficiency -= 2
+		filtering_efficiency -= 1
 	// Robotic organs filter better but don't get benefits from dylovene for filtering.
 	if(BP_IS_ROBOTIC(src) || owner.chem_effects[CE_ANTITOX])
 		filtering_efficiency += 1
@@ -89,6 +89,11 @@
 	// If the liver's not too busy, the body slowly regains its "anti-toxic shield".
 	if(filtering_efficiency >= 2 && !owner.chem_effects[CE_TOXIN])
 		stored_tox = max(damage, (stored_tox - filtering_efficiency * 0.1))
+
+/obj/item/organ/internal/liver/die()
+	..()
+	if(status & ORGAN_DEAD)
+		filtering_efficiency = 0
 
 /obj/item/organ/internal/liver/autoheal()
 	if(!damage)


### PR DESCRIPTION
казуальный мир подебил

```yml
🆑
tweak: Снижен вред от повреждений почек и печени - негативные эффекты, появлявшиеся при поломке ("broken") этих органов, теперь появляются при их смерти ("critical"/"destroyed"). Как следствие - лечить лёгкие/средние отравления (и тяжёлые/критические, если делать это вовремя) становится многократно проще. Пациент с токсическим уроном в лимите и отказом половины органов, впрочем, всё ещё требует некоторых усилий для спасания.
/🆑
```

- [x] Pull Request полностью завершен, мне не нужна помощь чтобы его закончить.
- [x] Я внимательно прочитал(-а) все свои изменения и багов в них не нашёл(-ла).
- [x] Я запускал(-а) сервер со своими изменениями локально и все протестировал(-а).
- [x] Я ознакомился(-ась) c [Guide to Contribute](https://github.com/ChaoticOnyx/OnyxBay/blob/dev/docs/contributing.md).
