### PR TITLE
tweak(mobs): metroids destroy blood, monkeys have less blood

### DIFF
--- a/code/datums/surgery/steps/bone.dm
+++ b/code/datums/surgery/steps/bone.dm
@@ -24,7 +24,7 @@
 	success_sound = 'sound/surgery/organ2.ogg'
 
 /datum/surgery_step/bone/glue_bone/check_parent_organ(obj/item/organ/external/parent_organ, mob/living/carbon/human/target, obj/item/tool, atom/user)
-	return (..() && parent_organ.stage == 0)
+	return (..() && parent_organ.bone_stage == 0)
 
 /datum/surgery_step/bone/glue_bone/initiate(obj/item/organ/external/parent_organ, obj/item/organ/target_organ, mob/living/carbon/human/target, obj/item/tool, mob/user)
 	var/bone = parent_organ.encased ? "[target]'s [parent_organ.encased]" : "bones in [target]'s [parent_organ]"
@@ -45,7 +45,7 @@
 		"[user] applies some [tool.name] to [bone]",
 		"You apply some [tool.name] to [bone]."
 		)
-	parent_organ.stage = 1
+	parent_organ.bone_stage = 1
 
 /datum/surgery_step/glue_bone/failure(obj/item/organ/external/parent_organ, obj/item/organ/target_organ, mob/living/carbon/human/target, obj/item/tool, mob/user)
 	announce_failure(user,
@@ -73,7 +73,7 @@
 	return (..() && target_zone != BP_HEAD)
 
 /datum/surgery_step/bone/mend_bone/check_parent_organ(obj/item/organ/external/parent_organ, mob/living/carbon/human/target, obj/item/tool, atom/user)
-	return (..() && parent_organ.stage == 1)
+	return (..() && parent_organ.bone_stage == 1)
 
 /datum/surgery_step/bone/mend_bone/initiate(obj/item/organ/external/parent_organ, obj/item/organ/target_organ, mob/living/carbon/human/target, obj/item/tool, mob/user)
 	var/bone = parent_organ.encased ? "[target]'s [parent_organ.encased]" : "bones in [target]'s [parent_organ]"
@@ -90,7 +90,7 @@
 		"You set [bone] with \the [tool]."
 		)
 	parent_organ.status &= ~ORGAN_DISFIGURED
-	parent_organ.stage = 2
+	parent_organ.bone_stage = 2
 
 /datum/surgery_step/bone/mend_bone/failure(obj/item/organ/external/parent_organ, obj/item/organ/target_organ, mob/living/carbon/human/target, obj/item/tool, mob/user)
 	announce_failure(user,
@@ -120,7 +120,7 @@
 	return (..() && target_zone == BP_HEAD)
 
 /datum/surgery_step/bone/mend_skull/check_parent_organ(obj/item/organ/external/parent_organ, mob/living/carbon/human/target, obj/item/tool, atom/user)
-	return (..() && parent_organ.stage == 1)
+	return (..() && parent_organ.bone_stage == 1)
 
 /datum/surgery_step/bone/mend_skull/initiate(obj/item/organ/external/parent_organ, obj/item/organ/target_organ, mob/living/carbon/human/target, obj/item/tool, mob/user)
 	announce_preop(user,
@@ -134,7 +134,7 @@
 		"[user] sets [target]'s skull with \the [tool].",
 		"You set [target]'s skull with \the [tool]."
 		)
-	parent_organ.stage = 2
+	parent_organ.bone_stage = 2
 
 /datum/surgery_step/bone/mend_skull/failure(obj/item/organ/external/parent_organ, obj/item/organ/target_organ, mob/living/carbon/human/target, obj/item/tool, mob/user)
 	announce_failure(user,
@@ -163,7 +163,7 @@
 	return (..() && target_zone != BP_HEAD)
 
 /datum/surgery_step/bone/set_bone/check_parent_organ(obj/item/organ/external/parent_organ, mob/living/carbon/human/target, obj/item/tool, atom/user)
-	return (..() && parent_organ.stage == 1)
+	return (..() && parent_organ.bone_stage == 1)
 
 /datum/surgery_step/bone/set_bone/initiate(obj/item/organ/external/parent_organ, obj/item/organ/target_organ, mob/living/carbon/human/target, obj/item/tool, mob/user)
 	var/bone = parent_organ.encased ? "[target]'s [parent_organ.encased]" : "bones in [target]'s [parent_organ]"
@@ -185,7 +185,7 @@
 			"[user] sets the [bone] in place with \the [tool].",
 			"You set the [bone] in place with \the [tool]."
 			)
-		parent_organ.stage = 2
+		parent_organ.bone_stage = 2
 	else
 		announce_success(user,
 			"[user] sets the [bone]" + SPAN("warning", " in the WRONG place with \the [tool]."),
@@ -216,7 +216,7 @@
 	success_sound = 'sound/surgery/organ1.ogg'
 
 /datum/surgery_step/bone/postset_bone/check_parent_organ(obj/item/organ/external/parent_organ, mob/living/carbon/human/target, obj/item/tool, atom/user)
-	return (..() && parent_organ.stage == 2)
+	return (..() && parent_organ.bone_stage == 2)
 
 /datum/surgery_step/bone/postset_bone/initiate(obj/item/organ/external/parent_organ, obj/item/organ/target_organ, mob/living/carbon/human/target, obj/item/tool, mob/user)
 	var/bone = parent_organ.encased ? "[target]'s [parent_organ.encased]" : "bones in [target]'s [parent_organ]"
@@ -233,7 +233,6 @@
 		"You have mended the damaged [bone] with \the [tool]."
 		)
 	parent_organ.mend_fracture()
-	parent_organ.stage = 0
 
 /datum/surgery_step/bone/postset_bone/failure(obj/item/organ/external/parent_organ, obj/item/organ/target_organ, mob/living/carbon/human/target, obj/item/tool, mob/user)
 	announce_failure(user,
@@ -255,7 +254,7 @@
 	success_sound = 'sound/surgery/organ1.ogg'
 
 /datum/surgery_step/bone/mender/check_parent_organ(obj/item/organ/external/parent_organ, mob/living/carbon/human/target, obj/item/tool, atom/user)
-	return (..() && parent_organ.stage <= 5)
+	return (..() && parent_organ.bone_stage <= 5)
 
 /datum/surgery_step/bone/mender/initiate(obj/item/organ/external/parent_organ, obj/item/organ/target_organ, mob/living/carbon/human/target, obj/item/tool, mob/user)
 	announce_preop(user,
@@ -275,7 +274,6 @@
 		"You have grasped the damaged bone edges in [target]'s [parent_organ] with \the [tool]."
 		)
 	parent_organ.mend_fracture()
-	parent_organ.stage = 0
 
 /datum/surgery_step/bone/mender/failure(obj/item/organ/external/parent_organ, obj/item/organ/target_organ, mob/living/carbon/human/target, obj/item/tool, mob/user)
 	announce_failure(user,

--- a/code/game/gamemodes/vampire/powers/bloodheal.dm
+++ b/code/game/gamemodes/vampire/powers/bloodheal.dm
@@ -83,7 +83,6 @@
 				organ_heal_blood += 12
 			if(E.status & ORGAN_BROKEN)
 				E.mend_fracture()
-				E.stage = 0
 				organ_heal_blood += 12
 				healed = TRUE
 

--- a/code/game/gamemodes/wizard/wizard_heals.dm
+++ b/code/game/gamemodes/wizard/wizard_heals.dm
@@ -18,7 +18,6 @@
 			E.status &= ~ORGAN_TENDON_CUT
 		if(E.status & ORGAN_BROKEN && heal.heal_bones) // some calcium
 			E.mend_fracture()
-			E.stage = 0
 
 		if(heal.removes_embeded)
 			E.drop_embedded_objects()

--- a/code/modules/mob/living/carbon/human/species/station/monkey.dm
+++ b/code/modules/mob/living/carbon/human/species/station/monkey.dm
@@ -9,7 +9,7 @@
 	damage_mask = 'icons/mob/human_races/masks/dam_mask_monkey.dmi'
 
 	language = null
-	default_language = "Chimpanzee"
+	default_language = "Chimpanzee" // They look and feel more like macaques though. TODO: Add actual chimpanzees. Like, big-ass muscular apes who can manfight a xenomorph.
 	greater_form = SPECIES_HUMAN
 	mob_size = MOB_SMALL
 	show_ssd = null
@@ -34,6 +34,10 @@
 	total_health = 75
 	brute_mod = 1.5
 	burn_mod = 1.5
+
+	// An average adult rhesus macaque weighs ~10kg, and has a blood volume of ~60 ml/kg. But let's be *a bit* generous, so that they won't bleed out in seconds because of anything.
+	// Perhaps, they are the SPACE macaques who are twice as large - their icons back up the idea.
+	blood_volume = 1.2 LITERS
 
 	spawn_flags = SPECIES_IS_RESTRICTED | SPECIES_NO_FBP_CONSTRUCTION | SPECIES_NO_FBP_CHARGEN | SPECIES_NO_LACE
 	species_appearance_flags = HAS_LIPS | HAS_EYE_COLOR

--- a/code/modules/mob/living/carbon/xenobiological/powers.dm
+++ b/code/modules/mob/living/carbon/xenobiological/powers.dm
@@ -47,6 +47,7 @@
 	regenerate_icons()
 	var/happyWithFood = 0
 	var/totalDrained = 0
+	var/comboMult = 1.0 // Damage increases if we deal it continuously.
 
 	while(Victim && stat != 2)
 		if(Adjacent(M))
@@ -54,13 +55,18 @@
 
 			var/hazmat = blocked_mult(M.get_flat_armor(null, "bio")) //scale feeding rate by overall bio protection
 			if(istype(M, /mob/living/carbon))
-				Victim.adjustCloneLoss(5 * hazmat)
-				Victim.adjustToxLoss(1 * hazmat)
+				if(ishuman(M))
+					var/mob/living/carbon/human/H = M
+					if(!H.species || !(H.species.species_flags & SPECIES_FLAG_NO_BLOOD))
+						H.vessel.remove_reagent(/datum/reagent/blood, 50 * hazmat * comboMult) // Not that bad for humans, lethal for monkeys.
+
+				Victim.adjustCloneLoss(5 * hazmat * comboMult)
+				Victim.adjustToxLoss(1 * hazmat * comboMult)
 				if(Victim.health <= 0)
-					Victim.adjustToxLoss(1 * hazmat)
+					Victim.adjustToxLoss(1 * hazmat * comboMult)
 
 			else if(istype(M, /mob/living/simple_animal))
-				Victim.adjustBruteLoss(10 * hazmat)
+				Victim.adjustBruteLoss(10 * hazmat * comboMult)
 
 			else
 				to_chat(src, "<span class='warning'>[pick("This subject is incompatable", "This subject does not have a life energy", "This subject is empty", "I am not satisified", "I can not feed from this subject", "I do not feel nourished", "This subject is not food")]...</span>")
@@ -82,7 +88,7 @@
 			if(totalDrained > 200)
 				happyWithFood = 1
 
-			var/heal_amt = 10 * hazmat
+			var/heal_amt = 10 * hazmat * comboMult
 			adjustOxyLoss(-heal_amt) //Heal yourself
 			adjustBruteLoss(-heal_amt)
 			adjustFireLoss(-heal_amt)
@@ -95,6 +101,7 @@
 				happyWithFood = 1
 				break
 
+			comboMult += 0.2
 			sleep(20) // Deal damage every 2 seconds
 		else
 			break

--- a/code/modules/mob/organs/external/_external.dm
+++ b/code/modules/mob/organs/external/_external.dm
@@ -104,7 +104,7 @@
 	// Surgery vars.
 	var/cavity_max_w_class = 0
 	var/hatch_state = 0
-	var/stage = 0
+	var/bone_stage = 0
 	var/cavity = 0
 	var/atom/movable/applied_pressure
 	var/atom/movable/splinted
@@ -275,7 +275,7 @@
 
 /obj/item/organ/external/attackby(obj/item/W, mob/user)
 	user.setClickCooldown(DEFAULT_ATTACK_COOLDOWN)
-	switch(stage)
+	switch(bone_stage)
 		if(0)
 			if(W.edge)
 				if(!do_mob(user, src, DEFAULT_ATTACK_COOLDOWN))
@@ -291,7 +291,7 @@
 					user.visible_message(SPAN("danger", "<b>[user]</b> cuts [external_child] from [src] with [W]!"))
 				else
 					user.visible_message(SPAN("danger", "<b>[user]</b> cuts [src] open with [W]!"))
-					stage++
+					bone_stage++
 				return
 		if(1)
 			if(istype(W) && W.force >= 5.0)
@@ -299,7 +299,7 @@
 					return
 				user.visible_message(SPAN("danger", "<b>[user]</b> cracks [src] open like an egg with [W]!"))
 				drop_embedded_objects()
-				stage++
+				bone_stage++
 				return
 		if(2)
 			if(W.sharp || W.edge || istype(W, /obj/item/hemostat) || isWirecutter(W))
@@ -373,10 +373,6 @@
 		all_items.Add(child.get_contents_recursive())
 
 	return all_items
-
-/obj/item/organ/external/update_health()
-	damage = min(max_damage, (brute_dam + burn_dam))
-	return
 
 /obj/item/organ/external/replaced(mob/living/carbon/human/target)
 	. = ..()
@@ -594,9 +590,12 @@ This function completely restores a damaged organ to perfect condition.
 		internal.cook_organ()
 
 /obj/item/organ/external/die()
+	. = ..()
+	if(!.)
+		return FALSE
 	for(var/obj/item/organ/external/E in children)
 		E.take_blunt_damage(10, "parent organ sepsis", TRUE)
-	..()
+	return TRUE
 
 // Handles natural heal, internal bleedings and infections
 /obj/item/organ/external/proc/handle_regeneration()
@@ -969,6 +968,7 @@ This function completely restores a damaged organ to perfect condition.
 	if(use_damage_check && (blunt_dam >= min_broken_damage * config.health.organ_health_multiplier))
 		return FALSE // will just immediately fracture again
 
+	bone_stage = 0 // So things don't get weird if a wizard fixes his own bone during surgery or something.
 	status &= ~ORGAN_BROKEN
 	update_tally()
 	return TRUE

--- a/code/modules/mob/organs/external/_external.dm
+++ b/code/modules/mob/organs/external/_external.dm
@@ -557,9 +557,6 @@ This function completely restores a damaged organ to perfect condition.
 
 //Determines if we even need to process this organ.
 /obj/item/organ/external/proc/need_process()
-	if(get_pain())
-		return TRUE
-
 	if(status & (ORGAN_CUT_AWAY|ORGAN_BLEEDING|ORGAN_BROKEN|ORGAN_DEAD|ORGAN_MUTATED))
 		return TRUE
 
@@ -582,7 +579,8 @@ This function completely restores a damaged organ to perfect condition.
 			should_update_damage_icons_this_tick = handle_regeneration()
 	else
 		remove_all_pain()
-		..()
+
+	..()
 
 /obj/item/organ/external/cook_organ()
 	..()

--- a/code/modules/mob/organs/internal/_internal.dm
+++ b/code/modules/mob/organs/internal/_internal.dm
@@ -111,9 +111,12 @@
 	return TRUE
 
 /obj/item/organ/internal/die()
-	..()
+	. = ..()
+	if(!.)
+		return FALSE
 	if((status & ORGAN_DEAD) && dead_icon)
 		icon_state = dead_icon
+	return TRUE
 
 /obj/item/organ/internal/remove_rejuv()
 	if(owner)

--- a/code/modules/mob/organs/organ.dm
+++ b/code/modules/mob/organs/organ.dm
@@ -141,9 +141,6 @@ var/list/organ_cache = list()
 	food_organ.appearance = src
 	reagents.trans_to(food_organ, reagents.total_volume)
 
-/obj/item/organ/proc/update_health()
-	return
-
 /obj/item/organ/proc/is_broken()
 	return (damage >= min_broken_damage || (status & ORGAN_CUT_AWAY) || (status & ORGAN_BROKEN))
 
@@ -158,12 +155,15 @@ var/list/organ_cache = list()
 	species = all_species[new_dna.species]
 
 /obj/item/organ/proc/die()
+	if(status & ORGAN_DEAD)
+		return FALSE // Already dead
 	damage = max_damage
 	status |= ORGAN_DEAD
 	set_next_think(0)
 	death_time = world.time
 	if(owner && vital)
 		owner.death()
+	return TRUE
 
 /obj/item/organ/proc/cook_organ()
 	die()

--- a/code/modules/spells/general/healthy_sleep.dm
+++ b/code/modules/spells/general/healthy_sleep.dm
@@ -49,7 +49,6 @@
 			E.status &= ~ORGAN_TENDON_CUT
 		if(E.status & ORGAN_BROKEN)
 			E.mend_fracture()
-			E.stage = 0
 
 	H.update_health()
 	H.sleeping = 0


### PR DESCRIPTION
не придумал, как ещё заставить метроидов убивать, но вроде бы логично
генка съедает днк целиком и засушивает труп, метроиды - жрут по чуть-чуть - и сушат по чуть-чуть

попутно /obj/item/organ/external/var/stage переименован в bone_stage, по аналогии с hatch_stage, и добавлено его обнуление в mend_fracture(), а то его вручную обнуляли везде где чинили кости, кринж 

```yml
🆑
tweak: Метроиды теперь не только наносят генетический и токсический урон, но и иссушают кровь.
tweak: Метроиды теперь наносят всё больше урона с каждым тиком, если беспрерывно высасывают моба.
bugfix: Значительно уменьшен объем крови у обезьян - с человеческих 5.6 литра до 1.2 литра (примерный объем крови у *крупного* резуса). 
bugfix: Отторжение органов снова работает не только с внутренними органами, но и с конечностями, спустя много лет. Да, такой механ существует.
/🆑
```

- [x] Pull Request полностью завершен, мне не нужна помощь чтобы его закончить.
- [x] Я внимательно прочитал(-а) все свои изменения и багов в них не нашёл(-ла).
- [ ] Я запускал(-а) сервер со своими изменениями локально и все протестировал(-а).
- [x] Я ознакомился(-ась) c [Guide to Contribute](https://github.com/ChaoticOnyx/OnyxBay/blob/dev/docs/contributing.md).
