### PR TITLE
fix(external organs): fixes droplimb and cut_away status

### DIFF
--- a/code/modules/mob/living/carbon/human/human_organs.dm
+++ b/code/modules/mob/living/carbon/human/human_organs.dm
@@ -163,7 +163,7 @@
 	for(var/limb_tag in list(BP_L_LEG, BP_L_FOOT))	// Left leg processing
 		var/obj/item/organ/external/E = external_organs_by_name[limb_tag]
 
-		if(!E || (E.status & ORGAN_DISFIGURED) || istype(E,/obj/item/organ/external/stump))
+		if(!E || (E.status & ORGAN_DISFIGURED) || (E.status & ORGAN_CUT_AWAY) || istype(E,/obj/item/organ/external/stump))
 			stance_d_l += 5
 
 		else if(E.is_malfunctioning())
@@ -192,7 +192,7 @@
 	for(var/limb_tag in list(BP_R_LEG, BP_R_FOOT))	// Right leg processing
 		var/obj/item/organ/external/E = external_organs_by_name[limb_tag]
 
-		if(!E || (E.status & ORGAN_DISFIGURED) || istype(E,/obj/item/organ/external/stump))
+		if(!E || (E.status & ORGAN_DISFIGURED) || (E.status & ORGAN_CUT_AWAY) || istype(E,/obj/item/organ/external/stump))
 			stance_d_r += 5
 
 		else if(E.is_malfunctioning())

--- a/code/modules/mob/organs/external/_external.dm
+++ b/code/modules/mob/organs/external/_external.dm
@@ -287,11 +287,14 @@
 					var/obj/item/organ/external/external_child = pick(children)
 					status |= ORGAN_CUT_AWAY
 					children.Remove(external_child)
-					external_child.forceMove(get_turf(src))
-					external_child.SetTransform(rotation = rand(180))
-					external_child.compile_icon()
-					compile_icon()
 					user.visible_message(SPAN("danger", "<b>[user]</b> cuts [external_child] from [src] with [W]!"))
+					external_child.forceMove(get_turf(src))
+					if(external_child.is_stump())
+						qdel(external_child)
+					else
+						external_child.SetTransform(rotation = round(rand(360), 45))
+						external_child.compile_icon()
+					compile_icon()
 				else
 					user.visible_message(SPAN("danger", "<b>[user]</b> cuts [src] open with [W]!"))
 					bone_stage++
@@ -416,7 +419,7 @@
 	if(parent)
 		if(!parent.children)
 			parent.children = list()
-		parent.children += src
+		parent.children |= src
 		/// NOWOUNDS TODO: Stump removal
 		parent.update_damages()
 
@@ -603,6 +606,9 @@ This function completely restores a damaged organ to perfect condition.
 	if(BP_IS_ROBOTIC(src)) // T-1000 would NOT be proud.
 		return
 
+	if(status & ORGAN_CUT_AWAY) // It's basically hanging on a scrap of flesh or a couple of staples, no bloodflow or anything.
+		return
+
 	var/mob/living/carbon/human/H
 	if(ishuman(owner))
 		H = owner
@@ -770,8 +776,15 @@ This function completely restores a damaged organ to perfect condition.
 	var/use_blood_colour = species.get_blood_colour(owner)
 	adjust_pain(60)
 
-	removed(null, 0, ignore_children, (disintegrate != DROPLIMB_EDGE))
-	if(QDELETED(src))
+	var/list/stuff_to_throw = list()
+	stuff_to_throw |= children
+	stuff_to_throw |= internal_organs
+	stuff_to_throw |= implants
+	stuff_to_throw |= embedded_objects
+
+	removed(null, TRUE, (disintegrate != DROPLIMB_EDGE))
+
+	if(QDELETED(src)) // Stumps get qdeleted during removed()
 		victim.update_health()
 		victim.update_damage_overlays()
 		victim.regenerate_icons()
@@ -780,6 +793,7 @@ This function completely restores a damaged organ to perfect condition.
 	if(drop_modules)
 		for(var/obj/item/organ_module/module in organ_modules.Copy())
 			module.remove(src)
+			stuff_to_throw |= module
 
 	if(!clean)
 		victim.shock_stage += min_broken_damage
@@ -789,7 +803,7 @@ This function completely restores a damaged organ to perfect condition.
 			/// NOWOUNDS TODO: Better way to implement clean cut bleeding
 			parent_organ.take_cut_damage(min_broken_damage, "a limb amputation", TRUE)
 			parent_organ.update_damages()
-		else if(!is_stump())
+		else
 			var/obj/item/organ/external/stump/stump = new (victim, src)
 			stump.SetName("stump of \a [name]")
 			stump.artery_name = "mangled [artery_name]"
@@ -813,32 +827,29 @@ This function completely restores a damaged organ to perfect condition.
 			victim.update_damage_overlays()
 			victim.regenerate_icons()
 
-	// We don't want to see these broken pieces of shit lying around
-	if(is_stump())
-		qdel(src)
-		return
+	dir = SOUTH
 
-	dir = 2
 	switch(disintegrate)
 		if(DROPLIMB_EDGE)
 			compile_icon()
 			add_blood(victim)
 			if(organ_tag == BP_HEAD)
-				SetTransform(rotation = 90)
+				SetTransform(rotation = pick(90, 270))
 			else
-				SetTransform(rotation = rand(180))
+				SetTransform(rotation = round(rand(360), 45))
 			forceMove(victim.loc)
 			update_icon_drop(victim)
 			if(!clean && !QDELETED(src)) // Throw limb around.
 				if(isturf(loc))
-					throw_at(get_edge_target_turf(src, pick(GLOB.alldirs)), rand(1, 3), rand(1, 2))
-				dir = 2
+					throw_at(get_edge_target_turf(src, pick(GLOB.alldirs)), rand(1, 3), 1)
+
 		if(DROPLIMB_BURN)
 			new /obj/effect/decal/cleanable/ash(victim.loc)
-			for(var/obj/item/I in src)
-				if(I.w_class > ITEM_SIZE_SMALL && !istype(I, /obj/item/organ))
+			for(var/obj/item/I in stuff_to_throw)
+				if(!QDELETED(I) && I.w_class > ITEM_SIZE_SMALL && !istype(I, /obj/item/organ))
 					I.forceMove(victim.loc)
 			qdel(src)
+
 		if(DROPLIMB_BLUNT)
 			var/obj/effect/decal/cleanable/blood/gibs/gore
 			if(BP_IS_ROBOTIC(src))
@@ -850,10 +861,12 @@ This function completely restores a damaged organ to perfect condition.
 					gore.basecolor = use_blood_colour
 					gore.update_icon()
 
-			for(var/obj/item/I in src)
+			for(var/obj/item/I in stuff_to_throw)
+				if(QDELETED(I))
+					continue
 				I.forceMove(victim.loc)
 				if(isturf(I.loc))
-					I.throw_at(get_edge_target_turf(I, pick(GLOB.alldirs)), rand(1, 2), rand(1, 2))
+					I.throw_at(get_edge_target_turf(I, pick(GLOB.alldirs)), rand(1, 2), 1)
 
 			qdel(src)
 
@@ -921,7 +934,9 @@ This function completely restores a damaged organ to perfect condition.
 
 /obj/item/organ/external/proc/update_tally()
 	movement_tally = initial(movement_tally)
-	if(splinted)
+	if(status & ORGAN_CUT_AWAY)
+		movement_tally += broken_tally * damage_multiplier
+	else if(splinted)
 		movement_tally += splinted_tally * damage_multiplier
 	else if(status & ORGAN_BROKEN)
 		movement_tally += broken_tally * damage_multiplier
@@ -1084,9 +1099,11 @@ This function completely restores a damaged organ to perfect condition.
 /obj/item/organ/external/proc/is_malfunctioning()
 	return (BP_IS_ROBOTIC(src) && (brute_dam + burn_dam) >= 10 && prob(brute_dam + burn_dam))
 
-/obj/item/organ/external/removed(mob/living/user, drop_organ = 1, ignore_children = 0, detach_children_and_internals = 0)
+/obj/item/organ/external/removed(mob/living/user, drop_organ = TRUE, detach_children_and_internals = FALSE)
 	if(!owner)
 		return
+
+	status |= ORGAN_CUT_AWAY
 
 	if(limb_flags & ORGAN_FLAG_CAN_GRASP) owner.grasp_limbs -= src
 	if(limb_flags & ORGAN_FLAG_CAN_STAND) owner.stance_limbs -= src
@@ -1136,28 +1153,28 @@ This function completely restores a damaged organ to perfect condition.
 			implant.forceMove(get_turf(src))
 
 	// Attached organs also fly off.
-	if(!ignore_children)
-		for(var/obj/item/organ/external/O in children)
-			O.removed()
-			if(!QDELETED(O) && !detach_children_and_internals)
-				O.forceMove(src)
+	for(var/obj/item/organ/external/O in children)
+		O.removed(user, detach_children_and_internals)
+		if(!QDELETED(O) && !detach_children_and_internals)
+			O.forceMove(src)
 
-				// if we didn't lose the organ we still want it as a child
-				children += O
-				O.parent = src
+			// if we didn't lose the organ we still want it as a child
+			children |= O
+			O.parent = src
 
 	// Grab all the internal giblets too.
 	for(var/obj/item/organ/organ in internal_organs)
-		organ.removed(user, 0, detach_children_and_internals)  // Organ stays inside and connected
-		if(!QDELETED(organ))
+		organ.removed(user, detach_children_and_internals, detach_children_and_internals)  // Organ stays inside and connected
+		if(!QDELETED(organ) && !detach_children_and_internals)
 			organ.forceMove(src)
 
+	release_restraints(victim)
+
 	// Remove parent references
-	if(parent)
+	if(parent && drop_organ)
 		parent.children -= src
 		parent = null
 
-	release_restraints(victim)
 	victim.external_organs -= src
 	victim.external_organs_by_name -= organ_tag
 
@@ -1175,7 +1192,7 @@ This function completely restores a damaged organ to perfect condition.
 		spawn(10)
 			qdel(spark_system)
 		qdel(src)
-	else if(is_stump())
+	else if(is_stump() && drop_organ)
 		qdel(src)
 
 /obj/item/organ/external/head/proc/disfigure(type = "brute")

--- a/code/modules/mob/organs/external/_external_icons.dm
+++ b/code/modules/mob/organs/external/_external_icons.dm
@@ -6,9 +6,19 @@ var/list/limb_icon_cache = list()
 /obj/item/organ/external/set_dir()
 	return
 
+/obj/item/organ/external/Move(newloc, direct)
+	. = ..()
+	if(!owner)
+		dir = SOUTH
+
 /obj/item/organ/external/proc/compile_icon()
 	ClearOverlays()
 	update_icon()
+	if(!owner && length(children))
+		for(var/obj/item/organ/external/E in children)
+			E.compile_icon()
+			E.ImmediateOverlayUpdate()
+			AddOverlays(E)
 
 /obj/item/organ/external/proc/sync_colour_to_human(mob/living/carbon/human/human)
 	s_tone = null
@@ -243,7 +253,7 @@ var/list/limb_icon_cache = list()
 		mob_overlays += limb_em_block
 
 	AddOverlays(mob_overlays)
-	dir = EAST
+	dir = SOUTH
 	icon = null
 
 /obj/item/organ/external/proc/update_icon_drop(mob/living/carbon/human/powner)

--- a/code/modules/mob/organs/external/stump.dm
+++ b/code/modules/mob/organs/external/stump.dm
@@ -5,7 +5,8 @@
 	disable_food_organ = TRUE
 
 /obj/item/organ/external/stump/Initialize(mapload, obj/item/organ/external/limb)
-	organ_tag = limb.organ_tag // Let's just hope we won't break everything by pushing this in front of the entire sequence
+	if(istype(limb))
+		organ_tag = limb.organ_tag // Let's just hope we won't break everything by pushing this in front of the entire sequence
 
 	. = ..()
 

--- a/code/modules/mob/organs/external/stump.dm
+++ b/code/modules/mob/organs/external/stump.dm
@@ -5,8 +5,9 @@
 	disable_food_organ = TRUE
 
 /obj/item/organ/external/stump/Initialize(mapload, obj/item/organ/external/limb)
-	if(istype(limb))
-		organ_tag = limb.organ_tag // Let's just hope we won't break everything by pushing this in front of the entire sequence
+	if(!istype(limb))
+		return INITIALIZE_HINT_QDEL
+	organ_tag = limb.organ_tag // Let's just hope we won't break everything by pushing this in front of the entire sequence
 
 	. = ..()
 

--- a/code/modules/mob/organs/external/stump.dm
+++ b/code/modules/mob/organs/external/stump.dm
@@ -11,8 +11,9 @@
 
 	. = ..()
 
-	if(!owner || !istype(limb)) // We definitely don't want these pieces of crap to be found outside of a human body.
+	if(!owner) // We definitely don't want these pieces of crap to be found outside of a human body.
 		return INITIALIZE_HINT_QDEL
+
 	if(!BP_IS_ROBOTIC(limb)) // These nasty fucks are broken, fuck robolimbs, their dumb icons and whomever the fuck created them in their current fucking state
 		icon_name = limb.icon_name
 	body_part = limb.body_part

--- a/code/modules/mob/organs/external/stump.dm
+++ b/code/modules/mob/organs/external/stump.dm
@@ -5,12 +5,12 @@
 	disable_food_organ = TRUE
 
 /obj/item/organ/external/stump/Initialize(mapload, obj/item/organ/external/limb)
+	organ_tag = limb.organ_tag // Let's just hope we won't break everything by pushing this in front of the entire sequence
+
 	. = ..()
 
 	if(!owner || !istype(limb)) // We definitely don't want these pieces of crap to be found outside of a human body.
 		return INITIALIZE_HINT_QDEL
-
-	organ_tag = limb.organ_tag
 	if(!BP_IS_ROBOTIC(limb)) // These nasty fucks are broken, fuck robolimbs, their dumb icons and whomever the fuck created them in their current fucking state
 		icon_name = limb.icon_name
 	body_part = limb.body_part
@@ -30,7 +30,7 @@
 
 /obj/item/organ/external/stump/droplimb(clean, disintegrate = DROPLIMB_EDGE, ignore_children, silent, drop_modules = FALSE)
 	..()
-	if(!owner && !QDELETED(src))
+	if(!parent && !QDELETED(src))
 		qdel_self()
 	return
 

--- a/code/modules/mob/organs/internal/_internal.dm
+++ b/code/modules/mob/organs/internal/_internal.dm
@@ -75,13 +75,13 @@
 	if(istype(parent)) //TODO ensure that we don't have to check this.
 		removed(user, FALSE, TRUE)
 
-/obj/item/organ/internal/removed(mob/living/user, drop_organ = TRUE, detach = TRUE, supplied_parent_organ = null)
+/obj/item/organ/internal/removed(mob/living/user, drop_organ = TRUE, detach = TRUE)
 	if(owner)
 		owner.internal_organs_by_name -= organ_tag
 		owner.internal_organs -= src
 
 	if(detach)
-		var/obj/item/organ/external/affected = supplied_parent_organ || owner?.get_organ(parent_organ)
+		var/obj/item/organ/external/affected = owner?.get_organ(parent_organ)
 		if(istype(affected))
 			affected.internal_organs -= src
 			status |= ORGAN_CUT_AWAY

--- a/code/modules/mob/organs/internal/_internal.dm
+++ b/code/modules/mob/organs/internal/_internal.dm
@@ -73,19 +73,20 @@
 /obj/item/organ/proc/cut_away(mob/living/user)
 	var/obj/item/organ/external/parent = owner.get_organ(parent_organ)
 	if(istype(parent)) //TODO ensure that we don't have to check this.
-		removed(user, 0)
-		parent.implants += src
+		removed(user, FALSE, TRUE)
 
-/obj/item/organ/internal/removed(mob/living/user, drop_organ = TRUE, detach = TRUE)
+/obj/item/organ/internal/removed(mob/living/user, drop_organ = TRUE, detach = TRUE, supplied_parent_organ = null)
 	if(owner)
 		owner.internal_organs_by_name -= organ_tag
 		owner.internal_organs -= src
 
-		if(detach)
-			var/obj/item/organ/external/affected = owner.get_organ(parent_organ)
-			if(affected)
-				affected.internal_organs -= src
-				status |= ORGAN_CUT_AWAY
+	if(detach)
+		var/obj/item/organ/external/affected = supplied_parent_organ || owner?.get_organ(parent_organ)
+		if(istype(affected))
+			affected.internal_organs -= src
+			status |= ORGAN_CUT_AWAY
+			if(!drop_organ)
+				affected.implants |= src
 	..()
 
 /obj/item/organ/internal/replaced(mob/living/carbon/human/target, obj/item/organ/external/affected)


### PR DESCRIPTION
Ёб твою мать, надеюсь, больше никогда не придётся трогать код органов.

```yml
🆑
bugfix: Рефактор древнего кода конечностей. Теперь отпиленные конечности можно пришивать обратно и не ловить перманентное замедление (конечно, если присоединить гемостатом, как в случае с протезами), при гибе конечности её дочерние конечности не пропадают, а падают (гибнуло локоть - ладошка отлетит), оторванные конечности не выглядят как искорёженная куча пикселей.
/🆑
```

- [x] Pull Request полностью завершен, мне не нужна помощь чтобы его закончить.
- [x] Я внимательно прочитал(-а) все свои изменения и багов в них не нашёл(-ла).
- [x] Я запускал(-а) сервер со своими изменениями локально и все протестировал(-а).
- [x] Я ознакомился(-ась) c [Guide to Contribute](https://github.com/ChaoticOnyx/OnyxBay/blob/dev/docs/contributing.md).
