### PR TITLE
tweak(holopad): adding intent check

### DIFF
--- a/code/game/machinery/hologram.dm
+++ b/code/game/machinery/hologram.dm
@@ -65,6 +65,8 @@ var/const/HOLOPAD_MODE = RANGE_BASED
 /obj/machinery/hologram/holopad/attack_hand(mob/living/carbon/human/user) //Carn: Hologram requests.
 	if(!istype(user))
 		return
+	if(user.a_intent != I_HELP) // We don't really want to interrupt fight because of this.
+		return
 	if(incoming_connection&&caller_id)
 		visible_message("The pad hums quietly as it establishes a connection.")
 		if(caller_id.loc!=sourcepad.loc)


### PR DESCRIPTION
Добавил проверку на интент чтобы диалоговое окно не ебало мозг посреди пиздиловки

<details>
<summary>Чейнджлог</summary>

```yml
🆑
tweak: Диалоговое окно голопада теперь вызывается только на хелпе
/🆑
```

</details>

- [x] Pull Request полностью завершен, мне не нужна помощь чтобы его закончить.
- [x] Я внимательно прочитал(-а) все свои изменения и багов в них не нашёл(-ла).
- [x] Я запускал(-а) сервер со своими изменениями локально и все протестировал(-а).
- [x] Я ознакомился(-ась) c [Guide to Contribute](https://github.com/ChaoticOnyx/OnyxBay/blob/dev/docs/contributing.md).
