### PR TITLE
Add radiation resistance to engineering voidsuit

### DIFF
--- a/code/modules/clothing/spacesuits/void/engineering.dm
+++ b/code/modules/clothing/spacesuits/void/engineering.dm
@@ -35,6 +35,7 @@
 	item_state = "engalt_helm"
 	armor = list(melee = 80, bullet = 70, laser = 60, energy = 65, bomb = 35, bio = 100)
 	light_overlay = "helmet_light_dual_low"
+	rad_resist_type = /datum/rad_resist/suit_radiation
 
 /obj/item/clothing/suit/space/void/engineering/alt
 	name = "engineering hardsuit"
@@ -42,6 +43,7 @@
 	icon_state = "engalt_voidsuit"
 	item_state = "engalt_voidsuit"
 	armor = list(melee = 80, bullet = 70, laser = 60, energy = 65, bomb = 35, bio = 100)
+	rad_resist_type = /datum/rad_resist/suit_radiation
 
 /obj/item/clothing/suit/space/void/engineering/alt/New()
 	..()


### PR DESCRIPTION
я проебал 2 пра
вернул иммунитет к адвансед войдсуиту инженера к радиации
<details>
<summary>Чейнджлог</summary>

```yml
🆑Roxreic
tweak: теперь адвансед костюм инженера защищает от радиации как должен
/🆑
```

</details>

- [x] Pull Request полностью завершен, мне не нужна помощь чтобы его закончить.
- [x] Я внимательно прочитал(-а) все свои изменения и багов в них не нашёл(-ла).
- [x] Я запускал(-а) сервер со своими изменениями локально и все протестировал(-а).
- [x] Я ознакомился(-ась) c [Guide to Contribute](https://github.com/ChaoticOnyx/OnyxBay/blob/dev/docs/contributing.md).
