### PR TITLE
fix(lungs): correct lung damage threshold for medium gas temperatures

### DIFF
--- a/code/modules/mob/organs/internal/normal/lungs.dm
+++ b/code/modules/mob/organs/internal/normal/lungs.dm
@@ -284,7 +284,7 @@
 
 			if (breath.temperature >= species.heat_level_3)
 				damage = HEAT_GAS_DAMAGE_LEVEL_3
-			else if (breath.temperature >= species.heat_level_3)
+			else if (breath.temperature >= species.heat_level_2)
 				damage = HEAT_GAS_DAMAGE_LEVEL_2
 			else
 				damage = HEAT_GAS_DAMAGE_LEVEL_1


### PR DESCRIPTION
Fixed a logic error in lungs.dm where temperature was compared against heat_level_3 twice. This made HEAT_GAS_DAMAGE_LEVEL_2 unreachable.


Исправлена логическая ошибка: вторая проверка температуры теперь использует корректный порог `heat_level_2` вместо дублирующегося `heat_level_3`. Это исправляет баланс урона от горячего газа, позволяя персонажам получать средний урон вместо моментального максимального при достижении средних температур.

Не нашёл ни одного связанного ишью.


<details>
<summary>Чейнджлог</summary>

```yml
🆑 MACTEP_ABATAP
bugfix: Исправлена ошибка в расчете повреждения легких. Теперь умеренно горячий газ наносит корректный средний урон вместо максимального.
/🆑
```

</details>



- [x] Pull Request полностью завершен, мне не нужна помощь чтобы его закончить.
- [x] Я внимательно прочитал(-а) все свои изменения и багов в них не нашёл(-ла).
- [x] Я запускал(-а) сервер со своими изменениями локально и все протестировал(-а).
- [x] Я ознакомился(-ась) c [Guide to Contribute](https://github.com/ChaoticOnyx/OnyxBay/blob/dev/docs/contributing.md).
