### PR TITLE
tweak(gatecrasher): adds a disclaimer

### DIFF
--- a/code/datums/events/gatecrasher.dm
+++ b/code/datums/events/gatecrasher.dm
@@ -1,7 +1,7 @@
 /datum/event/gatecrasher
 	id = "gatecrasher"
 	name = "Gatecrasher"
-	description = "An uninvited guest get teleported aboard the station"
+	description = "An unexpected guest appears aboard the station."
 
 	mtth = 6 HOURS
 	difficulty = 60

--- a/code/modules/mob/living/carbon/human/human_species.dm
+++ b/code/modules/mob/living/carbon/human/human_species.dm
@@ -51,18 +51,27 @@
 
 /mob/living/carbon/human/gatecrasher/on_ghost_possess()
 	. = ..()
-	if(prob(65))
-		return // Sorry no antagonizing today
+	var/role_notice = ""
+	if(prob(65)) // Sorry no antagonizing today
+		role_notice = "Given that you are not an antag,"
+	else
+		var/antag_poll = list(
+			MODE_CHANGELING = 3,
+			MODE_TRAITOR = 15,
+			MODE_VAMPIRE = 3,
+			MODE_CULTIST = 5,
+			MODE_REVOLUTIONARY = 5
+		)
+		var/datum/antagonist/selected_antag = GLOB.all_antag_types_[util_pick_weight(antag_poll)]
+		selected_antag?.add_antagonist(mind, TRUE, max_stat = UNCONSCIOUS)
+		role_notice = "Even though you happen to be an antag,"
 
-	var/antag_poll = list(
-		MODE_CHANGELING = 3,
-		MODE_TRAITOR = 15,
-		MODE_VAMPIRE = 3,
-		MODE_CULTIST = 5,
-		MODE_REVOLUTIONARY = 5
-	)
-	var/datum/antagonist/selected_antag = GLOB.all_antag_types_[util_pick_weight(antag_poll)]
-	selected_antag?.add_antagonist(mind, TRUE, max_stat = UNCONSCIOUS)
+	spawn(1 SECOND) // Added a delay so that this should pop up at the bottom, since we can get a lot of other spam by possessing a human and becoming an antag.
+		var/disclaimer = "*--------------------*\n<b>You're a gatecrasher!</b>\n"
+		disclaimer += "How did you end up in a locker aboard the station? What are your goals? Who are you? You tell the world! Your past and your future are yours to craft.\n"
+		disclaimer += "<b>[role_notice] remember, that you're not above the rules.</b> You have a chance to make this shift unique and unforgettable, don't waste it by aimlessly wrecking havoc and succumbing to wanton carnage.\n"
+		disclaimer += "Please, do your best to make it fun for the others, and have fun yourself!\n*--------------------*"
+		to_chat(src, SPAN("notice", "[disclaimer]"))
 
 /mob/living/carbon/human/skrell/New(new_loc)
 	h_style = "Skrell Male Tentacles"

--- a/code/modules/mob/living/carbon/human/human_species.dm
+++ b/code/modules/mob/living/carbon/human/human_species.dm
@@ -69,7 +69,7 @@
 	spawn(1 SECOND) // Added a delay so that this should pop up at the bottom, since we can get a lot of other spam by possessing a human and becoming an antag.
 		var/disclaimer = "*--------------------*\n<b>You're a gatecrasher!</b>\n"
 		disclaimer += "How did you end up in a locker aboard the station? What are your goals? Who are you? You tell the world! Your past and your future are yours to craft.\n"
-		disclaimer += "<b>[role_notice] remember, that you're not above the rules.</b> You have a chance to make this shift unique and unforgettable, don't waste it by aimlessly wrecking havoc and succumbing to wanton carnage.\n"
+		disclaimer += "<b>[role_notice] remember that you're not above the rules.</b> You have a chance to make this shift unique and unforgettable, don't waste it by aimlessly wreaking havoc and succumbing to wanton carnage.\n"
 		disclaimer += "Please, do your best to make it fun for the others, and have fun yourself!\n*--------------------*"
 		to_chat(src, SPAN("notice", "[disclaimer]"))
 


### PR DESCRIPTION
```yml
🆑
tweak: Грейткрашеры теперь получают сообщение при заходе.
/🆑
```

- [x] Pull Request полностью завершен, мне не нужна помощь чтобы его закончить.
- [x] Я внимательно прочитал(-а) все свои изменения и багов в них не нашёл(-ла).
- [x] Я запускал(-а) сервер со своими изменениями локально и все протестировал(-а).
- [x] Я ознакомился(-ась) c [Guide to Contribute](https://github.com/ChaoticOnyx/OnyxBay/blob/dev/docs/contributing.md).
