### PR TITLE
feat(events): make dust and solar storm suck less

### DIFF
--- a/code/__defines/announce.dm
+++ b/code/__defines/announce.dm
@@ -175,11 +175,11 @@ GLOBAL_VAR_CONST(PREF_ANNOUNCER_TGSTATION, "\[Cargo\] /TG/station (Legacy)")
 	title = "%STATION_NAME% Sensor Array"
 
 /datum/announce/space_dust_start
-	text = "The %STATION_NAME% is now passing through a belt of space dust."
+	text = "The %STATION_NAME% is entering a dense space dust cloud. Exterior visibility will be severely reduced. All EVA personnel are advised to return inside immediately."
 	title = "%STATION_NAME% Sensor Array"
 
 /datum/announce/space_dust_end
-	text = "The %STATION_NAME% has now passed through the belt of space dust."
+	text = "The %STATION_NAME% has cleared the dust cloud. Exterior conditions returning to normal."
 	title = "%STATION_NAME% Sensor Array"
 
 /datum/announce/wallrot

--- a/code/__defines/announce.dm
+++ b/code/__defines/announce.dm
@@ -179,7 +179,7 @@ GLOBAL_VAR_CONST(PREF_ANNOUNCER_TGSTATION, "\[Cargo\] /TG/station (Legacy)")
 	title = "%STATION_NAME% Sensor Array"
 
 /datum/announce/space_dust_end
-	text = "The %STATION_NAME% has cleared the dust cloud. Exterior conditions returning to normal."
+	text = "The %STATION_NAME% has cleared the dust cloud. Exterior conditions are returning to normal."
 	title = "%STATION_NAME% Sensor Array"
 
 /datum/announce/wallrot

--- a/code/datums/events/solar_storm.dm
+++ b/code/datums/events/solar_storm.dm
@@ -12,6 +12,7 @@
 	var/const/fire_loss     = 40
 	var/base_solar_gen_rate
 	var/list/affecting_z = list()
+	/// Assoc: processor -> original process_mode value.
 	var/list/scrambled_processors = list()
 	var/next_comms_disruption = 0
 
@@ -102,12 +103,12 @@
 	var/count = min(candidates.len, rand(1, 2))
 	for(var/i in 1 to count)
 		var/obj/machinery/telecomms/processor/P = pick_n_take(candidates)
+		scrambled_processors[P] = P.process_mode // save original mode
 		P.process_mode = 0 // switch to compress mode — signals come out garbled
-		scrambled_processors += P
 
-/// Restores all scrambled processors to normal decompression mode.
+/// Restores all scrambled processors to their original mode.
 /datum/event/solar_storm/proc/restore_comms()
 	for(var/obj/machinery/telecomms/processor/P in scrambled_processors)
-		if(!QDELETED(P))
-			P.process_mode = 1
+		if(!QDELETED(P) && P.process_mode == 0) // only restore if we still own the change
+			P.process_mode = scrambled_processors[P]
 	scrambled_processors.Cut()

--- a/code/datums/events/solar_storm.dm
+++ b/code/datums/events/solar_storm.dm
@@ -12,6 +12,8 @@
 	var/const/fire_loss     = 40
 	var/base_solar_gen_rate
 	var/list/affecting_z = list()
+	var/list/scrambled_processors = list()
+	var/next_comms_disruption = 0
 
 /datum/event/solar_storm/New()
 	. = ..()
@@ -35,6 +37,7 @@
 
 /datum/event/solar_storm/think()
 	radiate()
+	disrupt_comms()
 
 	set_next_think(world.time + (2 SECONDS))
 
@@ -70,4 +73,41 @@
 	SSannounce.play_station_announce(/datum/announce/solar_storm_end)
 
 	adjust_solar_output()
+	restore_comms()
 	set_next_think(0)
+
+/// Periodically flips random telecomms processors into compress mode, garbling radio messages.
+/datum/event/solar_storm/proc/disrupt_comms()
+	if(world.time < next_comms_disruption)
+		return
+	next_comms_disruption = world.time + rand(10 SECONDS, 30 SECONDS)
+
+	// Restore any previously scrambled processors
+	restore_comms()
+
+	var/list/station_z = GLOB.using_map.get_levels_with_trait(ZTRAIT_STATION)
+	var/list/candidates = list()
+	for(var/obj/machinery/telecomms/processor/P in telecomms_list)
+		if(!(P.z in station_z))
+			continue
+		if(!P.on)
+			continue
+		if(P.process_mode == 1) // only target processors in normal (uncompress) mode
+			candidates += P
+
+	if(!candidates.len)
+		return
+
+	// Scramble 1-2 random processors
+	var/count = min(candidates.len, rand(1, 2))
+	for(var/i in 1 to count)
+		var/obj/machinery/telecomms/processor/P = pick_n_take(candidates)
+		P.process_mode = 0 // switch to compress mode — signals come out garbled
+		scrambled_processors += P
+
+/// Restores all scrambled processors to normal decompression mode.
+/datum/event/solar_storm/proc/restore_comms()
+	for(var/obj/machinery/telecomms/processor/P in scrambled_processors)
+		if(!QDELETED(P))
+			P.process_mode = 1
+	scrambled_processors.Cut()

--- a/code/datums/events/space_dust.dm
+++ b/code/datums/events/space_dust.dm
@@ -1,7 +1,7 @@
 /datum/event/space_dust_base
 	id = "space_dust_base"
-	name = "Space Dust Incoming"
-	description = "Commonish random event that causes small clumps of \"space dust\" to hit the station at high speeds. The \"dust\" will damage the hull of the station causin minor hull breaches."
+	name = "Space Dust Storm"
+	description = "A dense cloud of space dust envelops the station, reducing visibility in space and abrading anything caught outside."
 
 	mtth = 1 HOURS
 	difficulty = 35
@@ -13,7 +13,7 @@
 			weight = 80;
 			weight_ratio = EVENT_OPTION_AI_AGGRESSION_R;
 			event_id = "space_dust";
-			description = "The station will face some difficulties";
+			description = "A light dust cloud reduces visibility outside the station.";
 			severity = EVENT_LEVEL_MUNDANE;
 		},
 		/datum/event_option/space_dust_option {
@@ -22,12 +22,10 @@
 			weight = 20;
 			weight_ratio = EVENT_OPTION_AI_AGGRESSION;
 			event_id = "space_dust";
-			description = "Damage to the hull is guaranteed...";
+			description = "A thick dust storm blankets the station exterior, severely limiting visibility and wearing down suits.";
 			severity = EVENT_LEVEL_MODERATE;
 		}
 	)
-
-
 
 /datum/event/space_dust_base/get_mtth()
 	. = ..()
@@ -54,6 +52,12 @@
 
 	var/list/affecting_z = list()
 	var/severity = EVENT_LEVEL_MUNDANE
+	/// Mobs currently affected by dust visibility reduction.
+	var/list/affected_mobs = list()
+	/// Areas currently showing the dust overlay.
+	var/list/overlayed_areas = list()
+	/// World.time of next breach check.
+	var/next_breach_check = 0
 
 /datum/event/space_dust/New()
 	. = ..()
@@ -67,7 +71,10 @@
 
 	SSannounce.play_station_announce(/datum/announce/space_dust_start)
 
-	set_next_think_ctx("end", world.time + (rand(1, 3) MINUTES))
+	// Apply dust overlay to all space areas on station z-levels.
+	apply_area_overlays()
+
+	set_next_think_ctx("end", world.time + (rand(2, 5) MINUTES))
 	set_next_think(world.time)
 
 /datum/event/space_dust/proc/end()
@@ -75,38 +82,141 @@
 	SSevents.evars["space_dust_running"] = FALSE
 	SSannounce.play_station_announce(/datum/announce/space_dust_end)
 
+	// Clear visibility effects from all affected mobs.
+	for(var/mob/living/L in affected_mobs)
+		clear_dust_effect(L)
+	affected_mobs.Cut()
+
+	// Remove dust overlays from all areas.
+	clear_area_overlays()
+
 /datum/event/space_dust/think()
-	if(!prob(10))
-		set_next_think(world.time + (2 SECONDS))
-		return
+	// Update breached area overlays every 10 seconds to avoid iterating ZAS zones too often.
+	if(world.time >= next_breach_check)
+		update_breached_overlays()
+		next_breach_check = world.time + (10 SECONDS)
 
-	var/numbers = rand(severity * 10, severity * 15)
-	var/start_dir = pick(GLOB.cardinal)
-	var/turf/startloc
-	var/turf/targloc
-	var/randomz = pick(affecting_z)
-	var/randomx = rand(1 + TRANSITION_EDGE * 2, world.maxx-TRANSITION_EDGE * 2)
-	var/randomy = rand(1 + TRANSITION_EDGE * 2, world.maxx-TRANSITION_EDGE * 2)
-	switch(start_dir)
-		if(NORTH)
-			startloc = locate(randomx, world.maxy - TRANSITION_EDGE, randomz)
-			targloc = locate(world.maxx - randomx,  1 + TRANSITION_EDGE, randomz)
-		if(SOUTH)
-			startloc = locate(randomx, 1 + TRANSITION_EDGE, randomz)
-			targloc = locate(world.maxx - randomx, world.maxy - TRANSITION_EDGE, randomz)
-		if(EAST)
-			startloc = locate(world.maxx - TRANSITION_EDGE, randomy, randomz)
-			targloc = locate(1 + TRANSITION_EDGE, world.maxy - randomy, randomz)
-		if(WEST)
-			startloc = locate(1 + TRANSITION_EDGE, randomy, randomz)
-			targloc = locate(world.maxx - TRANSITION_EDGE, world.maxy - randomy, randomz)
-	var/list/starters = getcircle(startloc, 3)
-	starters += startloc
-
-	var/rocks_per_tile = round(numbers/starters.len)
-	for(var/turf/T in starters)
-		for(var/i = 1 to rocks_per_tile)
-			var/obj/item/projectile/bullet/rock/R = new(T)
-			R.launch(targloc)
+	// Apply visibility and abrasion effects to mobs in space or breached areas.
+	process_mobs()
 
 	set_next_think(world.time + (2 SECONDS))
+
+/// Applies dust overlay to all space areas on station z-levels.
+/datum/event/space_dust/proc/apply_area_overlays()
+	for(var/area/space/A in world)
+		var/turf/T = locate(/turf) in A
+		if(!T || !(T.z in affecting_z))
+			continue
+		set_area_dust_overlay(A)
+
+/// Finds station areas directly connected to space via ZAS and applies/removes dust overlays.
+/datum/event/space_dust/proc/update_breached_overlays()
+	// Collect areas that currently have a direct zone-to-space connection.
+	var/list/breached_areas = list()
+	for(var/zone/Z in SSair.zones)
+		if(Z.invalid)
+			continue
+		var/has_space_edge = FALSE
+		for(var/connection_edge/unsimulated/E in Z.edges)
+			has_space_edge = TRUE
+			break
+		if(!has_space_edge)
+			continue
+		// This zone is directly touching space — find which station areas its turfs belong to.
+		for(var/turf/T in Z.contents)
+			if(!(T.z in affecting_z))
+				continue
+			var/area/A = get_area(T)
+			if(!A || istype(A, /area/space))
+				continue
+			breached_areas |= A
+
+	// Remove overlay from station areas that are no longer breached.
+	for(var/area/A in overlayed_areas)
+		if(istype(A, /area/space))
+			continue
+		if(!(A in breached_areas))
+			clear_area_dust_overlay(A)
+
+	// Add overlay to newly breached station areas.
+	for(var/area/A in breached_areas)
+		set_area_dust_overlay(A)
+
+/// Sets the dust overlay on an area.
+/datum/event/space_dust/proc/set_area_dust_overlay(area/A)
+	if(A in overlayed_areas)
+		return
+	overlayed_areas += A
+	A.icon = 'icons/effects/weather_effects.dmi'
+	A.layer = ABOVE_PROJECTILE_LAYER
+	A.icon_state = "dust_high"
+	if(severity >= EVENT_LEVEL_MODERATE)
+		A.set_opacity(TRUE)
+
+/// Clears the dust overlay from an area.
+/datum/event/space_dust/proc/clear_area_dust_overlay(area/A)
+	overlayed_areas -= A
+	A.icon = 'icons/turf/areas.dmi'
+	A.icon_state = ""
+	A.layer = initial(A.layer)
+	A.set_opacity(FALSE)
+
+/// Clears dust overlays from all affected areas.
+/datum/event/space_dust/proc/clear_area_overlays()
+	for(var/area/A in overlayed_areas)
+		clear_area_dust_overlay(A)
+	overlayed_areas.Cut()
+
+/// Applies dust effects to all living mobs currently in space or breached areas on station z-levels.
+/datum/event/space_dust/proc/process_mobs()
+	for(var/mob/living/L in GLOB.living_mob_list_)
+		var/turf/T = get_turf(L)
+		if(!T || !(T.z in affecting_z))
+			continue
+
+		var/area/A = get_area(L)
+		var/exposed = (A in overlayed_areas)
+		if(exposed)
+			apply_dust_effect(L)
+			// Abrasion damage — dust wears on anything exposed.
+			var/in_space = istype(T, /turf/space) || istype(A, /area/space)
+			if(in_space)
+				// Full abrasion in open space.
+				if(severity >= EVENT_LEVEL_MODERATE)
+					L.adjustBruteLoss(rand(1, 3))
+				else if(prob(30))
+					L.adjustBruteLoss(1)
+			else
+				// Reduced abrasion in breached rooms — dust seeps in but isn't as dense.
+				if(severity >= EVENT_LEVEL_MODERATE && prob(30))
+					L.adjustBruteLoss(1)
+		else
+			if(L in affected_mobs)
+				clear_dust_effect(L)
+				affected_mobs -= L
+
+/// Applies blurry vision to a mob caught in the dust.
+/datum/event/space_dust/proc/apply_dust_effect(mob/living/L)
+	if(!(L in affected_mobs))
+		affected_mobs += L
+		to_chat(L, SPAN_WARNING("Dense clouds of space dust swirl around you!"))
+
+	// Only blur vision if eyes are not covered.
+	if(eyes_exposed(L))
+		var/blur_amount = severity >= EVENT_LEVEL_MODERATE ? 8 : 4
+		L.eye_blurry = max(L.eye_blurry, blur_amount)
+
+/// Returns TRUE if the mob's eyes are not protected by headgear or a mask.
+/datum/event/space_dust/proc/eyes_exposed(mob/living/L)
+	if(!ishuman(L))
+		return TRUE
+	var/mob/living/carbon/human/H = L
+	if(H.head && (H.head.body_parts_covered & EYES))
+		return FALSE
+	if(H.wear_mask && (H.wear_mask.body_parts_covered & EYES))
+		return FALSE
+	return TRUE
+
+/// Clears dust visual effects from a mob.
+/datum/event/space_dust/proc/clear_dust_effect(mob/living/L)
+	to_chat(L, SPAN_NOTICE("The dust clears from around you."))

--- a/code/datums/events/space_dust.dm
+++ b/code/datums/events/space_dust.dm
@@ -114,7 +114,11 @@
 	// Collect areas that currently have a direct zone-to-space connection.
 	var/list/breached_areas = list()
 	for(var/zone/Z in SSair.zones)
-		if(Z.invalid)
+		if(Z.invalid || !length(Z.contents))
+			continue
+		// Quick z-level check using the first turf before iterating edges.
+		var/turf/first = Z.contents[1]
+		if(!(first.z in affecting_z))
 			continue
 		var/has_space_edge = FALSE
 		for(var/connection_edge/unsimulated/E in Z.edges)
@@ -124,8 +128,6 @@
 			continue
 		// This zone is directly touching space — find which station areas its turfs belong to.
 		for(var/turf/T in Z.contents)
-			if(!(T.z in affecting_z))
-				continue
 			var/area/A = get_area(T)
 			if(!A || istype(A, /area/space))
 				continue
@@ -146,7 +148,7 @@
 /datum/event/space_dust/proc/set_area_dust_overlay(area/A)
 	if(overlayed_areas[A])
 		return
-	overlayed_areas[A] = list(A.icon, A.icon_state, A.layer)
+	overlayed_areas[A] = list(A.icon, A.icon_state, A.layer, A.opacity)
 	A.icon = 'icons/effects/weather_effects.dmi'
 	A.layer = ABOVE_PROJECTILE_LAYER
 	A.icon_state = "dust_high"
@@ -156,12 +158,13 @@
 /// Clears the dust overlay from an area, restoring original visuals.
 /datum/event/space_dust/proc/clear_area_dust_overlay(area/A)
 	var/list/original = overlayed_areas[A]
-	if(original)
-		A.icon = original[1]
-		A.icon_state = original[2]
-		A.layer = original[3]
+	if(!original)
+		return
+	A.icon = original[1]
+	A.icon_state = original[2]
+	A.layer = original[3]
+	A.set_opacity(original[4])
 	overlayed_areas -= A
-	A.set_opacity(FALSE)
 
 /// Clears dust overlays from all affected areas.
 /datum/event/space_dust/proc/clear_area_overlays()

--- a/code/datums/events/space_dust.dm
+++ b/code/datums/events/space_dust.dm
@@ -8,7 +8,7 @@
 
 	options = newlist(
 		/datum/event_option/space_dust_option {
-			id = "option_mundande";
+			id = "option_mundane";
 			name = "Mundane Level";
 			weight = 80;
 			weight_ratio = EVENT_OPTION_AI_AGGRESSION_R;
@@ -54,7 +54,7 @@
 	var/severity = EVENT_LEVEL_MUNDANE
 	/// Mobs currently affected by dust visibility reduction.
 	var/list/affected_mobs = list()
-	/// Areas currently showing the dust overlay.
+	/// Areas currently showing the dust overlay. Assoc: area -> list(icon, icon_state, layer)
 	var/list/overlayed_areas = list()
 	/// World.time of next breach check.
 	var/next_breach_check = 0
@@ -142,23 +142,25 @@
 	for(var/area/A in breached_areas)
 		set_area_dust_overlay(A)
 
-/// Sets the dust overlay on an area.
+/// Sets the dust overlay on an area, saving original visuals for restoration.
 /datum/event/space_dust/proc/set_area_dust_overlay(area/A)
-	if(A in overlayed_areas)
+	if(overlayed_areas[A])
 		return
-	overlayed_areas += A
+	overlayed_areas[A] = list(A.icon, A.icon_state, A.layer)
 	A.icon = 'icons/effects/weather_effects.dmi'
 	A.layer = ABOVE_PROJECTILE_LAYER
 	A.icon_state = "dust_high"
 	if(severity >= EVENT_LEVEL_MODERATE)
 		A.set_opacity(TRUE)
 
-/// Clears the dust overlay from an area.
+/// Clears the dust overlay from an area, restoring original visuals.
 /datum/event/space_dust/proc/clear_area_dust_overlay(area/A)
+	var/list/original = overlayed_areas[A]
+	if(original)
+		A.icon = original[1]
+		A.icon_state = original[2]
+		A.layer = original[3]
 	overlayed_areas -= A
-	A.icon = 'icons/turf/areas.dmi'
-	A.icon_state = ""
-	A.layer = initial(A.layer)
 	A.set_opacity(FALSE)
 
 /// Clears dust overlays from all affected areas.

--- a/code/datums/events/space_dust.dm
+++ b/code/datums/events/space_dust.dm
@@ -176,11 +176,9 @@
 /datum/event/space_dust/proc/process_mobs()
 	for(var/mob/living/L in GLOB.living_mob_list_)
 		var/turf/T = get_turf(L)
-		if(!T || !(T.z in affecting_z))
-			continue
+		var/area/A = T ? get_area(T) : null
+		var/exposed = T && (T.z in affecting_z) && (A in overlayed_areas)
 
-		var/area/A = get_area(L)
-		var/exposed = (A in overlayed_areas)
 		if(exposed)
 			apply_dust_effect(L)
 			// Abrasion damage — dust wears on anything exposed.
@@ -195,10 +193,9 @@
 				// Reduced abrasion in breached rooms — dust seeps in but isn't as dense.
 				if(severity >= EVENT_LEVEL_MODERATE && prob(30))
 					L.adjustBruteLoss(1)
-		else
-			if(L in affected_mobs)
-				clear_dust_effect(L)
-				affected_mobs -= L
+		else if(L in affected_mobs)
+			clear_dust_effect(L)
+			affected_mobs -= L
 
 /// Applies blurry vision to a mob caught in the dust.
 /datum/event/space_dust/proc/apply_dust_effect(mob/living/L)


### PR DESCRIPTION
Небольшой реворк двух самых бесполезных ивентов:
Даст:
Теперь экшуали спавнит ДАСТ СТОРМ, наносит брут тем, кто находится в нем, слепит протекает в зоны с прямым коннектом в космос. Сильный дастсторм не транспарентный, так что еще и турфы закрывает сверху.

<img width="844" height="694" alt="image" src="https://github.com/user-attachments/assets/3ad1e56a-6ae9-4da2-a2b4-ee9c28ba5a70" />

Соляр:
Аддишионалли рандомно скрамблит радио каналы (используем очередную никому неизвестную телекомм фичу билда)

<details>
<summary>Чейнджлог</summary>

```yml
🆑
tweak: Даст и Соляр штормы теперь "ощущаются" куда более импактными для станционных!
/🆑
```

</details>

- [x] Pull Request полностью завершен, мне не нужна помощь чтобы его закончить.
- [x] Я внимательно прочитал(-а) все свои изменения и багов в них не нашёл(-ла).
- [x] Я запускал(-а) сервер со своими изменениями локально и все протестировал(-а).
- [x] Я ознакомился(-ась) c [Guide to Contribute](https://github.com/ChaoticOnyx/OnyxBay/blob/dev/docs/contributing.md).
