### PR TITLE
tweak(various): more rcd interactions

### DIFF
--- a/code/game/machinery/doors/firedoor.dm
+++ b/code/game/machinery/doors/firedoor.dm
@@ -463,6 +463,21 @@
 	if(changed)
 		update_icon()
 
+/obj/machinery/door/firedoor/rcd_vals(mob/user, obj/item/construction/rcd/the_rcd)
+	switch(the_rcd.mode)
+		if(RCD_DECONSTRUCT)
+			return list("delay" = 5 SECONDS, "cost" = 32)
+
+	return FALSE
+
+/obj/machinery/door/firedoor/rcd_act(mob/user, obj/item/construction/rcd/the_rcd, list/rcd_data)
+	switch(rcd_data["[RCD_DESIGN_MODE]"])
+		if(RCD_DECONSTRUCT)
+			qdel_self()
+			return TRUE
+
+	return FALSE
+
 //These are playing merry hell on ZAS.  Sorry fellas :(
 
 /obj/machinery/door/firedoor/border_only

--- a/code/game/objects/structures/window_frame.dm
+++ b/code/game/objects/structures/window_frame.dm
@@ -957,6 +957,19 @@
 		health -= damage
 		healthcheck()
 
+/obj/structure/window_frame/rcd_vals(mob/user, obj/item/construction/rcd/the_rcd)
+	if(the_rcd.mode == RCD_DECONSTRUCT)
+		return list("delay" = 2 SECONDS, "cost" = 5)
+
+	return FALSE
+
+/obj/structure/window_frame/rcd_act(mob/user, obj/item/construction/rcd/the_rcd, list/rcd_data)
+	if(rcd_data["[RCD_DESIGN_MODE]"] == RCD_DECONSTRUCT)
+		qdel_self()
+		return TRUE
+
+	return FALSE
+
 /obj/structure/window_frame/proc/toggle_tint()
 	if(frame_state != FRAME_ELECTRIC && frame_state != FRAME_RELECTRIC)
 		return
@@ -1026,6 +1039,12 @@
 	pane_melee_mult = 0.9
 
 	rad_resist_type = /datum/rad_resist/none
+
+/obj/structure/window_frame/reinforced/rcd_vals(mob/user, obj/item/construction/rcd/the_rcd)
+	if(the_rcd.mode == RCD_DECONSTRUCT)
+		return list("delay" = 3 SECONDS, "cost" = 10)
+
+	return FALSE
 
 // Pretty much the same as the old grille, but smarter.
 /obj/structure/window_frame/grille

--- a/code/game/turfs/space/space.dm
+++ b/code/game/turfs/space/space.dm
@@ -234,6 +234,9 @@
 /turf/space/rcd_act(mob/user, obj/item/construction/rcd/the_rcd, list/rcd_data)
 	if(rcd_data["[RCD_DESIGN_MODE]"] == RCD_TURF)
 		ChangeTurf(/turf/simulated/floor/plating/airless)
+		var/obj/structure/lattice/L = locate(/obj/structure/lattice, src)
+		if(L)
+			qdel(L)
 		return TRUE
 
 	return FALSE

--- a/code/modules/multiz/turf.dm
+++ b/code/modules/multiz/turf.dm
@@ -121,7 +121,7 @@
 		vis_contents += below
 
 /turf/simulated/open/attackby(obj/item/C, mob/user)
-	if (istype(C, /obj/item/stack/rods))
+	if(istype(C, /obj/item/stack/rods))
 		var/obj/structure/lattice/L = locate(/obj/structure/lattice, src)
 		if(L)
 			return L.attackby(C, user)
@@ -134,7 +134,7 @@
 			SSopen_space.add_turf(src, 1)
 		return
 
-	if (istype(C, /obj/item/stack/tile))
+	if(istype(C, /obj/item/stack/tile))
 		var/obj/structure/lattice/L = locate(/obj/structure/lattice, src)
 		if(L)
 			var/obj/item/stack/tile/floor/S = C
@@ -157,6 +157,26 @@
 		coil.turf_place(src, user)
 		return
 	return
+
+/turf/simulated/open/rcd_vals(mob/user, obj/item/construction/rcd/the_rcd)
+	if(the_rcd.mode == RCD_TURF && the_rcd.rcd_design_path == /turf/simulated/floor/plating)
+		var/obj/structure/lattice/L = locate(/obj/structure/lattice, src)
+		if(L)
+			return list("delay" = 0, "cost" = 1)
+		else
+			return list("delay" = 0, "cost" = 3)
+
+	return FALSE
+
+/turf/simulated/open/rcd_act(mob/user, obj/item/construction/rcd/the_rcd, list/rcd_data)
+	if(rcd_data["[RCD_DESIGN_MODE]"] == RCD_TURF)
+		ChangeTurf(/turf/simulated/floor/plating)
+		var/obj/structure/lattice/L = locate(/obj/structure/lattice, src)
+		if(L)
+			qdel(L)
+		return TRUE
+
+	return FALSE
 
 //Most things use is_plating to test if there is a cover tile on top (like regular floors)
 /turf/simulated/open/is_plating()


### PR DESCRIPTION
- РЦД теперь может разбирать фуллтайловые окна. Обычные окна разбираются за 2 секунды и 5 единиц материи, укреплённые -- за 3 секунды и 10 материи.
- РЦД теперь может разбирать экстренные заслонки. Цена аналогична шлюзам: 5 секунд и 32 материи.
- РЦД теперь может строить обшивку на дырках, ведущих на нижние Z-уровни. Если на тайле нет решётки (lattice), это стоит 3 материи, если есть -- 1 -- так же, как и при строительстве в космосе.
- При конструировании РЦД обшивки на тайле космоса или дырке, если на тайле была решётка, она теперь будет удаляться.

<details>
<summary>Чейнджлог</summary>

```yml
🆑TheUnknownOne
rscadd: РЦД теперь может деконструировать фуллтайловые окна и экстренные заслонки, а также строить на дырках в полу (open space).
bugfix: При конструировании с помощью РЦД обшивки на тайле космоса или дырке, если на тайле была решётка, она теперь всегда будет удаляться.
/🆑
```

</details>

- [x] Pull Request полностью завершен, мне не нужна помощь чтобы его закончить.
- [x] Я внимательно прочитал(-а) все свои изменения и багов в них не нашёл(-ла).
- [x] Я запускал(-а) сервер со своими изменениями локально и все протестировал(-а).
- [x] Я ознакомился(-ась) c [Guide to Contribute](https://github.com/ChaoticOnyx/OnyxBay/blob/dev/docs/contributing.md).
