### PR TITLE
tweak(assorted): *mostly* enforces add/remove_client_image() use

### DIFF
--- a/code/_onclick/hud/radial.dm
+++ b/code/_onclick/hud/radial.dm
@@ -28,7 +28,7 @@ GLOBAL_LIST_EMPTY(radial_menus)
 	icon_state = "radial_slice"
 
 /atom/movable/screen/radial/slice/Click(location, control, params)
-	if(usr.client == parent.current_user)
+	if(usr == parent.current_user)
 		if(next_page)
 			parent.next_page()
 		else
@@ -47,7 +47,7 @@ GLOBAL_LIST_EMPTY(radial_menus)
 	icon_state = "radial_center"
 
 /atom/movable/screen/radial/center/Click(location, control, params)
-	if(usr.client == parent.current_user)
+	if(usr == parent.current_user)
 		parent.finished = TRUE
 
 /datum/radial_menu
@@ -60,7 +60,7 @@ GLOBAL_LIST_EMPTY(radial_menus)
 	var/selected_choice
 	var/list/atom/movable/screen/elements = list()
 	var/atom/movable/screen/radial/center/close_button
-	var/client/current_user
+	var/mob/current_user
 	var/atom/anchor
 	var/image/menu_holder
 	var/finished = FALSE
@@ -257,18 +257,18 @@ GLOBAL_LIST_EMPTY(radial_menus)
 		hide()
 	if(!M.client || !anchor)
 		return
-	current_user = M.client
+	current_user = M
 	//Blank
 	menu_holder = image(icon='icons/effects/effects.dmi', loc=anchor, icon_state="nothing", layer = HUD_ABOVE_ITEM_LAYER)
 	menu_holder.plane = HUD_PLANE
 	menu_holder.appearance_flags |= KEEP_APART
 	menu_holder.vis_contents += elements + close_button
-	current_user.images += menu_holder
+	current_user.add_client_image(menu_holder)
 
 /datum/radial_menu/proc/hide()
 	menu_holder.vis_contents = null
-	if(current_user)
-		current_user.images -= menu_holder
+	current_user?.remove_client_image(menu_holder)
+	current_user = null
 
 /datum/radial_menu/proc/wait(atom/user, atom/anchor, require_near = FALSE)
 	while (current_user && !finished && !selected_choice)
@@ -287,7 +287,7 @@ GLOBAL_LIST_EMPTY(radial_menus)
 	Reset()
 	hide()
 	QDEL_NULL(close_button)
-	. = ..()
+	return ..()
 /*
 	Presents radial menu to user anchored to anchor (or user if the anchor is currently in users screen)
 	Choices should be a list where list keys are movables or text used for element names and return value

--- a/code/datums/appearances/appearance_manager.dm
+++ b/code/datums/appearances/appearance_manager.dm
@@ -27,8 +27,8 @@ var/decl/appearance_manager/appearance_manager = new()
 /decl/appearance_manager/proc/remove_appearance(mob/viewer, datum/appearance_data/ad, refresh_images)
 	var/datum/priority_queue/pq = appearances_[viewer]
 	pq.Remove(ad)
-	if(viewer.client)
-		viewer.client.images -= ad.images
+	for(var/image/I in ad.images)
+		viewer.remove_client_image(I)
 	if(!pq.Length())
 		unregister_signal(viewer, SIGNAL_LOGGED_IN)
 		unregister_signal(viewer, SIGNAL_QDELETING)
@@ -53,7 +53,8 @@ var/decl/appearance_manager/appearance_manager = new()
 		return
 	for(var/entry in pq.L)
 		var/datum/appearance_data/ad = entry
-		viewer.client.images -= ad.images
+		for(var/image/I in ad.images)
+			viewer.remove_client_image(I)
 
 /decl/appearance_manager/proc/apply_appearance_images(mob/viewer)
 	if(!viewer.client)
@@ -63,4 +64,5 @@ var/decl/appearance_manager/appearance_manager = new()
 		return
 	for(var/entry in pq.L)
 		var/datum/appearance_data/ad = entry
-		viewer.client.images |= ad.images
+		for(var/image/I in ad.images)
+			viewer.add_client_image(I)

--- a/code/game/antagonist/antagonist_update.dm
+++ b/code/game/antagonist/antagonist_update.dm
@@ -21,10 +21,11 @@
 		player.set_id_info(id)
 
 /datum/antagonist/proc/clear_indicators(datum/mind/recipient)
-	if(!recipient.current || !recipient.current.client)
+	if(!recipient.current)
 		return
-	for(var/image/I in recipient.current.client.images)
+	for(var/image/I in recipient.current.client_images)
 		if(I.icon_state == antag_indicator || (faction_indicator && I.icon_state == faction_indicator))
+			recipient.current.remove_client_image(I)
 			qdel(I)
 
 /datum/antagonist/proc/get_indicator(datum/mind/recipient, datum/mind/other)
@@ -41,8 +42,8 @@
 		if(faction_invisible && (antag in faction_members))
 			continue
 		for(var/datum/mind/other_antag in current_antagonists)
-			if(antag.current && antag.current.client)
-				antag.current.client.images |= get_indicator(antag, other_antag)
+			if(antag.current)
+				antag.current.add_client_image(get_indicator(antag, other_antag))
 
 /datum/antagonist/proc/update_icons_added(datum/mind/player)
 	if(!antag_indicator || !player.current)
@@ -53,12 +54,11 @@
 		for(var/datum/mind/antag in current_antagonists)
 			if(!antag.current)
 				continue
-			if(antag.current.client)
-				antag.current.client.images |= get_indicator(antag, player)
+			antag.current.add_client_image(get_indicator(antag, player))
 			if(!give_to_player)
 				continue
-			if(player.current.client)
-				player.current.client.images |= get_indicator(player, antag)
+			if(player.current)
+				player.current.add_client_image(get_indicator(player, antag))
 
 /datum/antagonist/proc/update_icons_removed(datum/mind/player)
 	if(!antag_indicator || !player.current)
@@ -68,8 +68,9 @@
 		if(player.current && player.current.client)
 			for(var/datum/mind/antag in current_antagonists)
 				if(antag.current && antag.current.client)
-					for(var/image/I in antag.current.client.images)
+					for(var/image/I in antag.current.client_images)
 						if(I.loc == player.current)
+							antag.current.remove_client_image(I)
 							qdel(I)
 
 /datum/antagonist/proc/update_current_antag_max(datum/game_mode/mode)

--- a/code/game/objects/items/devices/t_scanner.dm
+++ b/code/game/objects/items/devices/t_scanner.dm
@@ -17,7 +17,7 @@
 
 	var/on = 0
 	var/list/active_scanned = list() //assoc list of objects being scanned, mapped to their overlay
-	var/client/user_client //since making sure overlays are properly added and removed is pretty important, so we track the current user explicitly
+	var/mob/user_mob //since making sure overlays are properly added and removed is pretty important, so we track the current user explicitly
 	var/base_state = "t-ray"
 
 	var/global/list/overlay_cache = list() //cache recent overlays
@@ -44,7 +44,7 @@
 		set_next_think(world.time + 1 SECOND)
 	else
 		set_next_think(0)
-		set_user_client(null)
+		set_user_mob(null)
 	update_icon()
 
 //If reset is set, then assume the client has none of our overlays, otherwise we only send new overlays.
@@ -53,14 +53,12 @@
 		return
 
 	//handle clients changing
-	var/client/loc_client = null
-	if(ismob(src.loc))
-		var/mob/M = src.loc
-		loc_client = M.client
-	set_user_client(loc_client)
+	if(ismob(loc))
+		var/mob/M = loc
+		set_user_mob(M)
 
 	//no sense processing if no-one is going to see it.
-	if(!user_client)
+	if(!user_mob)
 		set_next_think(world.time + 1 SECOND)
 		return
 
@@ -73,11 +71,11 @@
 	for(var/obj/O in update_add)
 		var/image/overlay = get_overlay(O)
 		active_scanned[O] = overlay
-		user_client.images += overlay
+		user_mob.add_client_image(overlay)
 
 	//Remove stale overlays
 	for(var/obj/O in update_remove)
-		user_client.images -= active_scanned[O]
+		user_mob.remove_client_image(active_scanned[O])
 		active_scanned -= O
 
 	set_next_think(world.time + 1 SECOND)
@@ -149,22 +147,22 @@
 
 
 
-/obj/item/device/t_scanner/proc/set_user_client(client/new_client)
-	if(new_client == user_client)
+/obj/item/device/t_scanner/proc/set_user_mob(mob/new_mob)
+	if(new_mob == user_mob)
 		return
-	if(user_client)
+	if(user_mob)
 		for(var/scanned in active_scanned)
-			user_client.images -= active_scanned[scanned]
-	if(new_client)
+			user_mob.remove_client_image(active_scanned[scanned])
+	if(new_mob)
 		for(var/scanned in active_scanned)
-			new_client.images += active_scanned[scanned]
+			new_mob.add_client_image(active_scanned[scanned])
 	else
 		active_scanned.Cut()
 
-	user_client = new_client
+	user_mob = new_mob
 
 /obj/item/device/t_scanner/dropped(mob/user)
-	set_user_client(null)
+	set_user_mob(null)
 	..()
 
 /obj/item/device/t_scanner/advanced

--- a/code/modules/holomaps/holomarker_component.dm
+++ b/code/modules/holomaps/holomarker_component.dm
@@ -48,8 +48,9 @@
 
 	if(istype(activator))
 		unregister_signal(activator, SIGNAL_Z_CHANGED)
-		activator?.client?.images -= holomap_images
-		activator?.client?.images -= holomap_base
+		for(var/image/I in holomap_images)
+			activator?.remove_client_image(I)
+		activator?.remove_client_image(holomap_base)
 
 	if(istype(parent))
 		unregister_signal(parent, SIGNAL_ITEM_UNEQUIPPED)
@@ -70,7 +71,7 @@
 	GLOB.holocache["_\ref[src]_self"] = create_marker_image(parent_.x, parent_.y, "you", HUD_HOLOMARKER_SELF_LAYER)
 
 /datum/component/holomarker/toggleable/proc/toggle(mob/user)
-	if(!user || !user.client)
+	if(!user)
 		return
 
 	activator = user
@@ -98,7 +99,7 @@
 	holomap_base.layer = HUD_ABOVE_ITEM_LAYER
 
 	animate(holomap_base, alpha = 255, time = 5, easing = LINEAR_EASING)
-	activator.client.images |= holomap_base
+	activator.add_client_image(holomap_base)
 
 /datum/component/holomarker/toggleable/proc/deactivate()
 	toggled = FALSE
@@ -107,9 +108,10 @@
 	if(holomap_base)
 		animate(holomap_base, alpha = 0, time = 5, easing = LINEAR_EASING)
 
-	activator?.client?.images -= holomap_images
+	for(var/image/I in holomap_images)
+		activator?.remove_client_image(holomap_images)
 	spawn(5)
-		activator?.client?.images -= holomap_base
+		activator?.remove_client_image(holomap_base)
 
 	activator = null
 
@@ -123,13 +125,15 @@
 		return
 
 	if(holomap_images.len)
-		activator.client.images -= holomap_images
+		for(var/image/I in holomap_images)
+			activator.remove_client_image(I)
 		holomap_images.Cut()
 
 	handle_self_marker()
 	handle_markers()
 
-	activator.client.images += holomap_images
+	for(var/image/I in holomap_images)
+		activator.add_client_image(holomap_images)
 
 	set_next_think(world.time + 1 SECOND)
 
@@ -180,10 +184,10 @@
 
 /datum/component/holomarker/toggleable/proc/on_z_change(atom, old_turf, new_turf)
 	var/atom/new_loc = new_turf
-	if(!activator || !activator.client)
+	if(!activator)
 		return
 
-	activator.client.images -= holomap_base
+	activator.remove_client_image(holomap_base)
 
 	holomap_base = image(GLOB.holomaps[get_z(new_loc)])
 
@@ -196,7 +200,7 @@
 	holomap_base.plane = HUD_PLANE
 	holomap_base.layer = HUD_ABOVE_ITEM_LAYER
 	holomap_base.loc = activator.hud_used.holomap_obj
-	activator.client.images |= holomap_base
+	activator.add_client_image(holomap_base)
 
 /// Transmits & receives other holochips on the same frequency
 /datum/component/holomarker/toggleable/transmitting

--- a/code/modules/holomaps/holomarker_component.dm
+++ b/code/modules/holomaps/holomarker_component.dm
@@ -109,7 +109,7 @@
 		animate(holomap_base, alpha = 0, time = 5, easing = LINEAR_EASING)
 
 	for(var/image/I in holomap_images)
-		activator?.remove_client_image(holomap_images)
+		activator?.remove_client_image(I)
 	spawn(5)
 		activator?.remove_client_image(holomap_base)
 
@@ -133,7 +133,7 @@
 	handle_markers()
 
 	for(var/image/I in holomap_images)
-		activator.add_client_image(holomap_images)
+		activator.add_client_image(I)
 
 	set_next_think(world.time + 1 SECOND)
 

--- a/code/modules/mob/living/carbon/hallucinations.dm
+++ b/code/modules/mob/living/carbon/hallucinations.dm
@@ -143,8 +143,8 @@
 	plasma_image.plane = FLY_LAYER
 	flood_images += plasma_image
 	flood_turfs += center
-	if(holder.client)
-		holder.client.images |= flood_images
+	for(var/image/I in flood_images)
+		holder.add_client_image(I)
 	next_expand = world.time + FAKE_FLOOD_EXPAND_TIME
 	set_next_think(world.time + 1 SECOND)
 
@@ -182,14 +182,15 @@
 			flood_turfs += T
 			expanded = 1
 	radius += expanded
-	if(holder.client)
-		holder.client.images |= flood_images
+	for(var/image/I in flood_images)
+		holder.add_client_image(I)
 
 /datum/hallucination/fake_flood/end()
 	set_next_think(0)
 
-	if(holder.client)
-		holder.client.images.Remove(flood_images)
+	for(var/image/I in flood_images)
+		holder.remove_client_image(I)
+
 	QDEL_LIST(flood_images)
 	flood_turfs.Cut()
 	holder.hallucinations -= src
@@ -409,14 +410,17 @@
 
 /obj/item/mirage_item
 	var/image/img
-	var/client/client
+	var/mob/holder
 
 /obj/item/mirage_item/pickup(mob/living/carbon/human/H)
 	H.visible_message(SPAN_NOTICE("[H] tried to take something, but only grabbed air."),
 		SPAN_WARNING("Your hand seems to go right through the [name ? src : "item"]. It's like it doesn't exist."))
+	qdel_self()
 
-	client.images -= img
-	qdel(src)
+/obj/item/mirage_item/Destroy()
+	holder?.remove_client_image(img)
+	holder = null
+	return ..()
 
 /datum/hallucination/item_mirage
 	duration = 30 SECONDS
@@ -484,31 +488,29 @@
 	for(var/i = 1 to number)
 		var/turf/simulated/floor/point = pick(possible_points)
 		var/obj/item/mirage_item/thing = generate_mirage(point)
-		thing.client = holder.client
+		thing.holder = holder
 		items += thing
 		if(sound)
 			holder.playsound_local(point, sound, volume)
-		holder.client.images += thing.img
+		holder.add_client_image(thing.img)
 
 /datum/hallucination/item_mirage/end()
-	if(holder?.client)
-		for(var/obj/item/mirage_item/I in items)
-			holder.client.images -= I.img
-			qdel(I)
+	QDEL_NULL_LIST(items)
 
 // Singulo
-/obj/item/mirage_item/singulo
-	var/target
-
 /obj/item/mirage_item/singulo/Initialize()
 	. = ..()
 	set_next_think(world.time + 1 SECOND)
 
 /obj/item/mirage_item/singulo/think()
-	step_to(src, target, 1)
-	if(get_dist(src, target) < 2)
+	if(QDELETED(holder))
+		qdel_self()
+		return
+
+	step_to(src, holder, 1)
+	if(get_dist(src, holder) < 2)
 		qdel(src)
-		var/mob/living/carbon/human/H = target
+		var/mob/living/carbon/human/H = holder
 		H?.Paralyse(5)
 		H.playsound_local(get_turf(src), sound('sound/effects/bang.ogg'), 70, 1, 30)
 
@@ -521,13 +523,12 @@
 /datum/hallucination/item_mirage/singulo/generate_mirage(turf/loc)
 	var/obj/item/mirage_item/singulo/I = new(loc)
 	I.img = image('icons/effects/96x96.dmi', loc = I, icon_state = "singularity_s3")
-	I.target = holder
+	I.holder = holder
 	return I
 
 // Balloons
 
 /obj/item/mirage_item/balloon
-	var/target
 	var/mdir
 
 /obj/item/mirage_item/balloon/Initialize()
@@ -536,21 +537,25 @@
 	mdir = rand(-1, 1)
 
 /obj/item/mirage_item/balloon/think()
+	if(QDELETED(holder))
+		qdel_self()
+		return
+
 	pixel_x += sin(world.time) * 16 * mdir * rand(-1, 1)
 	pixel_y += cos(world.time) * 16 * mdir * rand(-1, 1)
 
 	if(!prob(10))
 		return
-	step_to(src, target, 1)
-	if(get_dist(src, target) < 2)
-		step_away(src, target, 5, 128)
+	step_to(src, holder, 1)
+	if(get_dist(src, holder) < 2)
+		step_away(src, holder, 5, 128)
 
 	set_next_think(world.time + 1 SECOND)
 
 /obj/item/mirage_item/balloon/pickup(mob/living/carbon/human/H)
 	H.visible_message(SPAN_NOTICE("[H] tried to take something, but only grabbed air."),
 		SPAN_WARNING("Your hand seems to go right through the [name ? src : "item"]. It's like it doesn't exist."))
-	qdel(src)
+	qdel_self()
 
 /datum/hallucination/item_mirage/balloon
 	number = 5
@@ -559,27 +564,29 @@
 /datum/hallucination/item_mirage/balloon/generate_mirage(turf/loc)
 	var/obj/item/mirage_item/balloon/I = new(loc)
 	I.img = image('icons/obj/weapons.dmi', loc = I, icon_state = pick("syndballoon", "ntballoon", "snailballoon"))
-	I.target = holder
+	I.holder = holder
 	return I
 
 // Black holes
 
 /obj/item/mirage_item/bhole
-	var/target
 	var/mdir
 
 /obj/item/mirage_item/bhole/Initialize()
 	. = ..()
 	set_next_think(world.time + 1 SECOND)
 	mdir = rand(-1, 1)
-	..(loc)
 
 /obj/item/mirage_item/bhole/think()
+	if(QDELETED(holder))
+		qdel_self()
+		return
+
 	pixel_x += sin(world.time) * 32 * mdir * rand(-1, 1)
 	pixel_y += cos(world.time) * 32 * mdir * rand(-1, 1)
 
-	if(get_dist(src, target) < 2)
-		var/mob/living/carbon/human/H = target
+	if(get_dist(src, holder) < 2)
+		var/mob/living/carbon/human/H = holder
 		if(!H)
 			return
 		H.Paralyse(1)
@@ -589,12 +596,12 @@
 	else if(prob(5))
 		step_rand(src)
 	else if(prob(6))
-		step_to(src, target)
+		step_to(src, holder)
 
 	set_next_think(world.time + 1 SECOND)
 
 /obj/item/mirage_item/bhole/pickup(mob/living/carbon/human/H)
-	qdel(src)
+	qdel_self()
 
 /datum/hallucination/item_mirage/bhole
 	number = 3
@@ -603,7 +610,7 @@
 /datum/hallucination/item_mirage/bhole/generate_mirage(turf/loc)
 	var/obj/item/mirage_item/bhole/I = new(loc)
 	I.img = image('icons/obj/objects.dmi', loc = I, icon_state = "bhole3")
-	I.target = holder
+	I.holder = holder
 	return I
 
 /datum/hallucination/mirage
@@ -615,7 +622,7 @@
 
 /datum/hallucination/mirage/Destroy()
 	end()
-	. = ..()
+	return ..()
 
 /datum/hallucination/mirage/proc/generate_mirage()
 	var/icon/T = new('icons/obj/trash.dmi')
@@ -633,11 +640,11 @@
 			thing.loc = point
 			if(sound)
 				holder.playsound_local(point, sound, volume)
-		holder.client.images += things
+			holder.add_client_image(thing)
 
 /datum/hallucination/mirage/end()
-	if(holder?.client)
-		holder.client.images -= things
+	for(var/image/thing in things)
+		holder.remove_client_image(thing)
 
 /datum/hallucination/mirage/crayon/generate_mirage()
 	var/icon/T  = new('icons/effects/crayondecal.dmi')
@@ -844,7 +851,7 @@
 		fake_look.invisibility = 0
 	if(fake.lying)
 		fake_look.SetTransform(others = fake.transform, rotation = -90)
-	holder.client.images |= fake_look
+	holder.add_client_image(fake_look)
 
 	log_misc("[holder.name] is hallucinating that [origin.name] is the [fake.name]")
 
@@ -869,8 +876,7 @@
 	if(!fake_look)
 		return // No ASSERT is needed, ending is correct
 
-	if(holder.client)
-		holder.client.images -= fake_look
+	holder?.remove_client_image(fake_look)
 
 	QDEL_NULL(fake_look)
 
@@ -974,18 +980,19 @@
 	var/chosen = rand(1, available_effects.len)
 	for(var/turf/simulated/T in room.contents)
 		effects.Add(image(icon = file(available_effects[chosen]), loc = T, icon_state = available_effects[available_effects[chosen]], layer = FLY_LAYER))
-	holder.client.images |= effects
+	for(var/image/I in effects)
+		holder.add_client_image(I)
 
 /datum/hallucination/room_effects/end()
 	if(!effects)
 		return // Already qdeleted
-	if(holder.client)
-		holder.client.images -= effects
+	for(var/image/I in effects)
+		holder.remove_client_image(I)
 	QDEL_NULL_LIST(effects)
 
 /datum/hallucination/room_effects/Destroy()
 	end()
-	. = ..()
+	return ..()
 
 /datum/hallucination/coloring
 	duration = 30 SECONDS
@@ -1005,15 +1012,15 @@
 		colored.override = 0 // This way, increasing I.plane or I.layer will reveal original icon. If you want to change this behavior, you need to make colored.override = 1, and manually change colored.plane and colored.layer along with original`s, because it's not inherited
 		colored.color = rgb(rand(60,255), rand(60,255), rand(60,255))
 		colored_images += colored
-	holder.client.images |= colored_images
+		holder.add_client_image(colored)
 
 /datum/hallucination/coloring/end()
 	if(!colored_images)
 		return // Already qdeleted
-	if(holder.client)
-		holder.client.images -= colored_images
+	for(var/image/colored in colored_images)
+		holder.remove_client_image(colored)
 	QDEL_NULL_LIST(colored_images)
 
 /datum/hallucination/coloring/Destroy()
 	end()
-	. = ..()
+	return ..()

--- a/code/modules/mob/living/carbon/obsession.dm
+++ b/code/modules/mob/living/carbon/obsession.dm
@@ -20,8 +20,8 @@
 			I.loc = L
 			I.color = COLOR_BLOOD_HUMAN
 
-			client.images += I
 			images += I
+			add_client_image(I)
 
 		while (obsession_time)
 			obsession_time = max(0, obsession_time - 1 SECOND)
@@ -30,4 +30,5 @@
 		Sleeping(5)
 		sleep(3 SECOND)
 		clear_fullscreen("red")
-		client.images -= images
+		for(var/image/I in images)
+			remove_client_image(I)

--- a/code/modules/mob/living/deity/phenomena/communication.dm
+++ b/code/modules/mob/living/deity/phenomena/communication.dm
@@ -34,14 +34,14 @@
 			var/mob/M = mind.current
 			if((M in view) && M.client)
 				to_chat(M, "<span class='cult'>Your attention is eerily drawn to \the [a].</span>")
-				M.client.images += arrow
+				M.add_client_image(arrow)
 				register_signal(M, SIGNAL_LOGGED_OUT, nameof(/datum/phenomena/point.proc/remove_image))
 				spawn(20)
 					if(M.client)
 						remove_image(M)
 
 /datum/phenomena/point/proc/remove_image(mob/living/L)
-	L.client.images -= arrow
+	L.remove_client_image(arrow)
 	unregister_signal(L, SIGNAL_LOGGED_OUT)
 
 /datum/phenomena/punish

--- a/code/modules/mob/living/silicon/robot/life.dm
+++ b/code/modules/mob/living/silicon/robot/life.dm
@@ -162,18 +162,18 @@
 			if(MED_VISION)
 				process_med_hud(src, 1)
 
-	if(syndicate && client)
-		for(var/datum/mind/traitor_mind in GLOB.traitors.current_antagonists)
-			if(traitor_mind.current)
+		if(syndicate)
+			for(var/datum/mind/traitor_mind in GLOB.traitors.current_antagonists)
+				if(traitor_mind.current)
+					// TODO: Update to new antagonist system.
+					var/I = image('icons/mob/mob.dmi', loc = traitor_mind.current, icon_state = "traitor")
+					add_client_image(I)
+			disconnect_from_ai()
+			if(mind)
 				// TODO: Update to new antagonist system.
-				var/I = image('icons/mob/mob.dmi', loc = traitor_mind.current, icon_state = "traitor")
-				client.images += I
-		disconnect_from_ai()
-		if(mind)
-			// TODO: Update to new antagonist system.
-			if(!mind.special_role)
-				mind.special_role = "Traitor"
-				GLOB.traitors.current_antagonists |= mind
+				if(!mind.special_role)
+					mind.special_role = "Traitor"
+					GLOB.traitors.current_antagonists |= mind
 
 	if(cells)
 		if(cell)

--- a/code/modules/mob/observer/freelook/chunk.dm
+++ b/code/modules/mob/observer/freelook/chunk.dm
@@ -104,14 +104,14 @@
 /datum/chunk/proc/add_eye(mob/observer/eye/eye)
 	seenby += eye
 	eye.visibleChunks += src
-	if(eye.owner && eye.owner.client)
+	if(eye.owner)
 		for(var/image/I in obscured)
 			eye.owner.add_client_image(I)
 
 /datum/chunk/proc/remove_eye(mob/observer/eye/eye)
 	seenby -= eye
 	eye.visibleChunks -= src
-	if(eye.owner && eye.owner.client)
+	if(eye.owner)
 		for(var/image/I in obscured)
 			eye.owner.remove_client_image(I)
 
@@ -167,7 +167,7 @@
 			for(var/eye in seenby)
 				var/mob/observer/eye/m = eye
 				if(m?.owner)
-					m.owner.remove_client_image(obfuscation_image)
+					m.owner.ad_client_image(obfuscation_image)
 
 	dirty = FALSE
 	updating = FALSE

--- a/code/modules/mob/observer/freelook/chunk.dm
+++ b/code/modules/mob/observer/freelook/chunk.dm
@@ -105,13 +105,15 @@
 	seenby += eye
 	eye.visibleChunks += src
 	if(eye.owner && eye.owner.client)
-		eye.owner.client.images += obscured
+		for(var/image/I in obscured)
+			eye.owner.add_client_image(I)
 
 /datum/chunk/proc/remove_eye(mob/observer/eye/eye)
 	seenby -= eye
 	eye.visibleChunks -= src
 	if(eye.owner && eye.owner.client)
-		eye.owner.client.images -= obscured
+		for(var/image/I in obscured)
+			eye.owner.remove_client_image(I)
 
 // Updates the chunk, makes sure that it doesn't update too much. If the chunk isn't being watched it will
 // instead be flagged to update the next time an AI Eye moves near it.
@@ -154,8 +156,8 @@
 			obscured -= obfuscation_image
 			for(var/eye in seenby)
 				var/mob/observer/eye/m = eye
-				if(m && m.owner && m.owner.client)
-					m.owner.client.images -= obfuscation_image
+				if(m?.owner?.client)
+					m.owner.remove_client_image(obfuscation_image)
 
 	for(var/turf in visRemoved)
 		var/turf/t = turf
@@ -164,8 +166,8 @@
 			obscured += obfuscation_image
 			for(var/eye in seenby)
 				var/mob/observer/eye/m = eye
-				if(m && m.owner && m.owner.client)
-					m.owner.client.images += obfuscation_image
+				if(m?.owner?.client)
+					m.owner.remove_client_image(obfuscation_image)
 
 	dirty = FALSE
 	updating = FALSE

--- a/code/modules/mob/observer/freelook/chunk.dm
+++ b/code/modules/mob/observer/freelook/chunk.dm
@@ -167,7 +167,7 @@
 			for(var/eye in seenby)
 				var/mob/observer/eye/m = eye
 				if(m?.owner)
-					m.owner.ad_client_image(obfuscation_image)
+					m.owner.add_client_image(obfuscation_image)
 
 	dirty = FALSE
 	updating = FALSE

--- a/code/modules/mob/observer/freelook/chunk.dm
+++ b/code/modules/mob/observer/freelook/chunk.dm
@@ -156,7 +156,7 @@
 			obscured -= obfuscation_image
 			for(var/eye in seenby)
 				var/mob/observer/eye/m = eye
-				if(m?.owner?.client)
+				if(m?.owner)
 					m.owner.remove_client_image(obfuscation_image)
 
 	for(var/turf in visRemoved)
@@ -166,7 +166,7 @@
 			obscured += obfuscation_image
 			for(var/eye in seenby)
 				var/mob/observer/eye/m = eye
-				if(m?.owner?.client)
+				if(m?.owner)
 					m.owner.remove_client_image(obfuscation_image)
 
 	dirty = FALSE

--- a/code/modules/mob/observer/ghost/ghost.dm
+++ b/code/modules/mob/observer/ghost/ghost.dm
@@ -178,17 +178,15 @@ Works together with spawning an observer, noted above.
 
 
 /mob/observer/ghost/proc/process_medHUD(mob/M)
-	var/client/C = M.client
 	for(var/mob/living/carbon/human/patient in oview(M, 14))
-		C.images += patient.hud_list[HEALTH_HUD]
-		C.images += patient.hud_list[STATUS_HUD_OOC]
+		M.add_client_image(patient.hud_list[HEALTH_HUD])
+		M.add_client_image(patient.hud_list[STATUS_HUD_OOC])
 
 /mob/observer/ghost/proc/assess_targets(list/target_list, mob/observer/ghost/U)
-	var/client/C = U.client
 	for(var/mob/living/carbon/human/target in target_list)
-		C.images += target.hud_list[SPECIALROLE_HUD]
+		U.add_client_image(target.hud_list[SPECIALROLE_HUD])
 	for(var/mob/living/silicon/target in target_list)
-		C.images += target.hud_list[SPECIALROLE_HUD]
+		U.add_client_image(target.hud_list[SPECIALROLE_HUD])
 	return 1
 
 /mob/proc/ghostize(can_reenter_corpse = CORPSE_CAN_REENTER)

--- a/code/modules/ventcrawl/ventcrawl.dm
+++ b/code/modules/ventcrawl/ventcrawl.dm
@@ -213,13 +213,13 @@ var/list/ventcrawl_machinery = list(
 			A.pipe_image.layer = ABOVE_LIGHTING_LAYER
 			A.pipe_image.plane = EFFECTS_ABOVE_LIGHTING_PLANE
 			pipes_shown += A.pipe_image
-			client.images += A.pipe_image
+			add_client_image(A.pipe_image)
 
 /mob/living/proc/remove_ventcrawl()
 	is_ventcrawling = 0
 	if(client)
 		for(var/image/current_image in pipes_shown)
-			client.images -= current_image
+			remove_client_image(current_image)
 		client.eye = src
 
 	pipes_shown.len = 0

--- a/code/modules/ventcrawl/ventcrawl.dm
+++ b/code/modules/ventcrawl/ventcrawl.dm
@@ -217,9 +217,9 @@ var/list/ventcrawl_machinery = list(
 
 /mob/living/proc/remove_ventcrawl()
 	is_ventcrawling = 0
+	for(var/image/current_image in pipes_shown)
+		remove_client_image(current_image)
 	if(client)
-		for(var/image/current_image in pipes_shown)
-			remove_client_image(current_image)
 		client.eye = src
 
 	pipes_shown.len = 0

--- a/code/modules/ventcrawl/ventcrawl_atmospherics.dm
+++ b/code/modules/ventcrawl/ventcrawl_atmospherics.dm
@@ -6,9 +6,8 @@
 		M.dropInto(loc)
 	if(pipe_image)
 		for(var/mob/living/M in GLOB.player_list)
-			if(M.client)
-				M.client.images -= pipe_image
-				M.pipes_shown -= pipe_image
+			M.remove_client_image(pipe_image)
+			M.pipes_shown -= pipe_image
 		pipe_image = null
 	return ..()
 

--- a/code/procs/hud.dm
+++ b/code/procs/hud.dm
@@ -20,14 +20,14 @@ the HUD updates properly! */
 			continue
 
 		if(local_scanner)
-			P.Client.images += patient.hud_list[HEALTH_HUD]
-			P.Client.images += patient.hud_list[STATUS_HUD]
+			P.Mob.add_client_image(patient.hud_list[HEALTH_HUD])
+			P.Mob.add_client_image(patient.hud_list[STATUS_HUD])
 		else
 			var/sensor_level = getsensorlevel(patient)
 			if(sensor_level >= SUIT_SENSOR_VITAL)
-				P.Client.images += patient.hud_list[HEALTH_HUD]
+				P.Mob.add_client_image(patient.hud_list[HEALTH_HUD])
 			if(sensor_level >= SUIT_SENSOR_BINARY)
-				P.Client.images += patient.hud_list[LIFE_HUD]
+				P.Mob.add_client_image(patient.hud_list[LIFE_HUD])
 
 //Security HUDs. Pass a value for the second argument to enable implant viewing or other special features.
 /proc/process_sec_hud(mob/M, advanced_mode, mob/Alt)
@@ -39,12 +39,12 @@ the HUD updates properly! */
 		if(perp.is_invisible_to(P.Mob))
 			continue
 
-		P.Client.images += perp.hud_list[ID_HUD]
+		P.Mob.add_client_image(perp.hud_list[ID_HUD])
 		if(advanced_mode)
-			P.Client.images += perp.hud_list[WANTED_HUD]
-			P.Client.images += perp.hud_list[IMPTRACK_HUD]
-			P.Client.images += perp.hud_list[IMPLOYAL_HUD]
-			P.Client.images += perp.hud_list[IMPCHEM_HUD]
+			P.Mob.add_client_image(perp.hud_list[WANTED_HUD])
+			P.Mob.add_client_image(perp.hud_list[IMPTRACK_HUD])
+			P.Mob.add_client_image(perp.hud_list[IMPLOYAL_HUD])
+			P.Mob.add_client_image(perp.hud_list[IMPCHEM_HUD])
 
 /proc/process_xeno_hud(mob/M, mob/Alt)
 	if(!can_process_hud(M))
@@ -56,7 +56,7 @@ the HUD updates properly! */
 		if(victim.is_invisible_to(P.Mob))
 			continue
 
-		P.Client.images += victim.hud_list[XENO_HUD]
+		P.Mob.add_client_image(victim.hud_list[XENO_HUD])
 
 /datum/arranged_hud_process
 	var/client/Client
@@ -82,9 +82,8 @@ the HUD updates properly! */
 
 //Deletes the current HUD images so they can be refreshed with new ones.
 /mob/proc/handle_hud_glasses() //Used in the life.dm of mobs that can use HUDs.
-	if(client)
-		for(var/image/hud_overlay/hud in client.images)
-			client.images -= hud
+	for(var/image/hud_overlay/hud in client_images)
+		remove_client_image(hud)
 
 	GLOB.med_hud_users -= src
 	GLOB.sec_hud_users -= src


### PR DESCRIPTION
забытые технологии древних
вместо прямого добавления/удаления имажей в client.images используем add/remove_client_image()
в итоге не теряем всякое при перезаходе/переезде в других мобов, плюс во многих местах не полагаемся на проверки клиента, они слишком ненадёжные
особенно критично - с новыми галюнами, там совсем больно было

туду на будущее: рунчат и прогрессбары, там надо сильно думать

- [x] Pull Request полностью завершен, мне не нужна помощь чтобы его закончить.
- [x] Я внимательно прочитал(-а) все свои изменения и багов в них не нашёл(-ла).
- [x] Я запускал(-а) сервер со своими изменениями локально и все протестировал(-а).
- [x] Я ознакомился(-ась) c [Guide to Contribute](https://github.com/ChaoticOnyx/OnyxBay/blob/dev/docs/contributing.md).
