### PR TITLE
fix(clicking): adds click precision assist, fixes a couple of bugs

### DIFF
--- a/code/_onclick/mouse_drag.dm
+++ b/code/_onclick/mouse_drag.dm
@@ -24,5 +24,5 @@
 /mob/proc/OnMouseUp(atom/object, location, control, params)
 	var/obj/item/gun/gun = get_active_hand()
 	if(istype(gun))
-		gun.clear_autofire()
+		return gun.clear_autofire()
 	return FALSE

--- a/code/_onclick/mouse_drag.dm
+++ b/code/_onclick/mouse_drag.dm
@@ -6,20 +6,23 @@
 	if(istype(loc, /atom))
 		var/atom/A = loc
 		if(A.RelayMouseDrag(src_object, over_object, src_location, over_location, src_control, over_control, params, src))
-			return
+			return TRUE
 
 	var/obj/item/gun/gun = get_active_hand()
 	var/list/click_params = params2list(params)
-	if(istype(over_object) && (isturf(over_object) || isturf(over_object.loc)) && !incapacitated() && istype(gun) && !click_params["shift"] && !click_params["ctrl"] && !click_params["alt"] && !click_params["right"])
-		gun.set_autofire(over_object, src)
+	if(istype(gun) && istype(over_object) && (isturf(over_object) || isturf(over_object.loc)) && !incapacitated() && !click_params["shift"] && !click_params["ctrl"] && !click_params["alt"] && !click_params["right"])
+		return gun.set_autofire(over_object, src)
+	return FALSE
 
 /mob/proc/OnMouseDown(atom/object, location, control, params)
 	var/obj/item/gun/gun = get_active_hand()
 	var/list/click_params = params2list(params)
-	if(istype(object) && (isturf(object) || isturf(object.loc)) && !incapacitated() && istype(gun) && !click_params["shift"] && !click_params["ctrl"] && !click_params["alt"] && !click_params["right"])
-		gun.set_autofire(object, src)
+	if(istype(gun) && istype(object) && (isturf(object) || isturf(object.loc)) && !incapacitated() && !click_params["shift"] && !click_params["ctrl"] && !click_params["alt"] && !click_params["right"])
+		return gun.set_autofire(object, src)
+	return FALSE
 
 /mob/proc/OnMouseUp(atom/object, location, control, params)
 	var/obj/item/gun/gun = get_active_hand()
 	if(istype(gun))
 		gun.clear_autofire()
+	return FALSE

--- a/code/game/machinery/OpTable.dm
+++ b/code/game/machinery/OpTable.dm
@@ -124,6 +124,9 @@
 		return
 
 	if(O.loc != loc)
+		if(!Adjacent(O))
+			to_chat(user, SPAN("warning", "\The [O] is too far away."))
+			return
 		step(O, get_dir(O, src))
 
 /obj/machinery/optable/verb/remove_clothes()
@@ -175,7 +178,11 @@
 
 	busy = FALSE
 
-/obj/machinery/optable/proc/take_victim_ref(mob/living/carbon/C, mob/living/carbon/user as mob)
+/obj/machinery/optable/proc/take_victim_ref(mob/living/carbon/C, mob/living/carbon/user)
+	if(!Adjacent(C))
+		to_chat(user, SPAN("warning", "\The [C] is too far away."))
+		return FALSE
+
 	if(C == user)
 		user.visible_message("[user] climbs on \the [src].","You climb on \the [src].")
 	else
@@ -193,6 +200,8 @@
 	if(ishuman(C))
 		victim_ref = weakref(C)
 		START_PROCESSING(SSmachines, src)
+
+	return TRUE
 
 /obj/machinery/optable/MouseDrop_T(mob/target, mob/user)
 	var/mob/living/M = user
@@ -223,8 +232,8 @@
 	if(istype(W, /obj/item/grab))
 		var/obj/item/grab/G = W
 		if(iscarbon(G.affecting) && check_table(G.affecting))
-			take_victim_ref(G.affecting, usr)
-			qdel(W)
+			if(take_victim_ref(G.affecting, usr))
+				qdel(W)
 
 /obj/machinery/optable/proc/check_table(mob/living/carbon/patient)
 	var/mob/living/carbon/human/occupant = victim_ref?.resolve()

--- a/code/game/machinery/OpTable.dm
+++ b/code/game/machinery/OpTable.dm
@@ -201,6 +201,9 @@
 		victim_ref = weakref(C)
 		START_PROCESSING(SSmachines, src)
 
+	if(C.pulledby)
+		C.pulledby.stop_pulling()
+
 	return TRUE
 
 /obj/machinery/optable/MouseDrop_T(mob/target, mob/user)

--- a/code/modules/admin/callproc/callproc.dm
+++ b/code/modules/admin/callproc/callproc.dm
@@ -225,22 +225,6 @@
 		holder.callproc.waiting_for_click = 0
 		holder.callproc.do_args()
 
-/client/Click(atom/A, location, control, params)
-	if(mouse_click_last_time == world.time)
-		return 0
-
-	mouse_click_last_time = world.time
-
-	if(holder && holder.callproc && holder.callproc.waiting_for_click)
-		if(alert("Do you want to select \the [A] as the [length(holder.callproc.arguments)+1]\th argument?",, "Yes", "No") == "Yes")
-			holder.callproc.arguments += A
-
-		holder.callproc.waiting_for_click = 0
-		verbs -= /client/proc/cancel_callproc_select
-		holder.callproc.do_args()
-	else
-		return ..()
-
 /datum/callproc/proc/finalise()
 	var/returnval
 

--- a/code/modules/admin/callproc/callproc.dm
+++ b/code/modules/admin/callproc/callproc.dm
@@ -225,7 +225,12 @@
 		holder.callproc.waiting_for_click = 0
 		holder.callproc.do_args()
 
-/client/Click(atom/A)
+/client/Click(atom/A, location, control, params)
+	if(mouse_click_last_time == world.time)
+		return 0
+
+	mouse_click_last_time = world.time
+
 	if(holder && holder.callproc && holder.callproc.waiting_for_click)
 		if(alert("Do you want to select \the [A] as the [length(holder.callproc.arguments)+1]\th argument?",, "Yes", "No") == "Yes")
 			holder.callproc.arguments += A

--- a/code/modules/client/client_defines.dm
+++ b/code/modules/client/client_defines.dm
@@ -96,3 +96,9 @@
 
 	/// Movement dir of the most recently pressed movement key. Used in cardinal-only movement mode.
 	var/last_move_dir_pressed
+
+	/// Full-auto guns broke clicking and now we have to invent workarounds. What a life.
+	var/mouse_down_last_time = 0
+	var/mouse_click_last_time = 0
+	var/mouse_click_opportunity_window = 2 // Must be enough for most users.
+	var/atom/mouse_down_atom = null

--- a/code/modules/client/client_procs.dm
+++ b/code/modules/client/client_procs.dm
@@ -666,21 +666,40 @@
 
 /client/MouseDrag(src_object, over_object, src_location, over_location, src_control, over_control, params)
 	. = ..()
-	var/mob/living/M = mob
-	if(istype(M))
+	if(isliving(mob))
+		var/mob/living/M = mob
 		M.OnMouseDrag(src_object, over_object, src_location, over_location, src_control, over_control, params)
 
 /client/MouseUp(object, location, control, params)
 	. = ..()
-	var/mob/living/M = mob
-	if(istype(M))
-		M.OnMouseUp(object, location, control, params)
+	if(isliving(mob))
+		var/mob/living/M = mob
+		if(M.OnMouseUp(object, location, control, params))
+			mouse_down_atom = null
+			return
+
+	// We simulate a normal click if:
+	// A - We release the mouse button over the same object we pressed it over;
+	// B - We release the mouse button over another object during the "windup" phase;
+	// The troublesome thing is, BYOND normally calls a regular Click() AFTER MouseUp(), so
+	// we have to prevent it by forbidding multiple clicks during a single tick. On one hand, it's
+	// not even a bad thing, and might prevent things like autoclickers from working normally.
+	// On the other, it might break something unexpectedly. ~NoSieve
+	if(object == mouse_down_atom || (object != mouse_down_atom && mouse_down_last_time + mouse_click_opportunity_window >= world.time))
+		Click(object, location, control, params)
+
+	mouse_down_atom = null
 
 /client/MouseDown(object, location, control, params)
 	. = ..()
-	var/mob/living/M = mob
-	if(istype(M) && !M.in_throw_mode)
-		M.OnMouseDown(object, location, control, params)
+	if(isliving(mob))
+		var/mob/living/M = mob
+		if(M.OnMouseDown(object, location, control, params))
+			mouse_down_atom = null
+			return
+
+	mouse_down_atom = object
+	mouse_down_last_time = world.time
 
 /client/proc/get_luck_for_type(luck_type)
 	switch(luck_type)
@@ -817,21 +836,6 @@
 					isnull(unbanned)
 					[isnull(config.general.server_id) ? "" : " AND server_id = $server_id"]
 				"}, dbcon, list(id = id, ckeytext = src.ckey, server_id = config.general.server_id))
-
-/client/Click(atom/A)
-	//if(!user_acted(src))
-	//	return
-
-	if(holder && holder.callproc && holder.callproc.waiting_for_click)
-		if(alert("Do you want to select \the [A] as the [holder.callproc.arguments.len+1]\th argument?",, "Yes", "No") == "Yes")
-			holder.callproc.arguments += A
-
-		holder.callproc.waiting_for_click = 0
-		verbs -= /client/proc/cancel_callproc_select
-		holder.callproc.do_args()
-		return
-
-	return ..()
 
 /**
  * Updates the keybinds for special keys

--- a/code/modules/client/client_procs.dm
+++ b/code/modules/client/client_procs.dm
@@ -664,6 +664,23 @@
 	 */
 	mob?.reload_fullscreen()
 
+/client/Click(atom/A, location, control, params)
+	if(mouse_click_last_time == world.time)
+		return 0
+
+	mouse_click_last_time = world.time
+
+	// See code/modules/admin/callproc/callproc.dm
+	if(holder && holder.callproc && holder.callproc.waiting_for_click)
+		if(alert("Do you want to select \the [A] as the [length(holder.callproc.arguments)+1]\th argument?",, "Yes", "No") == "Yes")
+			holder.callproc.arguments += A
+
+		holder.callproc.waiting_for_click = 0
+		verbs -= /client/proc/cancel_callproc_select
+		holder.callproc.do_args()
+	else
+		return ..()
+
 /client/MouseDrag(src_object, over_object, src_location, over_location, src_control, over_control, params)
 	. = ..()
 	if(isliving(mob))

--- a/code/modules/client/preference_setup/global/preferences.dm
+++ b/code/modules/client/preference_setup/global/preferences.dm
@@ -50,6 +50,12 @@ GLOBAL_VAR_CONST(PREF_SPLASH_CHAT, "Chat only")
 GLOBAL_VAR_CONST(PREF_SPLASH_BOTH, "Maptext and chat")
 GLOBAL_VAR_CONST(PREF_ENABLED, "Enabled")
 GLOBAL_VAR_CONST(PREF_DISABLED, "Disabled")
+GLOBAL_VAR_CONST(PREF_CLICK_PRECISION_NONE, "Disabled")
+GLOBAL_VAR_CONST(PREF_CLICK_PRECISION_1DS,  "0.1s")
+GLOBAL_VAR_CONST(PREF_CLICK_PRECISION_2DS,  "0.2s")
+GLOBAL_VAR_CONST(PREF_CLICK_PRECISION_3DS,  "0.3s")
+GLOBAL_VAR_CONST(PREF_CLICK_PRECISION_4DS,  "0.4s")
+GLOBAL_VAR_CONST(PREF_CLICK_PRECISION_5DS,  "0.5s")
 
 
 var/global/list/_client_preferences
@@ -264,6 +270,30 @@ var/global/list/_client_preferences_by_type
 	key = "SPECIAL_ABILITY"
 	category = PREF_CATEGORY_CONTROL
 	options = list(GLOB.PREF_MIDDLE_CLICK, GLOB.PREF_CTRL_CLICK, GLOB.PREF_ALT_CLICK, GLOB.PREF_CTRL_SHIFT_CLICK)
+
+/datum/client_preference/click_precision_assist
+	description = "Click Precision Assist"
+	key = "CLICK_PRECISION_ASSIST"
+	category = PREF_CATEGORY_CONTROL
+	default_value = GLOB.PREF_CLICK_PRECISION_2DS
+	options = list(GLOB.PREF_CLICK_PRECISION_NONE, GLOB.PREF_CLICK_PRECISION_1DS, GLOB.PREF_CLICK_PRECISION_2DS, GLOB.PREF_CLICK_PRECISION_3DS, GLOB.PREF_CLICK_PRECISION_4DS, GLOB.PREF_CLICK_PRECISION_5DS)
+
+/datum/client_preference/click_precision_assist/changed(mob/preference_mob, new_value)
+	if(!istype(preference_mob))
+		return
+	switch(new_value)
+		if(GLOB.PREF_CLICK_PRECISION_NONE)
+			preference_mob?.client.mouse_click_opportunity_window = 0
+		if(GLOB.PREF_CLICK_PRECISION_1DS)
+			preference_mob?.client.mouse_click_opportunity_window = 1
+		if(GLOB.PREF_CLICK_PRECISION_2DS)
+			preference_mob?.client.mouse_click_opportunity_window = 2
+		if(GLOB.PREF_CLICK_PRECISION_3DS)
+			preference_mob?.client.mouse_click_opportunity_window = 3
+		if(GLOB.PREF_CLICK_PRECISION_4DS)
+			preference_mob?.client.mouse_click_opportunity_window = 4
+		if(GLOB.PREF_CLICK_PRECISION_5DS)
+			preference_mob?.client.mouse_click_opportunity_window = 5
 
 /datum/client_preference/tgui_style
 	description = "TGUI Style"

--- a/code/modules/client/preference_setup/global/preferences.dm
+++ b/code/modules/client/preference_setup/global/preferences.dm
@@ -272,7 +272,7 @@ var/global/list/_client_preferences_by_type
 	options = list(GLOB.PREF_MIDDLE_CLICK, GLOB.PREF_CTRL_CLICK, GLOB.PREF_ALT_CLICK, GLOB.PREF_CTRL_SHIFT_CLICK)
 
 /datum/client_preference/click_precision_assist
-	description = "Click Precision Assist"
+	description = "Click Precision Assist Time"
 	key = "CLICK_PRECISION_ASSIST"
 	category = PREF_CATEGORY_CONTROL
 	default_value = GLOB.PREF_CLICK_PRECISION_2DS

--- a/code/modules/mob/login.dm
+++ b/code/modules/mob/login.dm
@@ -87,6 +87,19 @@
 	update_mouse_pointer()
 
 	client.mouse_click_opportunity_window = get_preference_value(/datum/client_preference/click_precision_assist)
+	switch(client.mouse_click_opportunity_window)
+		if(GLOB.PREF_CLICK_PRECISION_NONE)
+			client.mouse_click_opportunity_window = 0
+		if(GLOB.PREF_CLICK_PRECISION_1DS)
+			client.mouse_click_opportunity_window = 1
+		if(GLOB.PREF_CLICK_PRECISION_2DS)
+			client.mouse_click_opportunity_window = 2
+		if(GLOB.PREF_CLICK_PRECISION_3DS)
+			client.mouse_click_opportunity_window = 3
+		if(GLOB.PREF_CLICK_PRECISION_4DS)
+			client.mouse_click_opportunity_window = 4
+		if(GLOB.PREF_CLICK_PRECISION_5DS)
+			client.mouse_click_opportunity_window = 5
 
 	if(!skybox)
 		skybox = new(src)

--- a/code/modules/mob/login.dm
+++ b/code/modules/mob/login.dm
@@ -86,6 +86,8 @@
 
 	update_mouse_pointer()
 
+	client.mouse_click_opportunity_window = get_preference_value(/datum/client_preference/click_precision_assist)
+
 	if(!skybox)
 		skybox = new(src)
 		skybox.owner = src

--- a/code/modules/mob/organs/external/_external.dm
+++ b/code/modules/mob/organs/external/_external.dm
@@ -789,7 +789,7 @@ This function completely restores a damaged organ to perfect condition.
 			/// NOWOUNDS TODO: Better way to implement clean cut bleeding
 			parent_organ.take_cut_damage(min_broken_damage, "a limb amputation", TRUE)
 			parent_organ.update_damages()
-		else
+		else if(!is_stump())
 			var/obj/item/organ/external/stump/stump = new (victim, src)
 			stump.SetName("stump of \a [name]")
 			stump.artery_name = "mangled [artery_name]"
@@ -812,6 +812,11 @@ This function completely restores a damaged organ to perfect condition.
 			victim.update_health()
 			victim.update_damage_overlays()
 			victim.regenerate_icons()
+
+	// We don't want to see these broken pieces of shit lying around
+	if(is_stump())
+		qdel(src)
+		return
 
 	dir = 2
 	switch(disintegrate)

--- a/code/modules/mob/organs/external/stump.dm
+++ b/code/modules/mob/organs/external/stump.dm
@@ -4,11 +4,11 @@
 	dislocated = -1
 	disable_food_organ = TRUE
 
-/obj/item/organ/external/stump/Initialize(mapload, mob/living/carbon/holder, obj/item/organ/external/limb)
+/obj/item/organ/external/stump/Initialize(mapload, obj/item/organ/external/limb)
 	. = ..()
 
-	if(!istype(limb))
-		return .
+	if(!owner || !istype(limb)) // We definitely don't want these pieces of crap to be found outside of a human body.
+		return INITIALIZE_HINT_QDEL
 
 	organ_tag = limb.organ_tag
 	if(!BP_IS_ROBOTIC(limb)) // These nasty fucks are broken, fuck robolimbs, their dumb icons and whomever the fuck created them in their current fucking state
@@ -26,7 +26,13 @@
 		robotize() //if both limb and the parent are robotic, the stump is robotic too
 
 /obj/item/organ/external/stump/is_stump()
-	return 1
+	return TRUE
+
+/obj/item/organ/external/stump/droplimb(clean, disintegrate = DROPLIMB_EDGE, ignore_children, silent, drop_modules = FALSE)
+	..()
+	if(!owner && !QDELETED(src))
+		qdel_self()
+	return
 
 /obj/item/organ/external/stump/rejuvenate(ignore_prosthetic_prefs)
 	. = ..()

--- a/code/modules/projectiles/gun.dm
+++ b/code/modules/projectiles/gun.dm
@@ -154,11 +154,14 @@
 		autofiring_by = fire_by
 		if(!already_autofiring)
 			already_autofiring = TRUE
-			set_next_think_ctx("autofire_context", world.time + burst_delay)
+			set_next_think_ctx("autofire_context", world.time + fire_delay)
 	else
 		clear_autofire()
 
 /obj/item/gun/proc/clear_autofire()
+	if(already_autofiring)
+		next_fire_time = world.time + fire_delay // No Arc Raiders' Kettle gameplay, please
+
 	autofiring_at = null
 	autofiring_by = null
 	already_autofiring = FALSE
@@ -178,7 +181,7 @@
 	else if(can_autofire())
 		autofiring_by.set_dir(get_dir(src, autofiring_at))
 		Fire(autofiring_at, autofiring_by, null, (get_dist(autofiring_at, autofiring_by) <= 1), FALSE, FALSE, target_zone = autofiring_by.zone_sel?.selecting)
-		set_next_think_ctx("autofire_context", world.time + burst_delay)
+		set_next_think_ctx("autofire_context", world.time + fire_delay)
 
 /obj/item/gun/update_twohanding()
 	if(one_hand_penalty)
@@ -364,7 +367,8 @@
 	if(heat_amount >= 100)
 		overheat()
 
-	next_fire_time = world.time + fire_delay
+	if(!autofire_enabled) // Let the autofire handling do its thing.
+		next_fire_time = world.time + fire_delay
 
 /obj/item/gun/proc/overheat()
 	on_overheat = TRUE

--- a/code/modules/projectiles/gun.dm
+++ b/code/modules/projectiles/gun.dm
@@ -161,6 +161,7 @@
 /obj/item/gun/proc/clear_autofire()
 	if(already_autofiring)
 		next_fire_time = world.time + fire_delay // No Arc Raiders' Kettle gameplay, please
+		. = TRUE
 
 	autofiring_at = null
 	autofiring_by = null

--- a/code/modules/recycling/disposal.dm
+++ b/code/modules/recycling/disposal.dm
@@ -534,10 +534,10 @@
 		sleep(1)		// was 1
 		if(!loc) return // check if we got GC'd
 
-		if(hasmob && prob(3))
+		if(hasmob && prob(5))
 			for(var/mob/living/H in src)
-				if(!istype(H,/mob/living/silicon/robot/drone)) //Drones use the mailing code to move through the disposal system,
-					H.take_overall_damage(20, 0, 0, "Blunt Trauma", FALSE)//horribly maim any living creature jumping down disposals.  c'est la vie
+				if(!istype(H, /mob/living/silicon/robot/drone)) // Drones use the mailing code to move through the disposal system,
+					H.take_overall_damage(80, 0, 0, "Blunt Trauma")// horribly maim any living creature jumping down disposals.  c'est la vie
 
 		var/obj/structure/disposalpipe/curr = loc
 		last = curr


### PR DESCRIPTION
обмазываемся костылями для качества жизни

```yml
🆑
bugfix: Исправлены баги с культями. Теперь их снова можно ампутировать, а протезы не лепятся поверх них.
tweak: Полёты по мусорке теперь наносят меньше урона.
bugfix: Исправлен автоматический режим стрельбы, теперь он работает не только у L6 Saw.
bugfix: Переработана регистрация кликов. Ранее клики не засчитывались, если кнопка мыши была нажата, когда курсор был над одним тайлом/объектом/мобом, а отпущена - над другим. Особенно это было заметно при стрельбе/атаках в движении. Теперь есть небольшое окошко, во время которого клик будет засчитываться даже в таком случае. Длительность окошка по умолчанию выставлено на более-менее комфортное значение, но его можно изменить в настройках, раздел "Control", пункт "Click Precision Assist Time".
/🆑
```

- [x] Pull Request полностью завершен, мне не нужна помощь чтобы его закончить.
- [x] Я внимательно прочитал(-а) все свои изменения и багов в них не нашёл(-ла).
- [x] Я запускал(-а) сервер со своими изменениями локально и все протестировал(-а).
- [x] Я ознакомился(-ась) c [Guide to Contribute](https://github.com/ChaoticOnyx/OnyxBay/blob/dev/docs/contributing.md).
