### PR TITLE
fix(airlock): fixes assembly access assignment

### DIFF
--- a/code/game/machinery/doors/airlock.dm
+++ b/code/game/machinery/doors/airlock.dm
@@ -924,9 +924,9 @@ About the new airlock wires panel:
 		req_one_access = null
 		if(length(electronics.conf_access))
 			if(electronics.one_access)
-				req_one_access = list(electronics.conf_access)
+				req_one_access = electronics.conf_access
 			else
-				req_access = list(electronics.conf_access)
+				req_access = electronics.conf_access
 
 		//get the name from the assembly
 		if(assembly.created_name)


### PR DESCRIPTION
```yml
🆑
bugfix: Исправлена ошибка, из-за которой пересобранные шлюзы не могли быть открыты вне зависимости от доступа.
/🆑
```

- [x] Pull Request полностью завершен, мне не нужна помощь чтобы его закончить.
- [x] Я внимательно прочитал(-а) все свои изменения и багов в них не нашёл(-ла).
- [x] Я запускал(-а) сервер со своими изменениями локально и все протестировал(-а).
- [x] Я ознакомился(-ась) c [Guide to Contribute](https://github.com/ChaoticOnyx/OnyxBay/blob/dev/docs/contributing.md).
