### PR TITLE
tweak(QoL): inactive hand drop & activate hotkeys, fix rightclick verb

### DIFF
--- a/code/modules/client/client_procs.dm
+++ b/code/modules/client/client_procs.dm
@@ -870,3 +870,15 @@
 		if(!(key in list("F1","F2")) && !winget(src, "default-\ref[key]", "command"))
 			to_chat(src, "You probably entered the game with a different keyboard layout.\n<a href='?src=\ref[src];reset_macros=1'>Please switch to the English layout and click here to fix the communication hotkeys.</a>")
 			break
+
+/client/verb/fix_rightclick()
+	set name = "Fix Rightclick"
+	set desc = "Use if your RMB is stuck in the clicking mode."
+	set category = "OOC"
+
+	if(ishuman(mob))
+		var/mob/living/carbon/human/H = mob
+		H.toggle_twohanded_mode(FALSE, TRUE)
+	else
+		winset(src, "mapwindow.rightclickblocker", "is-visible=false")
+		winset(src, "mapwindow.map", "right-click=false")

--- a/code/modules/keybindings/living.dm
+++ b/code/modules/keybindings/living.dm
@@ -30,9 +30,20 @@
 	hotkey_keys = list("Q", "Northwest") // HOME
 	name = "drop_item"
 	full_name = "Drop Item"
-	description = ""
+	description = "Drop the currently held item."
 
 /datum/keybinding/living/drop_item/down(client/user)
 	var/mob/living/L = user.mob
 	L.drop_active_hand()
+	return TRUE
+
+/datum/keybinding/living/drop_inactive_item
+	hotkey_keys = list("ShiftQ")
+	name = "drop_inactive_item"
+	full_name = "Drop Inactive Item"
+	description = "Drop the item held in the inactive hand."
+
+/datum/keybinding/living/drop_inactive_item/down(client/user)
+	var/mob/living/L = user.mob
+	L.drop_inactive_hand()
 	return TRUE

--- a/code/modules/keybindings/mob.dm
+++ b/code/modules/keybindings/mob.dm
@@ -29,12 +29,23 @@
 /datum/keybinding/mob/activate_inhand
 	hotkey_keys = list("Z", "Y","Southeast") // Southeast = PAGEDOWN
 	name = "activate_inhand"
-	full_name = "Activate In-Hand"
-	description = "Uses whatever item you have inhand"
+	full_name = "Use Held Item"
+	description = "Uses whatever item you have in the active hand."
 
 /datum/keybinding/mob/activate_inhand/down(client/user)
 	var/mob/M = user.mob
-	M.mode()
+	M.use_attack_self()
+	return TRUE
+
+/datum/keybinding/mob/activate_inhand_2
+	hotkey_keys = list("ShiftZ")
+	name = "activate_inhand_2"
+	full_name = "Use Inactive Held Item"
+	description = "Uses whatever item you have in the inactive hand."
+
+/datum/keybinding/mob/activate_inhand_2/down(client/user)
+	var/mob/M = user.mob
+	M.use_attack_self(FALSE)
 	return TRUE
 
 /datum/keybinding/mob/target_head_cycle

--- a/code/modules/mob/living/carbon/human/human.dm
+++ b/code/modules/mob/living/carbon/human/human.dm
@@ -1828,8 +1828,8 @@
 			twohanded_mode_icon.icon_state = "act_twohanded0"
 
 	if(my_client)
-		winset(src, "mapwindow.rightclickblocker", "is-visible=[twohanded_mode ? "true" : "false"]") // Please, forgive me for this abomination, but I can't think of a faster, mostly-client-sided way to preserve Shift, Ctrl and Alt macros' behavior.
-		winset(src, "mapwindow.map", "right-click=[twohanded_mode ? "true" : "false"]")
+		winset(my_client, "mapwindow.rightclickblocker", "is-visible=[twohanded_mode ? "true" : "false"]") // Please, forgive me for this abomination, but I can't think of a faster, mostly-client-sided way to preserve Shift, Ctrl and Alt macros' behavior.
+		winset(my_client, "mapwindow.map", "right-click=[twohanded_mode ? "true" : "false"]")
 
 /mob/living/carbon/human/is_deaf()
 	var/obj/item/organ/external/head/head = organs_by_name[BP_HEAD]

--- a/code/modules/mob/living/silicon/robot/robot.dm
+++ b/code/modules/mob/living/silicon/robot/robot.dm
@@ -1064,15 +1064,17 @@
 		return 1
 	return 0
 
-/mob/living/silicon/robot/mode()
+/mob/living/silicon/robot/activate_held_object()
 	set name = "Activate Held Object"
 	set category = "IC"
 	set src = usr
 
+	use_attack_self()
+	return
+
+/mob/living/silicon/robot/use_attack_self(is_active_hand = TRUE)
 	var/obj/item/I = get_active_hand()
 	I?.attack_self(src)
-
-	return
 
 /mob/living/silicon/robot/proc/choose_hull(list/module_hulls)
 	if(!length(module_hulls))

--- a/code/modules/mob/mob.dm
+++ b/code/modules/mob/mob.dm
@@ -353,24 +353,34 @@
 					G.affecting.ret_grab(L)
 	return L
 
-/mob/verb/mode()
+/mob/verb/activate_held_object()
 	set name = "Activate Held Object"
 	set category = "Object"
 	set src = usr
 
-	if(istype(loc,/obj/mecha)) return
+	use_attack_self()
+	return
+
+/mob/proc/use_attack_self(is_active_hand = TRUE)
+	if(istype(loc, /obj/mecha))
+		return
 
 	if(hand)
-		var/obj/item/I = l_hand
+		var/obj/item/I = is_active_hand ? l_hand : r_hand
 		if(I)
 			I.attack_self(src)
-			update_inv_l_hand()
+			if(is_active_hand)
+				update_inv_l_hand()
+			else
+				update_inv_r_hand()
 	else
-		var/obj/item/I = r_hand
+		var/obj/item/I = is_active_hand ? r_hand : l_hand
 		if(I)
 			I.attack_self(src)
-			update_inv_r_hand()
-	return
+			if(is_active_hand)
+				update_inv_r_hand()
+			else
+				update_inv_l_hand()
 
 /*
 /mob/verb/dump_source()

--- a/code/modules/mob/mob_movement.dm
+++ b/code/modules/mob/mob_movement.dm
@@ -99,7 +99,7 @@
 /client/verb/attack_self()
 	set hidden = 1
 	if(mob)
-		mob.mode()
+		mob.use_attack_self()
 	return
 
 


### PR DESCRIPTION
```yml
🆑
tweak: Хоткей "Activate In-Hand" переименован в "Use Held Item".
rscadd: Добавлен хоткей "Use Inactive Held Item", по умолчанию - Shift+Z. Работает аналогично обычному, но использует предмет в неактивной руке.
rscadd: Добавлен хоткей "Drop Inactive Item", по умолчанию - Shift+Q. Работает аналогично обычному, но роняет предмет из неактивной руки.
rscadd: Добавлена команда "Fix Rightclick", во вкладке "OOC". Чинит открытие контекстного меню по нажатию правой кнопки мыши, если оно залипло.
/🆑
```

- [x] Pull Request полностью завершен, мне не нужна помощь чтобы его закончить.
- [x] Я внимательно прочитал(-а) все свои изменения и багов в них не нашёл(-ла).
- [x] Я запускал(-а) сервер со своими изменениями локально и все протестировал(-а).
- [x] Я ознакомился(-ась) c [Guide to Contribute](https://github.com/ChaoticOnyx/OnyxBay/blob/dev/docs/contributing.md).
